### PR TITLE
Set application properties to re-create DB schema.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,13 +17,13 @@ status-check-staleness-threshold.in.milliseconds=600000
 db.workspace.uri=jdbc:postgresql://127.0.0.1:5432/${DATABASE_NAME}
 db.workspace.username=${DATABASE_USER}
 db.workspace.password=${DATABASE_USER_PASSWORD}
-db.workspace.initializeOnStart=false
+db.workspace.initializeOnStart=true
 db.workspace.upgradeOnStart=true
 
 db.stairway.uri=jdbc:postgresql://127.0.0.1:5432/${STAIRWAY_DATABASE_NAME}
 db.stairway.username=${STAIRWAY_DATABASE_USER}
 db.stairway.password=${STAIRWAY_DATABASE_USER_PASSWORD}
-db.stairway.migrateUpgrade=false
+db.stairway.migrateUpgrade=true
 db.stairway.forceClean=true
 
 sam.basePath=${SAM_ADDRESS}


### PR DESCRIPTION
Pushing this to dev will re-create WM's db schema, deleting all existing data in dev per discussion on the backwards-incompatible change to the referenceType enum values. Afterwards, we should set these values back to false and push again.