### PR TITLE
[no ticket] Remove unnecessary fields from GetWorkspace client test

### DIFF
--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/GetWorkspace.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/GetWorkspace.java
@@ -32,8 +32,6 @@ public class GetWorkspace extends TestScript {
         try {
             CreateWorkspaceRequestBody requestBody = new CreateWorkspaceRequestBody();
             requestBody.setId(id);
-            requestBody.setJobId("testrunner");
-            requestBody.setSpendProfile(null);
             workspace = workspaceApi.createWorkspace(requestBody);
         } catch (ApiException apiEx) {
             logger.debug("Caught exception creating workspace ", apiEx);


### PR DESCRIPTION
Currently, the workspace creation request in the `GetWorkspace` client test always specifies the same value for `JobId`. This field is intended to deduplicate requests - by using the same value across multiple test runs, Workspace Manager is treating multiple workspace creation requests (with different IDs) as duplicates, which leads to unexpected return values.

This also cleans up explicitly setting SpendProfile to null, which is already the default value when unspecified. 