### PR TITLE
AS-458: upgrade postgres from 9.6 to 12.3 [risk: low]

### DIFF
--- a/.github/workflows/connected-test.yml
+++ b/.github/workflows/connected-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:12.3
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:12.3
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:12.3
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ Note: this document is being written during a time when code is rapidly evolving
 
 ### Prerequisites:
 
-- Install Postgres 9.6: https://www.postgresql.org/download/
+- Install Postgres 12.3: https://www.postgresql.org/download/
   - [The app](https://postgresapp.com/downloads.html) may be easier, just make sure to download the right version. It'll manage things for you and has a useful menulet where the server can be turned on and off. Don't forget to create a server if you go this route.
 - Install AdoptOpenJDK Java 11 (Hotspot). Here's an easy way on Mac, using [jEnv](https://www.jenv.be/) to manage the active version:
 

--- a/local-dev/run_postgres.sh
+++ b/local-dev/run_postgres.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Start up a postgres container with initial user/database setup.
-POSTGRES_VERSION=9.6
+POSTGRES_VERSION=12.3
 
 start() {
     echo "attempting to remove old $CONTAINER container..."


### PR DESCRIPTION
This upgrades Postgres from 9.6 to 12.3 in our tests, local dev env setup, and README. 

See also broadinstitute/terraform-ap-modules#97