### PR TITLE
Remove unused Sam resource types/actions

### DIFF
--- a/src/main/java/bio/terra/workspace/common/utils/SamUtils.java
+++ b/src/main/java/bio/terra/workspace/common/utils/SamUtils.java
@@ -3,10 +3,6 @@ package bio.terra.workspace.common.utils;
 public class SamUtils {
 
   public static String SAM_WORKSPACE_RESOURCE = "workspace";
-  // TODO: These don't actually exist in SAM yet.
-  public static String SAM_WORKSPACE_MANAGER_RESOURCE = "mc-workspace-manager";
-  public static String SAM_WORKSPACE_MANAGER_LIST_JOBS_ACTION = "list-job";
-  public static String SAM_WORKSPACE_MANAGER_DELETE_JOBS_ACTION = "delete-job";
   public static String SAM_WORKSPACE_READ_ACTION = "read";
   public static String SAM_WORKSPACE_WRITE_ACTION = "write";
   public static String SAM_WORKSPACE_DELETE_ACTION = "delete";

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -14,7 +14,6 @@ import bio.terra.stairway.exception.StairwayExecutionException;
 import bio.terra.workspace.app.configuration.external.JobConfiguration;
 import bio.terra.workspace.app.configuration.external.StairwayDatabaseConfiguration;
 import bio.terra.workspace.common.exception.stairway.StairwayInitializationException;
-import bio.terra.workspace.common.utils.SamUtils;
 import bio.terra.workspace.generated.model.JobModel;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
@@ -195,21 +194,7 @@ public class JobService {
 
   public void releaseJob(String jobId, AuthenticatedUserRequest userReq) {
     try {
-      if (userReq != null) {
-        // currently, this check will be true for stewards only
-        boolean canDeleteAnyJob =
-            samService.isAuthorized(
-                userReq.getRequiredToken(),
-                SamUtils.SAM_WORKSPACE_MANAGER_RESOURCE,
-                jobConfig.getResourceId(),
-                SamUtils.SAM_WORKSPACE_MANAGER_DELETE_JOBS_ACTION);
-
-        // if the user has access to all jobs, no need to check for this one individually
-        // otherwise, check that the user has access to this job before deleting
-        if (!canDeleteAnyJob) {
-          verifyUserAccess(jobId, userReq); // jobId=flightId
-        }
-      }
+      verifyUserAccess(jobId, userReq); // jobId=flightId
       stairway.deleteFlight(jobId, false);
     } catch (StairwayException | InterruptedException stairwayEx) {
       throw new InternalStairwayException(stairwayEx);


### PR DESCRIPTION
Will's investigation into Workspace creation authz found a few Sam constants that aren't used (and aren't valid in Sam), as well as a "steward" check we forgot to remove. The check is never executed as we've temporarily disabled the `deleteJob` endpoint, but we should still remove it. 