### PR TITLE
[no ticket] Bump WM version to publish updated client library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 
 allprojects {
 	group = "bio.terra"
-	version = "0.6.0-SNAPSHOT"
+	version = "0.7.0-SNAPSHOT"
 	ext {
 		artifactGroup = "${group}.workspace"
 		swaggerOutputDir = "${buildDir}/swagger-code"


### PR DESCRIPTION
#164 added a new set of endpoints for WM's permissions API, we need to publish a new version of the client library with those endpoints available.