### PR TITLE
AS-423: Non-Gatling Tool for Perf testing (JMeter)

### DIFF
--- a/automation-jmeter-plugins/.gitignore
+++ b/automation-jmeter-plugins/.gitignore
@@ -1,0 +1,38 @@
+HELP.md
+
+### Gradle ###
+.gradle
+**/build/
+!gradle-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Emacs backup files
+*.*~
+
+### Mac directory metadata
+.DS_Store

--- a/automation-jmeter-plugins/README.md
+++ b/automation-jmeter-plugins/README.md
@@ -1,23 +1,32 @@
 # automation-jmeter-plugins
 This module holds the following Custom JMeter Functions developed by us.
 
-### OAuth2Token - 
+### `OAuth2Token` - 
 
-- String: Cloud Provider (GCP, AWS, AZURE - only GCP implementation for now)
-- Env Var: FIRECLOUD_SERVICE_ACCT_CREDS: Service account key used for SAM User Authorization purpose
-- Env Var: SAM_USER: Email account for OAuth2 Authorization
+- String: Cloud Provider (`GCP`, `AWS`, `AZURE` - only `GCP` implementation exists for now)
+- Env Var: `FIRECLOUD_SERVICE_ACCT_CREDS`: Service account key used for SAM User Authorization purpose
+- Env Var: `SAM_USER`: Email account for OAuth2 Authorization
 
 ### Dependencies (see build.gradle)
 
-- JMeter core library (ApacheJMeter_core)
-- Google OAuth2 library google-auth-library-oauth2-http
+- JMeter core library (`ApacheJMeter_core`)
+- Google OAuth2 library `google-auth-library-oauth2-http`
+
+### Build
+Run `./gcloud_builds_submit.sh` to build the `jar` file and submit it to Google Storage bucket.
+
+The `cloudbuild.yaml` defines the build steps.
+
+For local development, make sure the application default credentials have access to
+the storage bucket defined in `cloudbuild.yaml`. 
+
+Substitute the project (`terra-kernel-k8s`) and bucket (`terra-kernel-k8s_cloudbuild`) names if needed (see `cloudbuild.yaml`, `gcloud_builds_submit.sh`).
 
 ### Deployment
-Use any CI/CD to deploy the automation-jmeter-plugins-${version}.jar in build/libs to JMeter Home lib/ext 
-on any slave containers for any JMeter script to use these custom functions.
+Download the `automation-jmeter-plugins-${version}.jar` from the bucket (`terra-kernel-k8s_cloudbuild`) into the ${JMETER_HOME}/`lib/ext` directory of any worker machine.
 
 ### Usage 
-#### OAuth2Token - 
-Use in any JMeter setUp Thread Group to set a Bearer token property for subsequent test run
+#### `OAuth2Token` - 
+Use this function in any JMeter setUp Thread Group to obtain a Bearer token property to run load tests.
 
