### PR TITLE
Expose 'critical' field of subsystem status

### DIFF
--- a/src/main/java/bio/terra/workspace/common/utils/BaseStatusService.java
+++ b/src/main/java/bio/terra/workspace/common/utils/BaseStatusService.java
@@ -49,10 +49,12 @@ public class BaseStatusService {
           SystemStatusSystems subsystemStatus = null;
           try {
             subsystemStatus = subsystem.getStatusCheckFn().get();
+            subsystemStatus.critical(subsystem.isCritical());
           } catch (Exception e) {
             subsystemStatus =
                 new SystemStatusSystems()
                     .ok(false)
+                    .critical(subsystem.isCritical())
                     .addMessagesItem("Error checking status: " + e.getLocalizedMessage());
           }
           tmpSubsystemStatusMap.put(name, subsystemStatus);

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -358,6 +358,8 @@ components:
             properties:
               ok:
                 type: boolean
+              critical:
+                type: boolean
               messages:
                 type: array
                 items:


### PR DESCRIPTION
This change allows callers to see which subsystems of WM are considered "critical" and which are not. Workspace Manager's overall status is defined as ok if all critical subsystems are ok. This change was brought up at a sprint review several months back, but never made it to a ticket.

Because this is an unauthenticated endpoint, I'm also going to explore using the new preview environments for this.