### PR TITLE
real last-modified date for files in jib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,9 @@ jib {
 	from {
 		image = "adoptopenjdk:11-jre-hotspot"
 	}
+	container {
+		filesModificationTime = java.time.ZonedDateTime.now().toString() // to prevent ui caching
+	}
 }
 
 // Internal dependencies


### PR DESCRIPTION
This should fix caching for non-local versions of the swagger UI.