-- ${__OAuth2Token(GCP, FIRECLOUD_SERVICE_ACCT_CREDS, SAM_USER)
+- `${__OAuth2Token(GCP, FIRECLOUD_SERVICE_ACCT_CREDS, SAM_USER)`

--- a/automation-jmeter-plugins/README.md
+++ b/automation-jmeter-plugins/README.md
@@ -12,7 +12,12 @@ This module holds the following Custom JMeter Functions developed by us.
 - JMeter core library (ApacheJMeter_core)
 - Google OAuth2 library google-auth-library-oauth2-http
 
+### Deployment
+Use any CI/CD to deploy the automation-jmeter-plugins-${version}.jar in build/libs to JMeter Home lib/ext 
+on any slave containers for any JMeter script to use these custom functions.
+
 ### Usage 
-Use in any JMeter Java setUp Thread Group to set a Bearer token property for subsequent test run
+#### OAuth2Token - 
+Use in any JMeter setUp Thread Group to set a Bearer token property for subsequent test run
 
 - ${__OAuth2Token(GCP, FIRECLOUD_SERVICE_ACCT_CREDS, SAM_USER)

--- a/automation-jmeter-plugins/README.md
+++ b/automation-jmeter-plugins/README.md
@@ -1,0 +1,18 @@
+# automation-jmeter-plugins
+This module holds the following Custom JMeter Functions developed by us.
+
+### OAuth2Token - 
+
+- String: Cloud Provider (GCP, AWS, AZURE - only GCP implementation for now)
+- Env Var: FIRECLOUD_SERVICE_ACCT_CREDS: Service account key used for SAM User Authorization purpose
+- Env Var: SAM_USER: Email account for OAuth2 Authorization
+
+### Dependencies (see build.gradle)
+
+- JMeter core library (ApacheJMeter_core)
+- Google OAuth2 library google-auth-library-oauth2-http
+
+### Usage 
+Use in any JMeter Java setUp Thread Group to set a Bearer token property for subsequent test run
+
+- ${__OAuth2Token(GCP, FIRECLOUD_SERVICE_ACCT_CREDS, SAM_USER)

--- a/automation-jmeter-plugins/build.gradle
+++ b/automation-jmeter-plugins/build.gradle
@@ -1,0 +1,53 @@
+plugins {
+    id 'idea'
+    id 'java-library'
+}
+
+repositories {
+    maven {
+        url 'https://repo.maven.apache.org/maven2'
+        metadataSources {
+            mavenPom()
+            ignoreGradleMetadataRedirection()
+        }
+    }
+}
+
+version = '0.1.0'
+
+dependencies {
+    // This dependency is exported to consumers, that is to say found on their compile classpath.
+    api 'org.apache.commons:commons-math3:3.6.1'
+
+    // This dependency is used internally, and not exposed to consumers on their own compile classpath.
+    implementation 'com.google.guava:guava:26.0-jre'
+
+    // Use JUnit test framework
+    testImplementation 'junit:junit:4.12'
+
+    // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
+
+    implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.20.0'
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/ApacheJMeter
+    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter', version: '5.3'
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/jorphan
+    implementation group: 'org.apache.jmeter', name: 'jorphan', version: '5.3'
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/ApacheJMeter_core
+    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: '5.3'
+}
+
+jar {
+    from('src/main/resources') {
+        include  '**/*.properties'
+        include  '**/*.xml'
+        include  '**/*.css'
+    }
+    manifest {
+        attributes('Implementation-Title': project.name,
+                'Implementation-Version': project.version)
+    }
+}

--- a/automation-jmeter-plugins/cloudbuild.yaml
+++ b/automation-jmeter-plugins/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+  - name: gradle
+    entrypoint: gradle
+    args: ["test"]
+  - name: gradle
+    entrypoint: gradle
+    args: ["assemble"]
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    args: ["gsutil", "cp", "build/libs/automation-jmeter-plugins-0.1.0.jar", "gs://terra-kernel-k8s_cloudbuild/automation-jmeter-plugins-0.1.0.jar"]

--- a/automation-jmeter-plugins/gcloud_builds_submit.sh
+++ b/automation-jmeter-plugins/gcloud_builds_submit.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud builds submit --billing-project=terra-kernel-k8s --region=us-central-1

--- a/automation-jmeter-plugins/settings.gradle
+++ b/automation-jmeter-plugins/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'automation-jmeter-plugins'

--- a/automation-jmeter-plugins/src/main/java/automation/plugins/jmeter/functions/OAuth2Token.java
+++ b/automation-jmeter-plugins/src/main/java/automation/plugins/jmeter/functions/OAuth2Token.java
@@ -1,0 +1,178 @@
+package automation.plugins.jmeter.functions;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.functions.AbstractFunction;
+import org.apache.jmeter.functions.InvalidVariableException;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.samplers.Sampler;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.*;
+
+public class OAuth2Token extends AbstractFunction {
+    private static final Logger log = LoggerFactory.getLogger(OAuth2Token.class);
+    private static final List<String> desc = new LinkedList<>();
+
+    private static final String KEY = "__OAuth2Token"; //$NON-NLS-1$
+
+    // Number of parameters expected - used to reject invalid calls
+    private static final int MIN_PARAMETER_COUNT = 3;
+    private static final int MAX_PARAMETER_COUNT = 4;
+
+    static {
+        desc.add(getResString("oauth2_provider")); //$NON-NLS-1$
+        desc.add(getResString("oauth2_service_accountkey_env_or_configpath")); //$NON-NLS-1$
+        desc.add(getResString("oauth2_user_email")); //$NON-NLS-1$
+        desc.add(getResString("function_name_paropt")); //$NON-NLS-1$
+    }
+
+    private Object[] values;
+
+    public OAuth2Token() {
+
+    }
+
+    @Override
+    public List<String> getArgumentDesc() {
+        return desc;
+    }
+
+    @Override
+    public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {
+        String authToken = null;
+
+        JMeterVariables vars = getVariables();
+
+        CloudProvider cloudProvider = CloudProvider.fromLabel(((CompoundVariable) values[0]).execute().trim());
+
+        String saKeyEnvVarOrConfigPath = ((CompoundVariable) values[1]).execute().trim();
+        String userEmail = System.getenv(((CompoundVariable) values[2]).execute().trim());
+        byte[] saKey = getBytesFromEnvVarOrConfigPath(saKeyEnvVarOrConfigPath);
+
+        switch (cloudProvider) {
+            case GCP:
+                GoogleCredentials credentials = null;
+                try {
+                    credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(saKey))
+                            .createScoped(new ArrayList<String>() {
+                                private static final long serialVersionUID = 2644360116969700916L;
+                                {
+                                    add("profile");
+                                    add("email");
+                                    add("openid");
+                                }
+                            }).createDelegated(userEmail);
+                    credentials.refreshIfExpired();
+                    authToken = credentials.getAccessToken().getTokenValue();
+                } catch (IOException e) {
+                    log.warn(e.getMessage());
+                    throw new RuntimeException(e.getMessage());
+                }
+                break;
+            case AWS:
+            case AZURE:
+                log.warn(cloudProvider.getDescription() + " not implemented");
+                throw new RuntimeException(cloudProvider.getDescription() + " not implemented");
+            default:
+                log.warn(cloudProvider.getDescription());
+                throw new RuntimeException(cloudProvider.getDescription());
+        }
+
+        if (StringUtils.isEmpty(authToken)) {
+            log.warn("Unable to obtain oauth2 token for user '{}'", userEmail);
+            throw new RuntimeException(String.format("Unable to obtain oauth2 token for user '%s'", userEmail));
+        }
+
+        String varName = null;
+
+        if (values.length > 3)
+            varName = ((CompoundVariable) values[3]).execute().trim();
+
+        if (vars != null && varName != null) {
+            vars.put(varName, authToken);
+        }
+
+        return authToken;
+    }
+
+    @Override
+    public void setParameters(Collection<CompoundVariable> parameters) throws InvalidVariableException {
+        checkParameterCount(parameters, MIN_PARAMETER_COUNT, MAX_PARAMETER_COUNT);
+        values = parameters.toArray();
+    }
+
+    @Override
+    public String getReferenceKey() {
+        return KEY;
+    }
+
+    private static String getResString(String key) {
+        ResourceBundle bundle = ResourceBundle.getBundle("messages");
+        return bundle.containsKey(key) ? bundle.getString(key) : String.format("[res_key=\"%s\"]", key);
+    }
+
+    private static byte[] getBytesFromEnvVarOrConfigPath(String env) {
+        String envVarOrConfigPath = System.getenv(env);
+        File f = new File(envVarOrConfigPath);
+        if (f.exists()) {
+            try {
+                return Files.readAllBytes(f.toPath());
+            } catch (IOException e) {
+                throw new RuntimeException(e.getMessage());
+            }
+        }
+        return envVarOrConfigPath.getBytes();
+    }
+
+    // Cloud providers
+    enum CloudProvider {
+        GCP(1L, "GCP", "Google Cloud Provider"), AWS(2L, "AWS", "Amazon Web Services"),
+        AZURE(3L, "AZURE", "Microsoft Azure"), UNKNOWN(-1L, "UNKNOWN", "Unknown Provider");
+
+        private Long id;
+        private String label;
+        private String description;
+
+        CloudProvider(Long id, String label, String description) {
+            this.id = id;
+            this.label = label;
+            this.description = description;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public static CloudProvider fromId(Long id) {
+            for (CloudProvider e : values()) {
+                if (e.id.equals(id))
+                    return e;
+            }
+            return UNKNOWN;
+        }
+
+        public static CloudProvider fromLabel(String label) {
+            for (CloudProvider e : values()) {
+                if (e.label.equals(label))
+                    return e;
+            }
+            return UNKNOWN;
+        }
+    }
+}

--- a/automation-jmeter-plugins/src/main/resources/messages.properties
+++ b/automation-jmeter-plugins/src/main/resources/messages.properties
@@ -1,0 +1,4 @@
+oauth2_provider=Cloud Provider (GCP (default), AWS, AZURE)
+oauth2_service_accountkey_env_or_configpath=Service Account Key ENV or Config Path
+oauth2_user_email=User email address
+function_name_paropt=Name of variable in which to store the result (optional)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,5 @@
 rootProject.name = 'terra-workspace-manager'
 include 'workspace-manager-client'
+include 'automation-jmeter-plugins'
+include 'terra-workspace-manager-jmeter'
+

--- a/terra-workspace-manager-jmeter/.gitignore
+++ b/terra-workspace-manager-jmeter/.gitignore
@@ -1,0 +1,38 @@
+HELP.md
+
+### Gradle ###
+.gradle
+**/build/
+!gradle-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Emacs backup files
+*.*~
+
+### Mac directory metadata
+.DS_Store

--- a/terra-workspace-manager-jmeter/README.md
+++ b/terra-workspace-manager-jmeter/README.md
@@ -1,0 +1,33 @@
+# terra-workspace-manager-jmeter
+This module holds the Workspace Manager JMeter Scripts for load testing.
+
+To run test in different environments (including per-developer environments). 
+Please refer to the jmeter-master-slave deployment definitions in this repo].
+
+### Env Vars - 
+
+- FIRECLOUD_SERVICE_ACCT_CREDS: Service account key used for SAM User Authorization purpose
+- SAM_USER: Email account for OAuth2 Authorization
+- WSM_SERVER: Workspace Manager Server, e.g. workspace.dsde-staging.broadinstitute.org
+- WSM_PORT: Workspace Manager Server Port (e.g. 80 for http, 443 for https)
+- WSM_PROTOCOL: http or https
+- INFLUXDB_WSM_URL: Influx DB URL for connecting to performance results database (demo only)
+- INFLUXDB_WSM_MEASUREMENT: Influx DB table for storing performance results (demo only)
+
+### Dependencies (see build.gradle)
+
+- JMeter core library (ApacheJMeter_core)
+- JMeter function library (ApacheJMeter_funtions)
+- JMeter http library (ApacheJMeter_http)
+- JMeter java library (ApacheJMeter_java)
+- jmeter-plugins-functions
+- Custom JMeter plugin functions by us (see module automation-jmeter-plugins)
+
+### Deploying test to JMeter master-slave Kubernetes cluster
+- $namespace is the namespace of JMeter master-slave infrastructure
+- $master_pod is JMeter master pod
+- $test_name is name of the test (e.g. CreateworkspaceSimulation)
+
+kubectl -n $namespace exec -ti $master_pod -- /bin/bash /load_test "$test_name"
+
+NB: Command will eventually be wrapped in a shell script

--- a/terra-workspace-manager-jmeter/README.md
+++ b/terra-workspace-manager-jmeter/README.md
@@ -2,7 +2,7 @@
 This module holds the Workspace Manager JMeter Scripts for load testing.
 
 To run test in different environments (including per-developer environments). 
-Please refer to the jmeter-master-slave deployment definitions in this repo].
+Please refer to the jmeter-director-worker deployment definitions in this repo].
 
 ### Env Vars - 
 
