### PR TITLE
PF-186 Update the API for spend profile ids to be strings instead of UUIDs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 
 allprojects {
 	group = "bio.terra"
-	version = "0.4.0-SNAPSHOT"
+	version = "0.5.0-SNAPSHOT"
 	ext {
 		artifactGroup = "${group}.workspace"
 		swaggerOutputDir = "${buildDir}/swagger-code"

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -4,13 +4,14 @@ import bio.terra.workspace.common.exception.DuplicateWorkspaceException;
 import bio.terra.workspace.common.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.WorkspaceCloudContext;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import java.sql.SQLException;
-import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
@@ -41,15 +42,15 @@ public class WorkspaceDao {
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public String createWorkspace(
-      UUID workspaceId, UUID spendProfile, WorkspaceStage workspaceStage) {
+      UUID workspaceId, Optional<SpendProfileId> spendProfileId, WorkspaceStage workspaceStage) {
     String sql =
         "INSERT INTO workspace (workspace_id, spend_profile, profile_settable, workspace_stage) values "
             + "(:id, :spend_profile, :spend_profile_settable, :workspace_stage)";
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("id", workspaceId.toString())
-            .addValue("spend_profile", spendProfile)
-            .addValue("spend_profile_settable", spendProfile == null)
+            .addValue("spend_profile", spendProfileId.map(SpendProfileId::id).orElse(null))
+            .addValue("spend_profile_settable", spendProfileId.isEmpty())
             .addValue("workspace_stage", workspaceStage.toString());
     try {
       jdbcTemplate.update(sql, params);
@@ -73,21 +74,17 @@ public class WorkspaceDao {
     String sql = "SELECT * FROM workspace where workspace_id = (:id)";
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("id", id.toString());
     try {
-      Map<String, Object> queryOutput = jdbcTemplate.queryForMap(sql, params);
-
-      WorkspaceDescription desc = new WorkspaceDescription();
-      desc.setId(UUID.fromString(queryOutput.get("workspace_id").toString()));
-
-      if (queryOutput.getOrDefault("spend_profile", null) == null) {
-        desc.setSpendProfile(null);
-      } else {
-        desc.setSpendProfile(UUID.fromString(queryOutput.get("spend_profile").toString()));
-      }
-
-      desc.setStage(
-          WorkspaceStage.valueOf(queryOutput.get("workspace_stage").toString()).toApiModel());
-
-      return desc;
+      return DataAccessUtils.requiredSingleResult(
+          jdbcTemplate.query(
+              sql,
+              params,
+              (rs, rowNum) -> {
+                WorkspaceDescription desc = new WorkspaceDescription();
+                desc.setId(UUID.fromString(rs.getString("workspace_id")));
+                desc.setSpendProfile(rs.getString("spend_profile"));
+                desc.setStage(WorkspaceStage.valueOf(rs.getString("workspace_stage")).toApiModel());
+                return desc;
+              }));
     } catch (EmptyResultDataAccessException e) {
       throw new WorkspaceNotFoundException("Workspace not found.");
     }

--- a/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -42,7 +42,8 @@ public class SpendProfileService {
    * the id if there is one and the user is authorized to link it. Otherwise, throws a {@link
    * SpendUnauthorizedException}.
    */
-  public SpendProfile authorizeLinking(SpendProfileId spendProfileId, AuthenticatedUserRequest userRequest) {
+  public SpendProfile authorizeLinking(
+      SpendProfileId spendProfileId, AuthenticatedUserRequest userRequest) {
     if (!samService.isAuthorized(
         userRequest.getRequiredToken(),
         SamUtils.SPEND_PROFILE_RESOURCE,

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -9,6 +9,8 @@ import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.generated.model.CreatedWorkspace;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 
@@ -30,18 +32,13 @@ public class CreateWorkspaceStep implements Step {
     FlightMap workingMap = flightContext.getWorkingMap();
     workingMap.put(CREATE_WORKSPACE_COMPLETED_KEY, false);
 
-    // This can be null if no spend profile is specified
-    UUID nullableSpendProfileId = null;
-
-    UUID spendProfileId = inputMap.get(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, UUID.class);
-    if (spendProfileId != null) {
-      nullableSpendProfileId = spendProfileId;
-    }
-
+    Optional<SpendProfileId> spendProfileId =
+        Optional.ofNullable(inputMap.get(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, String.class))
+            .map(SpendProfileId::create);
     WorkspaceStage workspaceStage =
         inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, WorkspaceStage.class);
 
-    workspaceDao.createWorkspace(workspaceId, nullableSpendProfileId, workspaceStage);
+    workspaceDao.createWorkspace(workspaceId, spendProfileId, workspaceStage);
     workingMap.put(CREATE_WORKSPACE_COMPLETED_KEY, true);
 
     CreatedWorkspace response = new CreatedWorkspace();

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -391,9 +391,8 @@ components:
           type: string
           format: uuid
         spendProfile:
-          description: UUID of provided spend profile
+          description: ID of provided spend profile
           type: string
-          format: uuid
         policies:
           description: Policies provided by the containing folder
           type: array
@@ -421,9 +420,8 @@ components:
           type: string
           format: uuid
         spendProfile:
-          description: UUID of provided spend profile
+          description: ID of provided spend profile
           type: string
-          format: uuid
         stage:
           $ref: '#/components/schemas/WorkspaceStageModel'
 

--- a/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
@@ -21,6 +21,7 @@ import bio.terra.workspace.generated.model.ReferenceTypeEnum;
 import bio.terra.workspace.service.datareference.exception.InvalidDataReferenceException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,7 +65,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyCreatedDataReferenceExists() {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -100,7 +101,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyCreateDuplicateNameFails() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -129,7 +130,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyGetDataReferenceByName() {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -148,7 +149,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyGetDataReference() {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -172,8 +173,9 @@ public class DataReferenceDaoTest extends BaseUnitTest {
   @Test
   public void verifyGetDataReferenceNotInWorkspaceNotFound() {
     UUID decoyWorkspaceId = UUID.randomUUID();
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
-    workspaceDao.createWorkspace(decoyWorkspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(
+        decoyWorkspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -194,7 +196,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void verifyDeleteDataReference() {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     dataReferenceDao.createDataReference(
         referenceId,
@@ -219,7 +221,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void enumerateWorkspaceReferences() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
     // Create two references in the same workspace.
     dataReferenceDao.createDataReference(
         referenceId,
@@ -257,7 +259,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
 
   @Test
   public void enumerateEmptyReferenceList() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     DataReferenceList result = dataReferenceDao.enumerateDataReferences(workspaceId, name, 0, 10);
     assertThat(result.getResources(), empty());

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -11,8 +11,10 @@ import bio.terra.workspace.common.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.generated.model.WorkspaceDescription;
 import bio.terra.workspace.generated.model.WorkspaceStageModel;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.WorkspaceCloudContext;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,14 +32,14 @@ public class WorkspaceDaoTest extends BaseUnitTest {
   @Autowired private WorkspaceDao workspaceDao;
 
   private UUID workspaceId;
-  private UUID spendProfileId;
+  private Optional<SpendProfileId> spendProfileId;
   private String readSql =
       "SELECT workspace_id, spend_profile, profile_settable FROM workspace WHERE workspace_id = :id";
 
   @BeforeEach
   public void setup() {
     workspaceId = UUID.randomUUID();
-    spendProfileId = UUID.randomUUID();
+    spendProfileId = Optional.of(SpendProfileId.create("foo"));
   }
 
   @Test
@@ -48,7 +50,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
     Map<String, Object> queryOutput = jdbcTemplate.queryForMap(readSql, params);
 
     assertThat(queryOutput.get("workspace_id"), equalTo(workspaceId.toString()));
-    assertThat(queryOutput.get("spend_profile"), equalTo(spendProfileId.toString()));
+    assertThat(queryOutput.get("spend_profile"), equalTo(spendProfileId.get().id()));
     assertThat(queryOutput.get("profile_settable"), equalTo(false));
 
     // This test doesn't clean up after itself - be sure it only runs on unit test DBs, which
@@ -57,7 +59,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void createAndDeleteWorkspace() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("id", workspaceId.toString());
     Map<String, Object> queryOutput = jdbcTemplate.queryForMap(readSql, params);
@@ -77,7 +79,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void createAndGetWorkspace() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     WorkspaceDescription workspace = workspaceDao.getWorkspace(workspaceId);
 
@@ -93,7 +95,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void createAndGetMcWorkspace() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.MC_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.MC_WORKSPACE);
 
     WorkspaceDescription workspace = workspaceDao.getWorkspace(workspaceId);
 
@@ -109,7 +111,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void getStageMatchesWorkspace() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.MC_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.MC_WORKSPACE);
     WorkspaceDescription workspace = workspaceDao.getWorkspace(workspaceId);
     WorkspaceStage stage = workspaceDao.getWorkspaceStage(workspaceId);
     assertThat(stage, equalTo(WorkspaceStage.MC_WORKSPACE));
@@ -133,17 +135,18 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void duplicateWorkspaceFails() throws Exception {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
     assertThrows(
         DuplicateWorkspaceException.class,
         () -> {
-          workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+          workspaceDao.createWorkspace(
+              workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
         });
   }
 
   @Test
   public void updateCloudContext_Google() {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     WorkspaceCloudContext googleContext1 = WorkspaceCloudContext.createGoogleContext("my-project1");
     workspaceDao.updateCloudContext(workspaceId, googleContext1);
@@ -156,7 +159,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void updateCloudContext_None() {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     WorkspaceCloudContext noneContext = WorkspaceCloudContext.none();
     workspaceDao.updateCloudContext(workspaceId, noneContext);
@@ -165,13 +168,13 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void noSetCloudContextIsNone() {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
     assertEquals(WorkspaceCloudContext.none(), workspaceDao.getCloudContext(workspaceId));
   }
 
   @Test
   public void updateAndNoneCloudContext() {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
 
     workspaceDao.updateCloudContext(
         workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
@@ -181,7 +184,7 @@ public class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   public void deleteWorkspaceWithCloudContext() {
-    workspaceDao.createWorkspace(workspaceId, null, WorkspaceStage.RAWLS_WORKSPACE);
+    workspaceDao.createWorkspace(workspaceId, Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
     workspaceDao.updateCloudContext(
         workspaceId, WorkspaceCloudContext.createGoogleContext("my-project"));
 

--- a/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileServiceTest.java
@@ -10,19 +10,19 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.spendprofile.exceptions.SpendUnauthorizedException;
 import com.google.common.collect.ImmutableList;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import java.util.Optional;
 
 // TODO(PF-186): Consider if this should be a connected test that talks to Sam.
 public class SpendProfileServiceTest extends BaseUnitTest {
   @MockBean SamService mockSamService;
 
   /** Fake user request with access token. */
-  private static final AuthenticatedUserRequest USER_REQUEST = new AuthenticatedUserRequest().token(Optional.of("fake-token"));
+  private static final AuthenticatedUserRequest USER_REQUEST =
+      new AuthenticatedUserRequest().token(Optional.of("fake-token"));
 
   @BeforeEach
   public void setUp() {
@@ -84,8 +84,7 @@ public class SpendProfileServiceTest extends BaseUnitTest {
 
     SpendProfileId fooId = SpendProfileId.create("foo");
     assertEquals(
-        SpendProfile.builder().id(fooId).build(),
-        service.authorizeLinking(fooId, USER_REQUEST));
+        SpendProfile.builder().id(fooId).build(), service.authorizeLinking(fooId, USER_REQUEST));
     SpendProfileId barId = SpendProfileId.create("bar");
     assertEquals(
         SpendProfile.builder().id(barId).billingAccountId("fake-billing-account").build(),

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -108,7 +108,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
     CreateWorkspaceRequestBody body =
         new CreateWorkspaceRequestBody()
             .id(workspaceId)
-            .spendProfile(UUID.randomUUID())
+            .spendProfile("foo")
             .policies(Collections.singletonList(UUID.randomUUID()));
 
     CreatedWorkspace workspace =

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -19,6 +19,7 @@ import com.google.api.services.serviceusage.v1.model.GoogleApiServiceusageV1Serv
 import com.google.api.services.serviceusage.v1.model.ListServicesResponse;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
@@ -97,7 +98,7 @@ public class CreateGoogleContextFlightTest extends BaseConnectedTest {
   private UUID createWorkspace() {
     UUID workspaceId = UUID.randomUUID();
     workspaceDao.createWorkspace(
-        workspaceId, /* spendProfile= */ null, WorkspaceStage.RAWLS_WORKSPACE);
+        workspaceId, /* spendProfile= */ Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
     return workspaceId;
   }
 

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.workspace.WorkspaceCloudContext;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,7 +89,7 @@ public class DeleteGoogleContextFlightTest extends BaseConnectedTest {
   private UUID createWorkspace() {
     UUID workspaceId = UUID.randomUUID();
     workspaceDao.createWorkspace(
-        workspaceId, /* spendProfile= */ null, WorkspaceStage.RAWLS_WORKSPACE);
+        workspaceId, /* spendProfile= */ Optional.empty(), WorkspaceStage.RAWLS_WORKSPACE);
     return workspaceId;
   }
 }


### PR DESCRIPTION
Change WM representation of a "spend profile id" from a UUID to a String. As-is, WM is dictating that spend profile ids have to look like UUIDs, but WM should be agnostic to SPM's id format.

This does change the API and client library, but nobody other than our own tests are using the spend profile id fields on create/get workspace. This will also invalidate any outstanding Stairway create workspace flights with the spend profile id set, but we really don't have any of those since the field is never used.
I will update Rawls after this is merged and a new client is built.
(couple misc spotlessApply changes in this PR. My fault from previous commit.)