### PR TITLE
AS-466: A reusable JMeter plugin for MDC log tracing

### DIFF
--- a/jmeter-plugins/.gitignore
+++ b/jmeter-plugins/.gitignore
@@ -1,0 +1,38 @@
+HELP.md
+
+### Gradle ###
+.gradle
+**/build/
+!gradle-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Emacs backup files
+*.*~
+
+### Mac directory metadata
+.DS_Store

--- a/jmeter-plugins/README.md
+++ b/jmeter-plugins/README.md
@@ -1,0 +1,28 @@
+# jmeter-plugins
+This module holds the following Custom JMeter Functions developed by Broad Institute.
+
+### `XCorrelationIDHeader` -
+
+### Dependencies (see build.gradle)
+
+- JMeter core library (`ApacheJMeter_core`)
+- Hashids
+
+### Build
+Run `./gcloud_builds_submit.sh` to build the `jar` file and submit it to Google Storage bucket.
+
+The `cloudbuild.yaml` defines the build steps.
+
+For local development, make sure the application default credentials have access to
+the storage bucket defined in `cloudbuild.yaml`.
+
+Substitute the project (`terra-kernel-k8s`) and bucket (`terra-kernel-k8s_cloudbuild`) names if needed (see `cloudbuild.yaml`, `gcloud_builds_submit.sh`).
+
+### Deployment
+Download the `jmeter-plugins-${version}.jar` from the bucket (`terra-kernel-k8s_cloudbuild`) into the ${JMETER_HOME}/`lib/ext` directory of any worker machine.
+
+### Usage
+#### `XCorrelationIDHeader` -
+Use this function in any JMeter HTTP Header Manager to generate a unique Correlation ID for MDC log tracing.
+
+- `${__XCorrelationIDHeader('WorkspaceManager:CreateWorkspace')`

--- a/jmeter-plugins/README.md
+++ b/jmeter-plugins/README.md
@@ -1,7 +1,7 @@
 # jmeter-plugins
 This module holds the following Custom JMeter Functions developed by Broad Institute.
 
-### `XCorrelationIDHeader` -
+### `XCorrelationID` -
 
 ### Dependencies (see build.gradle)
 
