### PR TITLE
AS228 Delete Workspace

### DIFF
--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -61,6 +61,16 @@ public class WorkspaceApiController implements WorkspaceApi {
   }
 
   @Override
+  public ResponseEntity<Void> deleteWorkspace(
+      @PathVariable("id") String id, DeleteWorkspaceRequestBody body) {
+    // Note: we do NOT use getAuthenticatedInfo here, as the request's authentication info comes
+    // from the folder manager, not the requesting user.
+    String userToken = body.getAuthToken();
+    workspaceService.deleteWorkspace(id, userToken);
+    return new ResponseEntity<>(HttpStatus.valueOf(204));
+  }
+
+  @Override
   public ResponseEntity<DataReferenceDescription> createDataReference(
       @PathVariable("id") String id, @RequestBody CreateDataReferenceRequestBody body) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();

--- a/src/main/java/bio/terra/workspace/common/utils/SamUtils.java
+++ b/src/main/java/bio/terra/workspace/common/utils/SamUtils.java
@@ -9,4 +9,5 @@ public class SamUtils {
   public static String SAM_WORKSPACE_MANAGER_DELETE_JOBS_ACTION = "delete-job";
   public static String SAM_WORKSPACE_READ_ACTION = "read";
   public static String SAM_WORKSPACE_WRITE_ACTION = "write";
+  public static String SAM_WORKSPACE_DELETE_ACTION = "delete";
 }

--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -40,7 +40,7 @@ public class DataReferenceService {
   public DataReferenceDescription getDataReference(
       String workspaceId, String referenceId, AuthenticatedUserRequest userReq) {
 
-    authz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_READ_ACTION);
+    samService.workspaceAuthz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_READ_ACTION);
 
     return dataReferenceDao.getDataReference(UUID.fromString(referenceId));
   }
@@ -55,7 +55,7 @@ public class DataReferenceService {
           "Data reference must contain either a resource id or a reference type and a reference description");
     }
 
-    authz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_WRITE_ACTION);
+    samService.workspaceAuthz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_WRITE_ACTION);
 
     UUID referenceId = UUID.randomUUID();
     String description =
@@ -88,7 +88,7 @@ public class DataReferenceService {
 
   public DataReferenceList enumerateDataReferences(
       String workspaceId, int offset, int limit, AuthenticatedUserRequest userReq) {
-    authz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_READ_ACTION);
+    samService.workspaceAuthz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_READ_ACTION);
     return dataReferenceDao.enumerateDataReferences(
         workspaceId, userReq.getReqId().toString(), offset, limit);
   }
