### PR TITLE
Small cleanups before demo

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             secretKeyRef:
               name: workspace-stairway-db-creds
               key: db
+        # TODO: how should this be provided?
+        - name: SAM_ADDRESS
+          value: https://sam.dsde-dev.broadinstitute.org/
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.16
         env:

--- a/src/main/java/bio/terra/workspace/app/configuration/ApiResourceConfig.java
+++ b/src/main/java/bio/terra/workspace/app/configuration/ApiResourceConfig.java
@@ -10,7 +10,7 @@ public class ApiResourceConfig implements WebMvcConfigurer {
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
     registry
-        .addResourceHandler("/swagger-webjar/**")
+        .addResourceHandler("/api/swagger-webjar/**")
         .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.24.0/");
     registry.addResourceHandler("/api/**").addResourceLocations("classpath:/api/");
   }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -7,6 +7,7 @@ info:
 
 servers:
 - url: http://localhost:8080
+- url: /dev-terra-workspace-manager
 
 paths:
   '/status':
@@ -227,6 +228,10 @@ paths:
               schema:
                 type: object
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
   parameters:
     Id:
       name: id
@@ -534,3 +539,5 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/DataReferenceList'
+security:
+- bearerAuth: []

--- a/src/main/resources/api/swagger-ui.html
+++ b/src/main/resources/api/swagger-ui.html
@@ -4,9 +4,9 @@
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI</title>
-    <link rel="stylesheet" type="text/css" href="/swagger-webjar/swagger-ui.css" >
-    <link rel="icon" type="image/png" href="/swagger-webjar/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/swagger-webjar/favicon-16x16.png" sizes="16x16" />
+    <link rel="stylesheet" type="text/css" href="swagger-webjar/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="swagger-webjar/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="swagger-webjar/favicon-16x16.png" sizes="16x16" />
     <style>
       html
       {
@@ -33,8 +33,8 @@
   <body>
     <div id="swagger-ui"></div>
 
-    <script src="/swagger-webjar/swagger-ui-bundle.js"> </script>
-    <script src="/swagger-webjar/swagger-ui-standalone-preset.js"> </script>
+    <script src="swagger-webjar/swagger-ui-bundle.js"> </script>
+    <script src="swagger-webjar/swagger-ui-standalone-preset.js"> </script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region


### PR DESCRIPTION
A collection of small changes necessary to demo endpoints with swagger-ui. Some of these changes were used in the 4/3 demo, but I never checked them in (sorry!)

-Adds bearer token auth to swagger API
-Fixes missing swagger resources
-Adds dev backend to the SwaggerUI selection box
-Provides address of dev Sam. I don't know exactly how we plan to wire these together in the future and it'll probably change when Sam moves to K8s.

You can see a demo of this running in my testing environment at `http://34.71.179.202/zloery-terra-workspace-manager/api/swagger-ui.html`.
I haven't tested data reference endpoints, but basic workspace endpoints work correctly.
