### PR TITLE
AS-317 Fix CreateWorkspace error serialization and auth before making SQL calls

### DIFF
--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.JobService.JobResultWithStatus;
 import bio.terra.workspace.service.workspace.WorkspaceService;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +49,10 @@ public class WorkspaceApiController implements WorkspaceApi {
   @Override
   public ResponseEntity<CreatedWorkspace> createWorkspace(
       @RequestBody CreateWorkspaceRequestBody body) {
-    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
+    // Note: we do NOT use getAuthenticatedInfo here, as the request's authentication info comes
+    // from the folder manager, not the requesting user.
+    String userToken = body.getAuthToken();
+    AuthenticatedUserRequest userReq = new AuthenticatedUserRequest().token(Optional.of(userToken));
     return new ResponseEntity<>(workspaceService.createWorkspace(body, userReq), HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/workspace/common/exception/DuplicateWorkspaceException.java
+++ b/src/main/java/bio/terra/workspace/common/exception/DuplicateWorkspaceException.java
@@ -1,0 +1,12 @@
+package bio.terra.workspace.common.exception;
+
+public class DuplicateWorkspaceException extends BadRequestException {
+
+  public DuplicateWorkspaceException(String message) {
+    super(message);
+  }
+
+  public DuplicateWorkspaceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/bio/terra/workspace/common/exception/SamApiException.java
+++ b/src/main/java/bio/terra/workspace/common/exception/SamApiException.java
@@ -10,6 +10,7 @@ public class SamApiException extends ErrorReportException {
   public SamApiException(ApiException samException) {
     super(
         "Error from SAM: ",
+        samException,
         Collections.singletonList(samException.getResponseBody()),
         HttpStatus.resolve(samException.getCode()));
   }

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.db;
 
 import bio.terra.workspace.app.configuration.WorkspaceManagerJdbcConfiguration;
+import bio.terra.workspace.common.exception.DuplicateWorkspaceException;
 import bio.terra.workspace.common.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
 import java.util.HashMap;
@@ -8,6 +9,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -35,7 +37,12 @@ public class WorkspaceDao {
     paramMap.put("spend_profile", spendProfile.orElse(null));
     paramMap.put("spend_profile_settable", !spendProfile.isPresent());
 
-    jdbcTemplate.update(sql, paramMap);
+    try {
+      jdbcTemplate.update(sql, paramMap);
+    } catch (DuplicateKeyException e) {
+      throw new DuplicateWorkspaceException(
+          "Workspace " + workspaceId.toString() + " already exists.", e);
+    }
     return workspaceId.toString();
   }
 

--- a/src/main/java/bio/terra/workspace/service/job/StairwayExceptionFields.java
+++ b/src/main/java/bio/terra/workspace/service/job/StairwayExceptionFields.java
@@ -8,6 +8,7 @@ public class StairwayExceptionFields {
   private String className;
   private String message;
   private List<String> errorDetails;
+  private int errorCode;
 
   public boolean isErrorReportException() {
     return isErrorReportException;
@@ -42,6 +43,15 @@ public class StairwayExceptionFields {
 
   public StairwayExceptionFields setErrorDetails(List<String> errorDetails) {
     this.errorDetails = errorDetails;
+    return this;
+  }
+
+  public int getErrorCode() {
+    return errorCode;
+  }
+
+  public StairwayExceptionFields setErrorCode(int errorCode) {
+    this.errorCode = errorCode;
     return this;
   }
 }

--- a/src/main/java/bio/terra/workspace/service/job/StairwayExceptionSerializer.java
+++ b/src/main/java/bio/terra/workspace/service/job/StairwayExceptionSerializer.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
 
 public class StairwayExceptionSerializer implements ExceptionSerializer {
   private ObjectMapper objectMapper;
@@ -38,7 +39,8 @@ public class StairwayExceptionSerializer implements ExceptionSerializer {
     if (exception instanceof ErrorReportException) {
       fields
           .setErrorReportException(true)
-          .setErrorDetails(((ErrorReportException) exception).getCauses());
+          .setErrorDetails(((ErrorReportException) exception).getCauses())
+          .setErrorCode(((ErrorReportException) exception).getStatusCode().value());
     } else {
       fields.setErrorReportException(false);
     }
@@ -81,7 +83,29 @@ public class StairwayExceptionSerializer implements ExceptionSerializer {
     }
 
     // If this is an ErrorReport exception and the exception exposes a constructor with the
-    // error details, then we try to use that.
+    // error details, then we try to use that. We first try a version with a message, causes, and
+    // status code.
+    if (fields.isErrorReportException()) {
+      try {
+        Constructor<?> ctor = clazz.getConstructor(String.class, List.class, HttpStatus.class);
+        Object object =
+            ctor.newInstance(
+                fields.getMessage(),
+                fields.getErrorDetails(),
+                HttpStatus.valueOf(fields.getErrorCode()));
+        return (Exception) object;
+      } catch (NoSuchMethodException
+          | SecurityException
+          | InstantiationException
+          | IllegalAccessException
+          | IllegalArgumentException
+          | InvocationTargetException ex) {
+        // We didn't find a constructor with error these error details or construction failed.
+      }
+    }
+
+    // If this is an ErrorReport exception but didn't match the above constructor signature, we
+    // try again with another common pattern of message + causes.
     if (fields.isErrorReportException()) {
       try {
         Constructor<?> ctor = clazz.getConstructor(String.class, List.class);

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceCreateFlight.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceCreateFlight.java
@@ -21,7 +21,7 @@ public class WorkspaceCreateFlight extends Flight {
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
-    addStep(new CreateWorkspaceStep(workspaceDao));
     addStep(new CreateWorkspaceAuthzStep(iamClient, userReq));
+    addStep(new CreateWorkspaceStep(workspaceDao));
   }
 }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -47,7 +47,7 @@ paths:
         400:
           description: Bad request - invalid id, badly formed
           $ref: '#/components/responses/ErrorResponse'
-        403:
+        401:
           description: Permission denied
           $ref: '#/components/responses/ErrorResponse'
         500:

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.workspace.app.Main;
 import bio.terra.workspace.app.configuration.WorkspaceManagerJdbcConfiguration;
+import bio.terra.workspace.common.exception.DuplicateWorkspaceException;
 import bio.terra.workspace.common.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
 import java.util.HashMap;
@@ -114,5 +115,15 @@ public class WorkspaceDaoTest {
   @Test
   public void deleteNonExistentWorkspaceFails() throws Exception {
     assertFalse(workspaceDao.deleteWorkspace(workspaceId));
+  }
+
+  @Test
+  public void duplicateWorkspaceFails() throws Exception {
+    workspaceDao.createWorkspace(workspaceId, JsonNullable.undefined());
+    assertThrows(
+        DuplicateWorkspaceException.class,
+        () -> {
+          workspaceDao.createWorkspace(workspaceId, JsonNullable.undefined());
+        });
   }
 }


### PR DESCRIPTION
This PR fixes the issue raised directly in AS-317 (WM not validating tokens before performing a createWorkspace SQL call) and also several issues that this uncovered. The full list of changes is:

-WM now authenticates with Sam to create an IAM object before creating a workspace in its own DB. This prevents unauthorized users from fishing for the existence of workspaces.
-WM now returns a user-friendly DuplicateWorkspaceException when an authorized user attempts to create a new Workspace with an ID that's already used, rather than directly returning an SQL error.
-WM now correctly uses the authentication token provided in the request body for create calls, rather than the token from the header. The token in the header is intended to validate that a request comes from the Folder Manager, not to represent a particular user.
-ErrorReportExceptions raised by steps in Stairway are now serialized (and de-serialized) with their error code, rather than only using the `message` and `causes` fields of the ErrorReportException.
-API documentation updated to reflect that the "permission denied" response to a `create` call has a 401 status, not a 403.