### PR TITLE
Separate API objects from internal objects in WorkspaceService

### DIFF
--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -66,14 +66,12 @@ public class WorkspaceApiController implements WorkspaceApi {
     WorkspaceStageModel requestStage = body.getStage();
     requestStage = (requestStage == null ? requestStage.RAWLS_WORKSPACE : requestStage);
     WorkspaceStage internalStage = WorkspaceStage.fromApiModel(requestStage);
-    Optional<SpendProfileId> spendProfile =
-        body.getSpendProfile() == null
-            ? Optional.empty()
-            : Optional.of(SpendProfileId.create(body.getSpendProfile()));
+    Optional<SpendProfileId> spendProfileId =
+        Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::create);
 
-    Workspace createdWorkspace =
-        workspaceService.createWorkspace(body.getId(), spendProfile, internalStage, userReq);
-    CreatedWorkspace responseWorkspace = new CreatedWorkspace().id(createdWorkspace.workspaceId());
+    UUID createdId =
+        workspaceService.createWorkspace(body.getId(), spendProfileId, internalStage, userReq);
+    CreatedWorkspace responseWorkspace = new CreatedWorkspace().id(createdId);
     return new ResponseEntity<>(responseWorkspace, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.app.controller;
 
+import bio.terra.workspace.common.model.Workspace;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.common.utils.ControllerValidationUtils;
 import bio.terra.workspace.generated.controller.WorkspaceApi;
@@ -63,16 +64,26 @@ public class WorkspaceApiController implements WorkspaceApi {
     WorkspaceStageModel requestStage = body.getStage();
     requestStage = (requestStage == null ? requestStage.RAWLS_WORKSPACE : requestStage);
     WorkspaceStage internalStage = WorkspaceStage.fromApiModel(requestStage);
-    return new ResponseEntity<>(
-        workspaceService.createWorkspace(body, internalStage, userReq), HttpStatus.OK);
+
+    Workspace createdWorkspace =
+        workspaceService.createWorkspace(
+            body.getId(), body.getSpendProfile(), internalStage, userReq);
+    CreatedWorkspace responseWorkspace = new CreatedWorkspace().id(createdWorkspace.workspaceId());
+    return new ResponseEntity<>(responseWorkspace, HttpStatus.OK);
   }
 
   @Override
   public ResponseEntity<WorkspaceDescription> getWorkspace(@PathVariable("id") UUID id) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    WorkspaceDescription desc = workspaceService.getWorkspace(id, userReq);
+    Workspace workspace = workspaceService.getWorkspace(id, userReq);
 
-    return new ResponseEntity<WorkspaceDescription>(desc, HttpStatus.OK);
+    WorkspaceDescription desc =
+        new WorkspaceDescription()
+            .id(workspace.workspaceId())
+            .spendProfile(workspace.spendProfileId())
+            .stage(workspace.workspaceStage().toApiModel());
+
+    return new ResponseEntity<>(desc, HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -79,12 +79,11 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<WorkspaceDescription> getWorkspace(@PathVariable("id") UUID id) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     Workspace workspace = workspaceService.getWorkspace(id, userReq);
-    String spendProfileStringId = workspace.spendProfileId().map(SpendProfileId::id).orElse(null);
 
     WorkspaceDescription desc =
         new WorkspaceDescription()
             .id(workspace.workspaceId())
-            .spendProfile(spendProfileStringId)
+            .spendProfile(workspace.spendProfileId().map(SpendProfileId::id).orElse(null))
             .stage(workspace.workspaceStage().toApiModel());
 
     return new ResponseEntity<>(desc, HttpStatus.OK);

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -79,8 +79,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<WorkspaceDescription> getWorkspace(@PathVariable("id") UUID id) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     Workspace workspace = workspaceService.getWorkspace(id, userReq);
-    String spendProfileStringId =
-        workspace.spendProfileId().isPresent() ? workspace.spendProfileId().get().id() : null;
+    String spendProfileStringId = workspace.spendProfileId().map(SpendProfileId::id).orElse(null);
 
     WorkspaceDescription desc =
         new WorkspaceDescription()

--- a/src/main/java/bio/terra/workspace/common/model/Workspace.java
+++ b/src/main/java/bio/terra/workspace/common/model/Workspace.java
@@ -5,14 +5,29 @@ import com.google.auto.value.AutoValue;
 import java.util.Optional;
 import java.util.UUID;
 
-/** Internal representation of a Workspace. */
+/**
+ * Internal representation of a Workspace.
+ *
+ * A workspace is a collection of resources, data references, and applications with some shared
+ * context. In general, a workspace is the fundamental unit of analysis in Terra. Workspaces may
+ * have an associated billing account and may have zero or one associated GCP projects.
+ */
 @AutoValue
 public abstract class Workspace {
 
+  /** The globally unique identifier of this workspace */
   public abstract UUID workspaceId();
 
+  /**
+   * The spend profile ID associated with this project, if one exists.
+   *
+   * In the future, this will correlate to a spend profile in the Spend Profile Manager. For now,
+   * it's just a unique identifier. Accounts with an associated GCP project must have a spend
+   * profile, while Rawls workspaces do not need one.
+   */
   public abstract Optional<SpendProfileId> spendProfileId();
 
+  /** Temporary feature flag indicating whether this workspace uses MC Terra features. */
   public abstract WorkspaceStage workspaceStage();
 
   public static Builder builder() {

--- a/src/main/java/bio/terra/workspace/common/model/Workspace.java
+++ b/src/main/java/bio/terra/workspace/common/model/Workspace.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 /**
  * Internal representation of a Workspace.
  *
- * A workspace is a collection of resources, data references, and applications with some shared
+ * <p>A workspace is a collection of resources, data references, and applications with some shared
  * context. In general, a workspace is the fundamental unit of analysis in Terra. Workspaces may
  * have an associated billing account and may have zero or one associated GCP projects.
  */
@@ -21,9 +21,9 @@ public abstract class Workspace {
   /**
    * The spend profile ID associated with this project, if one exists.
    *
-   * In the future, this will correlate to a spend profile in the Spend Profile Manager. For now,
-   * it's just a unique identifier. Accounts with an associated GCP project must have a spend
-   * profile, while Rawls workspaces do not need one.
+   * <p>In the future, this will correlate to a spend profile in the Spend Profile Manager. For now,
+   * it's just a unique identifier. To associate a GCP project with a workspace, the workspace must
+   * have a spend profile. They are not needed otherwise.
    */
   public abstract Optional<SpendProfileId> spendProfileId();
 

--- a/src/main/java/bio/terra/workspace/common/model/Workspace.java
+++ b/src/main/java/bio/terra/workspace/common/model/Workspace.java
@@ -1,0 +1,32 @@
+package bio.terra.workspace.common.model;
+
+import com.google.auto.value.AutoValue;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+/** Internal representation of a Workspace. */
+@AutoValue
+public abstract class Workspace {
+
+  public abstract UUID workspaceId();
+
+  @Nullable
+  public abstract String spendProfileId();
+
+  public abstract WorkspaceStage workspaceStage();
+
+  public static Builder builder() {
+    return new AutoValue_Workspace.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder workspaceId(UUID value);
+
+    public abstract Builder spendProfileId(String value);
+
+    public abstract Builder workspaceStage(WorkspaceStage value);
+
+    public abstract Workspace build();
+  }
+}

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -40,6 +40,7 @@ public class WorkspaceDao {
     this.jdbcTemplate = jdbcTemplate;
   }
 
+  /** Persists a workspace to DB. Returns ID of persisted workspace on success. */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public UUID createWorkspace(Workspace workspace) {
     String sql =
@@ -62,6 +63,7 @@ public class WorkspaceDao {
     return workspace.workspaceId();
   }
 
+  /** Deletes a workspace. Returns true on successful delete, false if there's nothing to delete. */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public boolean deleteWorkspace(UUID workspaceId) {
     MapSqlParameterSource params =
@@ -71,6 +73,7 @@ public class WorkspaceDao {
     return rowsAffected > 0;
   }
 
+  /** Retrieves a workspace from database by ID. */
   public Workspace getWorkspace(UUID id) {
     String sql = "SELECT * FROM workspace where workspace_id = (:id)";
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("id", id.toString());
@@ -94,6 +97,7 @@ public class WorkspaceDao {
   }
 
   // TODO: Unclear what level (if any) of @Transactional this requires.
+  /** Retrieves the MC Terra migration stage of a workspace from database by ID. */
   public WorkspaceStage getWorkspaceStage(UUID workspaceId) {
     String sql = "SELECT workspace_stage FROM workspace WHERE workspace_id = :id";
     MapSqlParameterSource params =

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -80,12 +80,11 @@ public class WorkspaceDao {
               sql,
               params,
               (rs, rowNum) -> {
-                String rawSpendProfileId = rs.getString("spend_profile");
-                SpendProfileId spendProfileId =
-                    rawSpendProfileId == null ? null : SpendProfileId.create(rawSpendProfileId);
                 return Workspace.builder()
                     .workspaceId(UUID.fromString(rs.getString("workspace_id")))
-                    .spendProfileId(Optional.ofNullable(spendProfileId))
+                    .spendProfileId(
+                        Optional.ofNullable(rs.getString("spend_profile"))
+                            .map(SpendProfileId::create))
                     .workspaceStage(WorkspaceStage.valueOf(rs.getString("workspace_stage")))
                     .build();
               }));

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -41,25 +41,25 @@ public class WorkspaceDao {
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public UUID createWorkspace(
-      UUID workspaceId, Optional<SpendProfileId> spendProfileId, WorkspaceStage workspaceStage) {
+  public UUID createWorkspace(Workspace workspace) {
     String sql =
         "INSERT INTO workspace (workspace_id, spend_profile, profile_settable, workspace_stage) values "
             + "(:id, :spend_profile, :spend_profile_settable, :workspace_stage)";
     MapSqlParameterSource params =
         new MapSqlParameterSource()
-            .addValue("id", workspaceId.toString())
-            .addValue("spend_profile", spendProfileId.map(SpendProfileId::id).orElse(null))
-            .addValue("spend_profile_settable", spendProfileId.isEmpty())
-            .addValue("workspace_stage", workspaceStage.toString());
+            .addValue("id", workspace.workspaceId().toString())
+            .addValue(
+                "spend_profile", workspace.spendProfileId().map(SpendProfileId::id).orElse(null))
+            .addValue("spend_profile_settable", workspace.spendProfileId().isEmpty())
+            .addValue("workspace_stage", workspace.workspaceStage().toString());
     try {
       jdbcTemplate.update(sql, params);
     } catch (DuplicateKeyException e) {
       throw new DuplicateWorkspaceException(
-          "Workspace " + workspaceId.toString() + " already exists.", e);
+          "Workspace " + workspace.workspaceId().toString() + " already exists.", e);
     }
 
-    return workspaceId;
+    return workspace.workspaceId();
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -41,7 +41,7 @@ public class WorkspaceDao {
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public Workspace createWorkspace(
+  public UUID createWorkspace(
       UUID workspaceId, Optional<SpendProfileId> spendProfileId, WorkspaceStage workspaceStage) {
     String sql =
         "INSERT INTO workspace (workspace_id, spend_profile, profile_settable, workspace_stage) values "
@@ -59,11 +59,7 @@ public class WorkspaceDao {
           "Workspace " + workspaceId.toString() + " already exists.", e);
     }
 
-    return Workspace.builder()
-        .workspaceId(workspaceId)
-        .spendProfileId(spendProfileId)
-        .workspaceStage(workspaceStage)
-        .build();
+    return workspaceId;
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -16,6 +16,12 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/**
+ * Service for workspace lifecycle operations.
+ *
+ * <p>This service holds core workspace management operations like creating, reading, and deleting
+ * workspaces as well as their cloud contexts. New methods generally should go in new services.
+ */
 @Component
 public class WorkspaceService {
 
@@ -30,6 +36,7 @@ public class WorkspaceService {
     this.samService = samService;
   }
 
+  /** Create a workspace with the specified parameters. Returns workspaceID of the new workspace. */
   @Traced
   public UUID createWorkspace(
       UUID workspaceId,
@@ -56,12 +63,14 @@ public class WorkspaceService {
     return createJob.submitAndWait(UUID.class);
   }
 
+  /** Retrieves an existing workspace by ID */
   @Traced
   public Workspace getWorkspace(UUID id, AuthenticatedUserRequest userReq) {
     samService.workspaceAuthz(userReq, id, SamUtils.SAM_WORKSPACE_READ_ACTION);
     return workspaceDao.getWorkspace(id);
   }
 
+  /** Delete an existing workspace by ID. Does not delete underlying cloud context. */
   @Traced
   public void deleteWorkspace(UUID id, AuthenticatedUserRequest userReq) {
 

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -31,7 +31,7 @@ public class WorkspaceService {
   }
 
   @Traced
-  public Workspace createWorkspace(
+  public UUID createWorkspace(
       UUID workspaceId,
       Optional<SpendProfileId> spendProfileId,
       WorkspaceStage workspaceStage,
@@ -47,11 +47,13 @@ public class WorkspaceService {
                 null,
                 userReq)
             .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
-    createJob.addParameter(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, spendProfileId);
+    if (spendProfileId.isPresent()) {
+      createJob.addParameter(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, spendProfileId.get().id());
+    }
 
     createJob.addParameter(WorkspaceFlightMapKeys.WORKSPACE_STAGE, workspaceStage);
 
-    return createJob.submitAndWait(Workspace.class);
+    return createJob.submitAndWait(UUID.class);
   }
 
   @Traced

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -5,10 +5,10 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.model.Workspace;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.WorkspaceDao;
-import bio.terra.workspace.generated.model.CreatedWorkspace;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 
@@ -31,9 +31,9 @@ public class CreateWorkspaceStep implements Step {
     workingMap.put(CREATE_WORKSPACE_COMPLETED_KEY, false);
 
     // This can be null if no spend profile is specified
-    UUID nullableSpendProfileId = null;
+    String nullableSpendProfileId = null;
 
-    UUID spendProfileId = inputMap.get(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, UUID.class);
+    String spendProfileId = inputMap.get(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, String.class);
     if (spendProfileId != null) {
       nullableSpendProfileId = spendProfileId;
     }
@@ -41,12 +41,11 @@ public class CreateWorkspaceStep implements Step {
     WorkspaceStage workspaceStage =
         inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, WorkspaceStage.class);
 
-    workspaceDao.createWorkspace(workspaceId, nullableSpendProfileId, workspaceStage);
+    Workspace createdWorkspace =
+        workspaceDao.createWorkspace(workspaceId, nullableSpendProfileId, workspaceStage);
     workingMap.put(CREATE_WORKSPACE_COMPLETED_KEY, true);
 
-    CreatedWorkspace response = new CreatedWorkspace();
-    response.setId(workspaceId);
-    FlightUtils.setResponse(flightContext, response, HttpStatus.OK);
+    FlightUtils.setResponse(flightContext, createdWorkspace, HttpStatus.OK);
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -5,6 +5,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.model.Workspace;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.WorkspaceDao;
@@ -36,8 +37,14 @@ public class CreateWorkspaceStep implements Step {
             .map(SpendProfileId::create);
     WorkspaceStage workspaceStage =
         inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, WorkspaceStage.class);
+    Workspace workspaceToCreate =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .spendProfileId(spendProfileId)
+            .workspaceStage(workspaceStage)
+            .build();
 
-    workspaceDao.createWorkspace(workspaceId, spendProfileId, workspaceStage);
+    workspaceDao.createWorkspace(workspaceToCreate);
     workingMap.put(CREATE_WORKSPACE_COMPLETED_KEY, true);
 
     FlightUtils.setResponse(flightContext, workspaceId, HttpStatus.OK);

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -5,7 +5,6 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
-import bio.terra.workspace.common.model.Workspace;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.WorkspaceDao;
@@ -33,15 +32,15 @@ public class CreateWorkspaceStep implements Step {
     workingMap.put(CREATE_WORKSPACE_COMPLETED_KEY, false);
 
     Optional<SpendProfileId> spendProfileId =
-        inputMap.get(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, Optional.class);
+        Optional.ofNullable(inputMap.get(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, String.class))
+            .map(SpendProfileId::create);
     WorkspaceStage workspaceStage =
         inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, WorkspaceStage.class);
 
-    Workspace createdWorkspace =
-        workspaceDao.createWorkspace(workspaceId, spendProfileId, workspaceStage);
+    workspaceDao.createWorkspace(workspaceId, spendProfileId, workspaceStage);
     workingMap.put(CREATE_WORKSPACE_COMPLETED_KEY, true);
 
-    FlightUtils.setResponse(flightContext, createdWorkspace, HttpStatus.OK);
+    FlightUtils.setResponse(flightContext, workspaceId, HttpStatus.OK);
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -391,15 +391,8 @@ components:
           type: string
           format: uuid
         spendProfile:
-          description: UUID of provided spend profile
+          description: ID of provided spend profile
           type: string
-          format: uuid
-        policies:
-          description: Policies provided by the containing folder
-          type: array
-          items:
-            type: string
-            format: uuid
         stage:
           $ref: '#/components/schemas/WorkspaceStageModel'
 
@@ -421,9 +414,8 @@ components:
           type: string
           format: uuid
         spendProfile:
-          description: UUID of provided spend profile
+          description: ID of provided spend profile
           type: string
-          format: uuid
         stage:
           $ref: '#/components/schemas/WorkspaceStageModel'
 

--- a/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfigura
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.exception.DataReferenceNotFoundException;
 import bio.terra.workspace.common.exception.DuplicateDataReferenceException;
+import bio.terra.workspace.common.model.Workspace;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.generated.model.CloningInstructionsEnum;
 import bio.terra.workspace.generated.model.DataReferenceDescription;
@@ -21,7 +22,6 @@ import bio.terra.workspace.generated.model.ReferenceTypeEnum;
 import bio.terra.workspace.service.datareference.exception.InvalidDataReferenceException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,7 +65,12 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyCreatedDataReferenceExists() {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -101,7 +106,12 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyCreateDuplicateNameFails() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -130,7 +140,12 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyGetDataReferenceByName() {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -149,7 +164,12 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyGetDataReference() {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -172,14 +192,22 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyGetDataReferenceNotInWorkspaceNotFound() {
-    UUID decoyWorkspaceId = UUID.randomUUID();
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
-    workspaceDao.createWorkspace(
-        decoyWorkspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
+    Workspace decoyWorkspace =
+        Workspace.builder()
+            .workspaceId(UUID.randomUUID())
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(decoyWorkspace);
 
     dataReferenceDao.createDataReference(
         referenceId,
-        decoyWorkspaceId,
+        decoyWorkspace.workspaceId(),
         name,
         null,
         credentialId,
@@ -196,7 +224,12 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyDeleteDataReference() {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -221,7 +254,13 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void enumerateWorkspaceReferences() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
+
     // Create two references in the same workspace.
     dataReferenceDao.createDataReference(
         referenceId,
@@ -259,7 +298,12 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void enumerateEmptyReferenceList() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
 
     DataReferenceList result = dataReferenceDao.enumerateDataReferences(workspaceId, name, 0, 10);
     assertThat(result.getResources(), empty());

--- a/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
@@ -65,12 +65,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyCreatedDataReferenceExists() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -106,12 +101,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyCreateDuplicateNameFails() throws Exception {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -140,12 +130,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyGetDataReferenceByName() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -164,12 +149,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyGetDataReference() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -192,12 +172,8 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyGetDataReferenceNotInWorkspaceNotFound() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
+
     Workspace decoyWorkspace =
         Workspace.builder()
             .workspaceId(UUID.randomUUID())
@@ -224,12 +200,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyDeleteDataReference() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -254,12 +225,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void enumerateWorkspaceReferences() throws Exception {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     // Create two references in the same workspace.
     dataReferenceDao.createDataReference(
@@ -298,12 +264,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void enumerateEmptyReferenceList() throws Exception {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     DataReferenceList result = dataReferenceDao.enumerateDataReferences(workspaceId, name, 0, 10);
     assertThat(result.getResources(), empty());
@@ -315,6 +276,13 @@ public class DataReferenceDaoTest extends BaseUnitTest {
     } catch (JsonProcessingException e) {
       throw new InvalidDataReferenceException("Invalid data reference");
     }
+  }
+
+  private Workspace defaultWorkspace() {
+    return Workspace.builder()
+        .workspaceId(workspaceId)
+        .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+        .build();
   }
 
   // TODO: currently no tests enumerating controlled data resources, as we have no way to create

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -8,9 +8,8 @@ import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfigura
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.exception.DuplicateWorkspaceException;
 import bio.terra.workspace.common.exception.WorkspaceNotFoundException;
+import bio.terra.workspace.common.model.Workspace;
 import bio.terra.workspace.common.model.WorkspaceStage;
-import bio.terra.workspace.generated.model.WorkspaceDescription;
-import bio.terra.workspace.generated.model.WorkspaceStageModel;
 import bio.terra.workspace.service.workspace.WorkspaceCloudContext;
 import java.util.Map;
 import java.util.UUID;
@@ -30,14 +29,14 @@ public class WorkspaceDaoTest extends BaseUnitTest {
   @Autowired private WorkspaceDao workspaceDao;
 
   private UUID workspaceId;
-  private UUID spendProfileId;
+  private String spendProfileId;
   private String readSql =
       "SELECT workspace_id, spend_profile, profile_settable FROM workspace WHERE workspace_id = :id";
 
   @BeforeEach
   public void setup() {
     workspaceId = UUID.randomUUID();
-    spendProfileId = UUID.randomUUID();
+    spendProfileId = UUID.randomUUID().toString();
   }
 
   @Test
@@ -79,12 +78,14 @@ public class WorkspaceDaoTest extends BaseUnitTest {
   public void createAndGetWorkspace() throws Exception {
     workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
 
-    WorkspaceDescription workspace = workspaceDao.getWorkspace(workspaceId);
+    Workspace workspace = workspaceDao.getWorkspace(workspaceId);
 
-    WorkspaceDescription expectedWorkspace = new WorkspaceDescription();
-    expectedWorkspace.setId(workspaceId);
-    expectedWorkspace.setSpendProfile(null);
-    expectedWorkspace.setStage(WorkspaceStageModel.RAWLS_WORKSPACE);
+    Workspace expectedWorkspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .spendProfileId(null)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
 
     assertThat(workspace, equalTo(expectedWorkspace));
 
@@ -95,13 +96,14 @@ public class WorkspaceDaoTest extends BaseUnitTest {
   public void createAndGetMcWorkspace() throws Exception {
     workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.MC_WORKSPACE);
 
-    WorkspaceDescription workspace = workspaceDao.getWorkspace(workspaceId);
+    Workspace workspace = workspaceDao.getWorkspace(workspaceId);
 
-    WorkspaceDescription expectedWorkspace = new WorkspaceDescription();
-    expectedWorkspace.setId(workspaceId);
-    expectedWorkspace.setSpendProfile(null);
-    expectedWorkspace.setStage(WorkspaceStageModel.MC_WORKSPACE);
-
+    Workspace expectedWorkspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .spendProfileId(null)
+            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+            .build();
     assertThat(workspace, equalTo(expectedWorkspace));
 
     assertTrue(workspaceDao.deleteWorkspace(workspaceId));
@@ -110,10 +112,10 @@ public class WorkspaceDaoTest extends BaseUnitTest {
   @Test
   public void getStageMatchesWorkspace() throws Exception {
     workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.MC_WORKSPACE);
-    WorkspaceDescription workspace = workspaceDao.getWorkspace(workspaceId);
+    Workspace workspace = workspaceDao.getWorkspace(workspaceId);
     WorkspaceStage stage = workspaceDao.getWorkspaceStage(workspaceId);
     assertThat(stage, equalTo(WorkspaceStage.MC_WORKSPACE));
-    assertThat(stage, equalTo(WorkspaceStage.fromApiModel(workspace.getStage())));
+    assertThat(stage, equalTo(workspace.workspaceStage()));
   }
 
   @Test

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -43,7 +43,14 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyCreatedWorkspaceExists() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, spendProfileId, WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .spendProfileId(spendProfileId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
+
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("id", workspaceId.toString());
     Map<String, Object> queryOutput = jdbcTemplate.queryForMap(readSql, params);
@@ -58,7 +65,12 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void createAndDeleteWorkspace() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("id", workspaceId.toString());
     Map<String, Object> queryOutput = jdbcTemplate.queryForMap(readSql, params);
@@ -78,42 +90,45 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void createAndGetWorkspace() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace createdWorkspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(createdWorkspace);
 
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
 
-    Workspace expectedWorkspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .spendProfileId(Optional.empty())
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-
-    assertThat(workspace, equalTo(expectedWorkspace));
+    assertEquals(workspace, createdWorkspace);
 
     assertTrue(workspaceDao.deleteWorkspace(workspaceId));
   }
 
   @Test
   public void createAndGetMcWorkspace() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.MC_WORKSPACE);
+    Workspace createdWorkspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(createdWorkspace);
 
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
 
-    Workspace expectedWorkspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .spendProfileId(Optional.empty())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
-    assertThat(workspace, equalTo(expectedWorkspace));
+    assertEquals(workspace, createdWorkspace);
 
     assertTrue(workspaceDao.deleteWorkspace(workspaceId));
   }
 
   @Test
   public void getStageMatchesWorkspace() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.MC_WORKSPACE);
+    Workspace createdWorkspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(createdWorkspace);
+
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
     WorkspaceStage stage = workspaceDao.getWorkspaceStage(workspaceId);
     assertThat(stage, equalTo(WorkspaceStage.MC_WORKSPACE));
@@ -137,18 +152,27 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void duplicateWorkspaceFails() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
     assertThrows(
         DuplicateWorkspaceException.class,
         () -> {
-          workspaceDao.createWorkspace(
-              workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+          workspaceDao.createWorkspace(workspace);
         });
   }
 
   @Test
   public void updateCloudContext_Google() {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
 
     WorkspaceCloudContext googleContext1 = WorkspaceCloudContext.createGoogleContext("my-project1");
     workspaceDao.updateCloudContext(workspaceId, googleContext1);
@@ -161,7 +185,12 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void updateCloudContext_None() {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
 
     WorkspaceCloudContext noneContext = WorkspaceCloudContext.none();
     workspaceDao.updateCloudContext(workspaceId, noneContext);
@@ -170,13 +199,24 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void noSetCloudContextIsNone() {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
+
     assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
   }
 
   @Test
   public void updateAndNoneCloudContext() {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
 
     workspaceDao.updateCloudContext(
         workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
@@ -186,7 +226,13 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void deleteWorkspaceWithCloudContext() {
-    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
+
     workspaceDao.updateCloudContext(
         workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
 

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -65,12 +65,8 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void createAndDeleteWorkspace() throws Exception {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
+
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("id", workspaceId.toString());
     Map<String, Object> queryOutput = jdbcTemplate.queryForMap(readSql, params);
@@ -90,11 +86,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void createAndGetWorkspace() throws Exception {
-    Workspace createdWorkspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
+    Workspace createdWorkspace = defaultWorkspace();
     workspaceDao.createWorkspace(createdWorkspace);
 
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
@@ -106,28 +98,28 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void createAndGetMcWorkspace() throws Exception {
-    Workspace createdWorkspace =
+    Workspace mcWorkspace =
         Workspace.builder()
             .workspaceId(workspaceId)
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
-    workspaceDao.createWorkspace(createdWorkspace);
+    workspaceDao.createWorkspace(mcWorkspace);
 
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
 
-    assertEquals(workspace, createdWorkspace);
+    assertEquals(workspace, mcWorkspace);
 
     assertTrue(workspaceDao.deleteWorkspace(workspaceId));
   }
 
   @Test
   public void getStageMatchesWorkspace() throws Exception {
-    Workspace createdWorkspace =
+    Workspace mcWorkspace =
         Workspace.builder()
             .workspaceId(workspaceId)
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
-    workspaceDao.createWorkspace(createdWorkspace);
+    workspaceDao.createWorkspace(mcWorkspace);
 
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
     WorkspaceStage stage = workspaceDao.getWorkspaceStage(workspaceId);
@@ -152,12 +144,9 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void duplicateWorkspaceFails() throws Exception {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
+    Workspace workspace = defaultWorkspace();
     workspaceDao.createWorkspace(workspace);
+
     assertThrows(
         DuplicateWorkspaceException.class,
         () -> {
@@ -167,12 +156,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void updateCloudContext_Google() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     WorkspaceCloudContext googleContext1 = WorkspaceCloudContext.createGoogleContext("my-project1");
     workspaceDao.updateCloudContext(workspaceId, googleContext1);
@@ -185,12 +169,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void updateCloudContext_None() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     WorkspaceCloudContext noneContext = WorkspaceCloudContext.none();
     workspaceDao.updateCloudContext(workspaceId, noneContext);
@@ -199,24 +178,14 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void noSetCloudContextIsNone() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
   }
 
   @Test
   public void updateAndNoneCloudContext() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     workspaceDao.updateCloudContext(
         workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
@@ -226,12 +195,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void deleteWorkspaceWithCloudContext() {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
-    workspaceDao.createWorkspace(workspace);
+    workspaceDao.createWorkspace(defaultWorkspace());
 
     workspaceDao.updateCloudContext(
         workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
@@ -259,5 +223,12 @@ public class WorkspaceDaoTest extends BaseUnitTest {
     assertEquals(WorkspaceDao.CloudType.GOOGLE, WorkspaceDao.CloudType.valueOf("GOOGLE"));
     assertEquals("GOOGLE", WorkspaceDao.CloudType.GOOGLE.toString());
     assertEquals(1, WorkspaceDao.CloudType.values().length);
+  }
+
+  private Workspace defaultWorkspace() {
+    return Workspace.builder()
+        .workspaceId(workspaceId)
+        .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+        .build();
   }
 }

--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -472,7 +472,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
 
   private CreatedWorkspace createDefaultWorkspace() throws Exception {
     CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody().id(workspaceId).spendProfile(null).policies(null);
+        new CreateWorkspaceRequestBody().id(workspaceId).spendProfile(null);
 
     return runCreateWorkspaceCall(body);
   }

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -8,14 +8,12 @@ import static org.mockito.Mockito.doThrow;
 import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.exception.*;
+import bio.terra.workspace.common.model.Workspace;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.generated.model.CloningInstructionsEnum;
 import bio.terra.workspace.generated.model.CreateDataReferenceRequestBody;
-import bio.terra.workspace.generated.model.CreateWorkspaceRequestBody;
-import bio.terra.workspace.generated.model.CreatedWorkspace;
 import bio.terra.workspace.generated.model.DataRepoSnapshot;
 import bio.terra.workspace.generated.model.ReferenceTypeEnum;
-import bio.terra.workspace.generated.model.WorkspaceDescription;
 import bio.terra.workspace.generated.model.WorkspaceStageModel;
 import bio.terra.workspace.service.datareference.DataReferenceService;
 import bio.terra.workspace.service.datarepo.DataRepoService;
@@ -23,7 +21,6 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
 import com.google.api.services.cloudresourcemanager.model.Project;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,55 +62,46 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   @Test
   public void testGetExistingWorkspace() {
     UUID workspaceId = UUID.randomUUID();
-    CreateWorkspaceRequestBody body = new CreateWorkspaceRequestBody().id(workspaceId);
+    workspaceService.createWorkspace(
+        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
-    CreatedWorkspace workspace =
-        workspaceService.createWorkspace(body, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
-    assertEquals(workspaceId, workspace.getId());
-
-    assertEquals(workspaceId, workspaceService.getWorkspace(workspaceId, USER_REQUEST).getId());
+    assertEquals(
+        workspaceId, workspaceService.getWorkspace(workspaceId, USER_REQUEST).workspaceId());
   }
 
   @Test
   public void testWorkspaceStagePersists() {
     UUID workspaceId = UUID.randomUUID();
-    CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody().id(workspaceId).stage(WorkspaceStageModel.MC_WORKSPACE);
+    workspaceService.createWorkspace(workspaceId, null, WorkspaceStage.MC_WORKSPACE, USER_REQUEST);
 
-    CreatedWorkspace workspace =
-        workspaceService.createWorkspace(body, WorkspaceStage.MC_WORKSPACE, USER_REQUEST);
-    assertEquals(workspaceId, workspace.getId());
-    WorkspaceDescription description = workspaceService.getWorkspace(workspaceId, USER_REQUEST);
-    assertEquals(workspaceId, description.getId());
-    assertEquals(WorkspaceStageModel.MC_WORKSPACE, description.getStage());
+    Workspace createdWorkspace = workspaceService.getWorkspace(workspaceId, USER_REQUEST);
+    assertEquals(workspaceId, createdWorkspace.workspaceId());
+    assertEquals(WorkspaceStageModel.MC_WORKSPACE, createdWorkspace.workspaceStage());
   }
 
   @Test
   public void duplicateWorkspaceRejected() {
     UUID workspaceId = UUID.randomUUID();
-    CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody().id(workspaceId).spendProfile(null).policies(null);
-    CreatedWorkspace workspace =
-        workspaceService.createWorkspace(body, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
-    assertEquals(workspaceId, workspace.getId());
+    workspaceService.createWorkspace(
+        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     assertThrows(
         DuplicateWorkspaceException.class,
-        () -> workspaceService.createWorkspace(body, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST));
+        () ->
+            workspaceService.createWorkspace(
+                workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST));
   }
 
   @Test
-  public void testWithSpendProfileAndPolicies() {
+  public void testWithSpendProfile() {
     UUID workspaceId = UUID.randomUUID();
-    CreateWorkspaceRequestBody body =
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .spendProfile(UUID.randomUUID())
-            .policies(Collections.singletonList(UUID.randomUUID()));
+    String spendProfileId = UUID.randomUUID().toString();
+    workspaceService.createWorkspace(
+        workspaceId, spendProfileId, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
-    CreatedWorkspace workspace =
-        workspaceService.createWorkspace(body, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
-    assertEquals(workspaceId, workspace.getId());
+    Workspace createdWorkspace = workspaceService.getWorkspace(workspaceId, USER_REQUEST);
+    assertEquals(workspaceId, createdWorkspace.workspaceId());
+    assertEquals(spendProfileId, createdWorkspace.spendProfileId());
   }
 
   @Test
@@ -124,24 +112,21 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
         .when(mockSamService)
         .createWorkspaceWithDefaults(any(), any());
 
-    CreateWorkspaceRequestBody body = new CreateWorkspaceRequestBody().id(UUID.randomUUID());
+    UUID workspaceId = UUID.randomUUID();
     SamApiException exception =
         assertThrows(
             SamApiException.class,
             () ->
                 workspaceService.createWorkspace(
-                    body, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST));
+                    workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST));
     assertEquals(errorMsg, exception.getMessage());
   }
 
   @Test
   public void createAndDeleteWorkspace() {
     UUID workspaceId = UUID.randomUUID();
-    CreateWorkspaceRequestBody body = new CreateWorkspaceRequestBody().id(workspaceId);
-
-    CreatedWorkspace workspace =
-        workspaceService.createWorkspace(body, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
-    assertEquals(workspaceId, workspace.getId());
+    workspaceService.createWorkspace(
+        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     workspaceService.deleteWorkspace(workspaceId, USER_REQUEST);
     assertThrows(
@@ -153,10 +138,8 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void deleteWorkspaceWithDataReference() {
     // First, create a workspace.
     UUID workspaceId = UUID.randomUUID();
-    CreateWorkspaceRequestBody body = new CreateWorkspaceRequestBody().id(workspaceId);
-    CreatedWorkspace workspace =
-        workspaceService.createWorkspace(body, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
-    assertEquals(workspaceId, workspace.getId());
+    workspaceService.createWorkspace(
+        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     // Next, add a data reference to that workspace.
     DataRepoSnapshot reference =
@@ -185,9 +168,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void deleteWorkspaceWithGoogleContext() throws Exception {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        new CreateWorkspaceRequestBody().id(workspaceId),
-        WorkspaceStage.RAWLS_WORKSPACE,
-        USER_REQUEST);
+        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     String jobId = workspaceService.createGoogleContext(workspaceId, USER_REQUEST);
     jobService.waitForJob(jobId);
@@ -209,9 +190,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void createGetDeleteGoogleContext() {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        new CreateWorkspaceRequestBody().id(workspaceId),
-        WorkspaceStage.RAWLS_WORKSPACE,
-        USER_REQUEST);
+        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     String jobId = workspaceService.createGoogleContext(workspaceId, USER_REQUEST);
     jobService.waitForJob(jobId);

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -14,7 +14,6 @@ import bio.terra.workspace.generated.model.CloningInstructionsEnum;
 import bio.terra.workspace.generated.model.CreateDataReferenceRequestBody;
 import bio.terra.workspace.generated.model.DataRepoSnapshot;
 import bio.terra.workspace.generated.model.ReferenceTypeEnum;
-import bio.terra.workspace.generated.model.WorkspaceStageModel;
 import bio.terra.workspace.service.datareference.DataReferenceService;
 import bio.terra.workspace.service.datarepo.DataRepoService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -64,7 +63,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void testGetExistingWorkspace() {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
+        workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     assertEquals(
         workspaceId, workspaceService.getWorkspace(workspaceId, USER_REQUEST).workspaceId());
@@ -73,24 +72,25 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   @Test
   public void testWorkspaceStagePersists() {
     UUID workspaceId = UUID.randomUUID();
-    workspaceService.createWorkspace(workspaceId, null, WorkspaceStage.MC_WORKSPACE, USER_REQUEST);
+    workspaceService.createWorkspace(
+        workspaceId, Optional.empty(), WorkspaceStage.MC_WORKSPACE, USER_REQUEST);
 
     Workspace createdWorkspace = workspaceService.getWorkspace(workspaceId, USER_REQUEST);
     assertEquals(workspaceId, createdWorkspace.workspaceId());
-    assertEquals(WorkspaceStageModel.MC_WORKSPACE, createdWorkspace.workspaceStage());
+    assertEquals(WorkspaceStage.MC_WORKSPACE, createdWorkspace.workspaceStage());
   }
 
   @Test
   public void duplicateWorkspaceRejected() {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
+        workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     assertThrows(
         DuplicateWorkspaceException.class,
         () ->
             workspaceService.createWorkspace(
-                workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST));
+                workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST));
   }
 
   @Test
@@ -119,7 +119,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
             SamApiException.class,
             () ->
                 workspaceService.createWorkspace(
-                    workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST));
+                    workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST));
     assertEquals(errorMsg, exception.getMessage());
   }
 
@@ -127,7 +127,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void createAndDeleteWorkspace() {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
+        workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     workspaceService.deleteWorkspace(workspaceId, USER_REQUEST);
     assertThrows(
@@ -140,7 +140,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
     // First, create a workspace.
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
+        workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     // Next, add a data reference to that workspace.
     DataRepoSnapshot reference =
@@ -169,7 +169,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void deleteWorkspaceWithGoogleContext() throws Exception {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
+        workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     String jobId = workspaceService.createGoogleContext(workspaceId, USER_REQUEST);
     jobService.waitForJob(jobId);
@@ -191,7 +191,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void createGetDeleteGoogleContext() {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
+        workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE, USER_REQUEST);
 
     String jobId = workspaceService.createGoogleContext(workspaceId, USER_REQUEST);
     jobService.waitForJob(jobId);

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -10,6 +10,7 @@ import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.model.Workspace;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.job.JobService;
@@ -19,7 +20,6 @@ import com.google.api.services.serviceusage.v1.model.GoogleApiServiceusageV1Serv
 import com.google.api.services.serviceusage.v1.model.ListServicesResponse;
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
@@ -96,10 +96,13 @@ public class CreateGoogleContextFlightTest extends BaseConnectedTest {
   /** Creates a workspace, returning its workspaceId. */
   // TODO make it easier for tests to create workspaces using WorkspaceService.
   private UUID createWorkspace() {
-    UUID workspaceId = UUID.randomUUID();
-    workspaceDao.createWorkspace(
-        workspaceId, /* spendProfile= */ Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
-    return workspaceId;
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(UUID.randomUUID())
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
+    return workspace.workspaceId();
   }
 
   private void assertServiceApisEnabled(Project project, List<String> enabledApis)

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -6,13 +6,13 @@ import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.stairway.*;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.model.Workspace;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.workspace.WorkspaceCloudContext;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import java.time.Duration;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,9 +87,12 @@ public class DeleteGoogleContextFlightTest extends BaseConnectedTest {
   /** Creates a workspace, returning its workspaceId. */
   // TODO make it easier for tests to create workspaces using WorkspaceService.
   private UUID createWorkspace() {
-    UUID workspaceId = UUID.randomUUID();
-    workspaceDao.createWorkspace(
-        workspaceId, /* spendProfile= */ Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
-    return workspaceId;
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(UUID.randomUUID())
+            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .build();
+    workspaceDao.createWorkspace(workspace);
+    return workspace.workspaceId();
   }
 }


### PR DESCRIPTION
This PR creates a new `Workspace` object for internal representation of workspaces and separates that internal representation from API objects. All changes happen at the Controller level and below, so this does not require an update to the client library.

This is the first of a few changes to apply this layering pattern across all of WM.