### PR TITLE
AS-368: Add Request-Id to every log message associated with an API call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	implementation(group: 'bio.terra', name: 'terra-workspace-manager-client', version: '0.0.2-SNAPSHOT')
 	implementation(group: 'io.vavr', name: 'vavr', version: '0.10.3')
 	implementation(group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.20.0')
+	implementation(group: 'org.hashids', name: 'hashids', version: '1.0.3')
 
 	// -- OpenAPI CodeGen dependencies --
 	// TODO: this version of swagger-annotations is old, but the code gen is still relying on it

--- a/src/main/java/bio/terra/workspace/mdc/MdcLogEnhancerFilter.java
+++ b/src/main/java/bio/terra/workspace/mdc/MdcLogEnhancerFilter.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class MdcLogEnhancerFilter implements Filter {
 
+  private Hashids hashids = new Hashids("requestIdSalt", 8);
+
   @Override
   public void doFilter(
       ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
@@ -34,7 +36,6 @@ public class MdcLogEnhancerFilter implements Filter {
   }
 
   private String generateRequestId() {
-    Hashids hashids = new Hashids("requestIdSalt", 8); // min length will be 8
     long generatedLong = ThreadLocalRandom.current().nextLong(0, Integer.MAX_VALUE);
 
     return hashids.encode(generatedLong);

--- a/src/main/java/bio/terra/workspace/mdc/MdcLogEnhancerFilter.java
+++ b/src/main/java/bio/terra/workspace/mdc/MdcLogEnhancerFilter.java
@@ -17,12 +17,19 @@ public class MdcLogEnhancerFilter implements Filter {
       throws IOException, ServletException {
     HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
 
-    String requestId =
-        ((requestId = httpRequest.getHeader("Request-Id")) != null)
-            ? requestId
-            : generateRequestId();
+    /* Services calling Workspace Manager can supply an X-Request-ID or X-Correlation-ID
+       HTTP header to trace requests through the system. X-Request-ID will be preferred over
+       X-Correlation-ID. If neither header is present, Workspace Manager will generate one.
+    */
 
-    MDC.put("requestId", requestId + " ");
+    String requestId =
+        ((requestId = httpRequest.getHeader("X-Request-ID")) != null)
+            ? requestId
+            : ((requestId = httpRequest.getHeader("X-Correlation-ID")) != null)
+                ? requestId
+                : generateRequestId();
+
+    MDC.put("requestId", requestId);
     filterChain.doFilter(servletRequest, servletResponse);
   }
 

--- a/src/main/java/bio/terra/workspace/mdc/MdcLogEnhancerFilter.java
+++ b/src/main/java/bio/terra/workspace/mdc/MdcLogEnhancerFilter.java
@@ -12,12 +12,6 @@ import org.springframework.stereotype.Component;
 public class MdcLogEnhancerFilter implements Filter {
 
   @Override
-  public void destroy() {}
-
-  @Override
-  public void init(FilterConfig filterConfig) throws ServletException {}
-
-  @Override
   public void doFilter(
       ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
       throws IOException, ServletException {
@@ -33,10 +27,9 @@ public class MdcLogEnhancerFilter implements Filter {
   }
 
   private String generateRequestId() {
-    Hashids hashids = new Hashids("requestIdSalt");
-    long generatedLong = ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
-    String id = hashids.encode(generatedLong);
+    Hashids hashids = new Hashids("requestIdSalt", 8); // min length will be 8
+    long generatedLong = ThreadLocalRandom.current().nextLong(0, Integer.MAX_VALUE);
 
-    return id;
+    return hashids.encode(generatedLong);
   }
 }

--- a/src/main/java/bio/terra/workspace/mdc/MdcLogEnhancerFilter.java
+++ b/src/main/java/bio/terra/workspace/mdc/MdcLogEnhancerFilter.java
@@ -1,0 +1,42 @@
+package bio.terra.workspace.mdc;
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import org.hashids.Hashids;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MdcLogEnhancerFilter implements Filter {
+
+  @Override
+  public void destroy() {}
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {}
+
+  @Override
+  public void doFilter(
+      ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+      throws IOException, ServletException {
+    HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+
+    String requestId =
+        ((requestId = httpRequest.getHeader("Request-Id")) != null)
+            ? requestId
+            : generateRequestId();
+
+    MDC.put("requestId", requestId + " ");
+    filterChain.doFilter(servletRequest, servletResponse);
+  }
+
+  private String generateRequestId() {
+    Hashids hashids = new Hashids("requestIdSalt");
+    long generatedLong = ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+    String id = hashids.encode(generatedLong);
+
+    return id;
+  }
+}

--- a/src/main/java/bio/terra/workspace/mdc/MdcResponseFilter.java
+++ b/src/main/java/bio/terra/workspace/mdc/MdcResponseFilter.java
@@ -1,0 +1,24 @@
+package bio.terra.workspace.mdc;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class MdcResponseFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse,
+      FilterChain filterChain)
+      throws ServletException, IOException {
+    httpServletResponse.addHeader("X-Request-ID", MDC.get("requestId"));
+    filterChain.doFilter(httpServletRequest, httpServletResponse);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,5 @@ sam.basePath=${SAM_ADDRESS}
 
 datarepo.instances.terra-dev=https://jade.datarepo-dev.broadinstitute.org
 datarepo.instances.terra-prod=https://jade-terra.datarepo-prod.broadinstitute.org
+
+logging.pattern.level = %X{requestId}%5p

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,4 +21,4 @@ sam.basePath=${SAM_ADDRESS}
 datarepo.instances.terra-dev=https://jade.datarepo-dev.broadinstitute.org
 datarepo.instances.terra-prod=https://jade-terra.datarepo-prod.broadinstitute.org
 
-logging.pattern.level = %X{requestId}%5p
+logging.pattern.level=%X{requestId} %5p


### PR DESCRIPTION
Log messages will look something like:

```
2020-06-19 09:40:41.535 pn3N7J3M ERROR 17147 --- [nio-8080-exec-1] b.t.w.a.c.GlobalExceptionHandler         :    cause: bio.terra.workspace.common.exception.DuplicateWorkspaceException@2696eb2[causes=<null>,statusCode=400 BAD_REQUEST]
```

This does _not_ add the ID to anything that happens asynchronously within stairway. It will be added to the message that says the flight was launched, but no subsequent messages from within the flight.