### PR TITLE
[AS-468] Fix test flakiness

### DIFF
--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -206,6 +206,7 @@ public class DataReferenceServiceTest {
 
   @Test
   public void testGetMissingDataReference() throws Exception {
+    // Random comment so I can make a PR so I can use github runners to run unit tests
     UUID initialWorkspaceId = createDefaultWorkspace().getId();
 
     MvcResult callResult =

--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -71,7 +70,6 @@ public class DataReferenceServiceTest {
   @BeforeEach
   public void setup() {
     workspaceId = UUID.randomUUID();
-    doNothing().when(mockSamService).workspaceAuthz(any(), any(), any());
     doReturn(true).when(mockDataRepoService).snapshotExists(any(), any(), any());
     doReturn(false).when(mockDataRepoService).snapshotExists(any(), eq("fake-id"), any());
     AuthenticatedUserRequest fakeAuthentication = new AuthenticatedUserRequest();

--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -204,7 +204,6 @@ public class DataReferenceServiceTest {
 
   @Test
   public void testGetMissingDataReference() throws Exception {
-    // Random comment so I can make a PR so I can use github runners to run unit tests
     UUID initialWorkspaceId = createDefaultWorkspace().getId();
 
     MvcResult callResult =

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -70,8 +69,6 @@ public class WorkspaceServiceTest {
 
   @BeforeEach
   public void setup() {
-    doNothing().when(mockSamService).createWorkspaceWithDefaults(any(), any());
-    doNothing().when(mockSamService).workspaceAuthz(any(), any(), any());
     doReturn(true).when(dataRepoService).snapshotExists(any(), any(), any());
     AuthenticatedUserRequest fakeAuthentication = new AuthenticatedUserRequest();
     fakeAuthentication


### PR DESCRIPTION
Removes calls to Mockito's `doNothing` method, as that's already the default behavior for mocks.

The failing test consistently has an error about calling `doNothing` on a method with the wrong return type. This isn't the actual issue, but it makes me suspicious that the unnecessary calls to `doNothing` are causing problems. I don't know Mockito well enough to understand why this is happening, or why it's specific to one test.

Removing the calls seems to fix the flakiness. On the dev branch, I was seeing something like a 1% to 5% failure rate. After the changes, I saw ~600 consecutive successes over two days.
I don't think it's worth digging further into Mockito to understand this since it seems like the fix works and the failure rate was so low.