### PR TITLE
Properly use the JdbcTemplate bean

### DIFF
--- a/src/main/java/bio/terra/workspace/db/DataReferenceDao.java
+++ b/src/main/java/bio/terra/workspace/db/DataReferenceDao.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.db;
 
-import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfiguration;
 import bio.terra.workspace.common.exception.DataReferenceNotFoundException;
 import bio.terra.workspace.common.exception.DuplicateDataReferenceException;
 import bio.terra.workspace.generated.model.CloningInstructionsEnum;
@@ -36,10 +35,8 @@ public class DataReferenceDao {
   private ObjectMapper objectMapper;
 
   @Autowired
-  public DataReferenceDao(
-      WorkspaceDatabaseConfiguration workspaceDatabaseConfiguration, ObjectMapper objectMapper) {
-    this.jdbcTemplate =
-        new NamedParameterJdbcTemplate(workspaceDatabaseConfiguration.getDataSource());
+  public DataReferenceDao(NamedParameterJdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+    this.jdbcTemplate = jdbcTemplate;
     this.objectMapper = objectMapper;
   }
 

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.db;
 
-import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfiguration;
 import bio.terra.workspace.common.exception.DuplicateWorkspaceException;
 import bio.terra.workspace.common.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
@@ -21,8 +20,8 @@ public class WorkspaceDao {
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   @Autowired
-  public WorkspaceDao(WorkspaceDatabaseConfiguration workspaceDatabaseConfiguration) {
-    jdbcTemplate = new NamedParameterJdbcTemplate(workspaceDatabaseConfiguration.getDataSource());
+  public WorkspaceDao(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)

--- a/src/main/java/bio/terra/workspace/service/status/WorkspaceManagerStatusService.java
+++ b/src/main/java/bio/terra/workspace/service/status/WorkspaceManagerStatusService.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.service.status;
 
 import bio.terra.workspace.app.configuration.external.DataRepoConfiguration;
-import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfiguration;
 import bio.terra.workspace.common.utils.BaseStatusService;
 import bio.terra.workspace.common.utils.StatusSubsystem;
 import bio.terra.workspace.generated.model.SystemStatusSystems;
@@ -25,12 +24,11 @@ public class WorkspaceManagerStatusService extends BaseStatusService {
   public WorkspaceManagerStatusService(
       DataRepoService dataRepoService,
       DataRepoConfiguration dataRepoConfiguration,
-      WorkspaceDatabaseConfiguration workspaceDatabaseConfiguration,
+      NamedParameterJdbcTemplate jdbcTemplate,
       SamService samService,
       @Value("${workspace.status-check.staleness-threshold-ms}") long staleThresholdMillis) {
     super(staleThresholdMillis);
-    this.jdbcTemplate =
-        new NamedParameterJdbcTemplate(workspaceDatabaseConfiguration.getDataSource());
+    this.jdbcTemplate = jdbcTemplate;
     Supplier<SystemStatusSystems> dbHealthFn =
         () ->
             new SystemStatusSystems()

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -24,7 +24,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Autowired private WorkspaceDatabaseConfiguration workspaceDatabaseConfiguration;
 
-  private NamedParameterJdbcTemplate jdbcTemplate;
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
 
   @Autowired private WorkspaceDao workspaceDao;
 
@@ -37,7 +37,6 @@ public class WorkspaceDaoTest extends BaseUnitTest {
   public void setup() {
     workspaceId = UUID.randomUUID();
     spendProfileId = UUID.randomUUID();
-    jdbcTemplate = new NamedParameterJdbcTemplate(workspaceDatabaseConfiguration.getDataSource());
   }
 
   @Test


### PR DESCRIPTION
Inspired by comments in https://github.com/DataBiosphere/jade-data-repo/pull/641

Currently, we create a NamedParameterJdbcTemplate bean and never use it. Instead, our code re-creates the NamedParameterJdbcTemplate from the same input in several places in the code. This is unnecessary duplication, and we should use the common bean throughout the code.