### PR TITLE
Remove webjar config that was accidentally re-added

### DIFF
--- a/src/main/java/bio/terra/workspace/app/configuration/ApiResourceConfig.java
+++ b/src/main/java/bio/terra/workspace/app/configuration/ApiResourceConfig.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration

--- a/src/main/java/bio/terra/workspace/app/configuration/ApiResourceConfig.java
+++ b/src/main/java/bio/terra/workspace/app/configuration/ApiResourceConfig.java
@@ -16,11 +16,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class ApiResourceConfig implements WebMvcConfigurer {
 
-  @Override
-  public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    registry.addResourceHandler("/**").addResourceLocations("classpath:/api/");
-  }
-
   @Autowired private SpanCustomizer spanCustomizer;
   private String mdcRequestIdKey = "X-Request-ID";
   private String mdcCorrelationIdKey = "X-Correlation-ID";


### PR DESCRIPTION
We deleted the entire ApiResourceConfig.java in a PR to use webjars and prevent UI caching, and then accidentally re-added the UI handling piece along with other functionality in that file.