### PR TITLE
Disable scheduled status checks in tests for Mockito flakiness.

### DIFF
--- a/src/main/java/bio/terra/workspace/common/utils/BaseStatusService.java
+++ b/src/main/java/bio/terra/workspace/common/utils/BaseStatusService.java
@@ -35,7 +35,7 @@ public class BaseStatusService {
     subsystems.put(name, subsystem);
   }
 
-  @Scheduled(fixedDelayString = "${workspace.status-check.frequency-ms}")
+  @Scheduled(cron = "${workspace.status-check.cron}")
   public void checkSubsystems() {
     // SystemStatus uses the thread-unsafe HashMap to hold SystemStatusSystems objects by default.
     // Instead of calling putSystemsItems from multiple threads, we safely construct a subsystem

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ workspace:
     username: ${env.db.stairway.user}
 
   status-check:
-    cron: "* * * * *" # Every minute.
+    cron: "0 * * * * *" # Every minute.
     staleness-threshold-ms: 600000
 
   tracing:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ workspace:
     username: ${env.db.stairway.user}
 
   status-check:
-    frequency-ms: 60000
+    cron: "* * * * *" # Every minute.
     staleness-threshold-ms: 600000
 
   tracing:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -17,6 +17,10 @@ workspace:
     password: stairwaypwd
     uri: jdbc:postgresql://127.0.0.1:5432/stairwaylib
     username: stairwayuser
+  status-check:
+    # Disable the periodic status check. We mock the Sam service, which is periodically called by
+    # this status check. Mockito does not like it's mocks being modified and called concurrently.
+    cron: "-"
 
   tracing.enabled: false
 


### PR DESCRIPTION
I think the Mockito flaky issue is due to the status service regularly (every 60s) calling the mocked Sam service. Mockito doesn't like concurrent modifications and calls to a mock (https://github.com/mockito/mockito/wiki/FAQ#is-mockito-thread-safe). How mockito decides to fail seems up in the air.

Switch to `@Scheduled` cron to allow easily disabling of the scheduled function.

Flakiness first noticed from connected test run https://github.com/DataBiosphere/terra-workspace-manager/runs/1387146442?check_suite_focus=true. The failing test creates/deletes a project, taking minutes.