### PR TITLE
Fix tag syntax

### DIFF
--- a/.github/workflows/dev_push.yml
+++ b/.github/workflows/dev_push.yml
@@ -26,6 +26,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: false
+        RELEASE_BRANCHES: dev
     - name: Pull Vault image
       run: docker pull vault:1.1.0
     # Currently, there's no way to add capabilities to Docker actions on Git, and Vault needs IPC_LOCK to run.


### PR DESCRIPTION
This [PR](https://github.com/DataBiosphere/terra-workspace-manager/pull/56) changed the git and image tag syntax to [this](https://github.com/broadinstitute/terra-helmfile/blob/c9994a6923834ba05eac35274880b0c341d77550/versions.yaml#L18). I'm assuming y'all don't want that. The [tagging action](https://github.com/broadinstitute/github-tag-action) has a baked-in assumption that any branch that's not master is not a release branch and thus has this syntax. The variable I set should fix that by telling it that dev is a release branch.