### PR TITLE
Tidy .gitignore and clean up deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
 HELP.md
-.gradle/
-build/
-local-dev/
-!gradle/wrapper/gradle-wrapper.jar
-!**/src/main/**
-!**/src/test/**
+
+### Gradle ###
+.gradle
+**/build/
+!gradle-wrapper.jar
 
 ### STS ###
 .apt_generated
@@ -37,7 +36,3 @@ out/
 
 ### Mac directory metadata
 .DS_Store
-
-### OpenAPI CodeGen detritus
-.openapi-generator/
-pom.xml

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -109,5 +109,7 @@ TODO: It would be nice to have a kickstart script that new devs can run that con
 
 ### Tips
 - Check out [gdub](https://github.com/gdubw/gdub), it'll save you typing `./gradlew` over and over, and also takes care of knowing when you're not in the root directory so you don't have to figure out the appropriate number of `../`s.
-- To run gradle actions in IntelliJ, edit your run configurations and add all of the exports under **Running Workspace Manager** to the Gradle template.
-- You can get live-ish reloading of for the local Swagger UI through Intellij. Instead of running the local server with `bootRun`, use the `Main` Spring Boot configuration that IntelliJ auto-generates. Edit it and add the following override parameter: `spring.resources.static-locations:file:src/main/resources/api` (also add the standard environment variables). It's not true live reloading, you still have to refresh the browser, but at least you don't have to restart the server.
+- To run gradle actions in IntelliJ, edit your run configurations and add all of the exports under *Running Workspace Manager* to the Gradle template.
+  
+  **ALTERNATIVELY**, if you've exported the environment variables in a `.profile` or similar, just re-launch IntelliJ and it should pick them up. 
+- You can get live-ish reloading of for the local Swagger UI through Intellij. Instead of running the local server with `bootRun`, use the `Main` Spring Boot configuration that IntelliJ auto-generates. Edit it and add the following override parameter: `spring.resources.static-locations:file:src/main/resources/api`. It's not true live reloading, you still have to refresh the browser, but at least you don't have to restart the server.

--- a/build.gradle
+++ b/build.gradle
@@ -77,17 +77,17 @@ dependencies {
 	// Swagger deps
 	implementation group: "io.swagger.core.v3", name: "swagger-annotations"
 	runtimeOnly group: "org.webjars.npm", name: "swagger-ui-dist", version: "3.30.2"
-	swaggerCodegen "io.swagger.codegen.v3:swagger-codegen-cli"
+	swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"
 
 	// Test deps
-	testImplementation(group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.21.1")
-	testImplementation(group: "io.vavr", name: "vavr", version: "0.10.3")
-	testImplementation("org.springframework.boot:spring-boot-starter-test") {
+	testImplementation group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.21.1"
+	testImplementation group: "io.vavr", name: "vavr", version: "0.10.3"
+	testImplementation(group: "org.springframework.boot", name: "spring-boot-starter-test") {
 		exclude group: "org.junit.vintage", module: "junit-vintage-engine"
 	}
 	testImplementation project(":workspace-manager-client")
 
-	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+	annotationProcessor group: "org.springframework.boot", name: "spring-boot-configuration-processor"
 }
 
 // Exclude the Spring logger, so everything will use SLF4J

--- a/build.gradle
+++ b/build.gradle
@@ -60,11 +60,11 @@ dependencies {
 	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.12", version: "0.1-3a0df80"
 
 	// Versioned direct deps
-	compile group: "org.webjars", name: "webjars-locator-core", version: "0.46"
 	implementation group: "org.hashids", name: "hashids", version: "1.0.3"
 	implementation group: "org.liquibase", name: "liquibase-core", version: "4.0.0"
+	implementation group: "org.springframework.cloud", name: "spring-cloud-gcp-starter-trace", version: "1.2.3.RELEASE"
+	implementation group: "org.webjars", name: "webjars-locator-core", version: "0.46"
 	runtimeOnly group: "org.postgresql", name: "postgresql", version: "42.2.14"
-	compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-trace', version: '1.2.3.RELEASE'
 
 	// Deps whose versions are controlled by Spring
 	implementation group: "javax.validation", name: "validation-api"
@@ -75,8 +75,8 @@ dependencies {
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web"
 
 	// Swagger deps
-	compile group: "org.webjars.npm", name: "swagger-ui-dist", version: "3.30.2"
 	implementation group: "io.swagger.core.v3", name: "swagger-annotations"
+	runtimeOnly group: "org.webjars.npm", name: "swagger-ui-dist", version: "3.30.2"
 	swaggerCodegen "io.swagger.codegen.v3:swagger-codegen-cli"
 
 	// Test deps

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Jul 20 13:28:57 EDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/local-dev/.gitignore
+++ b/local-dev/.gitignore
@@ -1,0 +1,8 @@
+# Ignore everything in this directory
+*
+# Except...
+!.gitignore
+!local-postgres-init.sql
+!README.md
+!setup_local_env.sh
+!*.template

--- a/workspace-manager-client/build.gradle
+++ b/workspace-manager-client/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 	implementation group: "org.glassfish.jersey.media", name: "jersey-media-multipart"
 	implementation group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jsr310"
 	implementation group: "io.swagger.core.v3", name: "swagger-annotations"
-	swaggerCodegen "io.swagger.codegen.v3:swagger-codegen-cli"
+	swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"
 }
 
 // OpenAPI/Swagger Client Generation


### PR DESCRIPTION
Compile is deprecated, more explicit ignoring.
Gitignore for Gradle from https://github.com/github/gitignore