### PR TITLE
Fix new DataReference integration tests to use renamed testConfig.getUserEmail()

### DIFF
--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -243,7 +243,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
     WorkspaceResponse<DataReferenceDescription> getResponse =
         workspaceManagerTestClient.get(
-            testConfig.getServiceAccountEmail(), path, DataReferenceDescription.class);
+            testConfig.getUserEmail(), path, DataReferenceDescription.class);
 
     assertEquals(HttpStatus.OK, getResponse.getStatusCode());
     assertTrue(getResponse.isResponseObject());
@@ -276,7 +276,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
     WorkspaceResponse<DataReferenceDescription> getResponse =
         workspaceManagerTestClient.get(
-            testConfig.getServiceAccountEmail(), path, DataReferenceDescription.class);
+            testConfig.getUserEmail(), path, DataReferenceDescription.class);
 
     assertEquals(HttpStatus.OK, getResponse.getStatusCode());
     assertTrue(getResponse.isResponseObject());


### PR DESCRIPTION
Broken at head by the combination of renaming the method (https://github.com/DataBiosphere/terra-workspace-manager/pull/125/files) and new use of the method with the old name (https://github.com/DataBiosphere/terra-workspace-manager/pull/122).