### PR TITLE
explicitly set db isolation levels to read committed [AS-457]

### DIFF
--- a/src/main/java/bio/terra/workspace/db/DataReferenceDao.java
+++ b/src/main/java/bio/terra/workspace/db/DataReferenceDao.java
@@ -19,6 +19,9 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class DataReferenceDao {
@@ -39,6 +42,7 @@ public class DataReferenceDao {
   private Logger logger = LoggerFactory.getLogger(DataReferenceDao.class);
 
   /** Create a data reference in a workspace and return the reference's ID. */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public String createDataReference(DataReferenceRequest request, UUID referenceId)
       throws DuplicateDataReferenceException {
     String sql =
@@ -68,6 +72,7 @@ public class DataReferenceDao {
   }
 
   /** Retrieve a data reference by ID from the DB. */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public DataReference getDataReference(UUID workspaceId, UUID referenceId) {
     String sql =
         "SELECT workspace_id, reference_id, name, cloning_instructions, reference_type, reference from workspace_data_reference where workspace_id = :workspace_id AND reference_id = :reference_id";
@@ -93,6 +98,7 @@ public class DataReferenceDao {
    * Retrieve a data reference by name from the DB. Names are unique per workspace, per reference
    * type.
    */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public DataReference getDataReferenceByName(
       UUID workspaceId, DataReferenceType type, String name) {
     String sql =
@@ -117,6 +123,7 @@ public class DataReferenceDao {
   }
 
   /** Look up whether a reference is a controlled or uncontrolled resource. */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public boolean isControlled(UUID workspaceId, UUID referenceId) {
     String sql =
         "SELECT CASE WHEN resource_id IS NULL THEN 'false' ELSE 'true' END FROM workspace_data_reference where reference_id = :id AND workspace_id = :workspace_id";
@@ -133,6 +140,7 @@ public class DataReferenceDao {
     }
   }
 
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public boolean deleteDataReference(UUID workspaceId, UUID referenceId) {
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -160,6 +168,7 @@ public class DataReferenceDao {
 
   // TODO: in the future, resource_id will be a foreign key to the workspace_resources table, and we
   // should consider joining and listing those entries here.
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public List<DataReference> enumerateDataReferences(UUID workspaceId, int offset, int limit) {
     String sql =
         "SELECT workspace_id, reference_id, name, cloning_instructions, reference_type, reference"

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -45,7 +45,7 @@ public class WorkspaceDao {
   private Logger logger = LoggerFactory.getLogger(WorkspaceDao.class);
 
   /** Persists a workspace to DB. Returns ID of persisted workspace on success. */
-  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public UUID createWorkspace(Workspace workspace) {
     String sql =
         "INSERT INTO workspace (workspace_id, spend_profile, profile_settable, workspace_stage) values "
@@ -70,7 +70,7 @@ public class WorkspaceDao {
   }
 
   /** Deletes a workspace. Returns true on successful delete, false if there's nothing to delete. */
-  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public boolean deleteWorkspace(UUID workspaceId) {
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("id", workspaceId.toString());
@@ -89,6 +89,7 @@ public class WorkspaceDao {
   }
 
   /** Retrieves a workspace from database by ID. */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public Workspace getWorkspace(UUID id) {
     String sql = "SELECT * FROM workspace where workspace_id = (:id)";
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("id", id.toString());
@@ -114,8 +115,8 @@ public class WorkspaceDao {
     }
   }
 
-  // TODO: Unclear what level (if any) of @Transactional this requires.
   /** Retrieves the MC Terra migration stage of a workspace from database by ID. */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public WorkspaceStage getWorkspaceStage(UUID workspaceId) {
     String sql = "SELECT workspace_stage FROM workspace WHERE workspace_id = :id";
     MapSqlParameterSource params =
@@ -124,7 +125,7 @@ public class WorkspaceDao {
   }
 
   /** Retrieves the cloud context of the workspace. */
-  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public WorkspaceCloudContext getCloudContext(UUID workspaceId) {
     String sql =
         "SELECT cloud_type, context FROM workspace_cloud_context "
@@ -137,7 +138,7 @@ public class WorkspaceDao {
   }
 
   /** Update the cloud context of the workspace, replacing the previous cloud context. */
-  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
   public void updateCloudContext(UUID workspaceId, WorkspaceCloudContext cloudContext) {
     if (cloudContext.googleProjectId().isPresent()) {
       String sql =


### PR DESCRIPTION
I downgraded the existing isolation levels in the workspace DAO, and added annotations explicitly setting the isolation level in data reference DAO. This way it is easy to see or change the isolation level of any given transaction. 

Let me know if any of the annotations are redundant or you disagree with setting them explicitly to read committed rather than the built-in default (the db default for postgres is already read committed, but it's more opaque which is why I've set it individually). 