@@ -22,7 +22,8 @@ Substitute the project (`terra-kernel-k8s`) and bucket (`terra-kernel-k8s_cloudb
 Download the `jmeter-plugins-${version}.jar` from the bucket (`terra-kernel-k8s_cloudbuild`) into the ${JMETER_HOME}/`lib/ext` directory of any worker machine.
 
 ### Usage
-#### `XCorrelationIDHeader` -
+#### `XCorrelationID` -
 Use this function in any JMeter HTTP Header Manager to generate a unique Correlation ID for MDC log tracing.
+Recommended use is to employ a consistent way of naming the prefixes to facilitate tracing. For example, WorkspaceManager:CreateWorkspace for WSM CreateWorkspace tests.
 
-- `${__XCorrelationIDHeader('WorkspaceManager:CreateWorkspace')`
+- `${__XCorrelationID('WorkspaceManager:CreateWorkspace')`

--- a/jmeter-plugins/build.gradle
+++ b/jmeter-plugins/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+    id 'idea'
+    id 'java-library'
+}
+
+repositories {
+    maven {
+        url 'https://repo.maven.apache.org/maven2'
+        metadataSources {
+            mavenPom()
+            ignoreGradleMetadataRedirection()
+        }
+    }
+}
+
+version = '0.1.0'
+
+dependencies {
+    // This dependency is exported to consumers, that is to say found on their compile classpath.
+    api 'org.apache.commons:commons-math3:3.6.1'
+
+    // This dependency is used internally, and not exposed to consumers on their own compile classpath.
+    implementation 'com.google.guava:guava:26.0-jre'
+
+    // Use JUnit test framework
+    testImplementation 'junit:junit:4.12'
+
+    // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
+
+    implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.20.0'
+    implementation group: "org.hashids", name: "hashids", version: "1.0.3"
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/ApacheJMeter
+    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter', version: '5.3'
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/jorphan
+    implementation group: 'org.apache.jmeter', name: 'jorphan', version: '5.3'
+
+    // https://mvnrepository.com/artifact/org.apache.jmeter/ApacheJMeter_core
+    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: '5.3'
+}
+
+jar {
+    from('src/main/resources') {
+        include  '**/*.properties'
+        include  '**/*.xml'
+        include  '**/*.css'
+    }
+    manifest {
+        attributes('Implementation-Title': project.name,
+                'Implementation-Version': project.version)
+    }
+}

--- a/jmeter-plugins/cloudbuild.yaml
+++ b/jmeter-plugins/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+  - name: gradle
+    entrypoint: gradle
+    args: ["test"]
+  - name: gradle
+    entrypoint: gradle
+    args: ["assemble"]
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    args: ["gsutil", "cp", "build/libs/jmeter-plugins-0.1.0.jar", "gs://terra-kernel-k8s_cloudbuild/jmeter-plugins-0.1.0.jar"]

--- a/jmeter-plugins/gcloud-build-submit.sh
+++ b/jmeter-plugins/gcloud-build-submit.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud builds submit --billing-project=terra-kernel-k8s --region=us-central-1

--- a/jmeter-plugins/settings.gradle
+++ b/jmeter-plugins/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'jmeter-plugins'

--- a/jmeter-plugins/src/main/java/plugins/jmeter/functions/XCorrelationID.java
+++ b/jmeter-plugins/src/main/java/plugins/jmeter/functions/XCorrelationID.java
@@ -5,7 +5,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.concurrent.ThreadLocalRandom;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.functions.AbstractFunction;
 import org.apache.jmeter.functions.InvalidVariableException;
@@ -16,13 +15,12 @@ import org.hashids.Hashids;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class XCorrelationIDHeader extends AbstractFunction {
-    private Hashids hashids = new Hashids("XCorrelatiomnIDSalt", 8);
-    private static final String MDC_CORRELATION_ID_HEADER = "X-Correlation-ID";
-    private static final Logger log = LoggerFactory.getLogger(XCorrelationIDHeader.class);
+public class XCorrelationID extends AbstractFunction {
+    private Hashids hashids = new Hashids("XCorrelationIDSalt", 8);
+    private static final Logger log = LoggerFactory.getLogger(XCorrelationID.class);
     private static final List<String> desc = new LinkedList<>();
 
-    private static final String KEY = "__XCorrelationIDHeader"; //$NON-NLS-1$
+    private static final String KEY = "__XCorrelationID"; //$NON-NLS-1$
 
     // Number of parameters expected - used to reject invalid calls
     private static final int MIN_PARAMETER_COUNT = 1;
@@ -35,7 +33,7 @@ public class XCorrelationIDHeader extends AbstractFunction {
 
     private Object[] values;
 
-    public XCorrelationIDHeader() {
+    public XCorrelationID() {
 
     }
 
@@ -46,16 +44,13 @@ public class XCorrelationIDHeader extends AbstractFunction {
 
     @Override
     public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {
-        StringBuilder header = new StringBuilder();
-        header.append(MDC_CORRELATION_ID_HEADER);
-        header.append(": ");
+        StringBuilder uniqueId = new StringBuilder();
         String correlationId = generateCorrelationId();
         String prefix = ((CompoundVariable) values[0]).execute().trim();
         if (prefix.length() > 0) {
-            header.append(prefix);
-            header.append("-");
+            uniqueId.append(prefix).append("-");
         }
-        header.append(correlationId);
+        uniqueId.append(correlationId);
 
         JMeterVariables vars = getVariables();
 
@@ -65,10 +60,10 @@ public class XCorrelationIDHeader extends AbstractFunction {
             varName = ((CompoundVariable) values[1]).execute().trim();
 
         if (vars != null && varName != null) {
-            vars.put(varName, header.toString());
+            vars.put(varName, uniqueId.toString());
         }
 
-        return header.toString();
+        return uniqueId.toString();
     }
 
     @Override

--- a/jmeter-plugins/src/main/java/plugins/jmeter/functions/XCorrelationIDHeader.java
+++ b/jmeter-plugins/src/main/java/plugins/jmeter/functions/XCorrelationIDHeader.java
@@ -29,6 +29,7 @@ public class XCorrelationIDHeader extends AbstractFunction {
     private static final int MAX_PARAMETER_COUNT = 2;
 
     static {
+        desc.add(getResString("x_correlation_id_prefix")); //$NON-NLS-1$
         desc.add(getResString("function_name_paropt")); //$NON-NLS-1$
     }
 

--- a/jmeter-plugins/src/main/java/plugins/jmeter/functions/XCorrelationIDHeader.java
+++ b/jmeter-plugins/src/main/java/plugins/jmeter/functions/XCorrelationIDHeader.java
@@ -1,0 +1,95 @@
+package plugins.jmeter.functions;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.functions.AbstractFunction;
+import org.apache.jmeter.functions.InvalidVariableException;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.samplers.Sampler;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.hashids.Hashids;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class XCorrelationIDHeader extends AbstractFunction {
+    private Hashids hashids = new Hashids("XCorrelatiomnIDSalt", 8);
+    private static final String MDC_CORRELATION_ID_HEADER = "X-Correlation-ID";
+    private static final Logger log = LoggerFactory.getLogger(XCorrelationIDHeader.class);
+    private static final List<String> desc = new LinkedList<>();
+
+    private static final String KEY = "__XCorrelationIDHeader"; //$NON-NLS-1$
+
+    // Number of parameters expected - used to reject invalid calls
+    private static final int MIN_PARAMETER_COUNT = 1;
+    private static final int MAX_PARAMETER_COUNT = 2;
+
+    static {
+        desc.add(getResString("function_name_paropt")); //$NON-NLS-1$
+    }
+
+    private Object[] values;
+
+    public XCorrelationIDHeader() {
+
+    }
+
+    @Override
+    public List<String> getArgumentDesc() {
+        return desc;
+    }
+
+    @Override
+    public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {
+        StringBuilder header = new StringBuilder();
+        header.append(MDC_CORRELATION_ID_HEADER);
+        header.append(": ");
+        String correlationId = generateCorrelationId();
+        String prefix = ((CompoundVariable) values[0]).execute().trim();
+        if (prefix.length() > 0) {
+            header.append(prefix);
+            header.append("-");
+        }
+        header.append(correlationId);
+
+        JMeterVariables vars = getVariables();
+
+        String varName = null;
+
+        if (values.length > 1)
+            varName = ((CompoundVariable) values[1]).execute().trim();
+
+        if (vars != null && varName != null) {
+            vars.put(varName, header.toString());
+        }
+
+        return header.toString();
+    }
+
+    @Override
+    public void setParameters(Collection<CompoundVariable> parameters) throws InvalidVariableException {
+        checkParameterCount(parameters, MIN_PARAMETER_COUNT, MAX_PARAMETER_COUNT);
+        values = parameters.toArray();
+    }
+
+    @Override
+    public String getReferenceKey() {
+        return KEY;
+    }
+
+    private static String getResString(String key) {
+        ResourceBundle bundle = ResourceBundle.getBundle("messages");
+
+        return bundle.containsKey(key) ? bundle.getString(key) : String.format("[res_key=\"%s\"]", key);
+    }
+
+    private String generateCorrelationId() {
+        long generatedLong = ThreadLocalRandom.current().nextLong(0, Integer.MAX_VALUE);
+
+        return hashids.encode(generatedLong);
+    }
+}

--- a/jmeter-plugins/src/main/resources/messages.properties
+++ b/jmeter-plugins/src/main/resources/messages.properties
@@ -1,0 +1,2 @@
+x_correlation_id_prefix=A custom prefix for X-Correlation-ID
+function_name_paropt=Name of variable in which to store the result (optional)


### PR DESCRIPTION
This function can be used by any Java JMeter code for MDC log tracing.