### PR TITLE
Add JobService to support async endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle/
 build/
+local-dev/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**
 !**/src/test/**

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-	compile(group: 'bio.terra', name: 'stairway', version: '0.0.1-SNAPSHOT')
+	compile(group: 'bio.terra', name: 'stairway', version: '0.0.4-SNAPSHOT')
 	compile(group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.12', version: '0.1-11a7002')
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jdbc'
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
@@ -89,6 +89,9 @@ openApiValidate {
 	inputSpec = "${openapiSourceFile}".toString()
 }
 
+// Note: Spotless deletes the classes OpenApi generates.
+// The order needs to be spotlessApply -> openApiGenerate -> build/test/run
+tasks.openApiGenerate.dependsOn tasks.spotlessApply
 compileJava.dependsOn tasks.openApiGenerate
 sourceSets.main.java.srcDir "${openapiTargetDir}/src/main/java"
 ideaModule.dependsOn tasks.openApiGenerate

--- a/src/main/java/bio/terra/workspace/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/workspace/app/configuration/ApplicationConfiguration.java
@@ -24,20 +24,19 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 public class ApplicationConfiguration {
 
   // Configurable properties
-  private String samAddress;
   private int maxStairwayThreads;
-
+  private int stairwayTimeoutSeconds;
   private String resourceId;
 
   // Not a property
   private PoolingDataSource<PoolableConnection> dataSource;
 
-  public String getSamAddress() {
-    return samAddress;
+  public int getStairwayTimeoutSeconds() {
+    return stairwayTimeoutSeconds;
   }
 
-  public void setSamAddress(String samAddress) {
-    this.samAddress = samAddress;
+  public void setStairwayTimeoutSeconds(int stairwayTimeoutSeconds) {
+    this.stairwayTimeoutSeconds = stairwayTimeoutSeconds;
   }
 
   public int getMaxStairwayThreads() {

--- a/src/main/java/bio/terra/workspace/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/workspace/app/configuration/ApplicationConfiguration.java
@@ -1,15 +1,10 @@
 package bio.terra.workspace.app.configuration;
 
-import bio.terra.stairway.DefaultExceptionSerializer;
-import bio.terra.stairway.ExceptionSerializer;
-import bio.terra.stairway.Stairway;
 import bio.terra.workspace.app.StartupInitializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.apache.commons.dbcp2.PoolableConnection;
 import org.apache.commons.dbcp2.PoolingDataSource;
 import org.openapitools.jackson.nullable.JsonNullableModule;
@@ -32,9 +27,10 @@ public class ApplicationConfiguration {
   private String samAddress;
   private int maxStairwayThreads;
 
+  private String resourceId;
+
   // Not a property
   private PoolingDataSource<PoolableConnection> dataSource;
-  private Stairway stairway;
 
   public String getSamAddress() {
     return samAddress;
@@ -52,13 +48,12 @@ public class ApplicationConfiguration {
     this.maxStairwayThreads = maxStairwayThreads;
   }
 
-  public Stairway getStairway() {
-    if (stairway == null) {
-      ExecutorService executorService = Executors.newFixedThreadPool(getMaxStairwayThreads());
-      ExceptionSerializer serializer = new DefaultExceptionSerializer();
-      stairway = new Stairway(executorService, null, serializer);
-    }
-    return stairway;
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  public void setResourceId(String resourceId) {
+    this.resourceId = resourceId;
   }
 
   @Bean("jdbcTemplate")

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -58,6 +58,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<CreatedWorkspace> create(@RequestBody CreateWorkspaceRequestBody body) {
     CreatedWorkspace result = createService.createWorkspace(body);
     return new ResponseEntity<>(result, HttpStatus.OK);
+  }
 
   public ResponseEntity<Object> retrieveJobResult(@PathVariable("id") String id) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -3,25 +3,66 @@ package bio.terra.workspace.app.controller;
 import bio.terra.workspace.generated.controller.WorkspaceApi;
 import bio.terra.workspace.generated.model.CreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.CreatedWorkspace;
+import bio.terra.workspace.generated.model.JobModel;
 import bio.terra.workspace.service.create.CreateService;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.job.JobService.JobResultWithStatus;
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Controller
 public class WorkspaceApiController implements WorkspaceApi {
   private CreateService createService;
+  private JobService jobService;
+  private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  private final HttpServletRequest request;
 
   @Autowired
-  public WorkspaceApiController(CreateService createService) {
+  public WorkspaceApiController(
+      CreateService createService,
+      JobService jobService,
+      AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
+      HttpServletRequest request) {
     this.createService = createService;
+    this.jobService = jobService;
+    this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
+    this.request = request;
+  }
+
+  private AuthenticatedUserRequest getAuthenticatedInfo() {
+    return authenticatedUserRequestFactory.from(request);
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteJob(@PathVariable("id") String id) {
+    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
+    jobService.releaseJob(id, userReq);
+    return new ResponseEntity<>(HttpStatus.valueOf(204));
+  }
+
+  @Override
+  public ResponseEntity<JobModel> pollAsyncJob(@PathVariable("id") String id) {
+    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
+    JobModel job = jobService.retrieveJob(id, userReq);
+    return new ResponseEntity<JobModel>(job, HttpStatus.valueOf(job.getStatusCode()));
   }
 
   @Override
   public ResponseEntity<CreatedWorkspace> create(@RequestBody CreateWorkspaceRequestBody body) {
     CreatedWorkspace result = createService.createWorkspace(body);
     return new ResponseEntity<>(result, HttpStatus.OK);
+
+  public ResponseEntity<Object> retrieveJobResult(@PathVariable("id") String id) {
+    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
+    JobResultWithStatus<Object> jobResultHolder =
+        jobService.retrieveJobResult(id, Object.class, userReq);
+    return new ResponseEntity<>(jobResultHolder.getResult(), jobResultHolder.getStatusCode());
   }
 }

--- a/src/main/java/bio/terra/workspace/common/exception/ApiException.java
+++ b/src/main/java/bio/terra/workspace/common/exception/ApiException.java
@@ -1,0 +1,15 @@
+package bio.terra.workspace.common.exception;
+
+public class ApiException extends InternalServerErrorException {
+  public ApiException(String message) {
+    super(message);
+  }
+
+  public ApiException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ApiException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/workspace/common/exception/SamApiException.java
+++ b/src/main/java/bio/terra/workspace/common/exception/SamApiException.java
@@ -1,0 +1,37 @@
+package bio.terra.workspace.common.exception;
+
+import java.util.Collections;
+import java.util.List;
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class SamApiException extends ErrorReportException {
+
+  public SamApiException(ApiException samException) {
+    super(
+        "Error from SAM: ",
+        Collections.singletonList(samException.getResponseBody()),
+        HttpStatus.resolve(samException.getCode()));
+  }
+
+  public SamApiException(String message) {
+    super(message);
+  }
+
+  public SamApiException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public SamApiException(Throwable cause) {
+    super(cause);
+  }
+
+  public SamApiException(String message, List<String> causes, HttpStatus statusCode) {
+    super(message, causes, statusCode);
+  }
+
+  public SamApiException(
+      String message, Throwable cause, List<String> causes, HttpStatus statusCode) {
+    super(message, cause, causes, statusCode);
+  }
+}

--- a/src/main/java/bio/terra/workspace/common/utils/FlightUtils.java
+++ b/src/main/java/bio/terra/workspace/common/utils/FlightUtils.java
@@ -1,0 +1,39 @@
+package bio.terra.workspace.common.utils;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.generated.model.ErrorReport;
+import bio.terra.workspace.service.job.JobMapKeys;
+import org.springframework.http.HttpStatus;
+
+/** Common methods for building flights */
+public final class FlightUtils {
+  private FlightUtils() {}
+
+  /**
+   * Build an error model and set it as the response
+   *
+   * @param context
+   * @param message
+   * @param responseStatus
+   */
+  public static void setErrorResponse(
+      FlightContext context, String message, HttpStatus responseStatus) {
+    ErrorReport errorModel = new ErrorReport().message(message);
+    setResponse(context, errorModel, responseStatus);
+  }
+
+  /**
+   * Set the response and status code in the result map.
+   *
+   * @param context flight context
+   * @param responseObject response object to set
+   * @param responseStatus status code to set
+   */
+  public static void setResponse(
+      FlightContext context, Object responseObject, HttpStatus responseStatus) {
+    FlightMap workingMap = context.getWorkingMap();
+    workingMap.put(JobMapKeys.RESPONSE.getKeyName(), responseObject);
+    workingMap.put(JobMapKeys.STATUS_CODE.getKeyName(), responseStatus);
+  }
+}

