### PR TITLE
PF-152 Add WorkspaceDao workspace_cloud_context methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.12", version: "0.1-3a0df80"
 
 	// Versioned direct deps
+	implementation group: "com.google.auto.value", name: "auto-value-annotations", version: "1.7.4"
+	annotationProcessor group: "com.google.auto.value", name: "auto-value", version: "1.7.4"
 	implementation group: "com.google.guava", name:"guava", version: "29.0-jre"
 	implementation group: "org.hashids", name: "hashids", version: "1.0.3"
 	implementation group: "org.liquibase", name: "liquibase-core", version: "4.1.0"

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -97,7 +97,7 @@ public class WorkspaceDao {
         new MapSqlParameterSource().addValue("workspace_id", workspaceId.toString());
     WorkspaceCloudContext context =
         DataAccessUtils.singleResult(jdbcTemplate.query(sql, params, GOOGLE_CONTEXT_ROW_MAPPER));
-    return (context != null) ? context : WorkspaceCloudContext.none();
+    return (context == null) ? WorkspaceCloudContext.none() : context;
   }
 
   /** Update the cloud context of the workspace, replacing the previous cloud context. */

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -3,12 +3,21 @@ package bio.terra.workspace.db;
 import bio.terra.workspace.common.exception.DuplicateWorkspaceException;
 import bio.terra.workspace.common.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
