### PR TITLE
[AS-417] Store MDC info in Stairway FlightMaps

### DIFF
--- a/src/main/java/bio/terra/workspace/common/exception/MDCHandlingException.java
+++ b/src/main/java/bio/terra/workspace/common/exception/MDCHandlingException.java
@@ -1,0 +1,26 @@
+package bio.terra.workspace.common.exception;
+
+import java.util.List;
+
+public class MDCHandlingException extends InternalServerErrorException {
+
+  public MDCHandlingException(String message) {
+    super(message);
+  }
+
+  public MDCHandlingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MDCHandlingException(Throwable cause) {
+    super(cause);
+  }
+
+  public MDCHandlingException(String message, List<String> causes) {
+    super(message, causes);
+  }
+
+  public MDCHandlingException(String message, Throwable cause, List<String> causes) {
+    super(message, cause, causes);
+  }
+}

--- a/src/main/java/bio/terra/workspace/common/utils/MDCUtils.java
+++ b/src/main/java/bio/terra/workspace/common/utils/MDCUtils.java
@@ -13,8 +13,7 @@ import org.springframework.stereotype.Component;
 public class MDCUtils {
 
   @Autowired ObjectMapper objectMapper;
-  private final TypeReference<Map<String, String>> mapType =
-      new TypeReference<Map<String, String>>() {};
+  private final TypeReference<Map<String, String>> mapType = new TypeReference<>() {};
 
   public String serializeMdc(Map<String, String> mdcMap) {
     try {

--- a/src/main/java/bio/terra/workspace/common/utils/MDCUtils.java
+++ b/src/main/java/bio/terra/workspace/common/utils/MDCUtils.java
@@ -1,0 +1,39 @@
+package bio.terra.workspace.common.utils;
+
+import bio.terra.workspace.common.exception.MDCHandlingException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component("mdcUtils")
+public class MDCUtils {
+
+  @Autowired ObjectMapper objectMapper;
+  private final TypeReference<Map<String, String>> mapType =
+      new TypeReference<Map<String, String>>() {};
+
+  public String serializeMdc(Map<String, String> mdcMap) {
+    try {
+      return objectMapper.writeValueAsString(mdcMap);
+    } catch (JsonProcessingException e) {
+      throw new MDCHandlingException("Error serializing MDC map from string: " + mdcMap.toString());
+    }
+  }
+
+  public String serializeCurrentMdc() {
+    return serializeMdc(MDC.getCopyOfContextMap());
+  }
+
+  public Map<String, String> deserializeMdcString(String serializedMdc) {
+    Map<String, String> mdcContextMap = null;
+    try {
+      return objectMapper.readValue(serializedMdc, mapType);
+    } catch (JsonProcessingException e) {
+      throw new MDCHandlingException("Error deserializing MDC map from string: " + serializedMdc);
+    }
+  }
+}

--- a/src/main/java/bio/terra/workspace/common/utils/MDCUtils.java
+++ b/src/main/java/bio/terra/workspace/common/utils/MDCUtils.java
@@ -29,7 +29,6 @@ public class MDCUtils {
   }
 
   public Map<String, String> deserializeMdcString(String serializedMdc) {
-    Map<String, String> mdcContextMap = null;
     try {
       return objectMapper.readValue(serializedMdc, mapType);
     } catch (JsonProcessingException e) {

--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.datareference;
 
-import bio.terra.workspace.common.exception.DataReferenceNotFoundException;
+import bio.terra.workspace.common.exception.*;
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.common.utils.SamUtils;
 import bio.terra.workspace.db.DataReferenceDao;
 import bio.terra.workspace.generated.model.CreateDataReferenceRequestBody;
@@ -26,17 +27,20 @@ public class DataReferenceService {
   private final SamService samService;
   private final JobService jobService;
   private final DataReferenceValidationUtils validationUtils;
+  private final MDCUtils mdcUtils;
 
   @Autowired
   public DataReferenceService(
       DataReferenceDao dataReferenceDao,
       SamService samService,
       JobService jobService,
-      DataReferenceValidationUtils validationUtils) {
+      DataReferenceValidationUtils validationUtils,
+      MDCUtils mdcUtils) {
     this.dataReferenceDao = dataReferenceDao;
     this.samService = samService;
     this.jobService = jobService;
     this.validationUtils = validationUtils;
+    this.mdcUtils = mdcUtils;
   }
 
   public DataReferenceDescription getDataReference(
@@ -94,7 +98,8 @@ public class DataReferenceService {
                 body,
                 userReq)
             .addParameter(DataReferenceFlightMapKeys.REFERENCE_ID, referenceId)
-            .addParameter(DataReferenceFlightMapKeys.WORKSPACE_ID, workspaceId);
+            .addParameter(DataReferenceFlightMapKeys.WORKSPACE_ID, workspaceId)
+            .addParameter(DataReferenceFlightMapKeys.MDC_KEY, mdcUtils.serializeCurrentMdc());
 
     String ref =
         validationUtils.validateReference(body.getReferenceType(), body.getReference(), userReq);

--- a/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceFlight.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceFlight.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.datareference.flight;
 
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.db.DataReferenceDao;
 import org.springframework.context.ApplicationContext;
 
@@ -12,7 +13,8 @@ public class CreateDataReferenceFlight extends Flight {
 
     ApplicationContext appContext = (ApplicationContext) applicationContext;
     DataReferenceDao dataReferenceDao = (DataReferenceDao) appContext.getBean("dataReferenceDao");
+    MDCUtils mdcUtils = (MDCUtils) appContext.getBean("mdcUtils");
 
-    addStep(new CreateDataReferenceStep(dataReferenceDao));
+    addStep(new CreateDataReferenceStep(dataReferenceDao, mdcUtils));
   }
 }

--- a/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceStep.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceStep.java
@@ -64,7 +64,7 @@ public class CreateDataReferenceStep implements Step {
     String serializedMdc = inputMap.get(DataReferenceFlightMapKeys.MDC_KEY, String.class);
     MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
 
-    if (workingMap.get(CREATE_DATA_REFERENCE_COMPLETED_KEY, Boolean.class) == true) {
+    if (workingMap.get(CREATE_DATA_REFERENCE_COMPLETED_KEY, Boolean.class)) {
       UUID workspaceId = inputMap.get(DataReferenceFlightMapKeys.REFERENCE_ID, UUID.class);
       dataReferenceDao.deleteDataReference(workspaceId);
     }

--- a/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceStep.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceStep.java
@@ -52,7 +52,6 @@ public class CreateDataReferenceStep implements Step {
     workingMap.put(CREATE_DATA_REFERENCE_COMPLETED_KEY, true);
 
     FlightUtils.setResponse(flightContext, referenceId.toString(), HttpStatus.OK);
-    MDC.clear();
 
     return StepResult.getStepResultSuccess();
   }
@@ -68,7 +67,6 @@ public class CreateDataReferenceStep implements Step {
       UUID workspaceId = inputMap.get(DataReferenceFlightMapKeys.REFERENCE_ID, UUID.class);
       dataReferenceDao.deleteDataReference(workspaceId);
     }
-    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceStep.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceStep.java
@@ -6,26 +6,32 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.db.DataReferenceDao;
 import bio.terra.workspace.generated.model.CreateDataReferenceRequestBody;
 import bio.terra.workspace.service.job.JobMapKeys;
 import java.util.UUID;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 
 public class CreateDataReferenceStep implements Step {
 
   private DataReferenceDao dataReferenceDao;
+  private MDCUtils mdcUtils;
 
   private static final String CREATE_DATA_REFERENCE_COMPLETED_KEY =
       "createDataReferenceStepCompleted";
 
-  public CreateDataReferenceStep(DataReferenceDao dataReferenceDao) {
+  public CreateDataReferenceStep(DataReferenceDao dataReferenceDao, MDCUtils mdcUtils) {
     this.dataReferenceDao = dataReferenceDao;
+    this.mdcUtils = mdcUtils;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
+    String serializedMdc = inputMap.get(DataReferenceFlightMapKeys.MDC_KEY, String.class);
+    MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
     FlightMap workingMap = flightContext.getWorkingMap();
     workingMap.put(CREATE_DATA_REFERENCE_COMPLETED_KEY, false);
     UUID referenceId = inputMap.get(DataReferenceFlightMapKeys.REFERENCE_ID, UUID.class);
@@ -46,18 +52,23 @@ public class CreateDataReferenceStep implements Step {
     workingMap.put(CREATE_DATA_REFERENCE_COMPLETED_KEY, true);
 
     FlightUtils.setResponse(flightContext, referenceId.toString(), HttpStatus.OK);
+    MDC.clear();
 
     return StepResult.getStepResultSuccess();
   }
 
   @Override
   public StepResult undoStep(FlightContext flightContext) {
+    FlightMap inputMap = flightContext.getInputParameters();
     FlightMap workingMap = flightContext.getWorkingMap();
-    if (workingMap.get(CREATE_DATA_REFERENCE_COMPLETED_KEY, Boolean.class)) {
-      FlightMap inputMap = flightContext.getInputParameters();
+    String serializedMdc = inputMap.get(DataReferenceFlightMapKeys.MDC_KEY, String.class);
+    MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
+
+    if (workingMap.get(CREATE_DATA_REFERENCE_COMPLETED_KEY, Boolean.class) == true) {
       UUID workspaceId = inputMap.get(DataReferenceFlightMapKeys.REFERENCE_ID, UUID.class);
       dataReferenceDao.deleteDataReference(workspaceId);
     }
+    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/workspace/service/datareference/flight/DataReferenceFlightMapKeys.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/flight/DataReferenceFlightMapKeys.java
@@ -4,6 +4,7 @@ public final class DataReferenceFlightMapKeys {
   public static final String REFERENCE_ID = "referenceId";
   public static final String WORKSPACE_ID = "workspaceId";
   public static final String REFERENCE = "reference";
+  public static final String MDC_KEY = "mdcKey";
 
   private DataReferenceFlightMapKeys() {}
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.common.utils.SamUtils;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.generated.model.CreateWorkspaceRequestBody;
@@ -26,15 +27,21 @@ public class WorkspaceService {
   private JobService jobService;
   private final WorkspaceDao workspaceDao;
   private final SamService samService;
+  private final MDCUtils mdcUtils;
   @Autowired private final Tracer tracer;
 
   @Autowired
   public WorkspaceService(
-      JobService jobService, WorkspaceDao workspaceDao, SamService samService, Tracer tracer) {
+      JobService jobService,
+      WorkspaceDao workspaceDao,
+      SamService samService,
+      Tracer tracer,
+      MDCUtils mdcUtils) {
     this.jobService = jobService;
     this.workspaceDao = workspaceDao;
     this.samService = samService;
     this.tracer = tracer;
+    this.mdcUtils = mdcUtils;
   }
 
   public CreatedWorkspace createWorkspace(
@@ -50,7 +57,8 @@ public class WorkspaceService {
                 WorkspaceCreateFlight.class,
                 body,
                 userReq)
-            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
+            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId)
+            .addParameter(WorkspaceFlightMapKeys.MDC_KEY, mdcUtils.serializeCurrentMdc());
     if (body.getSpendProfile() != null) {
       createJob.addParameter(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, body.getSpendProfile());
     }
@@ -85,7 +93,8 @@ public class WorkspaceService {
                 WorkspaceDeleteFlight.class,
                 null, // Delete does not have a useful request body
                 userReq)
-            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, id);
+            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, id)
+            .addParameter(WorkspaceFlightMapKeys.MDC_KEY, mdcUtils.serializeCurrentMdc());
     deleteJob.submitAndWait(null);
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
@@ -51,7 +51,6 @@ public class CreateWorkspaceAuthzStep implements Step {
       samService.createWorkspaceWithDefaults(userReq.getRequiredToken(), workspaceID);
       workingMap.put(AUTHZ_COMPLETED_KEY, true);
     }
-    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 
@@ -66,7 +65,6 @@ public class CreateWorkspaceAuthzStep implements Step {
       UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
       samService.deleteWorkspace(userReq.getRequiredToken(), workspaceID);
     }
-    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
@@ -62,7 +62,7 @@ public class CreateWorkspaceAuthzStep implements Step {
     MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
     // Only delete the Sam resource if we actually created it in the do step.
     FlightMap workingMap = flightContext.getWorkingMap();
-    if (workingMap.get(AUTHZ_COMPLETED_KEY, Boolean.class) == true) {
+    if (workingMap.get(AUTHZ_COMPLETED_KEY, Boolean.class)) {
       UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
       samService.deleteWorkspace(userReq.getRequiredToken(), workspaceID);
     }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
@@ -5,26 +5,33 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.common.utils.SamUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import java.util.UUID;
+import org.slf4j.MDC;
 
 public class CreateWorkspaceAuthzStep implements Step {
 
   private SamService samService;
   private AuthenticatedUserRequest userReq;
+  private MDCUtils mdcUtils;
 
   private static final String AUTHZ_COMPLETED_KEY = "createWorkspaceAuthzStepCompleted";
 
-  public CreateWorkspaceAuthzStep(SamService samService, AuthenticatedUserRequest userReq) {
+  public CreateWorkspaceAuthzStep(
+      SamService samService, AuthenticatedUserRequest userReq, MDCUtils mdcUtils) {
     this.samService = samService;
     this.userReq = userReq;
+    this.mdcUtils = mdcUtils;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
+    String serializedMdc = inputMap.get(WorkspaceFlightMapKeys.MDC_KEY, String.class);
+    MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
     UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
     FlightMap workingMap = flightContext.getWorkingMap();
     workingMap.put(AUTHZ_COMPLETED_KEY, false);
@@ -44,18 +51,22 @@ public class CreateWorkspaceAuthzStep implements Step {
       samService.createWorkspaceWithDefaults(userReq.getRequiredToken(), workspaceID);
       workingMap.put(AUTHZ_COMPLETED_KEY, true);
     }
+    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 
   @Override
   public StepResult undoStep(FlightContext flightContext) {
+    FlightMap inputMap = flightContext.getInputParameters();
+    String serializedMdc = inputMap.get(WorkspaceFlightMapKeys.MDC_KEY, String.class);
+    MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
     // Only delete the Sam resource if we actually created it in the do step.
     FlightMap workingMap = flightContext.getWorkingMap();
-    if (workingMap.get(AUTHZ_COMPLETED_KEY, Boolean.class)) {
-      FlightMap inputMap = flightContext.getInputParameters();
+    if (workingMap.get(AUTHZ_COMPLETED_KEY, Boolean.class) == true) {
       UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
       samService.deleteWorkspace(userReq.getRequiredToken(), workspaceID);
     }
+    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -61,7 +61,7 @@ public class CreateWorkspaceStep implements Step {
     FlightMap workingMap = flightContext.getWorkingMap();
     String serializedMdc = inputMap.get(WorkspaceFlightMapKeys.MDC_KEY, String.class);
     MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
-    if (workingMap.get(CREATE_WORKSPACE_COMPLETED_KEY, Boolean.class) == true) {
+    if (workingMap.get(CREATE_WORKSPACE_COMPLETED_KEY, Boolean.class)) {
       UUID workspaceId = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
       workspaceDao.deleteWorkspace(workspaceId);
     }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -6,24 +6,32 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.generated.model.CreatedWorkspace;
 import java.util.UUID;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 
 public class CreateWorkspaceStep implements Step {
 
   private WorkspaceDao workspaceDao;
+  private MDCUtils mdcUtils;
 
   private static final String CREATE_WORKSPACE_COMPLETED_KEY = "createWorkspaceStepCompleted";
 
-  public CreateWorkspaceStep(WorkspaceDao workspaceDao) {
+  public CreateWorkspaceStep(WorkspaceDao workspaceDao, MDCUtils mdcUtils) {
     this.workspaceDao = workspaceDao;
+    this.mdcUtils = mdcUtils;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
+
+    String serializedMdc = inputMap.get(WorkspaceFlightMapKeys.MDC_KEY, String.class);
+    MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
+
     UUID workspaceId = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
     FlightMap workingMap = flightContext.getWorkingMap();
     workingMap.put(CREATE_WORKSPACE_COMPLETED_KEY, false);
@@ -43,17 +51,21 @@ public class CreateWorkspaceStep implements Step {
     response.setId(workspaceId);
     FlightUtils.setResponse(flightContext, response, HttpStatus.OK);
 
+    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 
   @Override
   public StepResult undoStep(FlightContext flightContext) {
+    FlightMap inputMap = flightContext.getInputParameters();
     FlightMap workingMap = flightContext.getWorkingMap();
-    if (workingMap.get(CREATE_WORKSPACE_COMPLETED_KEY, Boolean.class)) {
-      FlightMap inputMap = flightContext.getInputParameters();
+    String serializedMdc = inputMap.get(WorkspaceFlightMapKeys.MDC_KEY, String.class);
+    MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
+    if (workingMap.get(CREATE_WORKSPACE_COMPLETED_KEY, Boolean.class) == true) {
       UUID workspaceId = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
       workspaceDao.deleteWorkspace(workspaceId);
     }
+    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -51,7 +51,6 @@ public class CreateWorkspaceStep implements Step {
     response.setId(workspaceId);
     FlightUtils.setResponse(flightContext, response, HttpStatus.OK);
 
-    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 
@@ -65,7 +64,6 @@ public class CreateWorkspaceStep implements Step {
       UUID workspaceId = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
       workspaceDao.deleteWorkspace(workspaceId);
     }
-    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
@@ -36,10 +36,8 @@ public class DeleteWorkspaceAuthzStep implements Step {
       samService.deleteWorkspace(userReq.getRequiredToken(), workspaceID);
     } catch (SamApiException e) {
       // Because there's no way to undo a Sam delete, we should always retry on Sam API errors.
-      MDC.clear();
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY);
     }
-    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
@@ -7,30 +7,39 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.exception.SamApiException;
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import java.util.UUID;
+import org.slf4j.MDC;
 
 public class DeleteWorkspaceAuthzStep implements Step {
 
   private SamService samService;
   private AuthenticatedUserRequest userReq;
+  private MDCUtils mdcUtils;
 
-  public DeleteWorkspaceAuthzStep(SamService samService, AuthenticatedUserRequest userReq) {
+  public DeleteWorkspaceAuthzStep(
+      SamService samService, AuthenticatedUserRequest userReq, MDCUtils mdcUtils) {
     this.samService = samService;
     this.userReq = userReq;
+    this.mdcUtils = mdcUtils;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
+    String serializedMdc = inputMap.get(WorkspaceFlightMapKeys.MDC_KEY, String.class);
+    MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
     UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
     try {
       samService.deleteWorkspace(userReq.getRequiredToken(), workspaceID);
     } catch (SamApiException e) {
       // Because there's no way to undo a Sam delete, we should always retry on Sam API errors.
+      MDC.clear();
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY);
     }
+    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
@@ -36,7 +36,6 @@ public class DeleteWorkspaceStateStep implements Step {
     // not found.
     workspaceDao.deleteWorkspace(workspaceID);
     FlightUtils.setResponse(flightContext, null, HttpStatus.valueOf(204));
-    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
@@ -7,29 +7,36 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.db.WorkspaceDao;
 import java.util.UUID;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 public class DeleteWorkspaceStateStep implements Step {
 
   private WorkspaceDao workspaceDao;
+  private MDCUtils mdcUtils;
 
   @Autowired
-  public DeleteWorkspaceStateStep(WorkspaceDao workspaceDao) {
+  public DeleteWorkspaceStateStep(WorkspaceDao workspaceDao, MDCUtils mdcUtils) {
     this.workspaceDao = workspaceDao;
+    this.mdcUtils = mdcUtils;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
+    String serializedMdc = inputMap.get(WorkspaceFlightMapKeys.MDC_KEY, String.class);
+    MDC.setContextMap(mdcUtils.deserializeMdcString(serializedMdc));
     UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
     // WorkspaceDao.deleteWorkspace returns true if a delete succeeds or false if the workspace is
     // not found, but the user-facing delete operation should return a 204 even if the workspace is
     // not found.
     workspaceDao.deleteWorkspace(workspaceID);
     FlightUtils.setResponse(flightContext, null, HttpStatus.valueOf(204));
+    MDC.clear();
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceCreateFlight.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceCreateFlight.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.workspace.flight;
 
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
@@ -16,12 +17,13 @@ public class WorkspaceCreateFlight extends Flight {
     ApplicationContext appContext = (ApplicationContext) applicationContext;
     WorkspaceDao workspaceDao = (WorkspaceDao) appContext.getBean("workspaceDao");
     SamService iamClient = (SamService) appContext.getBean("samService");
+    MDCUtils mdcUtils = (MDCUtils) appContext.getBean("mdcUtils");
 
     // get data from inputs that steps need
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
-    addStep(new CreateWorkspaceAuthzStep(iamClient, userReq));
-    addStep(new CreateWorkspaceStep(workspaceDao));
+    addStep(new CreateWorkspaceAuthzStep(iamClient, userReq, mdcUtils));
+    addStep(new CreateWorkspaceStep(workspaceDao, mdcUtils));
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.workspace.flight;
 
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.common.utils.MDCUtils;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
@@ -16,6 +17,7 @@ public class WorkspaceDeleteFlight extends Flight {
     ApplicationContext appContext = (ApplicationContext) applicationContext;
     WorkspaceDao workspaceDao = (WorkspaceDao) appContext.getBean("workspaceDao");
     SamService iamClient = (SamService) appContext.getBean("samService");
+    MDCUtils mdcUtils = (MDCUtils) appContext.getBean("mdcUtils");
 
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
@@ -23,7 +25,7 @@ public class WorkspaceDeleteFlight extends Flight {
     // 1. delete controlled resources using the Cloud Resource Manager library
     // 2. Notify all registered applications of deletion, once applications are supported
     // 3. Delete policy objects in Policy Manager, once it exists.
-    addStep(new DeleteWorkspaceAuthzStep(iamClient, userReq));
-    addStep(new DeleteWorkspaceStateStep(workspaceDao));
+    addStep(new DeleteWorkspaceAuthzStep(iamClient, userReq, mdcUtils));
+    addStep(new DeleteWorkspaceStateStep(workspaceDao, mdcUtils));
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.workspace.flight;
 public final class WorkspaceFlightMapKeys {
   public static final String WORKSPACE_ID = "workspaceId";
   public static final String SPEND_PROFILE_ID = "spendProfileId";
+  public static final String MDC_KEY = "mdcKey";
 
   private WorkspaceFlightMapKeys() {}
 }


### PR DESCRIPTION
MDC information is local to a thread, and Stairway does not execute flights on the same thread that submits the flights. Because of this, any work happening inside a Stairway flight couldn't be logged with the same MDC ID as the work happening outside the flight for the same request.

This PR stores MDC information in the input FlightMap for each of WM's three flights. Each step of these flights (in both directions) can then read and use this information. This allows us to use the same unique identifier for logging and tracing over a request's lifetime, even if that request is handled across multiple threads via Stairway.

This PR does not add MDC information to outbound requests (e.g. to Sam or Data Repo). That's still required to fully support MDC logging over the lifetime of a request across multiple MC Terra services, but will be addressed as part of [AS-416] and in changes to downstream services.

[AS-416]: https://broadworkbench.atlassian.net/browse/AS-416