### PR TITLE
PF-186 Add spend authz check and billing account setup to create google context flight.

### DIFF
--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -110,14 +110,14 @@ public class WorkspaceService {
   @Traced
   public String createGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     samService.workspaceAuthz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_WRITE_ACTION);
-    String rawSpendProfileId = workspaceDao.getWorkspace(workspaceId).getSpendProfile();
-    if (rawSpendProfileId == null) {
+    Optional<SpendProfileId> spendProfileId =
+        workspaceDao.getWorkspace(workspaceId).spendProfileId();
+    if (spendProfileId.isEmpty()) {
       throw new MissingSpendProfileException(workspaceId);
     }
-    SpendProfileId spendProfileId = SpendProfileId.create(rawSpendProfileId);
-    SpendProfile spendProfile = spendProfileService.authorizeLinking(spendProfileId, userReq);
+    SpendProfile spendProfile = spendProfileService.authorizeLinking(spendProfileId.get(), userReq);
     if (spendProfile.billingAccountId().isEmpty()) {
-      throw new NoBillingAccountException(spendProfileId);
+      throw new NoBillingAccountException(spendProfileId.get());
     }
 
     String jobId = UUID.randomUUID().toString();

--- a/src/main/java/bio/terra/workspace/service/workspace/exceptions/MissingSpendProfileException.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/exceptions/MissingSpendProfileException.java
@@ -1,0 +1,16 @@
+package bio.terra.workspace.service.workspace.exceptions;
+
+import bio.terra.workspace.common.exception.BadRequestException;
+import java.util.UUID;
+
+/**
+ * Exception for a workspace operation that needs a spend profile when the workspace has no spend
+ * profile associated with it.
+ */
+public class MissingSpendProfileException extends BadRequestException {
+  public MissingSpendProfileException(UUID workspaceId) {
+    super(
+        String.format(
+            "Spend profile id required, but none found on workspace %s", workspaceId.toString()));
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/workspace/exceptions/NoBillingAccountException.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/exceptions/NoBillingAccountException.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.service.workspace.exceptions;
+
+import bio.terra.workspace.common.exception.BadRequestException;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
+
+/**
+ * Exception for an operation using a Spend Profile when a billing account is required and the Spend
+ * Profile does not have a billing account associated with it.
+ */
+public class NoBillingAccountException extends BadRequestException {
+  public NoBillingAccountException(SpendProfileId spendProfileId) {
+    super(
+        String.format(
+            "Billing acocunt id required, but none found on spend profile %s",
+            spendProfileId.id()));
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlight.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlight.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.workspace.flight;
 
+import bio.terra.cloudres.google.billing.CloudBillingClientCow;
 import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.cloudres.google.serviceusage.ServiceUsageCow;
 import bio.terra.stairway.*;
@@ -19,6 +20,7 @@ public class CreateGoogleContextFlight extends Flight {
         appContext.getBean(GoogleWorkspaceConfiguration.class);
     CloudResourceManagerCow resourceManager = appContext.getBean(CloudResourceManagerCow.class);
     ServiceUsageCow serviceUsage = appContext.getBean(ServiceUsageCow.class);
+    CloudBillingClientCow billingClient = appContext.getBean(CloudBillingClientCow.class);
     WorkspaceDao workspaceDao = appContext.getBean(WorkspaceDao.class);
     TransactionTemplate transactionTemplate = appContext.getBean(TransactionTemplate.class);
 
@@ -31,6 +33,7 @@ public class CreateGoogleContextFlight extends Flight {
     addStep(
         new CreateProjectStep(resourceManager, serviceUsage, googleWorkspaceConfiguration),
         retryRule);
+    addStep(new SetProjectBillingStep(billingClient));
     addStep(new StoreGoogleContextStep(workspaceDao, transactionTemplate), retryRule);
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/SetProjectBillingStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/SetProjectBillingStep.java
@@ -1,0 +1,39 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.cloudres.google.billing.CloudBillingClientCow;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import com.google.cloud.billing.v1.ProjectBillingInfo;
+
+/** A {@link Step} to set the billing account on the Google project. */
+public class SetProjectBillingStep implements Step {
+  private final CloudBillingClientCow billingClient;
+
+  public SetProjectBillingStep(CloudBillingClientCow billingClient) {
+    this.billingClient = billingClient;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext) {
+    String projectId =
+        flightContext.getWorkingMap().get(WorkspaceFlightMapKeys.GOOGLE_PROJECT_ID, String.class);
+    String billingAccountId =
+        flightContext
+            .getInputParameters()
+            .get(WorkspaceFlightMapKeys.BILLING_ACCOUNT_ID, String.class);
+    ProjectBillingInfo setBilling =
+        ProjectBillingInfo.newBuilder()
+            .setBillingAccountName("billingAccounts/" + billingAccountId)
+            .build();
+    billingClient.updateProjectBillingInfo("projects/" + projectId, setBilling);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) {
+    // We're going to delete the project, so we don't need to worry about removing the billing
+    // account.
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -5,6 +5,7 @@ public final class WorkspaceFlightMapKeys {
   public static final String SPEND_PROFILE_ID = "spendProfileId";
   public static final String GOOGLE_PROJECT_ID = "googleProjectId";
   public static final String WORKSPACE_STAGE = "workspaceStage";
+  public static final String BILLING_ACCOUNT_ID = "billingAccountId";
 
   private WorkspaceFlightMapKeys() {}
 }

--- a/src/test/java/bio/terra/workspace/service/spendprofile/SpendConnectedTestUtils.java
+++ b/src/test/java/bio/terra/workspace/service/spendprofile/SpendConnectedTestUtils.java
@@ -4,7 +4,7 @@ import bio.terra.workspace.app.configuration.external.SpendProfileConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-/** Utiliteis for working with spend profiles in connected tests. */
+/** Utilities for working with spend profiles in connected tests. */
 @Component
 public class SpendConnectedTestUtils {
 

--- a/src/test/java/bio/terra/workspace/service/spendprofile/SpendConnectedTestUtils.java
+++ b/src/test/java/bio/terra/workspace/service/spendprofile/SpendConnectedTestUtils.java
@@ -1,0 +1,27 @@
+package bio.terra.workspace.service.spendprofile;
+
+import bio.terra.workspace.app.configuration.external.SpendProfileConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/** Utiliteis for working with spend profiles in connected tests. */
+@Component
+public class SpendConnectedTestUtils {
+
+  @Autowired private SpendProfileConfiguration spendConfig;
+
+  /** Returns a {@link SpendProfileId} that can be used to link to spend on workspaces. */
+  public SpendProfileId defaultSpendId() {
+    return SpendProfileId.create(spendConfig.getSpendProfiles().get(0).getId());
+  }
+
+  /** Returns a billing account id that can be used for billing projects on workspaces. */
+  public String defaultBillingAccountId() {
+    return spendConfig.getSpendProfiles().get(0).getBillingAccountId();
+  }
+
+  /** Returns a SpendProfileId in the spend profile service with no billing account associated. */
+  public SpendProfileId noBillingAccount() {
+    return SpendProfileId.create("no-billing-account");
+  }
+}

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -21,10 +21,10 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.spendprofile.exceptions.SpendUnauthorizedException;
 import bio.terra.workspace.service.workspace.exceptions.MissingSpendProfileException;
 import bio.terra.workspace.service.workspace.exceptions.NoBillingAccountException;
-import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import java.util.Optional;
 import java.util.UUID;
@@ -181,9 +181,8 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void deleteWorkspaceWithGoogleContext() throws Exception {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .spendProfile(spendUtils.defaultSpendId().id()),
+        workspaceId,
+        Optional.of(spendUtils.defaultSpendId()),
         WorkspaceStage.RAWLS_WORKSPACE,
         USER_REQUEST);
 
@@ -207,9 +206,8 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void createGetDeleteGoogleContext() {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .spendProfile(spendUtils.defaultSpendId().id()),
+        workspaceId,
+        Optional.of(spendUtils.defaultSpendId()),
         WorkspaceStage.RAWLS_WORKSPACE,
         USER_REQUEST);
 
@@ -230,8 +228,10 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void createGoogleContextNoSpendProfileIdThrows() {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
+        workspaceId,
+
         // Don't specify a spend profile on the created worksapce.
-        new CreateWorkspaceRequestBody().id(workspaceId).spendProfile(null),
+        Optional.empty(),
         WorkspaceStage.RAWLS_WORKSPACE,
         USER_REQUEST);
 
@@ -244,9 +244,8 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void createGoogleContextSpendLinkingUnauthorizedThrows() {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .spendProfile(spendUtils.defaultSpendId().id()),
+        workspaceId,
+        Optional.of(spendUtils.defaultSpendId()),
         WorkspaceStage.RAWLS_WORKSPACE,
         USER_REQUEST);
 
@@ -266,9 +265,8 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void createGoogleContextSpendWithoutBillingAccountThrows() {
     UUID workspaceId = UUID.randomUUID();
     workspaceService.createWorkspace(
-        new CreateWorkspaceRequestBody()
-            .id(workspaceId)
-            .spendProfile(spendUtils.noBillingAccount().id()),
+        workspaceId,
+        Optional.of(spendUtils.noBillingAccount()),
         WorkspaceStage.RAWLS_WORKSPACE,
         USER_REQUEST);
 

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -24,6 +24,7 @@ import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.spendprofile.exceptions.SpendUnauthorizedException;
 import bio.terra.workspace.service.workspace.exceptions.MissingSpendProfileException;
 import bio.terra.workspace.service.workspace.exceptions.NoBillingAccountException;
+import com.google.api.services.cloudresourcemanager.model.Project;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 
 public class WorkspaceServiceTest extends BaseConnectedTest {
   @Autowired private WorkspaceService workspaceService;

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -39,12 +39,10 @@ public class CreateGoogleContextFlightTest extends BaseConnectedTest {
   @Autowired private CloudBillingClientCow billingClient;
   @Autowired private JobService jobService;
   @Autowired private SpendProfileConfiguration spendConfiguration;
-  private String defaultBillingAccountId;
 
-  @BeforeEach
-  public void setUp() {
-    // Grab a billing account to use for this test from the spend profile configuration.
-    defaultBillingAccountId = spendConfiguration.getSpendProfiles().get(0).getBillingAccountId();
+  /** Return a billing account id to use for this test from the spend profile configuration.*/
+  private String defaultBillingAccountId() {
+    return spendConfiguration.getSpendProfiles().get(0).getBillingAccountId();
   }
 
   @Test
@@ -56,7 +54,7 @@ public class CreateGoogleContextFlightTest extends BaseConnectedTest {
         StairwayTestUtils.blockUntilFlightCompletes(
             jobService.getStairway(),
             CreateGoogleContextFlight.class,
-            createInputParameters(workspaceId, defaultBillingAccountId),
+            createInputParameters(workspaceId, defaultBillingAccountId()),
             STAIRWAY_FLIGHT_TIMEOUT);
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
 
@@ -72,7 +70,7 @@ public class CreateGoogleContextFlightTest extends BaseConnectedTest {
     assertEquals(projectId, project.getProjectId());
     assertServiceApisEnabled(project, CreateProjectStep.ENABLED_SERVICES);
     assertEquals(
-        "billingAccounts/" + defaultBillingAccountId,
+        "billingAccounts/" + defaultBillingAccountId(),
         billingClient.getProjectBillingInfo("projects/" + projectId).getBillingAccountName());
   }
 
@@ -86,7 +84,7 @@ public class CreateGoogleContextFlightTest extends BaseConnectedTest {
         StairwayTestUtils.blockUntilFlightCompletes(
             jobService.getStairway(),
             ErrorCreateGoogleContextFlight.class,
-            createInputParameters(workspaceId, defaultBillingAccountId),
+            createInputParameters(workspaceId, defaultBillingAccountId()),
             STAIRWAY_FLIGHT_TIMEOUT);
     assertEquals(FlightStatus.ERROR, flightState.getFlightStatus());
 

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -36,8 +36,6 @@ public class DeleteGoogleContextFlightTest extends BaseConnectedTest {
   @Test
   public void deleteContext() throws Exception {
     UUID workspaceId = createWorkspace();
-
-    // Both creating and deleting the google context happen to only need the workspace id as input.
     FlightMap createParameters = new FlightMap();
     createParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
     createParameters.put(

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.model.WorkspaceStage;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.WorkspaceCloudContext;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import java.time.Duration;
@@ -30,21 +31,24 @@ public class DeleteGoogleContextFlightTest extends BaseConnectedTest {
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private CloudResourceManagerCow resourceManager;
   @Autowired private JobService jobService;
+  @Autowired private SpendConnectedTestUtils spendUtils;
 
   @Test
   public void deleteContext() throws Exception {
     UUID workspaceId = createWorkspace();
 
     // Both creating and deleting the google context happen to only need the workspace id as input.
-    FlightMap inputParameters = new FlightMap();
-    inputParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
+    FlightMap createParameters = new FlightMap();
+    createParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
+    createParameters.put(
+        WorkspaceFlightMapKeys.BILLING_ACCOUNT_ID, spendUtils.defaultBillingAccountId());
 
     // Create the google context.
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
             jobService.getStairway(),
             CreateGoogleContextFlight.class,
-            inputParameters,
+            createParameters,
             CREATION_FLIGHT_TIMEOUT);
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
 
@@ -53,11 +57,13 @@ public class DeleteGoogleContextFlightTest extends BaseConnectedTest {
     assertEquals("ACTIVE", project.getLifecycleState());
 
     // Delete the google context.
+    FlightMap deleteParameters = new FlightMap();
+    deleteParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
     flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
             jobService.getStairway(),
             DeleteGoogleContextFlight.class,
-            inputParameters,
+            deleteParameters,
             DELETION_FLIGHT_TIMEOUT);
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
 

--- a/src/test/resources/application-connected-test.yml
+++ b/src/test/resources/application-connected-test.yml
@@ -1,3 +1,13 @@
 workspace:
   # workspace-dev folder id to match dev service account used in testing.
   google.folder-id: 7275817190
+  spend:
+    spend-profiles:
+      -
+        # TODO(PF-186): Create a meaningful spend profile id with a resource in Sam.
+        id: foo
+        # The billing account workspace-dev has access to.
+        billing-account-id: 01A82E-CA8A14-367457
+      -
+        # A special spend profile with no billing account associated with it.
+        id: no-billing-account


### PR DESCRIPTION
Check that a workspace has a valid spend profile id and that the user is authorized to link it before creating the google context. Set up that billing account on the project as a part of creating the google context. This allows the created project to spend money.
For now, only have tests with mocked sam spend link interaction.