### PR TITLE
PF-152 Use the WM service account and user delegated SA for integration tests correctly.

### DIFF
--- a/render_config.sh
+++ b/render_config.sh
@@ -1,25 +1,17 @@
 #!/bin/bash
 
 VAULT_TOKEN=${1:-$(cat "$HOME"/.vault-token)}
-TARGET_ENV=${2:-dev}
-
-FIRECLOUD_ACCOUNT_VAULT_PATH=secret/dsde/firecloud/$TARGET_ENV/common/firecloud-account.json
-SERVICE_ACCOUNT_OUTPUT_FILE_PATH=$(dirname "$0")/rendered/service-account.json
-
-if [[ ! "$TARGET_ENV" =~ ^(dev|alpha|perf|staging|prod)$ ]]; then
-    printf "\033[0;31m Unknown environment: $TARGET_ENV \n Must be one of [dev, alpha, perf, staging, prod] \n\033[0m"
-    exit 1
-fi
+WM_APP_SERVICE_ACCOUNT_VAULT_PATH=secret/dsde/terra/kernel/dev/dev/workspace/app-sa
+WM_APP_SERVICE_ACCOUNT_OUTPUT_PATH=$(dirname "$0")/rendered/service-account.json
+USER_DELEGATED_SERVICE_ACCOUNT_VAULT_PATH=secret/dsde/firecloud/dev/common/firecloud-account.json
+USER_DELEGATED_SERVICE_ACCOUNT_OUTPUT_PATH=$(dirname "$0")/rendered/user-delegated-service-account.json
 
 DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:consul-0.20.0
 
-SERVICE_ACCOUNT_CREDS=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" $DSDE_TOOLBOX_DOCKER_IMAGE \
-    vault read -format=json "$FIRECLOUD_ACCOUNT_VAULT_PATH" | \
-    jq .data)
-
-if [[ -z "$SERVICE_ACCOUNT_CREDS" ]]; then
-    printf "\033[0;31m Could not fetch service account creds. Check your vault token. \n\033[0m"
-    exit 1
-fi
-
-echo "$SERVICE_ACCOUNT_CREDS" > "$SERVICE_ACCOUNT_OUTPUT_FILE_PATH"
+docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" $DSDE_TOOLBOX_DOCKER_IMAGE \
+    vault read -format=json ${WM_APP_SERVICE_ACCOUNT_VAULT_PATH} | \
+    jq -r .data.key | base64 -d > ${WM_APP_SERVICE_ACCOUNT_OUTPUT_PATH}
+docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" $DSDE_TOOLBOX_DOCKER_IMAGE \
+    vault read -format=json ${USER_DELEGATED_SERVICE_ACCOUNT_VAULT_PATH} | \
+    # Not base64 encoded or stored under 'key'
+    jq -r .data > ${USER_DELEGATED_SERVICE_ACCOUNT_OUTPUT_PATH}

--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -92,7 +92,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
     createDefaultWorkspace(workspaceId);
 
-    String userEmail = testConfig.getServiceAccountEmail();
+    String userEmail = testConfig.getUserEmail();
     String path = testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId;
 
     WorkspaceResponse<WorkspaceDescription> getWorkspaceResponse =
@@ -111,7 +111,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
     WorkspaceResponse<CreatedWorkspace> workspaceResponse = createDefaultWorkspace(workspaceId);
 
-    String userEmail = testConfig.getServiceAccountEmail();
+    String userEmail = testConfig.getUserEmail();
     String token = authService.getAuthToken(userEmail);
     String path = testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId;
     DeleteWorkspaceRequestBody body = new DeleteWorkspaceRequestBody().authToken(token);
@@ -141,7 +141,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
     WorkspaceResponse<CreatedWorkspace> workspaceResponse = createDefaultWorkspace(workspaceId);
 
-    String userEmail = testConfig.getServiceAccountEmail();
+    String userEmail = testConfig.getUserEmail();
     String token = "invalidToken";
     String path = testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId;
     DeleteWorkspaceRequestBody body = new DeleteWorkspaceRequestBody().authToken(token);
@@ -190,7 +190,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
         testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId + "/datareferences/" + referenceId;
 
     WorkspaceResponse<?> deleteResponse =
-        workspaceManagerTestClient.delete(testConfig.getServiceAccountEmail(), deletePath, "");
+        workspaceManagerTestClient.delete(testConfig.getUserEmail(), deletePath, "");
     assertEquals(HttpStatus.valueOf(204), deleteResponse.getStatusCode());
   }
 
@@ -212,8 +212,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     assertEquals(HttpStatus.OK, secondPostResponse.getStatusCode());
     String path = testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId + "/datareferences";
     WorkspaceResponse<DataReferenceList> listResponse =
-        workspaceManagerTestClient.get(
-            testConfig.getServiceAccountEmail(), path, DataReferenceList.class);
+        workspaceManagerTestClient.get(testConfig.getUserEmail(), path, DataReferenceList.class);
     assertEquals(HttpStatus.OK, listResponse.getStatusCode());
     assertTrue(listResponse.isResponseObject());
     DataReferenceList referenceList = listResponse.getResponseObject();