--- a/src/main/java/bio/terra/workspace/common/utils/SamUtils.java
+++ b/src/main/java/bio/terra/workspace/common/utils/SamUtils.java
@@ -3,4 +3,8 @@ package bio.terra.workspace.common.utils;
 public class SamUtils {
 
   public static String SAM_WORKSPACE_RESOURCE = "mc-workspace";
+  // TODO: These don't actually exist in SAM yet.
+  public static String SAM_WORKSPACE_MANAGER_RESOURCE = "mc-workspace-manager";
+  public static String SAM_WORKSPACE_MANAGER_LIST_JOBS_ACTION = "list-job";
+  public static String SAM_WORKSPACE_MANAGER_DELETE_JOBS_ACTION = "delete-job";
 }

--- a/src/main/java/bio/terra/workspace/service/create/CreateService.java
+++ b/src/main/java/bio/terra/workspace/service/create/CreateService.java
@@ -3,7 +3,7 @@ package bio.terra.workspace.service.create;
 import bio.terra.workspace.app.configuration.ApplicationConfiguration;
 import bio.terra.workspace.generated.model.CreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.CreatedWorkspace;
-import bio.terra.workspace.service.iam.Sam;
+import bio.terra.workspace.service.iam.SamService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -11,10 +11,11 @@ import org.springframework.stereotype.Component;
 public class CreateService {
   private ApplicationConfiguration configuration;
   private final CreateDAO createDAO;
-  private final Sam sam;
+  private final SamService sam;
 
   @Autowired
-  public CreateService(ApplicationConfiguration configuration, CreateDAO createDAO, Sam sam) {
+  public CreateService(
+      ApplicationConfiguration configuration, CreateDAO createDAO, SamService sam) {
     this.configuration = configuration;
     this.createDAO = createDAO;
     this.sam = sam;
@@ -24,8 +25,9 @@ public class CreateService {
     CreatedWorkspace workspace = new CreatedWorkspace();
     String id = body.getId().toString();
 
-    // TODO: this SAM call should probably live in the folder manager, once it exists.
-    sam.createDefaultResource(body);
+    // TODO: this is commented out due to messy merge changes (SamService API was changed in this PR
+    // but this API is updated separately). This should be overwritten.
+    // sam.createDefaultResource(body);
     createDAO.create(id, body.getSpendProfile());
 
     workspace.setId(id);

--- a/src/main/java/bio/terra/workspace/service/iam/AuthHeaderKeys.java
+++ b/src/main/java/bio/terra/workspace/service/iam/AuthHeaderKeys.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.iam;
+
+public enum AuthHeaderKeys {
+  // keys for auth headers
+  OIDC_ACCESS_TOKEN("OIDC_ACCESS_token"),
+  AUTHORIZATION("Authorization"),
+  OIDC_CLAIM_EMAIL("OIDC_CLAIM_email"),
+  OIDC_CLAIM_USER_ID("OIDC_CLAIM_user_id");
+
+  private String keyName;
+
+  AuthHeaderKeys(String keyName) {
+    this.keyName = keyName;
+  }
+
+  public String getKeyName() {
+    return keyName;
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/iam/AuthenticatedUserRequest.java
+++ b/src/main/java/bio/terra/workspace/service/iam/AuthenticatedUserRequest.java
@@ -1,0 +1,68 @@
+package bio.terra.workspace.service.iam;
+
+import bio.terra.workspace.common.exception.ApiException;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Optional;
+import java.util.UUID;
+
+public class AuthenticatedUserRequest {
+
+  private String email;
+  private String subjectId;
+  private Optional<String> token;
+  private UUID reqId;
+
+  public AuthenticatedUserRequest() {
+    this.reqId = UUID.randomUUID();
+  }
+
+  public AuthenticatedUserRequest(String email, String subjectId, Optional<String> token) {
+    this.email = email;
+    this.subjectId = subjectId;
+    this.token = token;
+  }
+
+  public String getSubjectId() {
+    return subjectId;
+  }
+
+  public AuthenticatedUserRequest subjectId(String subjectId) {
+    this.subjectId = subjectId;
+    return this;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public AuthenticatedUserRequest email(String email) {
+    this.email = email;
+    return this;
+  }
+
+  public Optional<String> getToken() {
+    return token;
+  }
+
+  public AuthenticatedUserRequest token(Optional<String> token) {
+    this.token = token;
+    return this;
+  }
+
+  @JsonIgnore
+  public String getRequiredToken() {
+    if (!token.isPresent()) {
+      throw new ApiException("Token required");
+    }
+    return token.get();
+  }
+
+  public UUID getReqId() {
+    return reqId;
+  }
+
+  public AuthenticatedUserRequest reqId(UUID reqId) {
+    this.reqId = reqId;
+    return this;
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/iam/AuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/workspace/service/iam/AuthenticatedUserRequestFactory.java
@@ -1,0 +1,9 @@
+package bio.terra.workspace.service.iam;
+
+import javax.servlet.http.HttpServletRequest;
+
+// Making this an interface as I'm not sure what request authentication will look like in mc-terra.
+public interface AuthenticatedUserRequestFactory {
+
+  AuthenticatedUserRequest from(HttpServletRequest servletRequest);
+}

--- a/src/main/java/bio/terra/workspace/service/iam/ProxiedAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/workspace/service/iam/ProxiedAuthenticatedUserRequestFactory.java
@@ -1,0 +1,25 @@
+package bio.terra.workspace.service.iam;
+
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProxiedAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
+
+  // Method to build an AuthenticatedUserRequest from data available to the controller
+  public AuthenticatedUserRequest from(HttpServletRequest servletRequest) {
+    String token =
+        Optional.ofNullable(servletRequest.getHeader("oidc_access_token"))
+            .orElseGet(
+                () -> {
+                  String authHeader = servletRequest.getHeader("Authorization");
+                  return StringUtils.substring(authHeader, "Bearer:".length());
+                });
+    return new AuthenticatedUserRequest()
+        .email(servletRequest.getHeader("oidc_claim_email"))
+        .subjectId(servletRequest.getHeader("oidc_claim_user_id"))
+        .token(Optional.ofNullable(token));
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/iam/ProxiedAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/workspace/service/iam/ProxiedAuthenticatedUserRequestFactory.java
@@ -11,15 +11,16 @@ public class ProxiedAuthenticatedUserRequestFactory implements AuthenticatedUser
   // Method to build an AuthenticatedUserRequest from data available to the controller
   public AuthenticatedUserRequest from(HttpServletRequest servletRequest) {
     String token =
-        Optional.ofNullable(servletRequest.getHeader("oidc_access_token"))
+        Optional.ofNullable(servletRequest.getHeader(AuthHeaderKeys.OIDC_ACCESS_TOKEN.getKeyName()))
             .orElseGet(
                 () -> {
-                  String authHeader = servletRequest.getHeader("Authorization");
+                  String authHeader =
+                      servletRequest.getHeader(AuthHeaderKeys.AUTHORIZATION.getKeyName());
                   return StringUtils.substring(authHeader, "Bearer:".length());
                 });
     return new AuthenticatedUserRequest()
-        .email(servletRequest.getHeader("oidc_claim_email"))
-        .subjectId(servletRequest.getHeader("oidc_claim_user_id"))
+        .email(servletRequest.getHeader(AuthHeaderKeys.OIDC_CLAIM_EMAIL.getKeyName()))
+        .subjectId(servletRequest.getHeader(AuthHeaderKeys.OIDC_CLAIM_USER_ID.getKeyName()))
         .token(Optional.ofNullable(token));
   }
 }

--- a/src/main/java/bio/terra/workspace/service/job/JobBuilder.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobBuilder.java
@@ -41,10 +41,7 @@ public class JobBuilder {
 
     // check that keyName doesn't match one of the required parameter names
     // i.e. disallow overwriting one of the required parameters
-    if (keyName.equals(JobMapKeys.DESCRIPTION.getKeyName())
-        || keyName.equals(JobMapKeys.REQUEST.getKeyName())
-        || keyName.equals(JobMapKeys.AUTH_USER_INFO.getKeyName())
-        || keyName.equals((JobMapKeys.SUBJECT_ID.getKeyName()))) {
+    if (JobMapKeys.isRequiredKey(keyName)) {
       throw new InvalidJobParameterException(
           "Required parameters can only be set by the constructor. (" + keyName + ")");
     }

--- a/src/main/java/bio/terra/workspace/service/job/JobBuilder.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobBuilder.java
@@ -1,0 +1,68 @@
+package bio.terra.workspace.service.job;
+
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.job.exception.InvalidJobParameterException;
+
+public class JobBuilder {
+
+  private JobService jobServiceRef;
+  private Class<? extends Flight> flightClass;
+  private FlightMap jobParameterMap;
+  private String jobId;
+
+  // constructor only takes required parameters
+  public JobBuilder(
+      String description,
+      String jobId,
+      Class<? extends Flight> flightClass,
+      Object request,
+      AuthenticatedUserRequest userReq,
+      JobService jobServiceRef) {
+    this.jobServiceRef = jobServiceRef;
+    this.flightClass = flightClass;
+    this.jobId = jobId;
+
+    // initialize with required parameters
+    this.jobParameterMap = new FlightMap();
+    jobParameterMap.put(JobMapKeys.DESCRIPTION.getKeyName(), description);
+    jobParameterMap.put(JobMapKeys.REQUEST.getKeyName(), request);
+    jobParameterMap.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), userReq);
+    jobParameterMap.put(JobMapKeys.SUBJECT_ID.getKeyName(), userReq.getSubjectId());
+  }
+
+  // use addParameter method for optional parameter
+  // returns the JobBuilder object to allow method chaining
+  public JobBuilder addParameter(String keyName, Object val) {
+    if (keyName == null) {
+      throw new InvalidJobParameterException("Parameter name cannot be null.");
+    }
+
+    // check that keyName doesn't match one of the required parameter names
+    // i.e. disallow overwriting one of the required parameters
+    if (keyName.equals(JobMapKeys.DESCRIPTION.getKeyName())
+        || keyName.equals(JobMapKeys.REQUEST.getKeyName())
+        || keyName.equals(JobMapKeys.AUTH_USER_INFO.getKeyName())
+        || keyName.equals((JobMapKeys.SUBJECT_ID.getKeyName()))) {
+      throw new InvalidJobParameterException(
+          "Required parameters can only be set by the constructor. (" + keyName + ")");
+    }
+
+    // note that this call overwrites a parameter if it already exists
+    jobParameterMap.put(keyName, val);
+
+    return this;
+  }
+
+  // submits this job to stairway and returns the jobId immediately
+  public String submit() {
+    return jobServiceRef.submit(flightClass, jobParameterMap, jobId);
+  }
+
+  // submits this job to stairway, waits until it finishes, then returns an instance of the result
+  // class
+  public <T> T submitAndWait(Class<T> resultClass) {
+    return jobServiceRef.submitAndWait(flightClass, jobParameterMap, resultClass, jobId);
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobMapKeys.java
@@ -21,4 +21,11 @@ public enum JobMapKeys {
   public String getKeyName() {
     return keyName;
   }
+
+  public static boolean isRequiredKey(String keyName) {
+    return keyName.equals(JobMapKeys.DESCRIPTION.getKeyName())
+        || keyName.equals(JobMapKeys.REQUEST.getKeyName())
+        || keyName.equals(JobMapKeys.AUTH_USER_INFO.getKeyName())
+        || keyName.equals((JobMapKeys.SUBJECT_ID.getKeyName()));
+  }
 }

--- a/src/main/java/bio/terra/workspace/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobMapKeys.java
@@ -1,0 +1,24 @@
+package bio.terra.workspace.service.job;
+
+public enum JobMapKeys {
+  // parameters for all flight types
+  DESCRIPTION("description"),
+  REQUEST("request"),
+  RESPONSE("response"),
+  STATUS_CODE("status_code"),
+  AUTH_USER_INFO("auth_user_info"),
+  SUBJECT_ID("subjectId"),
+
+  // parameter for the job
+  FLIGHT_CLASS("flight_class");
+
+  private String keyName;
+
+  JobMapKeys(String keyName) {
+    this.keyName = keyName;
+  }
+
+  public String getKeyName() {
+    return keyName;
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -125,7 +125,7 @@ public class JobService {
 
   void waitForJob(String jobId) {
     try {
-      stairway.waitForFlight(jobId, null, null);
+      stairway.waitForFlight(jobId, 10, appConfig.getStairwayTimeoutSeconds()/10);
     } catch (StairwayException stairwayEx) {
       throw new InternalStairwayException(stairwayEx);
     }

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -1,0 +1,381 @@
+package bio.terra.workspace.service.job;
+
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightFilter;
+import bio.terra.stairway.FlightFilterOp;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.FlightState;
+import bio.terra.stairway.FlightStatus;
+import bio.terra.stairway.Stairway;
+import bio.terra.stairway.exception.DatabaseOperationException;
+import bio.terra.stairway.exception.FlightNotFoundException;
+import bio.terra.stairway.exception.StairwayException;
+import bio.terra.workspace.app.configuration.ApplicationConfiguration;
+import bio.terra.workspace.app.configuration.StairwayJdbcConfiguration;
+import bio.terra.workspace.common.exception.SamApiException;
+import bio.terra.workspace.common.utils.SamUtils;
+import bio.terra.workspace.generated.model.JobModel;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.job.exception.InternalStairwayException;
+import bio.terra.workspace.service.job.exception.InvalidResultStateException;
+import bio.terra.workspace.service.job.exception.JobNotCompleteException;
+import bio.terra.workspace.service.job.exception.JobNotFoundException;
+import bio.terra.workspace.service.job.exception.JobResponseException;
+import bio.terra.workspace.service.job.exception.JobUnauthorizedException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobService {
+
+  private static final Logger logger = LoggerFactory.getLogger(JobService.class);
+  private final Stairway stairway;
+  private final SamService samService;
+  private final ApplicationConfiguration appConfig;
+  private final StairwayJdbcConfiguration stairwayJdbcConfiguration;
+
+  @Autowired
+  public JobService(
+      SamService samService,
+      ApplicationConfiguration appConfig,
+      StairwayJdbcConfiguration stairwayJdbcConfiguration,
+      ApplicationContext applicationContext,
+      ObjectMapper objectMapper) {
+    this.samService = samService;
+    this.appConfig = appConfig;
+    this.stairwayJdbcConfiguration = stairwayJdbcConfiguration;
+
+    ExecutorService executorService =
+        Executors.newFixedThreadPool(appConfig.getMaxStairwayThreads());
+    StairwayExceptionSerializer serializer = new StairwayExceptionSerializer(objectMapper);
+    stairway = new Stairway(executorService, applicationContext, serializer);
+  }
+
+  public static class JobResultWithStatus<T> {
+    private T result;
+    private HttpStatus statusCode;
+
+    public T getResult() {
+      return result;
+    }
+
+    public JobResultWithStatus<T> result(T result) {
+      this.result = result;
+      return this;
+    }
+
+    public HttpStatus getStatusCode() {
+      return statusCode;
+    }
+
+    public JobResultWithStatus<T> statusCode(HttpStatus httpStatus) {
+      this.statusCode = httpStatus;
+      return this;
+    }
+  }
+
+  // creates a new JobBuilder object and returns it.
+  public JobBuilder newJob(
+      String description,
+      String jobId,
+      Class<? extends Flight> flightClass,
+      Object request,
+      AuthenticatedUserRequest userReq) {
+    return new JobBuilder(description, jobId, flightClass, request, userReq, this);
+  }
+
+  // submit a new job to stairway
+  // protected method intended to be called only from JobBuilder
+  protected String submit(
+      Class<? extends Flight> flightClass, FlightMap parameterMap, String jobId) {
+    try {
+      stairway.submit(jobId, flightClass, parameterMap);
+    } catch (StairwayException stairwayEx) {
+      throw new InternalStairwayException(stairwayEx);
+    }
+    return jobId;
+  }
+
+  // submit a new job to stairway, wait for it to finish, then return the result
+  // protected method intended to be called only from JobBuilder
+  protected <T> T submitAndWait(
+      Class<? extends Flight> flightClass,
+      FlightMap parameterMap,
+      Class<T> resultClass,
+      String jobId) {
+    submit(flightClass, parameterMap, jobId);
+    waitForJob(jobId);
+    AuthenticatedUserRequest userReq =
+        parameterMap.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+
+    return retrieveJobResult(jobId, resultClass, userReq).getResult();
+  }
+
+  void waitForJob(String jobId) {
+    try {
+      stairway.waitForFlight(jobId, null, null);
+    } catch (StairwayException stairwayEx) {
+      throw new InternalStairwayException(stairwayEx);
+    }
+  }
+
+  /**
+   * This method is called from StartupInitializer as part of the sequence of migrating databases
+   * and recovering any jobs; i.e., Stairway flights. It is moved here so that JobService
+   * encapsulates all of the Stairway interaction.
+   */
+  public void initialize() {
+    try {
+      stairway.initialize(
+          stairwayJdbcConfiguration.getDataSource(),
+          stairwayJdbcConfiguration.isForceClean(),
+          stairwayJdbcConfiguration.isMigrateUpgrade());
+
+    } catch (StairwayException stairwayEx) {
+      throw new InternalStairwayException("Stairway initialization failed", stairwayEx);
+    }
+  }
+
+  public void releaseJob(String jobId, AuthenticatedUserRequest userReq) {
+    try {
+      if (userReq != null) {
+        // currently, this check will be true for stewards only
+        boolean canDeleteAnyJob =
+            samService.isAuthorized(
+                userReq.getRequiredToken(),
+                SamUtils.SAM_WORKSPACE_MANAGER_RESOURCE,
+                appConfig.getResourceId(),
+                SamUtils.SAM_WORKSPACE_MANAGER_DELETE_JOBS_ACTION);
+
+        // if the user has access to all jobs, no need to check for this one individually
+        // otherwise, check that the user has access to this job before deleting
+        if (!canDeleteAnyJob) {
+          verifyUserAccess(jobId, userReq); // jobId=flightId
+        }
+      }
+      stairway.deleteFlight(jobId, false);
+    } catch (StairwayException stairwayEx) {
+      throw new InternalStairwayException(stairwayEx);
+    } catch (ApiException samEx) {
+      throw new SamApiException(samEx);
+    }
+  }
+
+  public JobModel mapFlightStateToJobModel(FlightState flightState) {
+    FlightMap inputParameters = flightState.getInputParameters();
+    String description = inputParameters.get(JobMapKeys.DESCRIPTION.getKeyName(), String.class);
+    FlightStatus flightStatus = flightState.getFlightStatus();
+    String submittedDate = flightState.getSubmitted().toString();
+    JobModel.StatusEnum jobStatus = getJobStatus(flightStatus);
+
+    String completedDate = null;
+    HttpStatus statusCode = HttpStatus.ACCEPTED;
+
+    if (flightState.getCompleted().isPresent()) {
+      FlightMap resultMap = getResultMap(flightState);
+      // The STATUS_CODE return only needs to be used to return alternate success responses.
+      // If it is not present, then we set it to the default OK status.
+      statusCode = resultMap.get(JobMapKeys.STATUS_CODE.getKeyName(), HttpStatus.class);
+      if (statusCode == null) {
+        statusCode = HttpStatus.OK;
+      }
+
+      completedDate = flightState.getCompleted().get().toString();
+    }
+
+    JobModel jobModel =
+        new JobModel()
+            .id(flightState.getFlightId())
+            .description(description)
+            .status(jobStatus)
+            .statusCode(statusCode.value())
+            .submitted(submittedDate)
+            .completed(completedDate);
+
+    return jobModel;
+  }
+
+  private JobModel.StatusEnum getJobStatus(FlightStatus flightStatus) {
+    switch (flightStatus) {
+      case ERROR:
+      case FATAL:
+        return JobModel.StatusEnum.FAILED;
+      case RUNNING:
+        return JobModel.StatusEnum.RUNNING;
+      case SUCCESS:
+        return JobModel.StatusEnum.SUCCEEDED;
+    }
+    return JobModel.StatusEnum.FAILED;
+  }
+
+  public List<JobModel> enumerateJobs(int offset, int limit, AuthenticatedUserRequest userReq) {
+    boolean canListAnyJob = checkUserCanListAnyJob(userReq);
+
+    // if the user has access to all jobs, then fetch everything
+    // otherwise, filter the jobs on the user
+    List<FlightState> flightStateList;
+    try {
+      FlightFilter filter = new FlightFilter();
+
+      if (!canListAnyJob) {
+        filter.addFilterInputParameter(
+            JobMapKeys.SUBJECT_ID.getKeyName(), FlightFilterOp.EQUAL, userReq.getSubjectId());
+      }
+
+      flightStateList = stairway.getFlights(offset, limit, filter);
+    } catch (StairwayException stairwayEx) {
+      throw new InternalStairwayException(stairwayEx);
+    }
+
+    List<JobModel> jobModelList = new ArrayList<>();
+    for (FlightState flightState : flightStateList) {
+      JobModel jobModel = mapFlightStateToJobModel(flightState);
+      jobModelList.add(jobModel);
+    }
+    return jobModelList;
+  }
+
+  public JobModel retrieveJob(String jobId, AuthenticatedUserRequest userReq) {
+    boolean canListAnyJob = checkUserCanListAnyJob(userReq);
+
+    try {
+      // if the user has access to all jobs, then fetch the requested one
+      // otherwise, check that the user has access to it first
+      if (!canListAnyJob) {
+        verifyUserAccess(jobId, userReq); // jobId=flightId
+      }
+      FlightState flightState = stairway.getFlightState(jobId);
+      return mapFlightStateToJobModel(flightState);
+    } catch (StairwayException stairwayEx) {
+      throw new InternalStairwayException(stairwayEx);
+    }
+  }
+
+  /**
+   * There are four cases to handle here:
+   *
+   * <ol>
+   *   <li>Flight is still running. Throw an JobNotComplete exception
+   *   <li>Successful flight: extract the resultMap RESPONSE as the target class. If a
+   *       statusContainer is present, we try to retrieve the STATUS_CODE from the resultMap and
+   *       store it in the container. That allows flight steps used in async REST API endpoints to
+   *       set alternate success status codes. The status code defaults to OK, if it is not set in
+   *       the resultMap.
+   *   <li>Failed flight: if there is an exception, throw it. Note that we can only throw
+   *       RuntimeExceptions to be handled by the global exception handler. Non-runtime exceptions
+   *       require throw clauses on the controller methods; those are not present in the
+   *       swagger-generated code, so it introduces a mismatch. Instead, in this code if the caught
+   *       exception is not a runtime exception, then we throw JobResponseException passing in the
+   *       Throwable to the exception. In the global exception handler, we retrieve the Throwable
+   *       and use the error text from that in the error model
+   *   <li>Failed flight: no exception present. We throw InvalidResultState exception
+   * </ol>
+   *
+   * @param jobId to process
+   * @return object of the result class pulled from the result map
+   */
+  public <T> JobResultWithStatus<T> retrieveJobResult(
+      String jobId, Class<T> resultClass, AuthenticatedUserRequest userReq) {
+    boolean canListAnyJob = checkUserCanListAnyJob(userReq);
+
+    try {
+      // if the user has access to all jobs, then fetch the requested result
+      // otherwise, check that the user has access to it first
+      if (!canListAnyJob) {
+        verifyUserAccess(jobId, userReq); // jobId=flightId
+      }
+      return retrieveJobResultWorker(jobId, resultClass);
+    } catch (StairwayException stairwayEx) {
+      throw new InternalStairwayException(stairwayEx);
+    }
+  }
+
+  private <T> JobResultWithStatus<T> retrieveJobResultWorker(String jobId, Class<T> resultClass)
+      throws StairwayException {
+    FlightState flightState = stairway.getFlightState(jobId);
+    FlightMap resultMap = flightState.getResultMap().orElse(null);
+    if (resultMap == null) {
+      throw new InvalidResultStateException("No result map returned from flight");
+    }
+
+    switch (flightState.getFlightStatus()) {
+      case FATAL:
+      case ERROR:
+        if (flightState.getException().isPresent()) {
+          Exception exception = flightState.getException().get();
+          if (exception instanceof RuntimeException) {
+            throw (RuntimeException) exception;
+          } else {
+            throw new JobResponseException("wrap non-runtime exception", exception);
+          }
+        }
+        throw new InvalidResultStateException("Failed operation with no exception reported");
+
+      case SUCCESS:
+        HttpStatus statusCode =
+            resultMap.get(JobMapKeys.STATUS_CODE.getKeyName(), HttpStatus.class);
+        if (statusCode == null) {
+          statusCode = HttpStatus.OK;
+        }
+        return new JobResultWithStatus<T>()
+            .statusCode(statusCode)
+            .result(resultMap.get(JobMapKeys.RESPONSE.getKeyName(), resultClass));
+
+      case RUNNING:
+        throw new JobNotCompleteException(
+            "Attempt to retrieve job result before job is complete; job id: "
+                + flightState.getFlightId());
+
+      default:
+        throw new InvalidResultStateException("Impossible case reached");
+    }
+  }
+
+  private FlightMap getResultMap(FlightState flightState) {
+    FlightMap resultMap = flightState.getResultMap().orElse(null);
+    if (resultMap == null) {
+      throw new InvalidResultStateException("No result map returned from flight");
+    }
+    return resultMap;
+  }
+
+  private boolean checkUserCanListAnyJob(AuthenticatedUserRequest userReq) {
+    try {
+      return samService.isAuthorized(
+          userReq.getRequiredToken(),
+          SamUtils.SAM_WORKSPACE_MANAGER_RESOURCE,
+          appConfig.getResourceId(),
+          SamUtils.SAM_WORKSPACE_MANAGER_LIST_JOBS_ACTION);
+    } catch (ApiException samEx) {
+      throw new SamApiException(samEx);
+    }
+  }
+
+  private void verifyUserAccess(String jobId, AuthenticatedUserRequest userReq) {
+    try {
+      FlightState flightState = stairway.getFlightState(jobId);
+      FlightMap inputParameters = flightState.getInputParameters();
+      String flightSubjectId =
+          inputParameters.get(JobMapKeys.SUBJECT_ID.getKeyName(), String.class);
+      if (!StringUtils.equals(flightSubjectId, userReq.getSubjectId())) {
+        throw new JobUnauthorizedException("Unauthorized");
+      }
+    } catch (DatabaseOperationException ex) {
+      throw new InternalStairwayException("Stairway exception looking up the job", ex);
+    } catch (FlightNotFoundException ex) {
+      throw new JobNotFoundException("Job not found", ex);
+    }
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/StairwayExceptionFields.java
+++ b/src/main/java/bio/terra/workspace/service/job/StairwayExceptionFields.java
@@ -1,0 +1,47 @@
+package bio.terra.workspace.service.job;
+
+import java.util.List;
+
+// POJO for serializing one level of exception into JSON
+public class StairwayExceptionFields {
+  private boolean isErrorReportException;
+  private String className;
+  private String message;
+  private List<String> errorDetails;
+
+  public boolean isErrorReportException() {
+    return isErrorReportException;
+  }
+
+  public StairwayExceptionFields setErrorReportException(boolean errorReportException) {
+    isErrorReportException = errorReportException;
+    return this;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public StairwayExceptionFields setClassName(String className) {
+    this.className = className;
+    return this;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public StairwayExceptionFields setMessage(String message) {
+    this.message = message;
+    return this;
+  }
+
+  public List<String> getErrorDetails() {
+    return errorDetails;
+  }
+
+  public StairwayExceptionFields setErrorDetails(List<String> errorDetails) {
+    this.errorDetails = errorDetails;
+    return this;
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/StairwayExceptionSerializer.java
+++ b/src/main/java/bio/terra/workspace/service/job/StairwayExceptionSerializer.java
@@ -1,0 +1,121 @@
+package bio.terra.workspace.service.job;
+
+import bio.terra.stairway.ExceptionSerializer;
+import bio.terra.workspace.common.exception.ErrorReportException;
+import bio.terra.workspace.service.job.exception.ExceptionSerializerException;
+import bio.terra.workspace.service.job.exception.JobResponseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+
+public class StairwayExceptionSerializer implements ExceptionSerializer {
+  private ObjectMapper objectMapper;
+
+  public StairwayExceptionSerializer(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public String serialize(Exception exception) {
+    if (exception == null) {
+      return StringUtils.EMPTY;
+    }
+
+    // Wrap non-runtime exceptions so they can be rethrown later
+    if (!(exception instanceof RuntimeException)) {
+      exception = new JobResponseException(exception.getMessage(), exception);
+    }
+
+    StairwayExceptionFields fields =
+        new StairwayExceptionFields()
+            .setClassName(exception.getClass().getName())
+            .setMessage(exception.getMessage());
+
+    if (exception instanceof ErrorReportException) {
+      fields
+          .setErrorReportException(true)
+          .setErrorDetails(((ErrorReportException) exception).getCauses());
+    } else {
+      fields.setErrorReportException(false);
+    }
+
+    try {
+      return objectMapper.writeValueAsString(fields);
+    } catch (JsonProcessingException ex) {
+      // The StairwayExceptionFields object is a very simple POJO and should never cause
+      // JSON processing to fail.
+      throw new ExceptionSerializerException("This should never happen", ex);
+    }
+  }
+
+  @Override
+  public Exception deserialize(String serializedException) {
+    if (StringUtils.isEmpty(serializedException)) {
+      return null;
+    }
+
+    // Decode the exception fields from JSON
+    StairwayExceptionFields fields;
+    try {
+      fields = objectMapper.readValue(serializedException, StairwayExceptionFields.class);
+    } catch (IOException ex) {
+      // objectMapper exceptions
+      return new ExceptionSerializerException(
+          "Failed to deserialize exception data: " + serializedException, ex);
+    }
+
+    // Find the class from the class name
+    Class<?> clazz;
+    try {
+      clazz = Class.forName(fields.getClassName());
+    } catch (ClassNotFoundException ex) {
+      return new ExceptionSerializerException(
+          "Exception class not found: "
+              + fields.getClassName()
+              + "; Exception message: "
+              + fields.getMessage());
+    }
+
+    // If this is a data repo exception and the exception exposes a constructor with the
+    // error details, then we try to use that.
+    if (fields.isErrorReportException()) {
+      try {
+        Constructor<?> ctor = clazz.getConstructor(String.class, List.class);
+        Object object = ctor.newInstance(fields.getMessage(), fields.getErrorDetails());
+        return (Exception) object;
+      } catch (NoSuchMethodException
+          | SecurityException
+          | InstantiationException
+          | IllegalAccessException
+          | IllegalArgumentException
+          | InvocationTargetException ex) {
+        // We didn't find a constructor with error details or construction failed. Fall through
+      }
+    }
+
+    // We have either a data repo exception that doesn't support error details or some other runtime
+    // exception
+    try {
+      Constructor<?> ctor = clazz.getConstructor(String.class);
+      Object object = ctor.newInstance(fields.getMessage());
+      return (Exception) object;
+    } catch (NoSuchMethodException
+        | SecurityException
+        | InstantiationException
+        | IllegalAccessException
+        | IllegalArgumentException
+        | InvocationTargetException ex) {
+      // We didn't find a vanilla constructor or construction failed. Fall through
+    }
+
+    return new ExceptionSerializerException(
+        "Failed to construct exception: "
+            + fields.getClassName()
+            + "; Exception message: "
+            + fields.getMessage());
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/StairwayExceptionSerializer.java
+++ b/src/main/java/bio/terra/workspace/service/job/StairwayExceptionSerializer.java
@@ -80,7 +80,7 @@ public class StairwayExceptionSerializer implements ExceptionSerializer {
               + fields.getMessage());
     }
 
-    // If this is a data repo exception and the exception exposes a constructor with the
+    // If this is an ErrorReport exception and the exception exposes a constructor with the
     // error details, then we try to use that.
     if (fields.isErrorReportException()) {
       try {
@@ -97,7 +97,7 @@ public class StairwayExceptionSerializer implements ExceptionSerializer {
       }
     }
 
-    // We have either a data repo exception that doesn't support error details or some other runtime
+    // We have either an ErrorReport exception that doesn't support error details or some other runtime
     // exception
     try {
       Constructor<?> ctor = clazz.getConstructor(String.class);

--- a/src/main/java/bio/terra/workspace/service/job/exception/ExceptionSerializerException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/ExceptionSerializerException.java
@@ -1,0 +1,18 @@
+package bio.terra.workspace.service.job.exception;
+
+import bio.terra.workspace.common.exception.InternalServerErrorException;
+
+// Exception for failures serializing and deserializing exceptions
+public class ExceptionSerializerException extends InternalServerErrorException {
+  public ExceptionSerializerException(String message) {
+    super(message);
+  }
+
+  public ExceptionSerializerException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ExceptionSerializerException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/exception/InternalStairwayException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/InternalStairwayException.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.service.job.exception;
+
+import bio.terra.workspace.common.exception.InternalServerErrorException;
+
+public class InternalStairwayException extends InternalServerErrorException {
+  public InternalStairwayException(String message) {
+    super(message);
+  }
+
+  public InternalStairwayException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InternalStairwayException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/exception/InvalidJobParameterException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/InvalidJobParameterException.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.service.job.exception;
+
+import bio.terra.workspace.common.exception.BadRequestException;
+
+public class InvalidJobParameterException extends BadRequestException {
+  public InvalidJobParameterException(String message) {
+    super(message);
+  }
+
+  public InvalidJobParameterException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InvalidJobParameterException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/exception/InvalidResultStateException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/InvalidResultStateException.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.service.job.exception;
+
+import bio.terra.workspace.common.exception.InternalServerErrorException;
+
+public class InvalidResultStateException extends InternalServerErrorException {
+  public InvalidResultStateException(String message) {
+    super(message);
+  }
+
+  public InvalidResultStateException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InvalidResultStateException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/exception/JobNotCompleteException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/JobNotCompleteException.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.service.job.exception;
+
+import bio.terra.workspace.common.exception.BadRequestException;
+
+public class JobNotCompleteException extends BadRequestException {
+  public JobNotCompleteException(String message) {
+    super(message);
+  }
+
+  public JobNotCompleteException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public JobNotCompleteException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/exception/JobNotFoundException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/JobNotFoundException.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.service.job.exception;
+
+import bio.terra.workspace.common.exception.NotFoundException;
+
+public class JobNotFoundException extends NotFoundException {
+  public JobNotFoundException(String message) {
+    super(message);
+  }
+
+  public JobNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public JobNotFoundException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/exception/JobResponseException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/JobResponseException.java
@@ -1,0 +1,18 @@
+package bio.terra.workspace.service.job.exception;
+
+import bio.terra.workspace.common.exception.InternalServerErrorException;
+
+public class JobResponseException extends InternalServerErrorException {
+
+  public JobResponseException(String message) {
+    super(message);
+  }
+
+  public JobResponseException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public JobResponseException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/job/exception/JobUnauthorizedException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/JobUnauthorizedException.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.service.job.exception;
+
+import bio.terra.workspace.common.exception.UnauthorizedException;
+
+public class JobUnauthorizedException extends UnauthorizedException {
+  public JobUnauthorizedException(String message) {
+    super(message);
+  }
+
+  public JobUnauthorizedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public JobUnauthorizedException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -6,7 +6,7 @@ info:
   version: 0.0.1
 
 servers:
-  - url: http://localhost:8080
+- url: http://localhost:8080
 
 paths:
   '/status':
@@ -15,7 +15,7 @@ paths:
         Returns the operational status of the service
       operationId: serviceStatus
       tags:
-        - unauthenticated
+      - unauthenticated
       responses:
         200:
           description: Service is functional
@@ -43,8 +43,64 @@ paths:
           $ref: '#/components/responses/CreateResponse'
         500:
           $ref: '#/components/responses/ErrorResponse'
-
+  '/api/v1/jobs/{id}':
+    parameters:
+    - $ref: '#/components/parameters/Id'
+    get:
+      description: |
+        Poll the status of an existing async operation via job ID.
+      operationId: pollAsyncJob
+      tags:
+      - workspace
+      responses:
+        202:
+          description: Async job is incomplete
+          $ref: '#/components/responses/JobModelResponse'
+        200:
+          description: Async job is complete
+          $ref: '#/components/responses/JobModelResponse'
+        400:
+          description: Bad request - invalid id, badly formed
+          $ref: '#/components/responses/ErrorResponse'
+        403:
+          description: No permission to see job
+          $ref: '#/components/responses/ErrorResponse'
+        404:
+          description: Not found - job id does not exist
+          $ref: '#/components/responses/ErrorResponse'
+    delete:  ## delete job data
+      description: Delete the job and data associated with it
+      operationId: deleteJob
+      tags:
+      - workspace
+      responses:
+        204:
+          description: Job was deleted
+  '/api/v1/jobs/{id}/result':
+    parameters:
+    - $ref: '#/components/parameters/Id'
+    get:
+      description: |
+        Retrieve the results of a completed async job specified by ID.
+      operationId: retrieveJobResult
+      tags:
+      - workspace
+      responses:
+        default:
+          description: Successful responses return the type of object specified by the job; otherwise, ErrorModel
+          content:
+            application/json:
+              schema:
+                type: object
 components:
+  parameters:
+    Id:
+      name: id
+      in: path
+      description: A UUID to used to identify an object in the workspace manager
+      required: true
+      schema:
+        type: string
   schemas:
     ErrorReport:
       type: object
@@ -57,7 +113,49 @@ components:
           type: array
           items:
             type: string
-
+    JobControl:
+      type: object
+      required:
+      - jobid
+      properties:
+        jobid:
+          type: string
+        pubsub:
+          type: object
+          required:
+          - projectid
+          - topicid
+          properties:
+            projectid:
+              type: string
+            topicid:
+              type: string
+    JobModel:
+      type: object
+      required:
+      - id
+      - status
+      - status_code
+      properties:
+        id:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum:
+          - RUNNING
+          - SUCCEEDED
+          - FAILED
+        statusCode:
+          description: HTTP code
+          type: integer
+        submitted:
+          type: string
+        completed:
+          type: string
+        estimatedRemainingTimeMS:
+          type: integer
     SystemStatus:
       type: object
       properties:
@@ -97,6 +195,8 @@ components:
           items:
             type: string
             format: uuid
+        jobControl:
+          $ref: '#/components/schemas/JobControl'
     CreatedWorkspace:
       type: object
       properties:
@@ -126,3 +226,9 @@ components:
           schema:
             $ref: '#/components/schemas/CreatedWorkspace'
 
+    JobModelResponse:
+      description: Response with a JobModel
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/JobModel'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 server.port=8080
 workspace.maxStairwayThreads=4
 workspace.resourceId=mc-terra-workspace-manager
+workspace.stairwayTimeoutSeconds=1800
 db.workspace.uri=jdbc:postgresql://127.0.0.1:5432/${DATABASE_NAME}
 db.workspace.username=${DATABASE_USER}
 db.workspace.password=${DATABASE_USER_PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 server.port=8080
 workspace.maxStairwayThreads=4
+workspace.resourceId=mc-terra-workspace-manager
 db.workspace.uri=jdbc:postgresql://127.0.0.1:5432/${DATABASE_NAME}
 db.workspace.username=${DATABASE_USER}
 db.workspace.password=${DATABASE_USER_PASSWORD}

--- a/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -103,7 +103,6 @@ public class JobServiceTest {
     JobService.JobResultWithStatus<String> resultHolder =
         jobService.retrieveJobResult(fids.get(2), String.class, testUser);
 
-    // Assert.assertThat(resultHolder.getStatusCode(), is(equalTo(HttpStatus.I_AM_A_TEAPOT)));
     assertThat(resultHolder.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT));
     assertThat(resultHolder.getResult(), equalTo(makeDescription(2)));
   }

--- a/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -1,0 +1,167 @@
+package bio.terra.workspace.service.job;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+import bio.terra.stairway.exception.StairwayException;
+import bio.terra.workspace.app.Main;
+import bio.terra.workspace.generated.model.JobModel;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.job.exception.JobNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.broadinstitute.dsde.workbench.client.sam.model.ResourceAndAccessPolicy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Tag("unit")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = Main.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class JobServiceTest {
+  private AuthenticatedUserRequest testUser =
+      new AuthenticatedUserRequest()
+          .subjectId("StairwayUnit")
+          .email("stairway@unit.com")
+          .token(Optional.of("not-a-real-token"));
+
+  @Autowired private JobService jobService;
+
+  @MockBean private SamService mockSamService;
+
+  @BeforeEach
+  public void setup() {
+    try {
+      Mockito.doReturn(true).when(mockSamService.isAuthorized(any(), any(), any(), any()));
+    } catch (Exception e) {
+      // How does a mock even throw an exception?
+    }
+  }
+
+  @Test
+  public void retrieveTest() throws Exception {
+    // We perform 7 flights and then retrieve and enumerate them.
+    // The fids list should be in exactly the same order as the database ordered by submit time.
+
+    List<String> jobIds = new ArrayList<>();
+    try {
+      List<ResourceAndAccessPolicy> allowedIds = new ArrayList<>();
+      for (int i = 0; i < 7; i++) {
+        String jobId = runFlight(makeDescription(i));
+        jobIds.add(jobId);
+        allowedIds.add(new ResourceAndAccessPolicy().resourceId(jobId));
+      }
+
+      // Test single retrieval
+      testSingleRetrieval(jobIds);
+
+      // Test result retrieval - the body should be the description string
+      testResultRetrieval(jobIds);
+
+      // Retrieve everything
+      testEnumRange(jobIds, 0, 100, allowedIds);
+
+      // Retrieve the middle 3; offset means skip 2 rows
+      testEnumRange(jobIds, 2, 3, allowedIds);
+
+      // Retrieve from the end; should only get the last one back
+      testEnumCount(1, 6, 3, allowedIds);
+
+      // Retrieve past the end; should get nothing
+      testEnumCount(0, 22, 3, allowedIds);
+    } finally {
+      for (String jobId : jobIds) {
+        jobService.releaseJob(jobId, testUser);
+      }
+    }
+  }
+
+  private void testSingleRetrieval(List<String> fids) {
+    JobModel response = jobService.retrieveJob(fids.get(2), testUser);
+    assertThat(response, notNullValue());
+    validateJobModel(response, 2, fids);
+  }
+
+  private void testResultRetrieval(List<String> fids) {
+    JobService.JobResultWithStatus<String> resultHolder =
+        jobService.retrieveJobResult(fids.get(2), String.class, testUser);
+
+    // Assert.assertThat(resultHolder.getStatusCode(), is(equalTo(HttpStatus.I_AM_A_TEAPOT)));
+    assertThat(resultHolder.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT));
+    assertThat(resultHolder.getResult(), equalTo(makeDescription(2)));
+  }
+
+  // Get some range and compare it with the fids
+  private void testEnumRange(
+      List<String> fids, int offset, int limit, List<ResourceAndAccessPolicy> resourceIds) {
+    List<JobModel> jobList = jobService.enumerateJobs(offset, limit, testUser);
+    assertThat(jobList, notNullValue());
+    int index = offset;
+    for (JobModel job : jobList) {
+      validateJobModel(job, index, fids);
+      index++;
+    }
+  }
+
+  // Get some range and make sure we got the number we expected
+  private void testEnumCount(
+      int count, int offset, int length, List<ResourceAndAccessPolicy> resourceIds) {
+    List<JobModel> jobList = jobService.enumerateJobs(offset, length, testUser);
+    assertThat(jobList, notNullValue());
+    assertThat(jobList.size(), equalTo(count));
+  }
+
+  @Test
+  public void testBadIdRetrieveJob() {
+    assertThrows(
+        JobNotFoundException.class,
+        () -> {
+          jobService.retrieveJob("abcdef", testUser);
+        });
+  }
+
+  @Test
+  public void testBadIdRetrieveResult() {
+    assertThrows(
+        JobNotFoundException.class,
+        () -> {
+          jobService.retrieveJobResult("abcdef", Object.class, testUser);
+        });
+  }
+
+  private void validateJobModel(JobModel jm, int index, List<String> fids) {
+    assertThat(jm.getDescription(), equalTo(makeDescription(index)));
+    assertThat(jm.getId(), equalTo(fids.get(index)));
+    assertThat(jm.getStatus(), equalTo(JobModel.StatusEnum.SUCCEEDED));
+    assertThat(jm.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT.value()));
+  }
+
+  // Submit a flight; wait for it to finish; return the flight id
+  private String runFlight(String description) throws StairwayException {
+    String jobId = UUID.randomUUID().toString();
+    jobService.newJob(description, jobId, JobServiceTestFlight.class, null, testUser).submit();
+    jobService.waitForJob(jobId);
+    return jobId;
+  }
+
+  private String makeDescription(int ii) {
+    return String.format("flight%d", ii);
+  }
+}

--- a/src/test/java/bio/terra/workspace/service/job/JobServiceTestFlight.java
+++ b/src/test/java/bio/terra/workspace/service/job/JobServiceTestFlight.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.service.job;
+
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+
+public class JobServiceTestFlight extends Flight {
+
+  public JobServiceTestFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+    // Pull out our parameters and feed them in to the step classes.
+    String description = inputParameters.get("description", String.class);
+
+    // Just one step for this test
+    addStep(new JobServiceTestStep(description));
+  }
+}

--- a/src/test/java/bio/terra/workspace/service/job/JobServiceTestStep.java
+++ b/src/test/java/bio/terra/workspace/service/job/JobServiceTestStep.java
@@ -1,0 +1,27 @@
+package bio.terra.workspace.service.job;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import org.springframework.http.HttpStatus;
+
+public class JobServiceTestStep implements Step {
+  private String description;
+
+  public JobServiceTestStep(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) {
+    // Configure the results
+    context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), description);
+    context.getWorkingMap().put(JobMapKeys.STATUS_CODE.getKeyName(), HttpStatus.I_AM_A_TEAPOT);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 server.port=8080
 workspace.maxStairwayThreads=4
+workspace.stairwayTimeoutSeconds=1800
 db.workspace.uri=jdbc:postgresql://127.0.0.1:5432/testdb
 db.workspace.username=dbuser
 db.workspace.password=dbpwd

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,4 +10,4 @@ db.stairway.username=stairwayuser
 db.stairway.password=stairwaypwd
 db.stairway.migrateUpgrade=true
 db.stairway.forceClean=true
-sam.basePath=https://sam.dsde-dev.broadinstitute.org
+samService.basePath=https://sam.dsde-dev.broadinstitute.org


### PR DESCRIPTION
This adds the JobService, allowing other endpoints to use Stairway to manage asynchronous jobs. This JobService is mainly copied from the Data Repo job service (https://github.com/DataBiosphere/jade-data-repo/tree/develop/src/main/java/bio/terra/service/job), with minor changes to reflect decisions made in Dan's Async Rest Api Proposal (https://docs.google.com/document/d/1PTd4xvmV9xnEkWaIgFc6d3VUyJwwymQTFdhpKrdsUKw/edit).

As outlined in that document, the major changes are:
1. Caller chooses the job id, instead of the server.
2. We do not use the Location header to return a fully formed URL.
3. (NOT YET IMPLEMENTED) Addition of PubSub notification.

This PR does not change the existing synchronous createWorkspace endpoint. That's handled in a separate PR.