### PR TITLE
AS-525: auth token in header for create- and delete-workspace [risk: low]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 
 allprojects {
 	group = "bio.terra"
-	version = "0.2.0-SNAPSHOT"
+	version = "0.3.0-SNAPSHOT"
 	ext {
 		artifactGroup = "${group}.workspace"
 		swaggerOutputDir = "${buildDir}/swagger-code"

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -15,7 +15,6 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
-import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -56,10 +55,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   @Override
   public ResponseEntity<CreatedWorkspace> createWorkspace(
       @RequestBody CreateWorkspaceRequestBody body) {
-    // Note: we do NOT use getAuthenticatedInfo here, as the request's authentication info comes
-    // from the folder manager, not the requesting user.
-    String userToken = body.getAuthToken();
-    AuthenticatedUserRequest userReq = new AuthenticatedUserRequest().token(Optional.of(userToken));
+    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     return new ResponseEntity<>(workspaceService.createWorkspace(body, userReq), HttpStatus.OK);
   }
 
@@ -74,10 +70,8 @@ public class WorkspaceApiController implements WorkspaceApi {
   @Override
   public ResponseEntity<Void> deleteWorkspace(
       @PathVariable("id") UUID id, DeleteWorkspaceRequestBody body) {
-    // Note: we do NOT use getAuthenticatedInfo here, as the request's authentication info comes
-    // from the folder manager, not the requesting user.
-    String userToken = body.getAuthToken();
-    workspaceService.deleteWorkspace(id, userToken);
+    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
+    workspaceService.deleteWorkspace(id, userReq);
     return new ResponseEntity<>(HttpStatus.valueOf(204));
   }
 

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -7,7 +7,6 @@ import bio.terra.workspace.generated.model.CreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.CreatedWorkspace;
 import bio.terra.workspace.generated.model.DataReferenceDescription;
 import bio.terra.workspace.generated.model.DataReferenceList;
-import bio.terra.workspace.generated.model.DeleteWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ReferenceTypeEnum;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
 import bio.terra.workspace.service.datareference.DataReferenceService;
@@ -68,8 +67,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   }
 
   @Override
-  public ResponseEntity<Void> deleteWorkspace(
-      @PathVariable("id") UUID id, DeleteWorkspaceRequestBody body) {
+  public ResponseEntity<Void> deleteWorkspace(@PathVariable("id") UUID id) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     workspaceService.deleteWorkspace(id, userReq);
     return new ResponseEntity<>(HttpStatus.valueOf(204));

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -15,7 +15,6 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import io.opencensus.contrib.spring.aop.Traced;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -70,9 +69,8 @@ public class WorkspaceService {
     return workspaceDao.getWorkspace(id);
   }
 
-  public void deleteWorkspace(UUID id, String userToken) {
+  public void deleteWorkspace(UUID id, AuthenticatedUserRequest userReq) {
 
-    AuthenticatedUserRequest userReq = new AuthenticatedUserRequest().token(Optional.of(userToken));
     samService.workspaceAuthz(userReq, id, SamUtils.SAM_WORKSPACE_DELETE_ACTION);
 
     String description = "Delete workspace " + id;

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -42,7 +42,7 @@ paths:
   # Workspace paths
   /api/workspaces/v1:
     post:
-      summary: Create a new Workspace. This should only be called by Folder Manager.
+      summary: Create a new Workspace.
       operationId: createWorkspace
       tags: [Workspace]
       requestBody:
@@ -82,16 +82,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
     delete:
-      summary: Delete a Workspace. This should only be called by the Folder Manager.
+      summary: Delete a Workspace.
       operationId: deleteWorkspace
       tags: [Workspace]
-      requestBody:
-        required: true
-        description: Auth token of user requesting the delete.
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeleteWorkspaceRequestBody'
       responses:
         '204':
           description: Success
@@ -391,15 +384,12 @@ components:
 
     CreateWorkspaceRequestBody:
       type: object
-      required: [id, authToken]
+      required: [id]
       properties:
         id:
           description: The ID of the workspace
           type: string
           format: uuid
-        authToken:
-          description: Requesting user's auth token
-          type: string
         spendProfile:
           description: UUID of provided spend profile
           type: string
@@ -419,14 +409,6 @@ components:
           description: UUID of a newly-created workspace
           type: string
           format: uuid
-
-    DeleteWorkspaceRequestBody:
-      type: object
-      required: [authToken]
-      properties:
-        authToken:
-          description: Requesting user's auth token
-          type: string
 
     WorkspaceDescription:
       type: object

--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -18,7 +18,6 @@ import bio.terra.workspace.model.CreatedWorkspace;
 import bio.terra.workspace.model.DataReferenceDescription;
 import bio.terra.workspace.model.DataReferenceList;
 import bio.terra.workspace.model.DataRepoSnapshot;
-import bio.terra.workspace.model.DeleteWorkspaceRequestBody;
 import bio.terra.workspace.model.ReferenceTypeEnum;
 import bio.terra.workspace.model.WorkspaceDescription;
 import java.util.Collections;
@@ -114,11 +113,9 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     String userEmail = testConfig.getUserEmail();
     String token = authService.getAuthToken(userEmail);
     String path = testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId;
-    DeleteWorkspaceRequestBody body = new DeleteWorkspaceRequestBody().authToken(token);
-    String jsonBody = testUtils.mapToJson(body);
 
     WorkspaceResponse<?> deleteWorkspaceResponse =
-        workspaceManagerTestClient.delete(userEmail, path, jsonBody);
+        workspaceManagerTestClient.delete(userEmail, path);
 
     assertEquals(HttpStatus.NO_CONTENT, deleteWorkspaceResponse.getStatusCode());
 
@@ -132,26 +129,6 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
      timeout, etc.
     */
     testToWorkspaceIdsMap.remove(testInfo.getDisplayName());
-  }
-
-  @Test
-  @Tag(TAG_NEEDS_CLEANUP)
-  public void deleteWorkspaceWithInvalidToken(TestInfo testInfo) throws Exception {
-    UUID workspaceId = UUID.randomUUID();
-    testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
-    WorkspaceResponse<CreatedWorkspace> workspaceResponse = createDefaultWorkspace(workspaceId);
-
-    String userEmail = testConfig.getUserEmail();
-    String token = "invalidToken";
-    String path = testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId;
-    DeleteWorkspaceRequestBody body = new DeleteWorkspaceRequestBody().authToken(token);
-    String jsonBody = testUtils.mapToJson(body);
-
-    WorkspaceResponse<?> deleteWorkspaceResponse =
-        workspaceManagerTestClient.delete(userEmail, path, jsonBody);
-
-    assertEquals(HttpStatus.UNAUTHORIZED, deleteWorkspaceResponse.getStatusCode());
-    assertTrue(deleteWorkspaceResponse.isErrorObject());
   }
 
   @Test
@@ -190,7 +167,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
         testConfig.getWsmWorkspacesBaseUrl() + "/" + workspaceId + "/datareferences/" + referenceId;
 
     WorkspaceResponse<?> deleteResponse =
-        workspaceManagerTestClient.delete(testConfig.getUserEmail(), deletePath, "");
+        workspaceManagerTestClient.delete(testConfig.getUserEmail(), deletePath);
     assertEquals(HttpStatus.valueOf(204), deleteResponse.getStatusCode());
   }
 
@@ -290,9 +267,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
       throws Exception {
     String path = testConfig.getWsmWorkspacesBaseUrl();
     String userEmail = testConfig.getUserEmail();
-    String token = authService.getAuthToken(userEmail);
-    CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody().id(workspaceId).authToken(token);
+    CreateWorkspaceRequestBody body = new CreateWorkspaceRequestBody().id(workspaceId);
     String jsonBody = testUtils.mapToJson(body);
 
     return workspaceManagerTestClient.post(userEmail, path, jsonBody, CreatedWorkspace.class);
@@ -337,14 +312,12 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
     String userEmail = testConfig.getUserEmail();
     String token = authService.getAuthToken(userEmail);
     String workspaceBaseUrl = testConfig.getWsmWorkspacesBaseUrl();
-    DeleteWorkspaceRequestBody body = new DeleteWorkspaceRequestBody().authToken(token);
-    String jsonBody = testUtils.mapToJson(body);
 
     for (UUID uuid : workspaceIds) {
       String path = workspaceBaseUrl + "/" + uuid;
 
       WorkspaceResponse<?> deleteWorkspaceResponse =
-          workspaceManagerTestClient.delete(userEmail, path, jsonBody);
+          workspaceManagerTestClient.delete(userEmail, path);
 
       /*
         TODO: If the delete call fails for some reason, we won't 'assert' as this is not a test. We

--- a/src/test/java/bio/terra/workspace/integration/common/utils/WorkspaceManagerTestClient.java
+++ b/src/test/java/bio/terra/workspace/integration/common/utils/WorkspaceManagerTestClient.java
@@ -50,9 +50,8 @@ public class WorkspaceManagerTestClient {
     return sendRequest(path, HttpMethod.GET, entity, ErrorReport.class, responseClass);
   }
 
-  public <T> WorkspaceResponse<T> delete(String userEmail, String path, String json)
-      throws Exception {
-    HttpEntity<String> entity = new HttpEntity<>(json, getHeaders(userEmail));
+  public <T> WorkspaceResponse<T> delete(String userEmail, String path) throws Exception {
+    HttpEntity<String> entity = new HttpEntity<>(getHeaders(userEmail));
     return sendRequest(path, HttpMethod.DELETE, entity, ErrorReport.class, null);
   }
 

--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -472,11 +472,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
 
   private CreatedWorkspace createDefaultWorkspace() throws Exception {
     CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .authToken("fake-user-auth-token")
-            .spendProfile(null)
-            .policies(null);
+        new CreateWorkspaceRequestBody().id(workspaceId).spendProfile(null).policies(null);
 
     return runCreateWorkspaceCall(body);
   }

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -22,7 +22,6 @@ import bio.terra.workspace.generated.model.CreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.CreatedWorkspace;
 import bio.terra.workspace.generated.model.DataReferenceDescription;
 import bio.terra.workspace.generated.model.DataRepoSnapshot;
-import bio.terra.workspace.generated.model.DeleteWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ErrorReport;
 import bio.terra.workspace.generated.model.ReferenceTypeEnum;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
@@ -84,7 +83,6 @@ public class WorkspaceServiceTest extends BaseUnitTest {
     CreateWorkspaceRequestBody body = new CreateWorkspaceRequestBody();
     UUID workspaceId = UUID.randomUUID();
     body.setId(workspaceId);
-    body.setAuthToken("fake-user-auth-token");
 
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
 
@@ -106,11 +104,7 @@ public class WorkspaceServiceTest extends BaseUnitTest {
   public void workspaceCreatedFromJobRequest() throws Exception {
     UUID workspaceId = UUID.randomUUID();
     CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .authToken("fake-user-auth-token")
-            .spendProfile(null)
-            .policies(null);
+        new CreateWorkspaceRequestBody().id(workspaceId).spendProfile(null).policies(null);
 
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
 
@@ -121,11 +115,7 @@ public class WorkspaceServiceTest extends BaseUnitTest {
   public void duplicateWorkspaceRejected() throws Exception {
     UUID workspaceId = UUID.randomUUID();
     CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .authToken("fake-user-auth-token")
-            .spendProfile(null)
-            .policies(null);
+        new CreateWorkspaceRequestBody().id(workspaceId).spendProfile(null).policies(null);
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
     assertThat(workspace.getId(), equalTo(workspaceId));
 
@@ -147,7 +137,6 @@ public class WorkspaceServiceTest extends BaseUnitTest {
     CreateWorkspaceRequestBody body =
         new CreateWorkspaceRequestBody()
             .id(workspaceId)
-            .authToken("fake-user-auth-token")
             .spendProfile(UUID.randomUUID())
             .policies(Collections.singletonList(UUID.randomUUID()));
 
@@ -165,11 +154,7 @@ public class WorkspaceServiceTest extends BaseUnitTest {
         .createWorkspaceWithDefaults(any(), any());
 
     CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody()
-            .id(UUID.randomUUID())
-            .authToken("todo: add token")
-            .spendProfile(null)
-            .policies(null);
+        new CreateWorkspaceRequestBody().id(UUID.randomUUID()).spendProfile(null).policies(null);
 
     MvcResult callResult =
         mvc.perform(
@@ -188,21 +173,12 @@ public class WorkspaceServiceTest extends BaseUnitTest {
   public void createAndDeleteWorkspace() throws Exception {
     UUID workspaceId = UUID.randomUUID();
     CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .authToken("fake-user-auth-token")
-            .spendProfile(null)
-            .policies(null);
+        new CreateWorkspaceRequestBody().id(workspaceId).spendProfile(null).policies(null);
 
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
     assertThat(workspace.getId(), equalTo(workspaceId));
 
-    DeleteWorkspaceRequestBody deleteBody =
-        new DeleteWorkspaceRequestBody().authToken("fake-user-auth-token");
-    mvc.perform(
-            delete("/api/workspaces/v1/" + workspaceId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(deleteBody)))
+    mvc.perform(delete("/api/workspaces/v1/" + workspaceId).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is(204))
         .andReturn();
     // Finally, assert that a call to the deleted workspace gives a 404
@@ -214,11 +190,7 @@ public class WorkspaceServiceTest extends BaseUnitTest {
     // First, create a workspace.
     UUID workspaceId = UUID.randomUUID();
     CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .authToken("fake-user-auth-token")
-            .spendProfile(null)
-            .policies(null);
+        new CreateWorkspaceRequestBody().id(workspaceId).spendProfile(null).policies(null);
     CreatedWorkspace workspace = runCreateWorkspaceCall(body);
     assertThat(workspace.getId(), equalTo(workspaceId));
 
@@ -252,12 +224,7 @@ public class WorkspaceServiceTest extends BaseUnitTest {
         .andExpect(status().is(200))
         .andReturn();
     // Delete the workspace.
-    DeleteWorkspaceRequestBody deleteRequest =
-        new DeleteWorkspaceRequestBody().authToken("fake-user-auth-token");
-    mvc.perform(
-            delete("/api/workspaces/v1/" + workspaceId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(deleteRequest)))
+    mvc.perform(delete("/api/workspaces/v1/" + workspaceId).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is(204))
         .andReturn();
     // Verify that the contained data reference is no longer returned.


### PR DESCRIPTION
This is a follow-on to broadinstitute/rawls#1298.

Highlights of this PR:
* for create- and delete-workspace, honor the auth token in the HTTP headers, and ignore any token sent in the request body
* in fact, remove the request-body token from the model definitions for the create- and delete-workspace API signatures
* since the token was the only member of the `DeleteWorkspaceRequestBody` class, remove that class entirely and define the delete API to not have a request body at all
* update all the runtime and test code to reflect these changes

Once these changes are in, we will publish a new workspace manager client lib, which we will adopt in Rawls in a future PR.

