### PR TITLE
[AS-406] Update stairway version to 0.0.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ repositories {
 dependencies {
 	// Terra deps
 	implementation group: "bio.terra", name: "datarepo-client", version: "1.0.1-SNAPSHOT"
-	implementation group: "bio.terra", name: "stairway", version: "0.0.4.1-SNAPSHOT"
+	implementation group: "bio.terra", name: "stairway", version: "0.0.20"
 	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.12", version: "0.1-3a0df80"
 
 	// Versioned direct deps

--- a/src/main/java/bio/terra/workspace/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/workspace/app/configuration/ApplicationConfiguration.java
@@ -24,6 +24,7 @@ public class ApplicationConfiguration {
   // Configurable properties
   private int maxStairwayThreads;
   private int stairwayTimeoutSeconds;
+  private int stairwayPollingIntervalSeconds;
   private String resourceId;
 
   // Not a property
@@ -35,6 +36,14 @@ public class ApplicationConfiguration {
 
   public void setStairwayTimeoutSeconds(int stairwayTimeoutSeconds) {
     this.stairwayTimeoutSeconds = stairwayTimeoutSeconds;
+  }
+
+  public int getStairwayPollingIntervalSeconds() {
+    return stairwayPollingIntervalSeconds;
+  }
+
+  public void setStairwayPollingIntervalSeconds(int stairwayPollingIntervalSeconds) {
+    this.stairwayPollingIntervalSeconds = stairwayPollingIntervalSeconds;
   }
 
   public int getMaxStairwayThreads() {

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -136,7 +136,7 @@ public class JobService {
 
   void waitForJob(String jobId) {
     try {
-      int pollIntervalSeconds = 10;
+      int pollIntervalSeconds = 1;
       waitForFlight(
           jobId, pollIntervalSeconds, appConfig.getStairwayTimeoutSeconds() / pollIntervalSeconds);
     } catch (StairwayException | InterruptedException stairwayEx) {

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -136,9 +136,10 @@ public class JobService {
 
   void waitForJob(String jobId) {
     try {
-      int pollIntervalSeconds = 1;
       waitForFlight(
-          jobId, pollIntervalSeconds, appConfig.getStairwayTimeoutSeconds() / pollIntervalSeconds);
+          jobId,
+          appConfig.getStairwayPollingIntervalSeconds(),
+          appConfig.getStairwayTimeoutSeconds() / appConfig.getStairwayPollingIntervalSeconds());
     } catch (StairwayException | InterruptedException stairwayEx) {
       throw new InternalStairwayException(stairwayEx);
     }

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -159,20 +159,7 @@ public class JobService {
     throw new InternalStairwayException("Flight did not complete in the allowed wait time");
   }
 
-  // private ScheduledFuture<FlightState> waitForFlight(String flightId, int pollSeconds, int
-  // pollCycles)
-  //   //     throws DatabaseOperationException, FlightException, InterruptedException {
-  //   //   for (int pollCount = 0; pollCount < pollCycles; ++pollCount) {
-  //   //     TimeUnit.SECONDS.sleep(pollSeconds);
-  //   //
-  //   //     if (!state.isActive()) {
-  //   //       return state;
-  //   //     }
-  //   //   }
-  //   //   throw new FlightException("Flight did not complete in the allowed wait time");
-  //   // }
   private class PollFlightTask implements Callable<FlightState> {
-
     private Stairway stairway;
     private String flightId;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@ server.port=8080
 workspace.maxStairwayThreads=4
 workspace.resourceId=mc-terra-workspace-manager
 workspace.stairwayTimeoutSeconds=1800
+workspace.stairwayPollingIntervalSeconds=1
 
 spring.cloud.gcp.trace.enabled=true
 spring.cloud.gcp.trace.project-id=${SERVICE_GOOGLE_PROJECT}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,6 +3,7 @@ server.port=8080
 workspace.maxStairwayThreads=4
 workspace.resourceId=mc-terra-workspace-manager
 workspace.stairwayTimeoutSeconds=1800
+workspace.stairwayPollingIntervalSeconds=1
 
 spring.cloud.gcp.trace.enabled=false
 


### PR DESCRIPTION
Made the following changes to be compatible with new Stairway version:

- Change Stairway constructor to use Builder pattern. Provided values are unchanged
- Places that caught StairwayExceptions now also catch InterruptedExceptions and treat them the same way
- Added a call to `recoverAndStart` as the third Stairway initialization step, as detailed in [Stairway code](https://github.com/DataBiosphere/stairway/blob/develop/src/main/java/bio/terra/stairway/Stairway.java#L244)
- Pulled `waitForFlight` into Workspace Manager instead of Stairway. The method was marked as deprecated in Stairway because it didn't work nicely with Stairway's new multi-instance functionality, but we don't use this new functionality.
- Changed polling time for stairway jobs from 10s to 1s, as all current WM Stairway jobs execute quickly.