### PR TITLE
Add DataReferenceDescription and ResourceDescription models to OpenAPI doc

### DIFF
--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -24,7 +24,7 @@ public class WorkspaceDao {
     jdbcTemplate = new NamedParameterJdbcTemplate(jdbcConfiguration.getDataSource());
   }
 
-  @Transactional(propagation =  Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public String createWorkspace(UUID workspaceId, JsonNullable<UUID> spendProfile) {
     String sql =
         "INSERT INTO workspace (workspace_id, spend_profile, profile_settable) values "
@@ -44,7 +44,7 @@ public class WorkspaceDao {
     return workspaceId.toString();
   }
 
-  @Transactional(propagation =  Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public boolean deleteWorkspace(UUID workspaceId) {
     Map<String, Object> paramMap = new HashMap<String, Object>();
     paramMap.put("id", workspaceId.toString());

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -234,6 +234,72 @@ components:
           type: string
           nullable: true
           format: uuid
+    DataReferenceDescription:
+      type: object
+      properties:
+        referenceId:
+          description: The ID of the data reference
+          type: string
+          format: uuid
+        name:
+          description: The name of the data reference; used to refer to the reference
+          type: string
+        workspaceId:
+          description: The ID of the workspace containing the reference
+          type: string
+          format: uuid
+        resourceDescription:
+          description: Description of the workspace resource, if this is a controlled reference.
+          nullable: true
+          $ref: '#/components/schemas/ResourceDescription'
+        referenceType:
+          description: The type of the reference, if an uncontrolled resource
+          type: string
+          enum: ["DataRepoSnapshot"] #eventually include GCS bucket, etc.
+          nullable: true
+        reference:
+          # Once https://github.com/OpenAPITools/openapi-generator/issues/5381
+          # is resolved, we can use a oneOf field to validate different
+          # reference schemas. Until then, I don't have a better solution
+          # than accepting a JSON string and validating in the service instead.
+          description: The description of the reference, if an uncontrolled resource
+          type: string
+          format: json
+          nullable: true
+        credentialId:
+          description: The ID of the credential to use when accessing the resource
+          type: string
+          nullable: true
+        cloningInstructions:
+          description: Instructions for copying this reference when cloning the workspace
+          type: string
+          enum: ["COPY_NOTHING", "COPY_DEFINITION", "COPY_RESOURCE", "COPY_REFERENCE"]
+    ResourceDescription:
+      type: object
+      properties:
+        resource_id:
+          description: The ID of the resource
+          type: string
+          format: uuid
+        workspace_id:
+          description: The ID of the workspace holding the resource
+          type: string
+          format: uuid
+        application_id:
+          description: ID of application this resource is associated with, if any
+          type: string
+          nullable: true
+        is_visible:
+          description: Whether this resource is visible or not
+          type: boolean
+        owner:
+          description: ID of owner. null for shared resources
+          type: string
+          nullable: true
+        attributes:
+          description: JSON map of user-provided attributes
+          type: string
+          nullable: true
 
   responses:
     ErrorResponse:

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -251,7 +251,8 @@ components:
         resourceDescription:
           description: Description of the workspace resource, if this is a controlled reference.
           nullable: true
-          $ref: '#/components/schemas/ResourceDescription'
+          allOf:
+          - $ref: '#/components/schemas/ResourceDescription'
         referenceType:
           description: The type of the reference, if an uncontrolled resource
           type: string


### PR DESCRIPTION
This adds new model objects to the OpenAPI document, but does not add any endpoints that use them. This doesn't add any useful functionality, but allows us to build multiple DataReference-based endpoints at the same time without merge conflicts.

The actual references are currently raw JSON strings with no schema specified, which we'll need to validate in the service itself. I'd like to use the `oneOf` operator (https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/) to validate them against one of several different schemas, but those don't work in the openapi-generator for spring-boot yet (see https://github.com/OpenAPITools/openapi-generator/issues/5381)