### PR TITLE
pin stairway to stable version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-	compile(group: 'bio.terra', name: 'stairway', version: '0.0.4-SNAPSHOT')
+	compile(group: 'bio.terra', name: 'stairway', version: '0.0.4.1-SNAPSHOT')
 	compile(group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.12', version: '0.1-11a7002')
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jdbc'
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'


### PR DESCRIPTION
Recently there were some stairway changes that overwrote the version that we were using in workspace manager. Some of the changes were breaking, so pinning to a self-published stable version for now until we can adopt the changes