### PR TITLE
[AS-381] Add integration test for creating a reference to a Data Repo Snapshot

### DIFF
--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -184,7 +184,7 @@ public class WorkspaceIntegrationTest {
     DataRepoSnapshot snapshotReference =
         new DataRepoSnapshot()
             .snapshot("97b5559a-2f8f-4df3-89ae-5a249173ee0c")
-            .instanceName("terra-dev");
+            .instanceName(testConfig.getDataRepoInstanceNameFromEnv());
     String dataReferenceName = "workspace_integration_test_snapshot";
     CreateDataReferenceRequestBody request =
         new CreateDataReferenceRequestBody()

--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -169,9 +169,12 @@ public class WorkspaceIntegrationTest {
     // This test relies on a persistent snapshot existing in Data Repo, currently in dev.
     // This snapshot was created using our dev service account, which is a steward in dev Data Repo.
     // First, I created a dataset "wm_integration_test_dataset" using TDR's
-    // snapshot-test-dataset.json. Then, I created the snapshot "workspace_integration_test_snapshot"
-    // using the "byFullView" mode. Finally, I added the integration test user as a reader of this snapshot.
-    // These steps should only need to be repeated if the dev DataRepo data is deleted, or to support
+    // snapshot-test-dataset.json. Then, I created the snapshot
+    // "workspace_integration_test_snapshot"
+    // using the "byFullView" mode. Finally, I added the integration test user as a reader of this
+    // snapshot.
+    // These steps should only need to be repeated if the dev DataRepo data is deleted, or to
+    // support
     // this test in other DataRepo environments.
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
@@ -183,7 +186,7 @@ public class WorkspaceIntegrationTest {
 
     DataRepoSnapshot snapshotReference =
         new DataRepoSnapshot()
-            .snapshot("97b5559a-2f8f-4df3-89ae-5a249173ee0c")
+            .snapshot(testConfig.getDataRepoSnapshotIdFromEnv())
             .instanceName(testConfig.getDataRepoInstanceNameFromEnv());
     String dataReferenceName = "workspace_integration_test_snapshot";
     CreateDataReferenceRequestBody request =

--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -170,12 +170,12 @@ public class WorkspaceIntegrationTest {
     // This snapshot was created using our dev service account, which is a steward in dev Data Repo.
     // First, I created a dataset "wm_integration_test_dataset" using TDR's
     // snapshot-test-dataset.json. Then, I created the snapshot
-    // "workspace_integration_test_snapshot"
-    // using the "byFullView" mode. Finally, I added the integration test user as a reader of this
-    // snapshot.
+    // "workspace_integration_test_snapshot" using the "byFullView" mode. Finally, I added the
+    // integration test user as a reader of this snapshot.
     // These steps should only need to be repeated if the dev DataRepo data is deleted, or to
-    // support
-    // this test in other DataRepo environments.
+    // support this test in other DataRepo environments.
+    // Data Repo makes a reasonable effort to maintain their dev environment, so this should be a
+    // very rare occurrence.
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
 

--- a/src/test/java/bio/terra/workspace/integration/common/configuration/TestConfiguration.java
+++ b/src/test/java/bio/terra/workspace/integration/common/configuration/TestConfiguration.java
@@ -16,6 +16,7 @@ public class TestConfiguration {
 
   private HashMap<String, String> wsmUrls;
   private HashMap<String, String> wsmEndpoints;
+  private HashMap<String, String> dataRepoInstanceNames;
   private String serviceAccountEmail;
   private String serviceAccountFilePath;
 
@@ -45,5 +46,9 @@ public class TestConfiguration {
 
   public void setServiceAccountFilePath(String serviceAccountFilePath) {
     this.serviceAccountFilePath = serviceAccountFilePath;
+  }
+
+  public String getDataRepoInstanceNameFromEnv() {
+    return this.dataRepoInstanceNames.get(testEnv);
   }
 }

--- a/src/test/java/bio/terra/workspace/integration/common/configuration/TestConfiguration.java
+++ b/src/test/java/bio/terra/workspace/integration/common/configuration/TestConfiguration.java
@@ -17,6 +17,7 @@ public class TestConfiguration {
   private HashMap<String, String> wsmUrls;
   private HashMap<String, String> wsmEndpoints;
   private HashMap<String, String> dataRepoInstanceNames;
+  private HashMap<String, String> dataRepoSnapshotId;
   private String serviceAccountEmail;
   private String serviceAccountFilePath;
 
@@ -50,5 +51,17 @@ public class TestConfiguration {
 
   public String getDataRepoInstanceNameFromEnv() {
     return this.dataRepoInstanceNames.get(testEnv);
+  }
+
+  public void setDataRepoInstanceNames(HashMap<String, String> instanceNames) {
+    this.dataRepoInstanceNames = instanceNames;
+  }
+
+  public String getDataRepoSnapshotIdFromEnv() {
+    return this.dataRepoSnapshotId.get(testEnv);
+  }
+
+  public void setDataRepoSnapshotId(HashMap<String, String> snapshotIds) {
+    this.dataRepoSnapshotId = snapshotIds;
   }
 }

--- a/src/test/resources/application-integration-test.properties
+++ b/src/test/resources/application-integration-test.properties
@@ -5,3 +5,5 @@ it.wsmEndpoints.workspaces=api/workspaces/v1
 
 it.serviceAccountEmail=william.thunderlord@test.firecloud.org
 it.serviceAccountFilePath=rendered/service-account.json
+
+it.dataRepoInstanceNames.dev=terra-dev

--- a/src/test/resources/application-integration-test.properties
+++ b/src/test/resources/application-integration-test.properties
@@ -7,3 +7,4 @@ it.serviceAccountEmail=william.thunderlord@test.firecloud.org
 it.serviceAccountFilePath=rendered/service-account.json
 
 it.dataRepoInstanceNames.dev=terra-dev
+it.dataRepoSnapshotId.dev=97b5559a-2f8f-4df3-89ae-5a249173ee0c


### PR DESCRIPTION
This adds an integration test which covers the flow of adding a reference to a Data Repo snapshot to a workspace. It does not create the referenced snapshot or dataset in Data Repo, and instead assumes that it persists as part of the dev environment. This pattern will need to be revisited if we ever test against non-dev environments of Data Repo.