### PR TITLE
DDO-545 Use new service-update workflow

### DIFF
--- a/.github/workflows/dev_push.yml
+++ b/.github/workflows/dev_push.yml
@@ -74,10 +74,10 @@ jobs:
       run: chmod +x gradlew
     - name: Build and push GCR image using Jib
       run: "./gradlew jib --image=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
-    - name: Update Version Mapping
+    - name: Deploy to Terra Dev environment
       uses: broadinstitute/repository-dispatch@master
       with:
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: broadinstitute/terra-helmfile
-        event-type: version-bump
-        client-payload: '{"service": "workspacemanager", "version": "${{ steps.tag.outputs.tag }}"}'
+        event-type: update-service
+        client-payload: '{"service": "workspacemanager", "version": "${{ steps.tag.outputs.tag }}", "dev_only": true}'


### PR DESCRIPTION
Use terra-helmfile's [new service-update workflow](https://github.com/broadinstitute/terra-helmfile/pull/101) to deploy the latest version of WSM to **`dev`** without automatically including it in the next Terra monolith release.