### PR TITLE
[AS-470] Add alpha and staging data repos as valid instances

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,8 @@ db.stairway.forceClean=true
 sam.basePath=${SAM_ADDRESS}
 
 datarepo.instances.terra-dev=https://jade.datarepo-dev.broadinstitute.org
+datarepo.instances.terra-alpha=https://data.alpha.envs-terra.bio
+datarepo.instances.terra-staging=https://data.staging.envs-terra.bio
 datarepo.instances.terra-prod=https://jade-terra.datarepo-prod.broadinstitute.org
 
 logging.pattern.level=%X{requestId} %5p


### PR DESCRIPTION
Adds `terra-alpha` and `terra-staging` as valid Data Repo instances.

All WM requests to reference snapshots from data repo specify which instance they are calling. Because we currently have no tests or calls that run on the alpha or staging instances of Workspace Manager, this is the only change needed for AS-470.