### PR TITLE
PF-227 Fix stairway working map interactions in DataReferenceService

### DIFF
--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -86,9 +86,7 @@ public class DataReferenceService {
     validationUtils.validateReferenceName(body.getName());
     samService.workspaceAuthz(userReq, workspaceId, SamUtils.SAM_WORKSPACE_WRITE_ACTION);
 
-    UUID referenceId = UUID.randomUUID();
-    String description =
-        "Create data reference " + referenceId.toString() + " in workspace " + workspaceId;
+    String description = "Create data reference in workspace " + workspaceId;
 
     JobBuilder createJob =
         jobService
@@ -98,16 +96,15 @@ public class DataReferenceService {
                 CreateDataReferenceFlight.class,
                 body,
                 userReq)
-            .addParameter(DataReferenceFlightMapKeys.REFERENCE_ID, referenceId)
             .addParameter(DataReferenceFlightMapKeys.WORKSPACE_ID, workspaceId);
 
     DataRepoSnapshot ref =
         validationUtils.validateReference(body.getReferenceType(), body.getReference(), userReq);
     createJob.addParameter(DataReferenceFlightMapKeys.REFERENCE, ref);
 
-    createJob.submitAndWait(String.class);
+    UUID referenceIdResult = createJob.submitAndWait(UUID.class);
 
-    return dataReferenceDao.getDataReference(workspaceId, referenceId);
+    return dataReferenceDao.getDataReference(workspaceId, referenceIdResult);
   }
 
   @Traced

--- a/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceFlight.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceFlight.java
@@ -13,6 +13,7 @@ public class CreateDataReferenceFlight extends Flight {
     ApplicationContext appContext = (ApplicationContext) applicationContext;
     DataReferenceDao dataReferenceDao = (DataReferenceDao) appContext.getBean("dataReferenceDao");
 
+    addStep(new GenerateReferenceIdStep());
     addStep(new CreateDataReferenceStep(dataReferenceDao));
   }
 }

--- a/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceStep.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/flight/CreateDataReferenceStep.java
@@ -5,6 +5,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.exception.DuplicateDataReferenceException;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.DataReferenceDao;
 import bio.terra.workspace.generated.model.CreateDataReferenceRequestBody;
@@ -33,15 +34,20 @@ public class CreateDataReferenceStep implements Step {
     CreateDataReferenceRequestBody body =
         inputMap.get(JobMapKeys.REQUEST.getKeyName(), CreateDataReferenceRequestBody.class);
 
-    dataReferenceDao.createDataReference(
-        referenceId,
-        workspaceId,
-        body.getName(),
-        body.getResourceId(),
-        body.getCredentialId(),
-        body.getCloningInstructions(),
-        body.getReferenceType(),
-        reference);
+    try {
+      dataReferenceDao.createDataReference(
+          referenceId,
+          workspaceId,
+          body.getName(),
+          body.getResourceId(),
+          body.getCredentialId(),
+          body.getCloningInstructions(),
+          body.getReferenceType(),
+          reference);
+    } catch (DuplicateDataReferenceException e) {
+      // Stairway can call the same step multiple times as part of a flight, so finding a duplicate
+      // reference here is fine.
+    }
 
     FlightUtils.setResponse(flightContext, referenceId, HttpStatus.OK);
 

--- a/src/main/java/bio/terra/workspace/service/datareference/flight/GenerateReferenceIdStep.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/flight/GenerateReferenceIdStep.java
@@ -1,0 +1,34 @@
+package bio.terra.workspace.service.datareference.flight;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+
+/**
+ * Stairway step to generate a unique id for a data reference.
+ *
+ * <p>Stairway's working map is only persisted at step boundaries. By generating an ID in its own
+ * step, we ensure that both do and undo methods of future steps will always have access to the same
+ * ID. In general, generating and storing IDs this way is a best practice in Stairway flights.
+ */
+public class GenerateReferenceIdStep implements Step {
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    FlightMap workingMap = flightContext.getWorkingMap();
+
+    UUID referenceId = UUID.randomUUID();
+    workingMap.put(DataReferenceFlightMapKeys.REFERENCE_ID, referenceId);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}


### PR DESCRIPTION
(These changes were originally in #142, I'm splitting them out here as the WorkspaceService-specific changes get more complex)

This PR makes changes related to the way we're using Stairway's working map. Working map updates are persisted at step boundaries, so the previous pattern of "set flag to false, perform action, set flag to true" within a single step did not work.

This breaks generating a data reference ID into a separate step, which allows us to handle undos more cleanly. Generating IDs as an early step in a flight is a best-practice when using Stairway.

This portion of the changes doesn't touch any objects in the interface layer, and so does not require an update to the client library.