### PR TITLE
[AS-371] Adopt Data Repo's snapshot naming standard for data references

### DIFF
--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -76,6 +76,7 @@ public class DataReferenceService {
           "Resource-specific credentials are not supported yet.");
     }
 
+    validationUtils.validateReferenceName(body.getName());
     samService.workspaceAuthz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_WRITE_ACTION);
 
     UUID referenceId = UUID.randomUUID();

--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -52,6 +52,7 @@ public class DataReferenceService {
       String name,
       AuthenticatedUserRequest userReq) {
 
+    validationUtils.validateReferenceName(name);
     samService.workspaceAuthz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_READ_ACTION);
 
     return dataReferenceDao.getDataReferenceByName(workspaceId, referenceType, name);

--- a/src/main/java/bio/terra/workspace/service/datareference/utils/DataReferenceValidationUtils.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/utils/DataReferenceValidationUtils.java
@@ -8,6 +8,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,7 +16,7 @@ public class DataReferenceValidationUtils {
 
   private ObjectMapper objectMapper;
   private DataRepoService dataRepoService;
-  final Pattern nameValidationPattern = Pattern.compile("^[a-zA-Z0-9][_a-zA-Z0-9]*$");
+  final Pattern nameValidationPattern = Pattern.compile("^[a-zA-Z0-9][_a-zA-Z0-9]{0,62}$");
 
   public DataReferenceValidationUtils(ObjectMapper objectMapper, DataRepoService dataRepoService) {
     this.objectMapper = objectMapper;
@@ -23,8 +24,7 @@ public class DataReferenceValidationUtils {
   }
 
   public void validateReferenceName(String name) {
-    if ((name.length() < 1 || name.length() > 63)
-        || !nameValidationPattern.matcher(name).matches()) {
+    if (StringUtils.isEmpty(name) || !nameValidationPattern.matcher(name).matches()) {
       throw new InvalidDataReferenceException(
           "Invalid reference name specified. Name must be 1 to 63 alphanumeric characters or underscores, and cannot start with an underscore.");
     }

--- a/src/main/java/bio/terra/workspace/service/datareference/utils/DataReferenceValidationUtils.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/utils/DataReferenceValidationUtils.java
@@ -7,6 +7,7 @@ import bio.terra.workspace.service.datarepo.DataRepoService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,10 +15,19 @@ public class DataReferenceValidationUtils {
 
   private ObjectMapper objectMapper;
   private DataRepoService dataRepoService;
+  final Pattern nameValidationPattern = Pattern.compile("^[a-zA-Z0-9][_a-zA-Z0-9]*$");
 
   public DataReferenceValidationUtils(ObjectMapper objectMapper, DataRepoService dataRepoService) {
     this.objectMapper = objectMapper;
     this.dataRepoService = dataRepoService;
+  }
+
+  public void validateReferenceName(String name) {
+    if ((name.length() < 1 || name.length() > 63)
+        || !nameValidationPattern.matcher(name).matches()) {
+      throw new InvalidDataReferenceException(
+          "Invalid reference name specified. Name must be 1 to 63 alphanumeric characters or underscores, and cannot start with an underscore.");
+    }
   }
 
   public String validateReference(

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -123,7 +123,7 @@ public class JobService {
 
   void waitForJob(String jobId) {
     try {
-      stairway.waitForFlight(jobId, 1, appConfig.getStairwayTimeoutSeconds());
+      stairway.waitForFlight(jobId, 10, appConfig.getStairwayTimeoutSeconds() / 10);
     } catch (StairwayException stairwayEx) {
       throw new InternalStairwayException(stairwayEx);
     }

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -123,7 +123,7 @@ public class JobService {
 
   void waitForJob(String jobId) {
     try {
-      stairway.waitForFlight(jobId, 10, appConfig.getStairwayTimeoutSeconds() / 10);
+      stairway.waitForFlight(jobId, 1, appConfig.getStairwayTimeoutSeconds());
     } catch (StairwayException stairwayEx) {
       throw new InternalStairwayException(stairwayEx);
     }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -292,7 +292,7 @@ components:
       description: A name used to identify an object in the workspace manager
       required: true
       schema:
-        type: string
+        $ref: '#/components/schemas/Name'
 
   schemas:
     ErrorReport:
@@ -362,6 +362,13 @@ components:
                 type: array
                 items:
                   type: string
+    Name:
+      # Note: These format restrictions are enforced by WM, not natively by
+      # Swagger.
+      type: string
+      pattern: '^[a-zA-Z0-9][_a-zA-Z0-9]*$'
+      minLength: 1
+      maxLength: 63
 
     SystemVersion:
       type: object
@@ -451,8 +458,7 @@ components:
       required: [name, cloningInstructions]
       properties:
         name:
-          description: The name of the data reference
-          type: string
+          $ref: "#/components/schemas/Name"
         resourceId:
           description: The ID of the resource
           type: string

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -366,7 +366,7 @@ components:
       # Note: These format restrictions are enforced by WM, not natively by
       # Swagger.
       type: string
-      pattern: '^[a-zA-Z0-9][_a-zA-Z0-9]*$'
+      pattern: '^[a-zA-Z0-9][_a-zA-Z0-9]{0,62}$'
       minLength: 1
       maxLength: 63
 

--- a/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
@@ -59,7 +59,7 @@ public class DataReferenceDaoTest {
   public void setup() {
     workspaceId = UUID.randomUUID();
     referenceId = UUID.randomUUID();
-    name = UUID.randomUUID().toString();
+    name = "this_is_a_name";
     referenceType = ReferenceTypeEnum.DATA_REPO_SNAPSHOT;
 
     DataRepoSnapshot drs = new DataRepoSnapshot();

--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -98,6 +98,56 @@ public class DataReferenceServiceTest {
   }
 
   @Test
+  public void testCreateInvalidDataReferenceNameFails() throws Exception {
+    DataRepoSnapshot snapshot = new DataRepoSnapshot();
+    snapshot.setSnapshot("foo");
+    snapshot.setInstanceName("bar");
+
+    CreateDataReferenceRequestBody refBody =
+        new CreateDataReferenceRequestBody()
+            .name("!!!!!!!!INVALID NAME!!!!!!!!1")
+            .cloningInstructions(CloningInstructionsEnum.NOTHING)
+            .referenceType(ReferenceTypeEnum.DATA_REPO_SNAPSHOT)
+            .reference(objectMapper.writeValueAsString(snapshot));
+
+    MvcResult failureResult =
+        mvc.perform(
+                post("/api/workspaces/v1/" + workspaceId.toString() + "/datareferences")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(refBody)))
+            .andExpect(status().is(400))
+            .andReturn();
+    ErrorReport error =
+        objectMapper.readValue(failureResult.getResponse().getContentAsString(), ErrorReport.class);
+    assertThat(error.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST.value()));
+  }
+
+  @Test
+  public void testCreateDataReferenceNameTooLongFails() throws Exception {
+    DataRepoSnapshot snapshot = new DataRepoSnapshot();
+    snapshot.setSnapshot("foo");
+    snapshot.setInstanceName("bar");
+
+    CreateDataReferenceRequestBody refBody =
+        new CreateDataReferenceRequestBody()
+            .name("1".repeat(100))
+            .cloningInstructions(CloningInstructionsEnum.NOTHING)
+            .referenceType(ReferenceTypeEnum.DATA_REPO_SNAPSHOT)
+            .reference(objectMapper.writeValueAsString(snapshot));
+
+    MvcResult failureResult =
+        mvc.perform(
+                post("/api/workspaces/v1/" + workspaceId.toString() + "/datareferences")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(refBody)))
+            .andExpect(status().is(400))
+            .andReturn();
+    ErrorReport error =
+        objectMapper.readValue(failureResult.getResponse().getContentAsString(), ErrorReport.class);
+    assertThat(error.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST.value()));
+  }
+
+  @Test
   public void testGetDataReference() throws Exception {
     UUID initialWorkspaceId = createDefaultWorkspace().getId();
 

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -247,7 +247,7 @@ public class WorkspaceServiceTest {
         new DataRepoSnapshot().instanceName("fake instance").snapshot("fake snapshot");
     CreateDataReferenceRequestBody referenceRequest =
         new CreateDataReferenceRequestBody()
-            .name("fake-data-reference")
+            .name("fake_data_reference")
             .cloningInstructions(CloningInstructionsEnum.NOTHING)
             .referenceType(ReferenceTypeEnum.DATA_REPO_SNAPSHOT)
             .reference(objectMapper.writeValueAsString(reference));


### PR DESCRIPTION
This adopts TDR's existing naming standard for data reference names in Workspace Manager. The standard is 1-63 alphanumeric characters and underscores, with the first character not an underscore. To quote TDR:

> Dataset, table, and column names follow this pattern. This should be used for the name of any object in the
> system. It enforces BigQuery naming rules except it disallows a leading underscore so we avoid collisions with
> any extra columns the DR adds. For table names, this is shorter than what BigQuery allows.

By aligning on a standard, we eliminates a source of potential bugs. I chose TDR's existing standard for snapshots because we expect that in an e2e user journey, the name WM stores for a data reference to a snapshot will match TDR's name for that snapshot and will be surfaced in a UI.

Some existing snapshots may already have invalid names. This PR will disallow accessing these references by name. We should keep that in mind until the next time we recreate DBs (which may not be long, given the pending postgres upgrade).

This shouldn't require any changes for Rawls. Because names may only include alphanumeric characters and underscores, we do not need to URL encode data reference names in requests to WM.