@@ -96,7 +96,7 @@ public class DataReferenceService {
   public void deleteDataReference(
       String workspaceId, String referenceId, AuthenticatedUserRequest userReq) {
 
-    authz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_WRITE_ACTION);
+    samService.workspaceAuthz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_WRITE_ACTION);
 
     if (dataReferenceDao.isControlled(UUID.fromString(referenceId))) {
       throw new ControlledResourceNotImplementedException(
@@ -106,20 +106,5 @@ public class DataReferenceService {
     if (!dataReferenceDao.deleteDataReference(UUID.fromString(referenceId))) {
       throw new DataReferenceNotFoundException("Data Reference not found.");
     }
-  }
-
-  private void authz(AuthenticatedUserRequest userReq, String workspaceId, String action) {
-    boolean isAuthorized =
-        samService.isAuthorized(
-            userReq.getRequiredToken(), SamUtils.SAM_WORKSPACE_RESOURCE, workspaceId, action);
-    if (!isAuthorized)
-      throw new SamUnauthorizedException(
-          "User "
-              + userReq.getEmail()
-              + " is not authorized to "
-              + action
-              + " workspace "
-              + workspaceId
-              + " or it doesn't exist.");
   }
 }

--- a/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.iam;
 
 import bio.terra.workspace.app.configuration.SamConfiguration;
 import bio.terra.workspace.common.exception.SamApiException;
+import bio.terra.workspace.common.exception.SamUnauthorizedException;
 import bio.terra.workspace.common.utils.SamUtils;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
@@ -55,5 +56,20 @@ public class SamService {
     } catch (ApiException samException) {
       throw new SamApiException(samException);
     }
+  }
+
+  public void workspaceAuthz(AuthenticatedUserRequest userReq, String workspaceId, String action) {
+    boolean isAuthorized =
+        isAuthorized(
+            userReq.getRequiredToken(), SamUtils.SAM_WORKSPACE_RESOURCE, workspaceId, action);
+    if (!isAuthorized)
+      throw new SamUnauthorizedException(
+          "User "
+              + userReq.getEmail()
+              + " is not authorized to "
+              + action
+              + " workspace "
+              + workspaceId
+              + " or it doesn't exist.");
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -61,7 +61,7 @@ public class WorkspaceService {
   public void deleteWorkspace(String id, String userToken) {
 
     AuthenticatedUserRequest userReq = new AuthenticatedUserRequest().token(Optional.of(userToken));
-    samService.workspaceAuthz(userReq, id, SamUtils.SAM_WORKSPACE_WRITE_ACTION);
+    samService.workspaceAuthz(userReq, id, SamUtils.SAM_WORKSPACE_DELETE_ACTION);
 
     String description = "Delete workspace " + id;
     JobBuilder deleteJob =

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.workspace;
 
-import bio.terra.workspace.common.exception.SamUnauthorizedException;
 import bio.terra.workspace.common.utils.SamUtils;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.generated.model.CreateWorkspaceRequestBody;
@@ -11,7 +10,9 @@ import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobBuilder;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceCreateFlight;
+import bio.terra.workspace.service.workspace.flight.WorkspaceDeleteFlight;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -52,16 +53,26 @@ public class WorkspaceService {
 
   public WorkspaceDescription getWorkspace(String id, AuthenticatedUserRequest userReq) {
 
-    if (!samService.isAuthorized(
-        userReq.getRequiredToken(),
-        SamUtils.SAM_WORKSPACE_RESOURCE,
-        id,
-        SamUtils.SAM_WORKSPACE_READ_ACTION)) {
-      throw new SamUnauthorizedException(
-          "User " + userReq.getEmail() + " is not allowed to read workspace " + id);
-    }
-
+    samService.workspaceAuthz(userReq, id, SamUtils.SAM_WORKSPACE_READ_ACTION);
     WorkspaceDescription result = workspaceDao.getWorkspace(id);
     return result;
+  }
+
+  public void deleteWorkspace(String id, String userToken) {
+
+    AuthenticatedUserRequest userReq = new AuthenticatedUserRequest().token(Optional.of(userToken));
+    samService.workspaceAuthz(userReq, id, SamUtils.SAM_WORKSPACE_WRITE_ACTION);
+
+    String description = "Delete workspace " + id;
+    JobBuilder deleteJob =
+        jobService
+            .newJob(
+                description,
+                UUID.randomUUID().toString(),
+                WorkspaceDeleteFlight.class,
+                null, // Delete does not have a useful request body
+                userReq)
+            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.fromString(id));
+    deleteJob.submitAndWait(null);
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
@@ -1,0 +1,40 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import java.util.UUID;
+
+public class DeleteWorkspaceAuthzStep implements Step {
+
+  private SamService samService;
+  private AuthenticatedUserRequest userReq;
+
+  public DeleteWorkspaceAuthzStep(SamService samService, AuthenticatedUserRequest userReq) {
+    this.samService = samService;
+    this.userReq = userReq;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext) throws RetryException {
+    FlightMap inputMap = flightContext.getInputParameters();
+    UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    samService.deleteWorkspace(userReq.getRequiredToken(), workspaceID);
+    return StepResult.getStepResultSuccess();
+  }
+
+  // Note: This doesn't fully undo the do-step, as the newly-created IAM resource will not have
+  // the same access policies as the old one. However, it prevents strange half-deleted states
+  // from occuring.
+  @Override
+  public StepResult undoStep(FlightContext flightContext) {
+    FlightMap inputMap = flightContext.getInputParameters();
+    UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    samService.createWorkspaceWithDefaults(userReq.getRequiredToken(), workspaceID);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
@@ -1,0 +1,44 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.db.WorkspaceDao;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+public class DeleteWorkspaceStateStep implements Step {
+
+  private WorkspaceDao workspaceDao;
+
+  @Autowired
+  public DeleteWorkspaceStateStep(WorkspaceDao workspaceDao) {
+    this.workspaceDao = workspaceDao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext) throws RetryException {
+    FlightMap inputMap = flightContext.getInputParameters();
+    UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    // WorkspaceDao.deleteWorkspace returns true if a delete succeeds or false if the workspace is
+    // not found, but the user-facing delete operation should return a 204 even if the workspace is
+    // not found.
+    workspaceDao.deleteWorkspace(workspaceID);
+    FlightUtils.setResponse(flightContext, null, HttpStatus.valueOf(204));
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) {
+    // We can't really undo a state delete: deleting the workspace cascades to multiple other
+    // state tables, and this undo can't re-create all that state.
+    // This should absolutely be the last step of a flight, and because we're unable to undo it
+    // we simply return a fatal status.
+    return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL);
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
@@ -1,0 +1,29 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.job.JobMapKeys;
+import org.springframework.context.ApplicationContext;
+
+public class WorkspaceDeleteFlight extends Flight {
+
+  public WorkspaceDeleteFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+    WorkspaceDao workspaceDao = (WorkspaceDao) appContext.getBean("workspaceDao");
+    SamService iamClient = (SamService) appContext.getBean("samService");
+
+    AuthenticatedUserRequest userReq =
+        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+    // TODO: we still need the following steps once their features are supported:
+    // 1. delete controlled resources using the Cloud Resource Manager library
+    // 2. Notify all registered applications of deletion, once applications are supported
+    // 3. Delete policy objects in Policy Manager, once it exists.
+    addStep(new DeleteWorkspaceAuthzStep(iamClient, userReq));
+    addStep(new DeleteWorkspaceStateStep(workspaceDao));
+  }
+}

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -68,6 +68,31 @@ paths:
         500:
           description: Get request error
           $ref: '#/components/responses/ErrorResponse'
+    delete:
+      description: |
+        Delete a Workspace. This should only be called by the Folder Manager.
+      operationId: deleteWorkspace
+      tags:
+      - workspace
+      requestBody:
+        description: |
+          Auth token of user requesting the delete.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteWorkspaceRequestBody'
+      responses:
+        204:
+          description: Success
+        400:
+          description: Bad Request
+          $ref: '#/components/responses/ErrorResponse'
+        401:
+          description: Unauthorized or not found
+          $ref: '#/components/responses/ErrorResponse'
+        500:
+          description: Server Error
+          $ref: '#/components/responses/ErrorResponse'
   '/api/v1/workspaces/{id}/datareferences':
     parameters:
       - $ref: '#/components/parameters/Id'
@@ -331,6 +356,12 @@ components:
         id:
           type: string
           description: UUID of a newly-created workspace
+    DeleteWorkspaceRequestBody:
+      type: object
+      properties:
+        authToken:
+          description: Requesting user's auth token
+          type: string
     WorkspaceDescription:
       type: object
       properties:

--- a/src/main/resources/db/changesets/20200227_initial_schema.yaml
+++ b/src/main/resources/db/changesets/20200227_initial_schema.yaml
@@ -107,7 +107,7 @@ databaseChangeLog:
               type: text
               constraints:
                 references: workspace(workspace_id)
-                foreignKeyName: fk_workspace_id_cascade
+                foreignKeyName: fk_workspace_id
                 nullable: false
                 deleteCascade: true
           - column:

--- a/src/main/resources/db/changesets/20200227_initial_schema.yaml
+++ b/src/main/resources/db/changesets/20200227_initial_schema.yaml
@@ -38,6 +38,7 @@ databaseChangeLog:
                 references: workspace(workspace_id)
                 foreignKeyName: fk_workspace_id
                 nullable: false
+                deleteCascade: true
           - column:
               name: application_id
               type: text
@@ -54,6 +55,7 @@ databaseChangeLog:
                 references: workspace(workspace_id)
                 foreignKeyName: fk_workspace_id
                 nullable: false
+                deleteCascade: true
           - column:
               name: resource_id
               type: text
@@ -86,6 +88,7 @@ databaseChangeLog:
               constraints:
                 primaryKey: true
                 nullable: false
+                deleteCascade: true
           - column:
               name: cloud_type
               # TODO: this should be an enum
@@ -104,8 +107,9 @@ databaseChangeLog:
               type: text
               constraints:
                 references: workspace(workspace_id)
-                foreignKeyName: fk_workspace_id
+                foreignKeyName: fk_workspace_id_cascade
                 nullable: false
+                deleteCascade: true
           - column:
               name: reference_id
               type: text

--- a/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -1,166 +1,166 @@
-// package bio.terra.workspace.service.job;
-//
-// import static org.hamcrest.CoreMatchers.equalTo;
-// import static org.hamcrest.CoreMatchers.notNullValue;
-// import static org.hamcrest.MatcherAssert.assertThat;
-// import static org.junit.jupiter.api.Assertions.assertThrows;
-// import static org.mockito.ArgumentMatchers.any;
-//
-// import bio.terra.stairway.exception.StairwayException;
-// import bio.terra.workspace.app.Main;
-// import bio.terra.workspace.generated.model.JobModel;
-// import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-// import bio.terra.workspace.service.iam.SamService;
-// import bio.terra.workspace.service.job.exception.JobNotFoundException;
-// import java.util.ArrayList;
-// import java.util.List;
-// import java.util.Optional;
-// import java.util.UUID;
-// import org.broadinstitute.dsde.workbench.client.sam.model.ResourceAndAccessPolicy;
-// import org.junit.jupiter.api.BeforeEach;
-// import org.junit.jupiter.api.Tag;
-// import org.junit.jupiter.api.Test;
-// import org.junit.jupiter.api.extension.ExtendWith;
-// import org.mockito.Mockito;
-// import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-// import org.springframework.boot.test.context.SpringBootTest;
-// import org.springframework.boot.test.mock.mockito.MockBean;
-// import org.springframework.http.HttpStatus;
-// import org.springframework.test.context.ContextConfiguration;
-// import org.springframework.test.context.junit.jupiter.SpringExtension;
-//
-// @Tag("unit")
-// @ExtendWith(SpringExtension.class)
-// @ContextConfiguration(classes = Main.class)
-// @SpringBootTest
-// @AutoConfigureMockMvc
-// public class JobServiceTest {
-//   private AuthenticatedUserRequest testUser =
-//       new AuthenticatedUserRequest()
-//           .subjectId("StairwayUnit")
-//           .email("stairway@unit.com")
-//           .token(Optional.of("not-a-real-token"));
-//
-//   @Autowired private JobService jobService;
-//
-//   @MockBean private SamService mockSamService;
-//
-//   @BeforeEach
-//   public void setup() {
-//     try {
-//       Mockito.doReturn(true).when(mockSamService.isAuthorized(any(), any(), any(), any()));
-//     } catch (Exception e) {
-//       // How does a mock even throw an exception?
-//     }
-//   }
-//
-//   @Test
-//   public void retrieveTest() throws Exception {
-//     // We perform 7 flights and then retrieve and enumerate them.
-//     // The fids list should be in exactly the same order as the database ordered by submit time.
-//
-//     List<String> jobIds = new ArrayList<>();
-//     try {
-//       List<ResourceAndAccessPolicy> allowedIds = new ArrayList<>();
-//       for (int i = 0; i < 7; i++) {
-//         String jobId = runFlight(makeDescription(i));
-//         jobIds.add(jobId);
-//         allowedIds.add(new ResourceAndAccessPolicy().resourceId(jobId));
-//       }
-//
-//       // Test single retrieval
-//       testSingleRetrieval(jobIds);
-//
-//       // Test result retrieval - the body should be the description string
-//       testResultRetrieval(jobIds);
-//
-//       // Retrieve everything
-//       testEnumRange(jobIds, 0, 100, allowedIds);
-//
-//       // Retrieve the middle 3; offset means skip 2 rows
-//       testEnumRange(jobIds, 2, 3, allowedIds);
-//
-//       // Retrieve from the end; should only get the last one back
-//       testEnumCount(1, 6, 3, allowedIds);
-//
-//       // Retrieve past the end; should get nothing
-//       testEnumCount(0, 22, 3, allowedIds);
-//     } finally {
-//       for (String jobId : jobIds) {
-//         jobService.releaseJob(jobId, testUser);
-//       }
-//     }
-//   }
-//
-//   private void testSingleRetrieval(List<String> fids) {
-//     JobModel response = jobService.retrieveJob(fids.get(2), testUser);
-//     assertThat(response, notNullValue());
-//     validateJobModel(response, 2, fids);
-//   }
-//
-//   private void testResultRetrieval(List<String> fids) {
-//     JobService.JobResultWithStatus<String> resultHolder =
-//         jobService.retrieveJobResult(fids.get(2), String.class, testUser);
-//
-//     assertThat(resultHolder.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT));
-//     assertThat(resultHolder.getResult(), equalTo(makeDescription(2)));
-//   }
-//
-//   // Get some range and compare it with the fids
-//   private void testEnumRange(
-//       List<String> fids, int offset, int limit, List<ResourceAndAccessPolicy> resourceIds) {
-//     List<JobModel> jobList = jobService.enumerateJobs(offset, limit, testUser);
-//     assertThat(jobList, notNullValue());
-//     int index = offset;
-//     for (JobModel job : jobList) {
-//       validateJobModel(job, index, fids);
-//       index++;
-//     }
-//   }
-//
-//   // Get some range and make sure we got the number we expected
-//   private void testEnumCount(
-//       int count, int offset, int length, List<ResourceAndAccessPolicy> resourceIds) {
-//     List<JobModel> jobList = jobService.enumerateJobs(offset, length, testUser);
-//     assertThat(jobList, notNullValue());
-//     assertThat(jobList.size(), equalTo(count));
-//   }
-//
-//   @Test
-//   public void testBadIdRetrieveJob() {
-//     assertThrows(
-//         JobNotFoundException.class,
-//         () -> {
-//           jobService.retrieveJob("abcdef", testUser);
-//         });
-//   }
-//
-//   @Test
-//   public void testBadIdRetrieveResult() {
-//     assertThrows(
-//         JobNotFoundException.class,
-//         () -> {
-//           jobService.retrieveJobResult("abcdef", Object.class, testUser);
-//         });
-//   }
-//
-//   private void validateJobModel(JobModel jm, int index, List<String> fids) {
-//     assertThat(jm.getDescription(), equalTo(makeDescription(index)));
-//     assertThat(jm.getId(), equalTo(fids.get(index)));
-//     assertThat(jm.getStatus(), equalTo(JobModel.StatusEnum.SUCCEEDED));
-//     assertThat(jm.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT.value()));
-//   }
-//
-//   // Submit a flight; wait for it to finish; return the flight id
-//   private String runFlight(String description) throws StairwayException {
-//     String jobId = UUID.randomUUID().toString();
-//     jobService.newJob(description, jobId, JobServiceTestFlight.class, null, testUser).submit();
-//     jobService.waitForJob(jobId);
-//     return jobId;
-//   }
-//
-//   private String makeDescription(int ii) {
-//     return String.format("flight%d", ii);
-//   }
-// }
+package bio.terra.workspace.service.job;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+import bio.terra.stairway.exception.StairwayException;
+import bio.terra.workspace.app.Main;
+import bio.terra.workspace.generated.model.JobModel;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.job.exception.JobNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.broadinstitute.dsde.workbench.client.sam.model.ResourceAndAccessPolicy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Tag("unit")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = Main.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class JobServiceTest {
+  private AuthenticatedUserRequest testUser =
+      new AuthenticatedUserRequest()
+          .subjectId("StairwayUnit")
+          .email("stairway@unit.com")
+          .token(Optional.of("not-a-real-token"));
+
+  @Autowired private JobService jobService;
+
+  @MockBean private SamService mockSamService;
+
+  @BeforeEach
+  public void setup() {
+    try {
+      Mockito.doReturn(true).when(mockSamService.isAuthorized(any(), any(), any(), any()));
+    } catch (Exception e) {
+      // How does a mock even throw an exception?
+    }
+  }
+
+  @Test
+  public void retrieveTest() throws Exception {
+    // We perform 7 flights and then retrieve and enumerate them.
+    // The fids list should be in exactly the same order as the database ordered by submit time.
+
+    List<String> jobIds = new ArrayList<>();
+    try {
+      List<ResourceAndAccessPolicy> allowedIds = new ArrayList<>();
+      for (int i = 0; i < 7; i++) {
+        String jobId = runFlight(makeDescription(i));
+        jobIds.add(jobId);
+        allowedIds.add(new ResourceAndAccessPolicy().resourceId(jobId));
+      }
+
+      // Test single retrieval
+      testSingleRetrieval(jobIds);
+
+      // Test result retrieval - the body should be the description string
+      testResultRetrieval(jobIds);
+
+      // Retrieve everything
+      testEnumRange(jobIds, 0, 100, allowedIds);
+
+      // Retrieve the middle 3; offset means skip 2 rows
+      testEnumRange(jobIds, 2, 3, allowedIds);
+
+      // Retrieve from the end; should only get the last one back
+      testEnumCount(1, 6, 3, allowedIds);
+
+      // Retrieve past the end; should get nothing
+      testEnumCount(0, 22, 3, allowedIds);
+    } finally {
+      for (String jobId : jobIds) {
+        jobService.releaseJob(jobId, testUser);
+      }
+    }
+  }
+
+  private void testSingleRetrieval(List<String> fids) {
+    JobModel response = jobService.retrieveJob(fids.get(2), testUser);
+    assertThat(response, notNullValue());
+    validateJobModel(response, 2, fids);
+  }
+
+  private void testResultRetrieval(List<String> fids) {
+    JobService.JobResultWithStatus<String> resultHolder =
+        jobService.retrieveJobResult(fids.get(2), String.class, testUser);
+
+    assertThat(resultHolder.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT));
+    assertThat(resultHolder.getResult(), equalTo(makeDescription(2)));
+  }
+
+  // Get some range and compare it with the fids
+  private void testEnumRange(
+      List<String> fids, int offset, int limit, List<ResourceAndAccessPolicy> resourceIds) {
+    List<JobModel> jobList = jobService.enumerateJobs(offset, limit, testUser);
+    assertThat(jobList, notNullValue());
+    int index = offset;
+    for (JobModel job : jobList) {
+      validateJobModel(job, index, fids);
+      index++;
+    }
+  }
+
+  // Get some range and make sure we got the number we expected
+  private void testEnumCount(
+      int count, int offset, int length, List<ResourceAndAccessPolicy> resourceIds) {
+    List<JobModel> jobList = jobService.enumerateJobs(offset, length, testUser);
+    assertThat(jobList, notNullValue());
+    assertThat(jobList.size(), equalTo(count));
+  }
+
+  @Test
+  public void testBadIdRetrieveJob() {
+    assertThrows(
+        JobNotFoundException.class,
+        () -> {
+          jobService.retrieveJob("abcdef", testUser);
+        });
+  }
+
+  @Test
+  public void testBadIdRetrieveResult() {
+    assertThrows(
+        JobNotFoundException.class,
+        () -> {
+          jobService.retrieveJobResult("abcdef", Object.class, testUser);
+        });
+  }
+
+  private void validateJobModel(JobModel jm, int index, List<String> fids) {
+    assertThat(jm.getDescription(), equalTo(makeDescription(index)));
+    assertThat(jm.getId(), equalTo(fids.get(index)));
+    assertThat(jm.getStatus(), equalTo(JobModel.StatusEnum.SUCCEEDED));
+    assertThat(jm.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT.value()));
+  }
+
+  // Submit a flight; wait for it to finish; return the flight id
+  private String runFlight(String description) throws StairwayException {
+    String jobId = UUID.randomUUID().toString();
+    jobService.newJob(description, jobId, JobServiceTestFlight.class, null, testUser).submit();
+    jobService.waitForJob(jobId);
+    return jobId;
+  }
+
+  private String makeDescription(int ii) {
+    return String.format("flight%d", ii);
+  }
+}

--- a/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -1,166 +1,166 @@
-package bio.terra.workspace.service.job;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-
-import bio.terra.stairway.exception.StairwayException;
-import bio.terra.workspace.app.Main;
-import bio.terra.workspace.generated.model.JobModel;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
-import bio.terra.workspace.service.job.exception.JobNotFoundException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import org.broadinstitute.dsde.workbench.client.sam.model.ResourceAndAccessPolicy;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-@Tag("unit")
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
-@AutoConfigureMockMvc
-public class JobServiceTest {
-  private AuthenticatedUserRequest testUser =
-      new AuthenticatedUserRequest()
-          .subjectId("StairwayUnit")
-          .email("stairway@unit.com")
-          .token(Optional.of("not-a-real-token"));
-
-  @Autowired private JobService jobService;
-
-  @MockBean private SamService mockSamService;
-
-  @BeforeEach
-  public void setup() {
-    try {
-      Mockito.doReturn(true).when(mockSamService.isAuthorized(any(), any(), any(), any()));
-    } catch (Exception e) {
-      // How does a mock even throw an exception?
-    }
-  }
-
-  @Test
-  public void retrieveTest() throws Exception {
-    // We perform 7 flights and then retrieve and enumerate them.
-    // The fids list should be in exactly the same order as the database ordered by submit time.
-
-    List<String> jobIds = new ArrayList<>();
-    try {
-      List<ResourceAndAccessPolicy> allowedIds = new ArrayList<>();
-      for (int i = 0; i < 7; i++) {
-        String jobId = runFlight(makeDescription(i));
-        jobIds.add(jobId);
-        allowedIds.add(new ResourceAndAccessPolicy().resourceId(jobId));
-      }
-
-      // Test single retrieval
-      testSingleRetrieval(jobIds);
-
-      // Test result retrieval - the body should be the description string
-      testResultRetrieval(jobIds);
-
-      // Retrieve everything
-      testEnumRange(jobIds, 0, 100, allowedIds);
-
-      // Retrieve the middle 3; offset means skip 2 rows
-      testEnumRange(jobIds, 2, 3, allowedIds);
-
-      // Retrieve from the end; should only get the last one back
-      testEnumCount(1, 6, 3, allowedIds);
-
-      // Retrieve past the end; should get nothing
-      testEnumCount(0, 22, 3, allowedIds);
-    } finally {
-      for (String jobId : jobIds) {
-        jobService.releaseJob(jobId, testUser);
-      }
-    }
-  }
-
-  private void testSingleRetrieval(List<String> fids) {
-    JobModel response = jobService.retrieveJob(fids.get(2), testUser);
-    assertThat(response, notNullValue());
-    validateJobModel(response, 2, fids);
-  }
-
-  private void testResultRetrieval(List<String> fids) {
-    JobService.JobResultWithStatus<String> resultHolder =
-        jobService.retrieveJobResult(fids.get(2), String.class, testUser);
-
-    assertThat(resultHolder.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT));
-    assertThat(resultHolder.getResult(), equalTo(makeDescription(2)));
-  }
-
-  // Get some range and compare it with the fids
-  private void testEnumRange(
-      List<String> fids, int offset, int limit, List<ResourceAndAccessPolicy> resourceIds) {
-    List<JobModel> jobList = jobService.enumerateJobs(offset, limit, testUser);
-    assertThat(jobList, notNullValue());
-    int index = offset;
-    for (JobModel job : jobList) {
-      validateJobModel(job, index, fids);
-      index++;
-    }
-  }
-
-  // Get some range and make sure we got the number we expected
-  private void testEnumCount(
-      int count, int offset, int length, List<ResourceAndAccessPolicy> resourceIds) {
-    List<JobModel> jobList = jobService.enumerateJobs(offset, length, testUser);
-    assertThat(jobList, notNullValue());
-    assertThat(jobList.size(), equalTo(count));
-  }
-
-  @Test
-  public void testBadIdRetrieveJob() {
-    assertThrows(
-        JobNotFoundException.class,
-        () -> {
-          jobService.retrieveJob("abcdef", testUser);
-        });
-  }
-
-  @Test
-  public void testBadIdRetrieveResult() {
-    assertThrows(
-        JobNotFoundException.class,
-        () -> {
-          jobService.retrieveJobResult("abcdef", Object.class, testUser);
-        });
-  }
-
-  private void validateJobModel(JobModel jm, int index, List<String> fids) {
-    assertThat(jm.getDescription(), equalTo(makeDescription(index)));
-    assertThat(jm.getId(), equalTo(fids.get(index)));
-    assertThat(jm.getStatus(), equalTo(JobModel.StatusEnum.SUCCEEDED));
-    assertThat(jm.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT.value()));
-  }
-
-  // Submit a flight; wait for it to finish; return the flight id
-  private String runFlight(String description) throws StairwayException {
-    String jobId = UUID.randomUUID().toString();
-    jobService.newJob(description, jobId, JobServiceTestFlight.class, null, testUser).submit();
-    jobService.waitForJob(jobId);
-    return jobId;
-  }
-
-  private String makeDescription(int ii) {
-    return String.format("flight%d", ii);
-  }
-}
+// package bio.terra.workspace.service.job;
+//
+// import static org.hamcrest.CoreMatchers.equalTo;
+// import static org.hamcrest.CoreMatchers.notNullValue;
+// import static org.hamcrest.MatcherAssert.assertThat;
+// import static org.junit.jupiter.api.Assertions.assertThrows;
+// import static org.mockito.ArgumentMatchers.any;
+//
+// import bio.terra.stairway.exception.StairwayException;
+// import bio.terra.workspace.app.Main;
+// import bio.terra.workspace.generated.model.JobModel;
+// import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+// import bio.terra.workspace.service.iam.SamService;
+// import bio.terra.workspace.service.job.exception.JobNotFoundException;
+// import java.util.ArrayList;
+// import java.util.List;
+// import java.util.Optional;
+// import java.util.UUID;
+// import org.broadinstitute.dsde.workbench.client.sam.model.ResourceAndAccessPolicy;
+// import org.junit.jupiter.api.BeforeEach;
+// import org.junit.jupiter.api.Tag;
+// import org.junit.jupiter.api.Test;
+// import org.junit.jupiter.api.extension.ExtendWith;
+// import org.mockito.Mockito;
+// import org.springframework.beans.factory.annotation.Autowired;
+// import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+// import org.springframework.boot.test.context.SpringBootTest;
+// import org.springframework.boot.test.mock.mockito.MockBean;
+// import org.springframework.http.HttpStatus;
+// import org.springframework.test.context.ContextConfiguration;
+// import org.springframework.test.context.junit.jupiter.SpringExtension;
+//
+// @Tag("unit")
+// @ExtendWith(SpringExtension.class)
+// @ContextConfiguration(classes = Main.class)
+// @SpringBootTest
+// @AutoConfigureMockMvc
+// public class JobServiceTest {
+//   private AuthenticatedUserRequest testUser =
+//       new AuthenticatedUserRequest()
+//           .subjectId("StairwayUnit")
+//           .email("stairway@unit.com")
+//           .token(Optional.of("not-a-real-token"));
+//
+//   @Autowired private JobService jobService;
+//
+//   @MockBean private SamService mockSamService;
+//
+//   @BeforeEach
+//   public void setup() {
+//     try {
+//       Mockito.doReturn(true).when(mockSamService.isAuthorized(any(), any(), any(), any()));
+//     } catch (Exception e) {
+//       // How does a mock even throw an exception?
+//     }
+//   }
+//
+//   @Test
+//   public void retrieveTest() throws Exception {
+//     // We perform 7 flights and then retrieve and enumerate them.
+//     // The fids list should be in exactly the same order as the database ordered by submit time.
+//
+//     List<String> jobIds = new ArrayList<>();
+//     try {
+//       List<ResourceAndAccessPolicy> allowedIds = new ArrayList<>();
+//       for (int i = 0; i < 7; i++) {
+//         String jobId = runFlight(makeDescription(i));
+//         jobIds.add(jobId);
+//         allowedIds.add(new ResourceAndAccessPolicy().resourceId(jobId));
+//       }
+//
+//       // Test single retrieval
+//       testSingleRetrieval(jobIds);
+//
+//       // Test result retrieval - the body should be the description string
+//       testResultRetrieval(jobIds);
+//
+//       // Retrieve everything
+//       testEnumRange(jobIds, 0, 100, allowedIds);
+//
+//       // Retrieve the middle 3; offset means skip 2 rows
+//       testEnumRange(jobIds, 2, 3, allowedIds);
+//
+//       // Retrieve from the end; should only get the last one back
+//       testEnumCount(1, 6, 3, allowedIds);
+//
+//       // Retrieve past the end; should get nothing
+//       testEnumCount(0, 22, 3, allowedIds);
+//     } finally {
+//       for (String jobId : jobIds) {
+//         jobService.releaseJob(jobId, testUser);
+//       }
+//     }
+//   }
+//
+//   private void testSingleRetrieval(List<String> fids) {
+//     JobModel response = jobService.retrieveJob(fids.get(2), testUser);
+//     assertThat(response, notNullValue());
+//     validateJobModel(response, 2, fids);
+//   }
+//
+//   private void testResultRetrieval(List<String> fids) {
+//     JobService.JobResultWithStatus<String> resultHolder =
+//         jobService.retrieveJobResult(fids.get(2), String.class, testUser);
+//
+//     assertThat(resultHolder.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT));
+//     assertThat(resultHolder.getResult(), equalTo(makeDescription(2)));
+//   }
+//
+//   // Get some range and compare it with the fids
+//   private void testEnumRange(
+//       List<String> fids, int offset, int limit, List<ResourceAndAccessPolicy> resourceIds) {
+//     List<JobModel> jobList = jobService.enumerateJobs(offset, limit, testUser);
+//     assertThat(jobList, notNullValue());
+//     int index = offset;
+//     for (JobModel job : jobList) {
+//       validateJobModel(job, index, fids);
+//       index++;
+//     }
+//   }
+//
+//   // Get some range and make sure we got the number we expected
+//   private void testEnumCount(
+//       int count, int offset, int length, List<ResourceAndAccessPolicy> resourceIds) {
+//     List<JobModel> jobList = jobService.enumerateJobs(offset, length, testUser);
+//     assertThat(jobList, notNullValue());
+//     assertThat(jobList.size(), equalTo(count));
+//   }
+//
+//   @Test
+//   public void testBadIdRetrieveJob() {
+//     assertThrows(
+//         JobNotFoundException.class,
+//         () -> {
+//           jobService.retrieveJob("abcdef", testUser);
+//         });
+//   }
+//
+//   @Test
+//   public void testBadIdRetrieveResult() {
+//     assertThrows(
+//         JobNotFoundException.class,
+//         () -> {
+//           jobService.retrieveJobResult("abcdef", Object.class, testUser);
+//         });
+//   }
+//
+//   private void validateJobModel(JobModel jm, int index, List<String> fids) {
+//     assertThat(jm.getDescription(), equalTo(makeDescription(index)));
+//     assertThat(jm.getId(), equalTo(fids.get(index)));
+//     assertThat(jm.getStatus(), equalTo(JobModel.StatusEnum.SUCCEEDED));
+//     assertThat(jm.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT.value()));
+//   }
+//
+//   // Submit a flight; wait for it to finish; return the flight id
+//   private String runFlight(String description) throws StairwayException {
+//     String jobId = UUID.randomUUID().toString();
+//     jobService.newJob(description, jobId, JobServiceTestFlight.class, null, testUser).submit();
+//     jobService.waitForJob(jobId);
+//     return jobId;
+//   }
+//
+//   private String makeDescription(int ii) {
+//     return String.format("flight%d", ii);
+//   }
+// }


### PR DESCRIPTION
Adds an endpoint to delete a workspace.

This uses Stairway, but `delete` seems like a weird operation for the Saga pattern - generally, it's really hard to undo partial deletes. It's also currently missing steps for planned but unimplemented features: deleting controlled resources with the Resource Manager library, notifying registered applications, and deleting policy objects in the Policy Manager.