### PR TITLE
update deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,13 @@ plugins {
 	id "idea"
 	id "java"
 
-	id "com.diffplug.spotless" version "5.1.1"
-	id "com.github.ben-manes.versions" version "0.29.0"
+	id "com.diffplug.spotless" version "5.6.1"
+	id "com.github.ben-manes.versions" version "0.33.0"
 	id "com.google.cloud.tools.jib" version "2.5.0"
 	id "com.palantir.git-version" version "0.12.3"
 	id "io.spring.dependency-management" version "1.0.10.RELEASE"
 	id "org.hidetake.swagger.generator" version "2.18.2"
-	id "org.springframework.boot" version "2.3.3.RELEASE"
+	id "org.springframework.boot" version "2.3.4.RELEASE"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11
@@ -65,10 +65,10 @@ dependencies {
 
 	// Versioned direct deps
 	implementation group: "org.hashids", name: "hashids", version: "1.0.3"
-	implementation group: "org.liquibase", name: "liquibase-core", version: "4.0.0"
-	implementation group: "org.springframework.cloud", name: "spring-cloud-gcp-starter-trace", version: "1.2.4.RELEASE"
+	implementation group: "org.liquibase", name: "liquibase-core", version: "4.1.0"
+	implementation group: "org.springframework.cloud", name: "spring-cloud-gcp-starter-trace", version: "1.2.5.RELEASE"
 	implementation group: "org.webjars", name: "webjars-locator-core", version: "0.46"
-	runtimeOnly group: "org.postgresql", name: "postgresql", version: "42.2.14"
+	runtimeOnly group: "org.postgresql", name: "postgresql", version: "42.2.16"
 
 	// Deps whose versions are controlled by Spring
 	implementation group: "javax.validation", name: "validation-api"
@@ -80,7 +80,7 @@ dependencies {
 
 	// Swagger deps
 	implementation group: "io.swagger.core.v3", name: "swagger-annotations"
-	runtimeOnly group: "org.webjars.npm", name: "swagger-ui-dist", version: "3.31.1"
+	runtimeOnly group: "org.webjars.npm", name: "swagger-ui-dist", version: "3.34.0"
 	swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"
 
 	// Test deps

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 	id "com.diffplug.spotless" version "5.6.1"
 	id "com.github.ben-manes.versions" version "0.33.0"
-	id "com.google.cloud.tools.jib" version "2.5.0"
+	id "com.google.cloud.tools.jib" version "2.5.1"
 	id "com.palantir.git-version" version "0.12.3"
 	id "io.spring.dependency-management" version "1.0.10.RELEASE"
 	id "org.hidetake.swagger.generator" version "2.18.2"
@@ -29,7 +29,7 @@ allprojects {
 			mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
 		}
 		dependencies {
-			dependency group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.1.4"
+			dependency group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.1.5"
 			dependency group: "io.swagger.codegen.v3", name: "swagger-codegen-cli", version: "3.0.21"
 		}
 	}
@@ -80,7 +80,7 @@ dependencies {
 
 	// Swagger deps
 	implementation group: "io.swagger.core.v3", name: "swagger-annotations"
-	runtimeOnly group: "org.webjars.npm", name: "swagger-ui-dist", version: "3.34.0"
+	runtimeOnly group: "org.webjars.npm", name: "swagger-ui-dist", version: "3.35.0"
 	swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"
 
 	// Test deps

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/workspace-manager-client/build.gradle
+++ b/workspace-manager-client/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java-library"
 	id "maven-publish"
 
-	id "com.jfrog.artifactory" version "4.17.0"
+	id "com.jfrog.artifactory" version "4.17.2"
 	id "org.hidetake.swagger.generator"
 }
 


### PR DESCRIPTION
Read changelogs and ran tests; nothing of particular interest changed, except that there's now an option in the swagger ui to persist authorization between page loads. There's a fix for a regression on how postgres numbers binary array indices, but we don't read/write any arrays from the database.