### PR TITLE
Disable integration tests that talk to Data Repo

### DIFF
--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -26,11 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -158,11 +154,9 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     assertTrue(deleteWorkspaceResponse.isErrorObject());
   }
 
-  /*
-   Disable temporarily due to Jade dev maintenance. AS-506 to re-enable
-   @Test
-   @Tag(TAG_NEEDS_CLEANUP)
-  */
+  @Disabled("Disable temporarily due to Jade dev maintenance. AS-506 to re-enable")
+  @Test
+  @Tag(TAG_NEEDS_CLEANUP)
   public void createDataReference(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
@@ -181,11 +175,9 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
         CloningInstructionsEnum.NOTHING, dataReferenceDescription.getCloningInstructions());
   }
 
-  /*
-   Disable temporarily due to Jade dev maintenance. AS-506 to re-enable
-   @Test
-   @Tag(TAG_NEEDS_CLEANUP)
-  */
+  @Disabled("Disable temporarily due to Jade dev maintenance. AS-506 to re-enable")
+  @Test
+  @Tag(TAG_NEEDS_CLEANUP)
   public void deleteDataReference(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
@@ -204,11 +196,9 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     assertEquals(HttpStatus.valueOf(204), deleteResponse.getStatusCode());
   }
 
-  /*
-   Disable temporarily due to Jade dev maintenance. AS-506 to re-enable
-   @Test
-   @Tag(TAG_NEEDS_CLEANUP)
-  */
+  @Disabled("Disable temporarily due to Jade dev maintenance. AS-506 to re-enable")
+  @Test
+  @Tag(TAG_NEEDS_CLEANUP)
   public void listDataReference(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));

--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -158,8 +158,11 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     assertTrue(deleteWorkspaceResponse.isErrorObject());
   }
 
-  @Test
-  @Tag(TAG_NEEDS_CLEANUP)
+  /*
+   Disable temporarily due to Jade dev maintenance. AS-506 to re-enable
+   @Test
+   @Tag(TAG_NEEDS_CLEANUP)
+  */
   public void createDataReference(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
@@ -178,8 +181,11 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
         CloningInstructionsEnum.NOTHING, dataReferenceDescription.getCloningInstructions());
   }
 
-  @Test
-  @Tag(TAG_NEEDS_CLEANUP)
+  /*
+   Disable temporarily due to Jade dev maintenance. AS-506 to re-enable
+   @Test
+   @Tag(TAG_NEEDS_CLEANUP)
+  */
   public void deleteDataReference(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
@@ -198,8 +204,11 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     assertEquals(HttpStatus.valueOf(204), deleteResponse.getStatusCode());
   }
 
-  @Test
-  @Tag(TAG_NEEDS_CLEANUP)
+  /*
+   Disable temporarily due to Jade dev maintenance. AS-506 to re-enable
+   @Test
+   @Tag(TAG_NEEDS_CLEANUP)
+  */
   public void listDataReference(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));


### PR DESCRIPTION
Data Repo dev environment is having stability issues. Jade team needs to about two weeks to look into fixing it, so disabling automated integration tests that involve Data Repo. 

I've created a small task AS-506 to follow up on re-enabling the tests.