### PR TITLE
[PF-199] Run integration test against localhost instead of dev

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,8 +5,6 @@ name: Run Integration Tests
 
 on:
   push:
-    branches:
-      - dev
     paths-ignore:
       - 'README.md'
       - '.github/**'
@@ -62,13 +60,17 @@ jobs:
       - name: Render configuration for tests
         run: ./render_config.sh ${{ steps.vault-token-step.outputs.vault-token }} dev
       - name: Ensure read permissions for rendered files
-        run: sudo chmod +r rendered/service-account.json
+        run: sudo chmod +r rendered
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Initialize Postgres DB
         env:
           PGPASSWORD: postgres
         run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
+      - name: Run local server (in background)
+        run: ./gradlew bootRun &
+      - name: Wait for local server to start
+        run: timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 0.5; done'
       - name: Run integration tests
         env:
           TEST_ENV: dev

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,10 +5,9 @@ name: Run Integration Tests
 
 on:
   push:
-    paths-ignore:
-      - 'README.md'
-      - '.github/**'
-      - 'local-dev/**'
+    branches: [ dev ]
+  pull_request:
+    branches: [ '**' ]
 jobs:
   integration-test:
 
@@ -70,7 +69,8 @@ jobs:
       - name: Run local server (in background)
         run: ./gradlew bootRun &
       - name: Wait for local server to start
-        run: timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 0.5; done'
+        # With a timeout of 60 seconds, try to connect to localhost:8080 every 1 second.
+        run: timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
       - name: Run integration tests
         env:
           TEST_ENV: dev

--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -225,6 +225,68 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     assertThat(referenceList.getResources(), containsInAnyOrder(expectedResults));
   }
 
+  @Test
+  @Tag(TAG_NEEDS_CLEANUP)
+  public void getDataReferenceById(TestInfo testInfo) throws Exception {
+    UUID workspaceId = UUID.randomUUID();
+    testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
+
+    createDefaultWorkspace(workspaceId);
+    String referenceName = "workspace_integration_test_snapshot";
+    WorkspaceResponse<DataReferenceDescription> postResponse =
+        createDefaultDataReference(workspaceId, referenceName);
+    assertEquals(HttpStatus.OK, postResponse.getStatusCode());
+    assertTrue(postResponse.isResponseObject());
+
+    UUID referenceId = postResponse.getResponseObject().getReferenceId();
+    String path =
+        testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId + "/datareferences/" + referenceId;
+
+    WorkspaceResponse<DataReferenceDescription> getResponse =
+        workspaceManagerTestClient.get(
+            testConfig.getServiceAccountEmail(), path, DataReferenceDescription.class);
+
+    assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+    assertTrue(getResponse.isResponseObject());
+    DataReferenceDescription dataReferenceDescription = getResponse.getResponseObject();
+
+    assertEquals(referenceName, dataReferenceDescription.getName());
+    assertEquals(workspaceId, dataReferenceDescription.getWorkspaceId());
+  }
+
+  @Test
+  @Tag(TAG_NEEDS_CLEANUP)
+  public void getDataReferenceByNameAndType(TestInfo testInfo) throws Exception {
+    UUID workspaceId = UUID.randomUUID();
+    testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
+
+    createDefaultWorkspace(workspaceId);
+    String referenceName = "workspace_integration_test_snapshot";
+    String referenceType = ReferenceTypeEnum.DATA_REPO_SNAPSHOT.toString();
+    WorkspaceResponse<DataReferenceDescription> postResponse =
+        createDefaultDataReference(workspaceId, referenceName);
+    assertEquals(HttpStatus.OK, postResponse.getStatusCode());
+    assertTrue(postResponse.isResponseObject());
+
+    UUID referenceId = postResponse.getResponseObject().getReferenceId();
+
+    String path =
+        String.format(
+            "%s/%s/datareferences/%s/%s",
+            testConfig.getWsmWorkspacesBaseUrl(), workspaceId, referenceType, referenceName);
+
+    WorkspaceResponse<DataReferenceDescription> getResponse =
+        workspaceManagerTestClient.get(
+            testConfig.getServiceAccountEmail(), path, DataReferenceDescription.class);
+
+    assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+    assertTrue(getResponse.isResponseObject());
+    DataReferenceDescription dataReferenceDescription = getResponse.getResponseObject();
+
+    assertEquals(referenceId, dataReferenceDescription.getReferenceId());
+    assertEquals(workspaceId, dataReferenceDescription.getWorkspaceId());
+  }
+
   private WorkspaceResponse<CreatedWorkspace> createDefaultWorkspace(UUID workspaceId)
       throws Exception {
     String path = testConfig.getWsmWorkspacesBaseUrl();

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -8,6 +8,6 @@ workspace.integration-test:
   wsm-endpoints:
     workspaces: api/workspaces/v1
   wsm-urls:
-# swap the commented line to run integration tests against local
-    dev: https://workspace.dsde-dev.broadinstitute.org/
-#    dev: http://localhost:8080/
+# swap the commented line to run integration tests against dev
+#    dev: https://workspace.dsde-dev.broadinstitute.org/
+    dev: http://localhost:8080/


### PR DESCRIPTION
Currently, the integration test runs against the dev environment after the PR is merged, but before the new image is pushed to dev. This PR makes it so that the integration test for a PR is run against a local instance of the service with the PR changes.
Also change the integration test workflow to run on PRs as well as after merges to dev.