### PR TITLE
Tolerate sam resource already existing

### DIFF
--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
@@ -5,6 +5,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.SamUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import java.util.UUID;
@@ -23,7 +24,21 @@ public class CreateWorkspaceAuthzStep implements Step {
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
     UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
-    samService.createWorkspaceWithDefaults(userReq.getRequiredToken(), workspaceID);
+
+    // This may seem a bit counterintuitive, but in many of the existing use-cases, the workspace
+    // resource already exists
+    // If the user has access to the workspace, it means that we can skip the case of trying (and
+    // failing) to create
+    // the Sam resource. If the user doesn't have access, we'll default to the existing behavior and
+    // return the following
+    // error or success message from Sam.
+    if (!samService.isAuthorized(
+        userReq.getRequiredToken(),
+        SamUtils.SAM_WORKSPACE_RESOURCE,
+        workspaceID.toString(),
+        SamUtils.SAM_WORKSPACE_READ_ACTION)) {
+      samService.createWorkspaceWithDefaults(userReq.getRequiredToken(), workspaceID);
+    }
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;


### PR DESCRIPTION
In the case of Rawls/TDR integration, the workspace created in WSM will fail because a Sam resource has always already been created for the workspace by Rawls.

If we test if the user isAuthorized to read the workspace, we can know whether or not the workspace exists (or whether the user should think it exists) and we can skip the resource creation step and avoid the conflict.

The original plan was to inspect the token passed in the header to see who is calling WSM, and if it was the rawls SA, we could skip this step. But the `userReq` doesn't contain enough information to know the email address of the user behind the request. This seemed like an appropriate alternative.