@@ -23,11 +23,11 @@ Please refer to the jmeter-master-slave deployment definitions in this repo].
 - jmeter-plugins-functions
 - Custom JMeter plugin functions by us (see module automation-jmeter-plugins)
 
-### Deploying test to JMeter master-slave Kubernetes cluster
-- $namespace is the namespace of JMeter master-slave infrastructure
-- $master_pod is JMeter master pod
+### Deploying test to JMeter director/worker Kubernetes cluster
+- $namespace is the namespace of JMeter director/worker infrastructure
+- $director_pod is JMeter director pod
 - $test_name is name of the test (e.g. CreateworkspaceSimulation)
 
-kubectl -n $namespace exec -ti $master_pod -- /bin/bash /load_test "$test_name"
+kubectl -n $namespace exec -ti $director_pod -- /bin/bash /load_test "$test_name"
 
 NB: Command will eventually be wrapped in a shell script

--- a/terra-workspace-manager-jmeter/build.gradle
+++ b/terra-workspace-manager-jmeter/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    id 'idea'
+    id 'java-library'
+}
+
+group 'bio.terra'
+version '0.1.0-SNAPSHOT'
+
+repositories {
+    maven {
+        url 'https://repo.maven.apache.org/maven2'
+        metadataSources {
+            mavenPom()
+            ignoreGradleMetadataRedirection()
+        }
+    }
+}
+
+dependencies {
+    // This dependency is exported to consumers, that is to say found on their compile classpath.
+    api 'org.apache.commons:commons-math3:3.6.1'
+
+    testImplementation(group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.20.0')
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/ApacheJMeter_core
+    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: '5.3'
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/ApacheJMeter_java
+    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_java', version: '5.3'
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/ApacheJMeter_http
+    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_http', version: '5.3'
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/ApacheJMeter_functions
+    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_functions', version: '5.3'
+
+    // https://mvnrepository.com/artifact/kg.apc/jmeter-plugins-functions
+    implementation group: 'kg.apc', name: 'jmeter-plugins-functions', version: '2.1'
+
+    // This dependency is used internally, and not exposed to consumers on their own compile classpath.
+    implementation 'com.google.guava:guava:26.0-jre'
+
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+}

--- a/terra-workspace-manager-jmeter/settings.gradle
+++ b/terra-workspace-manager-jmeter/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'terra-workspace-manager-jmeter'

--- a/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
+++ b/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
@@ -129,6 +129,7 @@ public class CreateWorkspaceSimulation {
         httpSamplerProxy.setProperty("HTTPSampler.protocol", "${__env(WSM_PROTOCOL)}");
         httpSamplerProxy.setPath(setPath);
         httpSamplerProxy.setMethod(requestType);
+        // TODO: Look up request body from Swagger (by providing key of API)
         String body = "{" + "\"id\"" + ":" + " \"" + "${workspaceId}" + "\", " + "\"authToken\"" + ":" + " \""
                 + "${__P(oauth2Token)}" + "\", " + "\"spendProfile\"" + ":" + " \"" + "${workspaceId}" + "\", " + "\"policies\""
                 + ":" + "[ \"" + "${workspaceId}" + "\" ]" + "}";
@@ -279,6 +280,7 @@ public class CreateWorkspaceSimulation {
         setJSR223PreProcessor();
         setLoopController(1);
         setThreadGroup(2, 2);
+        // TODO: Look up API Path from Swagger
         setHttpSampler("POST", "api/workspaces/v1");
         setHeaders();
         setUserParameters();

--- a/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
+++ b/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
@@ -231,7 +231,7 @@ public class CreateWorkspaceSimulation {
         HashTree parametersTree = new HashTree();
         parametersTree.add(headerManager);
         parametersTree.add(userParameters);
-        //parametersTree.add(backendListener);
+        parametersTree.add(backendListener);
 
         HashTree httpSamplerTree = new HashTree();
         httpSamplerTree.add(httpSamplerProxy);

--- a/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
+++ b/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
@@ -260,6 +260,8 @@ public class CreateWorkspaceSimulation {
         // System.setProperty("https.proxyHost", "127.0.0.1");
         // System.setProperty("https.proxyPort", "8888");
 
+        // TODO: Replace hardcoded location of JMeter installation
+        // by JMETER_HOME envvar
         File jmeterHome = new File("/apache-jmeter-5.3");
         String slash = System.getProperty("file.separator");
 

--- a/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
+++ b/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
@@ -1,0 +1,307 @@
+package automation.jmeter;
+
+import org.apache.jmeter.config.Argument;
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.config.gui.ArgumentsPanel;
+import org.apache.jmeter.control.LoopController;
+import org.apache.jmeter.control.gui.LoopControlPanel;
+import org.apache.jmeter.control.gui.TestPlanGui;
+import org.apache.jmeter.engine.StandardJMeterEngine;
+import org.apache.jmeter.modifiers.JSR223PreProcessor;
+import org.apache.jmeter.modifiers.UserParameters;
+import org.apache.jmeter.modifiers.gui.UserParametersGui;
+import org.apache.jmeter.protocol.http.control.Header;
+import org.apache.jmeter.protocol.http.control.HeaderManager;
+import org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui;
+import org.apache.jmeter.protocol.http.gui.HeaderPanel;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerProxy;
+import org.apache.jmeter.reporters.ResultCollector;
+import org.apache.jmeter.reporters.Summariser;
+import org.apache.jmeter.save.SaveService;
+import org.apache.jmeter.testbeans.gui.TestBeanGUI;
+import org.apache.jmeter.testelement.TestElement;
+import org.apache.jmeter.testelement.TestPlan;
+import org.apache.jmeter.testelement.property.CollectionProperty;
+import org.apache.jmeter.testelement.property.StringProperty;
+import org.apache.jmeter.threads.SetupThreadGroup;
+import org.apache.jmeter.threads.ThreadGroup;
+import org.apache.jmeter.threads.gui.SetupThreadGroupGui;
+import org.apache.jmeter.threads.gui.ThreadGroupGui;
+import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.visualizers.backend.BackendListener;
+import org.apache.jmeter.visualizers.backend.BackendListenerGui;
+import org.apache.jorphan.collections.HashTree;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+public class CreateWorkspaceSimulation {
+    private static StandardJMeterEngine jMeterEngine = new StandardJMeterEngine();
+
+    private static TestPlan testPlan;
+    private static SetupThreadGroup setupThreadGroup;
+    private static LoopController setUpLoopController;
+    private static JSR223PreProcessor jsr223PreProcessor;
+    private static ThreadGroup threadGroup;
+    private static LoopController loopController;
+    private static HTTPSamplerProxy httpSamplerProxy;
+    private static HashTree testPlanTree;
+    private static HeaderManager headerManager;
+    private static UserParameters userParameters;
+    private static BackendListener backendListener;
+
+    private static void initializeTestPlan(String testPlanName) {
+        testPlan = new TestPlan(testPlanName);
+        testPlan.setComment("");
+        testPlan.setFunctionalMode(false);
+        testPlan.setTearDownOnShutdown(true);
+        testPlan.setSerialized(false);
+        testPlan.setUserDefinedVariables((Arguments) new ArgumentsPanel().createTestElement());
+        testPlan.setProperty(TestElement.TEST_CLASS, TestPlan.class.getName());
+        testPlan.setProperty(TestElement.GUI_CLASS, TestPlanGui.class.getName());
+    }
+
+    private static void setLoopController(int loopCount) {
+        loopController = new LoopController();
+        loopController.setLoops(loopCount);
+        loopController.setFirst(true);
+        loopController.setProperty(TestElement.TEST_CLASS, LoopController.class.getName());
+        loopController.setProperty(TestElement.GUI_CLASS, LoopControlPanel.class.getName());
+        loopController.initialize();
+    }
+
+    private static void setUpThreadGroup() {
+        setupThreadGroup = new SetupThreadGroup();
+        setupThreadGroup.setName("setUp Thread Group");
+        setupThreadGroup.setEnabled(true);
+        setupThreadGroup.setNumThreads(1);
+        setupThreadGroup.setRampUp(1);
+        setupThreadGroup.setScheduler(false);
+        setupThreadGroup.setIsSameUserOnNextIteration(true);
+        setupThreadGroup.setProperty(SetupThreadGroup.ON_SAMPLE_ERROR, SetupThreadGroup.ON_SAMPLE_ERROR_CONTINUE);
+        setupThreadGroup.setSamplerController(setUpLoopController);
+        setupThreadGroup.setProperty(TestElement.TEST_CLASS, SetupThreadGroup.class.getName());
+        setupThreadGroup.setProperty(TestElement.GUI_CLASS, SetupThreadGroupGui.class.getName());
+    }
+
+    private static void setUpLoopController() {
+        setUpLoopController = new LoopController();
+        setUpLoopController.setName("setUp Loop controller");
+        setUpLoopController.setLoops(1);
+        setUpLoopController.setContinueForever(false);
+        setUpLoopController.setFirst(true);
+        setUpLoopController.setProperty(TestElement.TEST_CLASS, LoopController.class.getName());
+        setUpLoopController.setProperty(TestElement.GUI_CLASS, LoopControlPanel.class.getName());
+        setUpLoopController.initialize();
+    }
+
+    private static void setJSR223PreProcessor() {
+        jsr223PreProcessor = new JSR223PreProcessor();
+        jsr223PreProcessor.setName("JSR223 Pre Processor");
+        jsr223PreProcessor.setEnabled(true);
+        jsr223PreProcessor.setProperty("cacheKey", "true");
+        jsr223PreProcessor.setProperty("script", "${__setProperty(oauth2Token, ${__OAuth2Token(GCP, FIRECLOUD_SERVICE_ACCT_CREDS, SAM_USER)})}");
+        jsr223PreProcessor.setProperty("scriptLanguage", "groovy");
+        jsr223PreProcessor.setProperty(TestElement.TEST_CLASS, JSR223PreProcessor.class.getName());
+        jsr223PreProcessor.setProperty(TestElement.GUI_CLASS, TestBeanGUI.class.getName());
+    }
+
+    private static void setThreadGroup(int noOfThreads, int setRamupNo) {
+        threadGroup = new ThreadGroup();
+        threadGroup.setName("CreateWorkspace Thread Group");
+        threadGroup.setNumThreads(noOfThreads);
+        threadGroup.setRampUp(setRamupNo);
+        threadGroup.setScheduler(false);
+        threadGroup.setIsSameUserOnNextIteration(false);
+        threadGroup.setProperty(ThreadGroup.ON_SAMPLE_ERROR, ThreadGroup.ON_SAMPLE_ERROR_CONTINUE);
+        threadGroup.setSamplerController(loopController);
+        threadGroup.setProperty(TestElement.TEST_CLASS, ThreadGroup.class.getName());
+        threadGroup.setProperty(TestElement.GUI_CLASS, ThreadGroupGui.class.getName());
+    }
+
+    private static void setHttpSampler(String requestType, String setPath) {
+        httpSamplerProxy = new HTTPSamplerProxy();
+        httpSamplerProxy.setDomain("${__env(WSM_SERVER)}");
+        httpSamplerProxy.setProperty("HTTPSampler.port", "${__env(WSM_PORT)}");
+        httpSamplerProxy.setProperty("HTTPSampler.protocol", "${__env(WSM_PROTOCOL)}");
+        httpSamplerProxy.setPath(setPath);
+        httpSamplerProxy.setMethod(requestType);
+        String body = "{" + "\"id\"" + ":" + " \"" + "${workspaceId}" + "\", " + "\"authToken\"" + ":" + " \""
+                + "${__P(oauth2Token)}" + "\", " + "\"spendProfile\"" + ":" + " \"" + "${workspaceId}" + "\", " + "\"policies\""
+                + ":" + "[ \"" + "${workspaceId}" + "\" ]" + "}";
+        httpSamplerProxy.addNonEncodedArgument("", body, "=");
+        httpSamplerProxy.setPostBodyRaw(true);
+        httpSamplerProxy.setFollowRedirects(true);
+        httpSamplerProxy.setAutoRedirects(false);
+        httpSamplerProxy.setUseKeepAlive(true);
+        httpSamplerProxy.setDoMultipartPost(false);
+        httpSamplerProxy.setName("CreateWorkspaceSimulation");
+        httpSamplerProxy.setProperty(TestElement.TEST_CLASS, HTTPSamplerProxy.class.getName());
+        httpSamplerProxy.setProperty(TestElement.GUI_CLASS, HttpTestSampleGui.class.getName());
+    }
+
+    private static void setHeaders() {
+        headerManager = new HeaderManager();
+        headerManager.setName("HTTP Header Manager");
+        headerManager.add(new Header("Content-type", "application/json"));
+        headerManager.add(new Header("Authorization", "Bearer ${__P(oauth2Token)}"));
+        headerManager.add(new Header("accept", "application/json"));
+        headerManager.setProperty(TestElement.TEST_CLASS, HeaderManager.class.getName());
+        headerManager.setProperty(TestElement.GUI_CLASS, HeaderPanel.class.getName());
+    }
+
+    private static void setUserParameters() {
+        userParameters = new UserParameters();
+        userParameters.setName("User Parameters UUID");
+        userParameters.setComment("TestPlan.comments");
+
+        CollectionProperty namesProp = new CollectionProperty();
+        namesProp.setName("UserParameters.names");
+        StringProperty workspaceIdProp = new StringProperty("-836030906", "workspaceId");
+        namesProp.addProperty(workspaceIdProp);
+        userParameters.setNames(namesProp);
+
+        CollectionProperty threadListsProp = new CollectionProperty();
+        threadListsProp.setName("UserParameters.thread_values");
+        CollectionProperty threadValuesProp = new CollectionProperty();
+        threadValuesProp.setName("681405977");
+        StringProperty uuidProp = new StringProperty("118040362", "${__UUID}");
+        threadValuesProp.addProperty(uuidProp);
+        threadListsProp.addProperty(threadValuesProp);
+        userParameters.setThreadLists(threadListsProp);
+
+        userParameters.setPerIteration(true);
+
+        userParameters.setProperty(TestElement.TEST_CLASS, UserParameters.class.getName());
+        userParameters.setProperty(TestElement.GUI_CLASS, UserParametersGui.class.getName());
+        userParameters.setEnabled(true);
+    }
+
+    private static void setupBackendListeners() {
+        backendListener = new BackendListener();
+        backendListener.setProperty(TestElement.TEST_CLASS, BackendListener.class.getName());
+        backendListener.setProperty(TestElement.GUI_CLASS, BackendListenerGui.class.getName());
+        backendListener.setName("Backend Listener");
+        backendListener.setEnabled(true);
+        backendListener.setClassname("org.apache.jmeter.visualizers.backend.influxdb.InfluxdbBackendListenerClient");
+        backendListener.setQueueSize("5000");
+
+        CollectionProperty props = new CollectionProperty();
+        props.setName("Arguments.arguments");
+
+        Argument influxdbMetricsSender = new Argument("influxdbMetricsSender",
+                "org.apache.jmeter.visualizers.backend.influxdb.HttpMetricsSender", "=");
+        Argument influxdbUrl = new Argument("influxdbUrl", "${__env(INFLUXDB_WSM_URL)}", "=");
+        Argument application = new Argument("application", "Terra Workspace Manager", "=");
+        Argument measurement = new Argument("measurement", "${__env(INFLUXDB_WSM_MEASUREMENT)}", "=");
+        Argument summaryOnly = new Argument("summaryOnly", "false", "=");
+        Argument samplersRegex = new Argument("samplersRegex", ".*", "=");
+        Argument percentiles = new Argument("percentiles", "90;95;99", "=");
+        Argument testTitle = new Argument("testTitle", "Test name", "=");
+        Argument eventTags = new Argument("eventTags", "", "=");
+
+        props.addItem(influxdbMetricsSender);
+        props.addItem(influxdbUrl);
+        props.addItem(application);
+        props.addItem(measurement);
+        props.addItem(summaryOnly);
+        props.addItem(samplersRegex);
+        props.addItem(percentiles);
+        props.addItem(testTitle);
+        props.addItem(eventTags);
+
+        Arguments arguments = new Arguments();
+        arguments.setName("arguments");
+        arguments.setEnabled(true);
+        arguments.setProperty(TestElement.TEST_CLASS, Arguments.class.getName());
+        arguments.setProperty(TestElement.GUI_CLASS, ArgumentsPanel.class.getName());
+        arguments.setProperty(props);
+
+        backendListener.setArguments(arguments);
+    }
+
+    private static HashTree configureTestPlan() {
+        testPlanTree = new HashTree();
+        testPlanTree.add(testPlan);
+
+        HashTree setUpThreadGroupTree = new HashTree();
+        setUpThreadGroupTree.add(threadGroup);
+        setUpThreadGroupTree.add(setupThreadGroup);
+
+        HashTree parametersTree = new HashTree();
+        parametersTree.add(headerManager);
+        parametersTree.add(userParameters);
+        //parametersTree.add(backendListener);
+
+        HashTree httpSamplerTree = new HashTree();
+        httpSamplerTree.add(httpSamplerProxy);
+        httpSamplerTree.add(httpSamplerProxy, parametersTree);
+
+        setUpThreadGroupTree.add(threadGroup, httpSamplerTree);
+
+        HashTree jsr223PreProcessorTree = new HashTree();
+        jsr223PreProcessorTree.add(jsr223PreProcessor);
+        setUpThreadGroupTree.add(setupThreadGroup, jsr223PreProcessorTree);
+
+        testPlanTree.add(testPlan, setUpThreadGroupTree);
+
+        return testPlanTree;
+    }
+
+    public static void main(String[] argv) throws Exception {
+
+        // for capturing HTTP traffic
+        // System.setProperty("http.proxyHost", "127.0.0.1");
+        // System.setProperty("http.proxyPort", "8888");
+        // for capturing HTTPS traffic
+        // System.setProperty("https.proxyHost", "127.0.0.1");
+        // System.setProperty("https.proxyPort", "8888");
+
+        File jmeterHome = new File("/apache-jmeter-5.3");
+        String slash = System.getProperty("file.separator");
+
+        File jmeterProperties = new File(jmeterHome.getPath() + slash + "bin" + slash + "jmeter.properties");
+
+        // JMeter initialization (properties, log levels, locale, etc)
+        JMeterUtils.setJMeterHome(jmeterHome.getPath());
+        JMeterUtils.loadJMeterProperties(jmeterProperties.getPath());
+        JMeterUtils.initLogging();// you can comment this line out to see extra log messages of i.e. DEBUG level
+        JMeterUtils.initLocale();
+
+        initializeTestPlan("Terra Workspace Manager Test Plan");
+        setUpLoopController();
+        setUpThreadGroup();
+        setJSR223PreProcessor();
+        setLoopController(1);
+        setThreadGroup(2, 2);
+        setHttpSampler("POST", "api/workspaces/v1");
+        setHeaders();
+        setUserParameters();
+        setupBackendListeners();
+        configureTestPlan();
+
+        // save generated test plan to JMeter's .jmx file format
+        SaveService.saveTree(testPlanTree, new FileOutputStream(jmeterHome + slash + "createworkspace.jmx"));
+
+        // add Summarizer output to get test progress in stdout like:
+        // summary = 2 in 1.3s = 1.5/s Avg: 631 Min: 290 Max: 973 Err: 0 (0.00%)
+        Summariser summer = null;
+        String summariserName = JMeterUtils.getPropDefault("summariser.name", "summary");
+        if (summariserName.length() > 0) {
+            summer = new Summariser(summariserName);
+        }
+
+        // Store execution results into a .jtl file
+        String logFile = jmeterHome + slash + "createworkspace.jtl";
+        ResultCollector logger = new ResultCollector(summer);
+        logger.setFilename(logFile);
+        testPlanTree.add(testPlanTree.getArray()[0], logger);
+
+        // Run Test Plan
+        //jMeterEngine.configure(testPlanTree);
+        //jMeterEngine.run();
+
+        // System.out.println("Test completed. See createworkspace.jtl file for results");
+        System.out.println("Open createworkspacec.jmx file in JMeter GUI to validate the code");
+    }
+}

--- a/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
+++ b/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
@@ -50,6 +50,9 @@ public class CreateWorkspaceSimulation {
     private static UserParameters userParameters;
     private static BackendListener backendListener;
 
+    // TODO: All JMeter test has a root test plan node
+    // much of this is boilerplate code. Refactoring
+    // will be taken up in a separate Jira ticket.
     private static void initializeTestPlan(String testPlanName) {
         testPlan = new TestPlan(testPlanName);
         testPlan.setComment("");

--- a/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
+++ b/terra-workspace-manager-jmeter/src/main/java/automation/jmeter/CreateWorkspaceSimulation.java
@@ -100,7 +100,7 @@ public class CreateWorkspaceSimulation {
         jsr223PreProcessor.setName("JSR223 Pre Processor");
         jsr223PreProcessor.setEnabled(true);
         jsr223PreProcessor.setProperty("cacheKey", "true");
-        jsr223PreProcessor.setProperty("script", "${__setProperty(oauth2Token, ${__OAuth2Token(GCP, FIRECLOUD_SERVICE_ACCT_CREDS, SAM_USER)})}");
+        jsr223PreProcessor.setProperty("script", "${__setProperty(oauth2Token, ${__OAuth2Token(GCP, FIRECLOUD_SERVICE_ACCOUNT_CREDS, SAM_USER)})}");
         jsr223PreProcessor.setProperty("scriptLanguage", "groovy");
         jsr223PreProcessor.setProperty(TestElement.TEST_CLASS, JSR223PreProcessor.class.getName());
         jsr223PreProcessor.setProperty(TestElement.GUI_CLASS, TestBeanGUI.class.getName());


### PR DESCRIPTION
This PR is a POC for demonstrating the capability of JMeter as a possible replacement of Gatling.
Writing Java code for test development rather than using Scala.

The `CreateWorkspaceSimulation` class demonstrates the typical workflow of writing a JMeter test in Java. Although it seems like a lot of code, most are boilerplate code that can be refactored into the following sequence of steps. In addition, the code also include *Gui imports which supports the generation of _jmx_ script. The _jmx_ script can be loaded into the JMeter GUI tool for test developers who are more familiar with GUI tool than Java for local development and testing purposes.

- Create a top-level test plan node for all JMeter tasks
- Create a setUp thread group that run once for initialization (e.g. obtain a bearer token for the test)
- Create regular thread groups representing concurrent users and configure load profile
- Parameterize user parameters for each thread
- Build Http request for CreateWorkspace API including required headers
- Configure backend listener for the reporting framework (either Graphite or InfluxDb)

Our next step would be to use this PR as a step forward to investigate what kind of custom header does JMeter need to provide to support the tracking of trace or log information. The reporting framework will need to be extended to include these headers as well.

NB: The `Jmeter-director-worker` module has been left out from this PR to keep the PR small. There will be a separate PR for this which will include devOps as reviewers.