### PR TITLE
use Broad proxy repo before maven central [no ticket; risk: low]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ allprojects {
 }
 
 repositories {
+	maven {
+		// Terra proxy for maven central
+		url "https://broadinstitute.jfrog.io/broadinstitute/maven-central/"
+	}
 	mavenCentral()
 	maven {
 		url "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/"


### PR DESCRIPTION
list our Artifactory proxy to maven central before the real maven central, inside our gradle build.

I like this approach, since it affects anywhere our builds run, and our artifactory is internet-facing. An alternate approach is to leave the build.gradle as-is, but modify individual build/test scripts to override the repository settings. I like that less due to its complexity.

See https://www.jfrog.com/confluence/display/JFROG/Repository+Management#RepositoryManagement-RemoteRepositories for context