### PR TITLE
shim test class

### DIFF
--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/GetWorkspace.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/GetWorkspace.java
@@ -1,5 +1,8 @@
 package scripts.testscripts;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiException;
@@ -8,22 +11,23 @@ import bio.terra.workspace.model.CreatedWorkspace;
 import bio.terra.workspace.model.WorkspaceDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.util.List;
 import java.util.UUID;
 import scripts.utils.WorkspaceTestScriptBase;
 
 public class GetWorkspace extends WorkspaceTestScriptBase {
     private static final Logger logger = LoggerFactory.getLogger(GetWorkspace.class);
-    private CreatedWorkspace workspace;
+
+    private UUID workspaceId;
 
     @Override
     public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
         throws ApiException {
-        final UUID workspaceId = UUID.randomUUID();
-        final CreateWorkspaceRequestBody requestBody = new CreateWorkspaceRequestBody();
-        requestBody.setId(workspaceId);
-        workspace = workspaceApi.createWorkspace(requestBody);
+        workspaceId = UUID.randomUUID();
+        final var requestBody = new CreateWorkspaceRequestBody()
+            .id(workspaceId);
+        final CreatedWorkspace workspace = workspaceApi.createWorkspace(requestBody);
+        assertThat(workspace.getId(), equalTo(workspaceId));
     }
 
     @Override
@@ -35,13 +39,14 @@ public class GetWorkspace extends WorkspaceTestScriptBase {
          *
          * Throw exception if anything goes wrong
          * **/
-        final WorkspaceDescription workspaceDescription = workspaceApi.getWorkspace(workspace.getId());
+        final WorkspaceDescription workspaceDescription = workspaceApi.getWorkspace(workspaceId);
+        assertThat(workspaceDescription.getId(), equalTo(workspaceId));
     }
 
     @Override
     public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
         throws ApiException {
-        workspaceApi.deleteWorkspace(workspace.getId());
+        workspaceApi.deleteWorkspace(workspaceId);
     }
 
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/GetWorkspace.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/GetWorkspace.java
@@ -1,8 +1,6 @@
 package scripts.testscripts;
 
-import bio.terra.testrunner.runner.TestScript;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
-import bio.terra.workspace.client.ApiClient;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.CreateWorkspaceRequestBody;
@@ -10,69 +8,40 @@ import bio.terra.workspace.model.CreatedWorkspace;
 import bio.terra.workspace.model.WorkspaceDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scripts.utils.WorkspaceManagerServiceUtils;
 
 import java.util.List;
 import java.util.UUID;
+import scripts.utils.WorkspaceTestScriptBase;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
-public class GetWorkspace extends TestScript {
+public class GetWorkspace extends WorkspaceTestScriptBase {
     private static final Logger logger = LoggerFactory.getLogger(GetWorkspace.class);
-    private UUID id;
     private CreatedWorkspace workspace;
 
     @Override
-    public void setup(List<TestUserSpecification> testUsers) throws Exception {
-        assertThat("There must be at least one test user in configs/testusers directory.", testUsers!=null && testUsers.size()>0);
-        id = UUID.randomUUID();
-        ApiClient apiClient = WorkspaceManagerServiceUtils.getClientForTestUser(testUsers.get(0), server);
-        WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-        try {
-            CreateWorkspaceRequestBody requestBody = new CreateWorkspaceRequestBody();
-            requestBody.setId(id);
-            workspace = workspaceApi.createWorkspace(requestBody);
-        } catch (ApiException apiEx) {
-            logger.debug("Caught exception creating workspace ", apiEx);
-        }
-
-        int httpCode = workspaceApi.getApiClient().getStatusCode();
-        logger.info("CREATE workspace HTTP code: {}", httpCode);
-        assertThat(httpCode, equalTo(200));
+    public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+        throws ApiException {
+        final UUID workspaceId = UUID.randomUUID();
+        final CreateWorkspaceRequestBody requestBody = new CreateWorkspaceRequestBody();
+        requestBody.setId(workspaceId);
+        workspace = workspaceApi.createWorkspace(requestBody);
     }
 
     @Override
-    public void userJourney(TestUserSpecification testUser) throws Exception {
-        ApiClient apiClient = WorkspaceManagerServiceUtils.getClientForTestUser(testUser, server);
-        WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-
+    public void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
+        throws ApiException {
         /**
          * This GetWorkspace test expects a valid workspace id
          * created by the setup step.
          *
          * Throw exception if anything goes wrong
          * **/
-        WorkspaceDescription workspaceDescription = workspaceApi.getWorkspace(workspace.getId());
-        int httpCode = workspaceApi.getApiClient().getStatusCode();
-        logger.info("GET workspace HTTP code: {}", httpCode);
-        assertThat(httpCode, equalTo(200));
+        final WorkspaceDescription workspaceDescription = workspaceApi.getWorkspace(workspace.getId());
     }
 
     @Override
-    public void cleanup(List<TestUserSpecification> testUsers) throws Exception {
-        assertThat("There must be at least one test user in configs/testusers directory.", testUsers!=null && testUsers.size()>0);
-        ApiClient apiClient = WorkspaceManagerServiceUtils.getClientForTestUser(testUsers.get(0), server);
-        WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-
-        try {
-            workspaceApi.deleteWorkspace(workspace.getId());
-        } catch (ApiException apiEx) {
-            logger.debug("Caught exception deleting workspace ", apiEx);
-        }
-
-        int httpCode = workspaceApi.getApiClient().getStatusCode();
-        logger.info("DELETE workspace HTTP code: {}", httpCode);
-        assertThat(httpCode, equalTo(204));
+    public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+        throws ApiException {
+        workspaceApi.deleteWorkspace(workspace.getId());
     }
+
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceManagerServiceUtils.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceManagerServiceUtils.java
@@ -2,8 +2,6 @@ package scripts.utils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThan;
 
 import bio.terra.testrunner.common.utils.AuthenticationUtils;
 import bio.terra.testrunner.runner.config.ServerSpecification;
@@ -114,11 +112,7 @@ public class WorkspaceManagerServiceUtils {
 
     public static void assertHttpOk(WorkspaceApi workspaceApi, String label) {
         int httpCode = workspaceApi.getApiClient().getStatusCode();
-        logger.info("{} HTTP code: {}", label, httpCode);
-        // Code will initialize to zero for non-overridden methods like setup()
-        if (httpCode > 0) {
-            assertThat(httpCode, greaterThanOrEqualTo(HttpStatusCodes.STATUS_CODE_OK));
-            assertThat(httpCode, lessThan(300));
-        }
+        logger.debug("{} HTTP code: {}", label, httpCode);
+        assertThat(HttpStatusCodes.isSuccess(httpCode), equalTo(true));
     }
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceManagerServiceUtils.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceManagerServiceUtils.java
@@ -114,7 +114,7 @@ public class WorkspaceManagerServiceUtils {
 
     public static void assertHttpOk(WorkspaceApi workspaceApi, String label) {
         int httpCode = workspaceApi.getApiClient().getStatusCode();
-        logger.info("{}} HTTP code: {}", label, httpCode);
+        logger.info("{} HTTP code: {}", label, httpCode);
         // Code will initialize to zero for non-overridden methods like setup()
         if (httpCode > 0) {
             assertThat(httpCode, greaterThanOrEqualTo(HttpStatusCodes.STATUS_CODE_OK));

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceManagerServiceUtils.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceManagerServiceUtils.java
@@ -1,9 +1,16 @@
 package scripts.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+
 import bio.terra.testrunner.common.utils.AuthenticationUtils;
 import bio.terra.testrunner.runner.config.ServerSpecification;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiClient;
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Strings;
@@ -73,6 +80,11 @@ public class WorkspaceManagerServiceUtils {
         return buildClient(accessToken, server);
     }
 
+    public static WorkspaceApi getWorkspaceClient(TestUserSpecification testUser, ServerSpecification server) throws IOException {
+        final ApiClient apiClient = getClientForTestUser(testUser, server);
+        return new WorkspaceApi(apiClient);
+    }
+
     /**
      * Build the Workspace Manager API client object for the server specifications.
      * No access token is needed for this API client.
@@ -98,5 +110,15 @@ public class WorkspaceManagerServiceUtils {
         }
 
         return apiClient;
+    }
+
+    public static void assertHttpOk(WorkspaceApi workspaceApi, String label) {
+        int httpCode = workspaceApi.getApiClient().getStatusCode();
+        logger.info("{}} HTTP code: {}", label, httpCode);
+        // Code will initialize to zero for non-overridden methods like setup()
+        if (httpCode > 0) {
+            assertThat(httpCode, greaterThanOrEqualTo(HttpStatusCodes.STATUS_CODE_OK));
+            assertThat(httpCode, lessThan(300));
+        }
     }
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceTestScriptBase.java
@@ -1,0 +1,67 @@
+package scripts.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import bio.terra.testrunner.runner.TestScript;
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class WorkspaceTestScriptBase extends TestScript {
+  private static final Logger logger = LoggerFactory.getLogger(WorkspaceTestScriptBase.class);
+
+  @Override
+  public void setup(List<TestUserSpecification> testUsers) throws Exception {
+    assertThat("There must be at least one test user in configs/testusers directory.",
+        testUsers != null && testUsers.size() > 0);
+    final WorkspaceApi workspaceApi = WorkspaceManagerServiceUtils
+        .getWorkspaceClient(testUsers.get(0), server);
+    try {
+      doSetup(testUsers, workspaceApi);
+    } catch (ApiException apiEx) {
+      logger.debug("Caught exception creating setup ", apiEx);
+      throw(apiEx);
+    }
+    WorkspaceManagerServiceUtils.assertHttpOk(workspaceApi, "setup");
+  }
+
+  @Override
+  public void userJourney(TestUserSpecification testUser) throws Exception {
+    final WorkspaceApi workspaceApi = WorkspaceManagerServiceUtils
+        .getWorkspaceClient(testUser, server);
+    try {
+      doUserJourney(testUser, workspaceApi);
+    } catch (ApiException apiEx) {
+      logger.debug("Caught exception in userJourney ", apiEx);
+      throw(apiEx);
+    }
+    WorkspaceManagerServiceUtils.assertHttpOk(workspaceApi, "userJourney");
+  }
+
+  @Override
+  public void cleanup(List<TestUserSpecification> testUsers) throws Exception {
+    assertThat("There must be at least one test user in configs/testusers directory.",
+        testUsers != null && testUsers.size() > 0);
+    final WorkspaceApi workspaceApi = WorkspaceManagerServiceUtils
+        .getWorkspaceClient(testUsers.get(0), server);
+    try {
+      doCleanup(testUsers, workspaceApi);
+    } catch (ApiException apiEx) {
+      logger.debug("Caught exception during cleanup ", apiEx);
+      throw(apiEx);
+    }
+    WorkspaceManagerServiceUtils.assertHttpOk(workspaceApi, "cleanup");
+  }
+
+  public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) throws ApiException {
+  }
+
+  // doUserJourney is hte only method we force the class to override, so we don't get trivially passing tests that forget
+  // to have a body
+  public abstract void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi) throws ApiException;
+
+  public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) throws ApiException { };
+}

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceTestScriptBase.java
@@ -10,6 +10,13 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Intermediate base class for testing Workspace Manager in the TestRunner framework. This class handles
+ * obtaining the WorkspaceApi object and basic checks and debugging around its status code.
+ *
+ * Users of this class need to o verload doUserJourney() with efssentially the body of the userJourney() method,
+ * and optionally doSetup() and doCleanup() aw well.
+ */
 public abstract class WorkspaceTestScriptBase extends TestScript {
   private static final Logger logger = LoggerFactory.getLogger(WorkspaceTestScriptBase.class);
 
@@ -56,12 +63,11 @@ public abstract class WorkspaceTestScriptBase extends TestScript {
     WorkspaceManagerServiceUtils.assertHttpOk(workspaceApi, "cleanup");
   }
 
-  public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) throws ApiException {
-  }
+  public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) throws ApiException {}
 
-  // doUserJourney is hte only method we force the class to override, so we don't get trivially passing tests that forget
+  // doUserJourney is the only method we force the class to override, so we don't get trivially passing tests that forget
   // to have a body
   public abstract void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi) throws ApiException;
 
-  public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) throws ApiException { };
+  public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) throws ApiException {};
 }


### PR DESCRIPTION
Introduce a base TestScript class called `WorkspaceTestScriptBase`. This class takes care of

- obtaining a WorkspaceApi object
- basic logging
- assertions around common things (like nonempty user lists)
- checking HTTP codes

It currently only handles authenticated  tests.

I updated the `GetWorkspace` test script to use the new base class.