### PR TITLE
Make workspaceId field of CreatedWorkspace a UUID instead of string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 
 allprojects {
 	group = "bio.terra"
-	version = "0.1.0-SNAPSHOT"
+	version = "0.1.1-SNAPSHOT"
 	ext {
 		artifactGroup = "${group}.workspace"
 		swaggerOutputDir = "${buildDir}/swagger-code"

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -40,7 +40,7 @@ public class CreateWorkspaceStep implements Step {
     workingMap.put(CREATE_WORKSPACE_COMPLETED_KEY, true);
 
     CreatedWorkspace response = new CreatedWorkspace();
-    response.setId(workspaceId.toString());
+    response.setId(workspaceId);
     FlightUtils.setResponse(flightContext, response, HttpStatus.OK);
 
     return StepResult.getStepResultSuccess();

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -409,7 +409,7 @@ components:
         id:
           description: UUID of a newly-created workspace
           type: string
-          # format: uuid
+          format: uuid
 
     DeleteWorkspaceRequestBody:
       type: object

--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -84,7 +84,7 @@ public class WorkspaceIntegrationTest {
     Assertions.assertEquals(HttpStatus.OK, workspaceResponse.getStatusCode());
     Assertions.assertTrue(workspaceResponse.isResponseObject());
     CreatedWorkspace createdWorkspace = workspaceResponse.getResponseObject();
-    Assertions.assertEquals(workspaceId.toString(), createdWorkspace.getId());
+    Assertions.assertEquals(workspaceId, createdWorkspace.getId());
   }
 
   @Test

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -104,7 +104,7 @@ public class WorkspaceServiceTest {
 
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
 
-    assertThat(workspace.getId(), not(blankOrNullString()));
+    assertThat(workspace.getId().toString(), not(blankOrNullString()));
 
     MvcResult callResult =
         mvc.perform(get("/api/workspaces/v1/" + workspace.getId()))
@@ -130,7 +130,7 @@ public class WorkspaceServiceTest {
 
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
 
-    assertThat(workspace.getId(), equalTo(workspaceId.toString()));
+    assertThat(workspace.getId(), equalTo(workspaceId));
   }
 
   @Test
@@ -143,7 +143,7 @@ public class WorkspaceServiceTest {
             .spendProfile(null)
             .policies(null);
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
-    assertThat(workspace.getId(), equalTo(workspaceId.toString()));
+    assertThat(workspace.getId(), equalTo(workspaceId));
 
     MvcResult failureResult =
         mvc.perform(
@@ -169,7 +169,7 @@ public class WorkspaceServiceTest {
 
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
 
-    assertThat(workspace.getId(), equalTo(workspaceId.toString()));
+    assertThat(workspace.getId(), equalTo(workspaceId));
   }
 
   @Test
@@ -211,7 +211,7 @@ public class WorkspaceServiceTest {
             .policies(null);
 
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
-    assertThat(workspace.getId(), equalTo(workspaceId.toString()));
+    assertThat(workspace.getId(), equalTo(workspaceId));
 
     DeleteWorkspaceRequestBody deleteBody =
         new DeleteWorkspaceRequestBody().authToken("fake-user-auth-token");
@@ -240,7 +240,7 @@ public class WorkspaceServiceTest {
             .spendProfile(null)
             .policies(null);
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
-    assertThat(workspace.getId(), equalTo(workspaceId.toString()));
+    assertThat(workspace.getId(), equalTo(workspaceId));
 
     // Next, add a data reference to that workspace.
     DataRepoSnapshot reference =


### PR DESCRIPTION
This will require minor changes to update to the newest client library, but the new 0.1.1 server code is fully compatible with the existing 0.1.0 client library because serialized UUIDs and strings are interchangeable.

That means this will not break Rawls, but will require a small change to Rawls when it updates its dependency on the WM client library.