+import bio.terra.workspace.service.workspace.CloudType;
+import bio.terra.workspace.service.workspace.WorkspaceCloudContext;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
@@ -18,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class WorkspaceDao {
   private final NamedParameterJdbcTemplate jdbcTemplate;
+  /** Database JSON ObjectMapper. Should not be shared with request/response serialization. */
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Autowired
   public WorkspaceDao(NamedParameterJdbcTemplate jdbcTemplate) {
@@ -74,6 +85,84 @@ public class WorkspaceDao {
       return desc;
     } catch (EmptyResultDataAccessException e) {
       throw new WorkspaceNotFoundException("Workspace not found.");
+    }
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public WorkspaceCloudContext getCloudContext(UUID workspaceId) {
+    String sql =
+        "SELECT cloud_type, content FROM workspace_cloud_context "
+            + "WHERE workspace_id = :workspace_id;";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("workspace_id", workspaceId.toString());
+    WorkspaceCloudContext context =
+        DataAccessUtils.singleResult(jdbcTemplate.query(sql, params, CLOUD_CONTEXT_ROW_MAPPER));
+    return (context != null) ? context : WorkspaceCloudContext.none();
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public void insertCloudContext(UUID workspaceId, WorkspaceCloudContext cloudContext) {
+    String sql =
+        "INSERT INTO workspace_cloud_content (workspace_id, cloud_type, content) "
+            + "VALUES (:workspace_id, :cloud_type, :content::json)";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("workspace_id", workspaceId.toString())
+            .addValue("cloud_type", cloudContext.cloudType().toString())
+            .addValue("content", CloudContextV1.from(cloudContext).serialize());
+    jdbcTemplate.update(sql, params);
+  }
+
+  private static final RowMapper<WorkspaceCloudContext> CLOUD_CONTEXT_ROW_MAPPER =
+      (rs, rowNum) -> {
+        CloudType cloudType = CloudType.valueOf(rs.getString("cloud_type"));
+        WorkspaceCloudContext result = WorkspaceCloudContext.none();
+        switch (cloudType) {
+          case NONE:
+            result = WorkspaceCloudContext.none();
+            break;
+          case GOOGLE:
+            CloudContextV1 cloudContext;
+            try {
+              cloudContext = objectMapper.readValue(rs.getString("content"), CloudContextV1.class);
+            } catch (JsonProcessingException e) {
+              throw new SQLException("Unable to deserialize workspace_cloud_context.content", e);
+            }
+            result = WorkspaceCloudContext.createGoogleContext(cloudContext.googleProjectId);
+            break;
+        }
+        return result;
+      };
+
+  /** JSON serialization class for the workspace_cloud_context.context column. */
+  private static class CloudContextV1 {
+    /** Version marker to store in the db so that we can update the format later if we need to. */
+    @JsonProperty long version = 1;
+
+    @JsonProperty String googleProjectId;
+
+    public static CloudContextV1 from(WorkspaceCloudContext workspaceCloudContext) {
+      CloudContextV1 result = new CloudContextV1();
+      result.googleProjectId = workspaceCloudContext.googleProjectId().orElse(null);
+      return result;
+    }
+
+    /** Serialize for a JDBC string parameter value. */
+    public String serialize() {
+      try {
+        return objectMapper.writeValueAsString(this);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException("Unable to serialize workspace_cloud_context.content", e);
+      }
+    }
+
+    /** Deserialize from a JDBC result set string value. */
+    public static CloudContextV1 deserialize(String serialized) throws SQLException {
+      try {
+        return objectMapper.readValue(serialized, CloudContextV1.class);
+      } catch (JsonProcessingException e) {
+        throw new SQLException("Unable to deserialize workspace_cloud_context.content", e);
+      }
     }
   }
 }

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -3,7 +3,6 @@ package bio.terra.workspace.db;
 import bio.terra.workspace.common.exception.DuplicateWorkspaceException;
 import bio.terra.workspace.common.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
-import bio.terra.workspace.service.workspace.CloudType;
 import bio.terra.workspace.service.workspace.WorkspaceCloudContext;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,7 +26,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class WorkspaceDao {
   private final NamedParameterJdbcTemplate jdbcTemplate;
-  /** Database JSON ObjectMapper. Should not be shared with request/response serialization. */
+  /**
+   * Database JSON ObjectMapper. Should not be shared with request/response serialization. We do not
+   * want necessary changes to request/response serialization to change what's stored in the
+   * database and possibly break backwards compatibility.
+   */
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Autowired
@@ -84,6 +87,7 @@ public class WorkspaceDao {
     }
   }
 
+  /** Retrieves the cloud context of the workspace. */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public WorkspaceCloudContext getCloudContext(UUID workspaceId) {
     String sql =
@@ -92,57 +96,55 @@ public class WorkspaceDao {
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("workspace_id", workspaceId.toString());
     WorkspaceCloudContext context =
-        DataAccessUtils.singleResult(jdbcTemplate.query(sql, params, CLOUD_CONTEXT_ROW_MAPPER));
+        DataAccessUtils.singleResult(jdbcTemplate.query(sql, params, GOOGLE_CONTEXT_ROW_MAPPER));
     return (context != null) ? context : WorkspaceCloudContext.none();
   }
 
+  /** Update the cloud context of the workspace, replacing the previous cloud context. */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public void insertCloudContext(UUID workspaceId, WorkspaceCloudContext cloudContext) {
-    String sql =
-        "INSERT INTO workspace_cloud_context (workspace_id, cloud_type, context) "
-            + "VALUES (:workspace_id, :cloud_type, :context::json)";
-    MapSqlParameterSource params =
-        new MapSqlParameterSource()
-            .addValue("workspace_id", workspaceId.toString())
-            .addValue("cloud_type", cloudContext.cloudType().toString())
-            .addValue("context", CloudContextV1.from(cloudContext).serialize());
-    jdbcTemplate.update(sql, params);
+  public void updateCloudContext(UUID workspaceId, WorkspaceCloudContext cloudContext) {
+    if (cloudContext.googleProjectId().isPresent()) {
+      String sql =
+          "INSERT INTO workspace_cloud_context (workspace_id, cloud_type, context) "
+              + "VALUES (:workspace_id, :cloud_type, :context::json) "
+              + "ON CONFLICT(workspace_id, cloud_type) DO UPDATE SET context = :context::json";
+      MapSqlParameterSource params =
+          new MapSqlParameterSource()
+              .addValue("workspace_id", workspaceId.toString())
+              .addValue("cloud_type", CloudType.GOOGLE.toString())
+              .addValue("context", GoogleCloudContextV1.from(cloudContext).serialize());
+      jdbcTemplate.update(sql, params);
+    } else {
+      // Clear the context if there is none.
+      String sql = "DELETE FROM workspace_cloud_context WHERE workspace_id = :workspace_id";
+      MapSqlParameterSource params =
+          new MapSqlParameterSource().addValue("workspace_id", workspaceId.toString());
+      jdbcTemplate.update(sql, params);
+    }
   }
 
-  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public boolean deleteCloudContext(UUID workspaceId) {
-    String sql = "DELETE FROM workspace_cloud_context WHERE workspace_id = :workspace_id";
-    MapSqlParameterSource params =
-        new MapSqlParameterSource().addValue("workspace_id", workspaceId.toString());
-    return jdbcTemplate.update(sql, params) > 0;
-  }
-
-  private static final RowMapper<WorkspaceCloudContext> CLOUD_CONTEXT_ROW_MAPPER =
+  // TODO: Once we have multiple CloudTypes, we will need to handle other contexts.
+  private static final RowMapper<WorkspaceCloudContext> GOOGLE_CONTEXT_ROW_MAPPER =
       (rs, rowNum) -> {
-        CloudType cloudType = CloudType.valueOf(rs.getString("cloud_type"));
-        WorkspaceCloudContext result = WorkspaceCloudContext.none();
-        switch (cloudType) {
-          case NONE:
-            result = WorkspaceCloudContext.none();
-            break;
-          case GOOGLE:
-            CloudContextV1 cloudContext = CloudContextV1.deserialize(rs.getString("context"));
-            result = WorkspaceCloudContext.createGoogleContext(cloudContext.googleProjectId);
-            break;
-        }
-        return result;
+        GoogleCloudContextV1 context = GoogleCloudContextV1.deserialize(rs.getString("context"));
+        return WorkspaceCloudContext.createGoogleContext(context.googleProjectId);
       };
+
+  @VisibleForTesting
+  enum CloudType {
+    GOOGLE,
+  }
 
   /** JSON serialization class for the workspace_cloud_context.context column. */
   @VisibleForTesting
-  static class CloudContextV1 {
+  static class GoogleCloudContextV1 {
     /** Version marker to store in the db so that we can update the format later if we need to. */
     @JsonProperty long version = 1;
 
     @JsonProperty String googleProjectId;
 
-    public static CloudContextV1 from(WorkspaceCloudContext workspaceCloudContext) {
-      CloudContextV1 result = new CloudContextV1();
+    public static GoogleCloudContextV1 from(WorkspaceCloudContext workspaceCloudContext) {
+      GoogleCloudContextV1 result = new GoogleCloudContextV1();
       result.googleProjectId = workspaceCloudContext.googleProjectId().orElse(null);
       return result;
     }
@@ -157,9 +159,9 @@ public class WorkspaceDao {
     }
 
     /** Deserialize from a JDBC result set string value. */
-    public static CloudContextV1 deserialize(String serialized) throws SQLException {
+    public static GoogleCloudContextV1 deserialize(String serialized) throws SQLException {
       try {
-        return objectMapper.readValue(serialized, CloudContextV1.class);
+        return objectMapper.readValue(serialized, GoogleCloudContextV1.class);
       } catch (JsonProcessingException e) {
         throw new SQLException("Unable to deserialize workspace_cloud_context.context", e);
       }

--- a/src/main/java/bio/terra/workspace/service/workspace/CloudType.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/CloudType.java
@@ -1,0 +1,7 @@
+package bio.terra.workspace.service.workspace;
+
+/** The cloud providers used by Workspace Manager for workspaces. */
+public enum CloudType {
+  NONE, // No known CloudProvider for the workspace.
+  GOOGLE,
+}

--- a/src/main/java/bio/terra/workspace/service/workspace/CloudType.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/CloudType.java
@@ -1,7 +1,0 @@
-package bio.terra.workspace.service.workspace;
-
-/** The cloud providers used by Workspace Manager for workspaces. */
-public enum CloudType {
-  NONE, // No known CloudProvider for the workspace.
-  GOOGLE,
-}

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceCloudContext.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceCloudContext.java
@@ -4,23 +4,21 @@ import com.google.auto.value.AutoValue;
 import java.util.Optional;
 
 /**
- * The cloud provider and its associated resource for a workspace.
+ * The cloud contexts associated with a resource.
  *
- * <p>Each workspace has resources in one cloud provider, its "cloud context."
+ * <p>A workspace can have resources with each cloud provider, its "cloud context."
  * <li>For GCP, a Google Project is associated with every resource.
  */
 @AutoValue
 public abstract class WorkspaceCloudContext {
-  public abstract CloudType cloudType();
-
-  /** The Google Project id. Only present if the provider is {@link CloudType#GOOGLE}. */
+  /** The Google Project id for workspaces with Google context. */
   public abstract Optional<String> googleProjectId();
 
   public static WorkspaceCloudContext createGoogleContext(String projectId) {
-    return new AutoValue_WorkspaceCloudContext(CloudType.GOOGLE, Optional.of(projectId));
+    return new AutoValue_WorkspaceCloudContext(Optional.of(projectId));
   }
 
   public static WorkspaceCloudContext none() {
-    return new AutoValue_WorkspaceCloudContext(CloudType.NONE, Optional.empty());
+    return new AutoValue_WorkspaceCloudContext(Optional.empty());
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceCloudContext.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceCloudContext.java
@@ -1,0 +1,26 @@
+package bio.terra.workspace.service.workspace;
+
+import com.google.auto.value.AutoValue;
+import java.util.Optional;
+
+/**
+ * The cloud provider and its associated resource for a workspace.
+ *
+ * <p>Each workspace has resources in one cloud provider, its "cloud context."
+ * <li>For GCP, a Google Project is associated with every resource.
+ */
+@AutoValue
+public abstract class WorkspaceCloudContext {
+  public abstract CloudType cloudType();
+
+  /** The Google Project id. Only present if the provider is {@link CloudType#GOOGLE}. */
+  public abstract Optional<String> googleProjectId();
+
+  public static WorkspaceCloudContext createGoogleContext(String projectId) {
+    return new AutoValue_WorkspaceCloudContext(CloudType.GOOGLE, Optional.of(projectId));
+  }
+
+  public static WorkspaceCloudContext none() {
+    return new AutoValue_WorkspaceCloudContext(CloudType.NONE, Optional.empty());
+  }
+}

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -2,4 +2,5 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <include file="changesets/20200227_initial_schema.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20200512_reference_unique_index.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20201016_fk_cloud_context.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20200227_initial_schema.yaml
+++ b/src/main/resources/db/changesets/20200227_initial_schema.yaml
@@ -85,6 +85,7 @@ databaseChangeLog:
           - column:
               name: workspace_id
               type: text
+              # This constraint is ill formatted and doesn't work.
               constraints:
                 primaryKey: true
                 nullable: false

--- a/src/main/resources/db/changesets/20201016_fk_cloud_context.yaml
+++ b/src/main/resources/db/changesets/20201016_fk_cloud_context.yaml
@@ -1,0 +1,13 @@
+# Fixes badly formatted constraint in initial_schema.
+databaseChangeLog:
+- changeSet:
+    id:  addFkCloudContext
+    author:  wchamber
+    changes:
+      -  addForeignKeyConstraint:
+           baseColumnNames:  workspace_id
+           baseTableName:  workspace_cloud_context
+           constraintName:  fk_workspace_id
+           onDelete:  CASCADE
+           referencedColumnNames:  workspace_id
+           referencedTableName:  workspace

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -136,4 +136,21 @@ public class WorkspaceDaoTest extends BaseUnitTest {
     workspaceDao.createWorkspace(workspaceId, null);
     assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
   }
+
+  /**
+   * Hard code serialized values to check that code changes do not break backwards compatibility of
+   * stored JSON values. If this test fails, your change may not work with existing databases.
+   */
+  @Test
+  public void cloudContextBackwardsCompatibility() throws Exception {
+    WorkspaceDao.CloudContextV1 googleDeserialized =
+        WorkspaceDao.CloudContextV1.deserialize("{\"version\":1,\"googleProjectId\":\"foo\"}");
+    assertEquals(1, googleDeserialized.version);
+    assertEquals("foo", googleDeserialized.googleProjectId);
+
+    WorkspaceDao.CloudContextV1 noneDeserialized =
+        WorkspaceDao.CloudContextV1.deserialize("{\"version\":1,\"googleProjectId\":null}");
+    assertEquals(1, noneDeserialized.version);
+    assertNull(noneDeserialized.googleProjectId);
+  }
 }

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -114,33 +114,25 @@ public class WorkspaceDaoTest extends BaseUnitTest {
   }
 
   @Test
-  public void insertAndGetCloudContext_Google() {
+  public void updateCloudContext_Google() {
     workspaceDao.createWorkspace(workspaceId, null);
-    WorkspaceCloudContext googleContext = WorkspaceCloudContext.createGoogleContext("my-project");
-    workspaceDao.insertCloudContext(workspaceId, googleContext);
 
-    assertEquals(googleContext, workspaceDao.getCloudContext(workspaceId));
+    WorkspaceCloudContext googleContext1 = WorkspaceCloudContext.createGoogleContext("my-project1");
+    workspaceDao.updateCloudContext(workspaceId, googleContext1);
+    assertEquals(googleContext1, workspaceDao.getCloudContext(workspaceId));
+
+    WorkspaceCloudContext googleContext2 = WorkspaceCloudContext.createGoogleContext("my-project2");
+    workspaceDao.updateCloudContext(workspaceId, googleContext2);
+    assertEquals(googleContext2, workspaceDao.getCloudContext(workspaceId));
   }
 
   @Test
-  public void insertAndGetCloudContext_None() {
+  public void updateCloudContext_None() {
     workspaceDao.createWorkspace(workspaceId, null);
+
     WorkspaceCloudContext noneContext = WorkspaceCloudContext.none();
-    workspaceDao.insertCloudContext(workspaceId, noneContext);
-
+    workspaceDao.updateCloudContext(workspaceId, noneContext);
     assertEquals(noneContext, workspaceDao.getCloudContext(workspaceId));
-  }
-
-  @Test
-  public void insertAndDeleteCloudContext() {
-    workspaceDao.createWorkspace(workspaceId, null);
-    assertFalse(workspaceDao.deleteCloudContext(workspaceId));
-    assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
-
-    workspaceDao.insertCloudContext(
-        workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
-    assertTrue(workspaceDao.deleteCloudContext(workspaceId));
-    assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
   }
 
   @Test
@@ -149,20 +141,44 @@ public class WorkspaceDaoTest extends BaseUnitTest {
     assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
   }
 
+  @Test
+  public void updateAndNoneCloudContext() {
+    workspaceDao.createWorkspace(workspaceId, null);
+
+    workspaceDao.updateCloudContext(
+        workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
+    workspaceDao.updateCloudContext(workspaceId, WorkspaceCloudContext.none());
+    assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
+  }
+
+  @Test
+  public void deleteWorkspaceWithCloudContext() {
+    workspaceDao.createWorkspace(workspaceId, null);
+    workspaceDao.updateCloudContext(
+        workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
+
+    assertTrue(workspaceDao.deleteWorkspace(workspaceId));
+    assertThrows(WorkspaceNotFoundException.class, () -> workspaceDao.getWorkspace(workspaceId));
+    assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
+  }
+
   /**
    * Hard code serialized values to check that code changes do not break backwards compatibility of
    * stored JSON values. If this test fails, your change may not work with existing databases.
    */
   @Test
-  public void cloudContextBackwardsCompatibility() throws Exception {
-    WorkspaceDao.CloudContextV1 googleDeserialized =
-        WorkspaceDao.CloudContextV1.deserialize("{\"version\":1,\"googleProjectId\":\"foo\"}");
+  public void googleCloudContextBackwardsCompatibility() throws Exception {
+    WorkspaceDao.GoogleCloudContextV1 googleDeserialized =
+        WorkspaceDao.GoogleCloudContextV1.deserialize(
+            "{\"version\":1,\"googleProjectId\":\"foo\"}");
     assertEquals(1, googleDeserialized.version);
     assertEquals("foo", googleDeserialized.googleProjectId);
+  }
 
-    WorkspaceDao.CloudContextV1 noneDeserialized =
-        WorkspaceDao.CloudContextV1.deserialize("{\"version\":1,\"googleProjectId\":null}");
-    assertEquals(1, noneDeserialized.version);
-    assertNull(noneDeserialized.googleProjectId);
+  @Test
+  public void cloudTypeBackwardsCompatibility() {
+    assertEquals(WorkspaceDao.CloudType.GOOGLE, WorkspaceDao.CloudType.valueOf("GOOGLE"));
+    assertEquals("GOOGLE", WorkspaceDao.CloudType.GOOGLE.toString());
+    assertEquals(1, WorkspaceDao.CloudType.values().length);
   }
 }

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -2,15 +2,14 @@ package bio.terra.workspace.db;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfiguration;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.exception.DuplicateWorkspaceException;
 import bio.terra.workspace.common.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
+import bio.terra.workspace.service.workspace.WorkspaceCloudContext;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -112,5 +111,29 @@ public class WorkspaceDaoTest extends BaseUnitTest {
         () -> {
           workspaceDao.createWorkspace(workspaceId, null);
         });
+  }
+
+  @Test
+  public void insertAndGetCloudContext_Google() {
+    workspaceDao.createWorkspace(workspaceId, null);
+    WorkspaceCloudContext googleContext = WorkspaceCloudContext.createGoogleContext("my-project");
+    workspaceDao.insertCloudContext(workspaceId, googleContext);
+
+    assertEquals(googleContext, workspaceDao.getCloudContext(workspaceId));
+  }
+
+  @Test
+  public void insertAndGetCloudContext_None() {
+    workspaceDao.createWorkspace(workspaceId, null);
+    WorkspaceCloudContext noneContext = WorkspaceCloudContext.none();
+    workspaceDao.insertCloudContext(workspaceId, noneContext);
+
+    assertEquals(noneContext, workspaceDao.getCloudContext(workspaceId));
+  }
+
+  @Test
+  public void noSetCloudContextIsNone() {
+    workspaceDao.createWorkspace(workspaceId, null);
+    assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
   }
 }

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -132,6 +132,18 @@ public class WorkspaceDaoTest extends BaseUnitTest {
   }
 
   @Test
+  public void insertAndDeleteCloudContext() {
+    workspaceDao.createWorkspace(workspaceId, null);
+    assertFalse(workspaceDao.deleteCloudContext(workspaceId));
+    assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
+
+    workspaceDao.insertCloudContext(
+        workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
+    assertTrue(workspaceDao.deleteCloudContext(workspaceId));
+    assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
+  }
+
+  @Test
   public void noSetCloudContextIsNone() {
     workspaceDao.createWorkspace(workspaceId, null);
     assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));


### PR DESCRIPTION
Add WorkspaceDao methods for working with the workspace_cloud_context table.
Define an intial JSON format for workspace_cloud_context.context. Initially, we're just storing a Google project id.
Change `Map<String, Object> paramMap` to the more descriptive `MapSqlParameterSource params` type.

Cloud context first used in follow up PR where we will create a google project as a part of workspace creation.

Also fix foreign key constraint on workspace_cloud_context. In the intial_schema, no `references: workspace(workspace_id)` was set. Compare to other FK constraints that are correct.