@@ -228,7 +227,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
   private WorkspaceResponse<CreatedWorkspace> createDefaultWorkspace(UUID workspaceId)
       throws Exception {
     String path = testConfig.getWsmWorkspacesBaseUrl();
-    String userEmail = testConfig.getServiceAccountEmail();
+    String userEmail = testConfig.getUserEmail();
     String token = authService.getAuthToken(userEmail);
     CreateWorkspaceRequestBody body =
         new CreateWorkspaceRequestBody().id(workspaceId).authToken(token);
@@ -249,7 +248,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     // support this test in other DataRepo environments.
     // Data Repo makes a reasonable effort to maintain their dev environment, so this should be a
     // very rare occurrence.
-    String userEmail = testConfig.getServiceAccountEmail();
+    String userEmail = testConfig.getUserEmail();
     String path = testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId + "/datareferences";
 
     DataRepoSnapshot snapshotReference =
@@ -273,7 +272,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
         the next one)? In any case, caching the auth token will enable us to efficiently auth before EACH delete request.
         This ticket will implement caching for auth token using Caffeine AS-428
     */
-    String userEmail = testConfig.getServiceAccountEmail();
+    String userEmail = testConfig.getUserEmail();
     String token = authService.getAuthToken(userEmail);
     String workspaceBaseUrl = testConfig.getWsmWorkspacesBaseUrl();
     DeleteWorkspaceRequestBody body = new DeleteWorkspaceRequestBody().authToken(token);

--- a/src/test/java/bio/terra/workspace/integration/common/auth/AuthService.java
+++ b/src/test/java/bio/terra/workspace/integration/common/auth/AuthService.java
@@ -20,7 +20,7 @@ public class AuthService {
   public AuthService(IntegrationTestConfiguration testConfig) {
     this.testConfig = testConfig;
     Optional<String> serviceAccountFilePath =
-        Optional.ofNullable(this.testConfig.getServiceAccountFilePath());
+        Optional.ofNullable(this.testConfig.getUserDelegatedServiceAccountPath());
     serviceAccountFilePath.ifPresent(s -> serviceAccountFile = new File(s));
   }
 
@@ -33,7 +33,8 @@ public class AuthService {
     if (!Optional.ofNullable(serviceAccountFile).isPresent()) {
       throw new IllegalStateException(
           String.format(
-              "Service account file not found: %s", testConfig.getServiceAccountFilePath()));
+              "Service account file not found: %s",
+              testConfig.getUserDelegatedServiceAccountPath()));
     }
     GoogleCredentials credentials =
         GoogleCredentials.fromStream(

--- a/src/test/java/bio/terra/workspace/integration/common/configuration/IntegrationTestConfiguration.java
+++ b/src/test/java/bio/terra/workspace/integration/common/configuration/IntegrationTestConfiguration.java
@@ -18,8 +18,13 @@ public class IntegrationTestConfiguration {
   private HashMap<String, String> wsmEndpoints;
   private HashMap<String, String> dataRepoInstanceNames;
   private HashMap<String, String> dataRepoSnapshotId;
-  private String serviceAccountEmail;
-  private String serviceAccountFilePath;
+  /** What user to impersonate to run the integration tests. */
+  private String userEmail;
+  /**
+   * The path to the service account to use. This service account should be delegated to impersonate
+   * users. https://developers.google.com/admin-sdk/directory/v1/guides/delegation
+   */
+  private String userDelegatedServiceAccountPath;
 
   public void setWsmEndpoints(HashMap<String, String> wsmEndpoints) {
     this.wsmEndpoints = wsmEndpoints;
@@ -33,20 +38,20 @@ public class IntegrationTestConfiguration {
     return this.wsmUrls.get(testEnv) + this.wsmEndpoints.get("workspaces");
   }
 
-  public String getServiceAccountEmail() {
-    return serviceAccountEmail;
+  public String getUserEmail() {
+    return userEmail;
   }
 
-  public void setServiceAccountEmail(String serviceAccountEmail) {
-    this.serviceAccountEmail = serviceAccountEmail;
+  public void setUserEmail(String userEmail) {
+    this.userEmail = userEmail;
   }
 
-  public String getServiceAccountFilePath() {
-    return serviceAccountFilePath;
+  public String getUserDelegatedServiceAccountPath() {
+    return userDelegatedServiceAccountPath;
   }
 
-  public void setServiceAccountFilePath(String serviceAccountFilePath) {
-    this.serviceAccountFilePath = serviceAccountFilePath;
+  public void setUserDelegatedServiceAccountPath(String userDelegatedServiceAccountPath) {
+    this.userDelegatedServiceAccountPath = userDelegatedServiceAccountPath;
   }
 
   public String getDataRepoInstanceNameFromEnv() {

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -3,8 +3,8 @@ workspace.integration-test:
     dev: terra
   data-repo-snapshot-id:
     dev: 97b5559a-2f8f-4df3-89ae-5a249173ee0c
-  service-account-email: william.thunderlord@test.firecloud.org
-  service-account-file-path: rendered/service-account.json
+  user-email: william.thunderlord@test.firecloud.org
+  user-delegated-service-account-path: rendered/user-delegated-service-account.json
   wsm-endpoints:
     workspaces: api/workspaces/v1
   wsm-urls:


### PR DESCRIPTION
Use the firecloud delegated service account to act as the test user in integration tests and use WM app service account to run WM application.
Previously, the common firecloud service account was used for both purposes.

Rename WorkspaceIntegrationTest config field names to make it clearer how they are used.