### PR TITLE
PF-155 Add service level methods for getting and creating google cloud context.

### DIFF
--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -139,7 +139,8 @@ public class JobService {
     return retrieveJobResult(jobId, resultClass, userReq).getResult();
   }
 
-  protected void waitForJob(String jobId) {
+  @VisibleForTesting
+  public void waitForJob(String jobId) {
     try {
       int pollSeconds = jobConfig.getPollingIntervalSeconds();
       int pollCycles = jobConfig.getTimeoutSeconds() / jobConfig.getPollingIntervalSeconds();

--- a/src/test/java/bio/terra/workspace/common/BaseConnectedTest.java
+++ b/src/test/java/bio/terra/workspace/common/BaseConnectedTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.common;
 
 import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -11,4 +12,5 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @Tag("connected")
 @ActiveProfiles("connected-test")
+@AutoConfigureMockMvc
 public class BaseConnectedTest extends BaseTest {}

--- a/src/test/java/bio/terra/workspace/common/BaseConnectedTest.java
+++ b/src/test/java/bio/terra/workspace/common/BaseConnectedTest.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.common;
 
 import org.junit.jupiter.api.Tag;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -12,5 +11,4 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @Tag("connected")
 @ActiveProfiles("connected-test")
-@AutoConfigureMockMvc
 public class BaseConnectedTest extends BaseTest {}

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -39,12 +39,14 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+@AutoConfigureMockMvc
 public class WorkspaceServiceTest extends BaseConnectedTest {
   @Autowired private WorkspaceService workspaceService;
   @Autowired private JobService jobService;


### PR DESCRIPTION
Add methods to WorkspaceService for creating and getting cloud context. Delete to follow. 

I'm ambivalent about adding these methods to WorkspaceService vs creating a CloudContextService. There's not much meat to them, but they cold be considered distinct. The WorkspaceService's workspace deletion flight will want to reference steps in the cloud context deletion service, so there will be cross package dependencies.

I would like to change the other tests in WorkspaceService to use its API instead of http endpoints in another PR.
Also removes a WorkspaceServiceTest `workspaceCreatedFromJobRequest` that duplicates `testGetExistingWorkspace` AFAICT.