### PR TITLE
Base Class for tests with single workspace as a fixture

### DIFF
--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/GetWorkspace.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/GetWorkspace.java
@@ -6,30 +6,10 @@ import static org.hamcrest.Matchers.equalTo;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiException;
-import bio.terra.workspace.model.CreateWorkspaceRequestBody;
-import bio.terra.workspace.model.CreatedWorkspace;
 import bio.terra.workspace.model.WorkspaceDescription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.util.List;
-import java.util.UUID;
-import scripts.utils.WorkspaceTestScriptBase;
+import scripts.utils.WorkspaceFixtureTestScriptBase;
 
-public class GetWorkspace extends WorkspaceTestScriptBase {
-    private static final Logger logger = LoggerFactory.getLogger(GetWorkspace.class);
-
-    private UUID workspaceId;
-
-    @Override
-    public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
-        throws ApiException {
-        workspaceId = UUID.randomUUID();
-        final var requestBody = new CreateWorkspaceRequestBody()
-            .id(workspaceId);
-        final CreatedWorkspace workspace = workspaceApi.createWorkspace(requestBody);
-        assertThat(workspace.getId(), equalTo(workspaceId));
-    }
-
+public class GetWorkspace extends WorkspaceFixtureTestScriptBase {
     @Override
     public void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
         throws ApiException {
@@ -39,14 +19,8 @@ public class GetWorkspace extends WorkspaceTestScriptBase {
          *
          * Throw exception if anything goes wrong
          * **/
-        final WorkspaceDescription workspaceDescription = workspaceApi.getWorkspace(workspaceId);
-        assertThat(workspaceDescription.getId(), equalTo(workspaceId));
+        final WorkspaceDescription workspaceDescription = workspaceApi
+            .getWorkspace(getWorkspaceId());
+        assertThat(workspaceDescription.getId(), equalTo(getWorkspaceId()));
     }
-
-    @Override
-    public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
-        throws ApiException {
-        workspaceApi.deleteWorkspace(workspaceId);
-    }
-
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceFixtureTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceFixtureTestScriptBase.java
@@ -17,7 +17,7 @@ import scripts.testscripts.GetWorkspace;
 
 /**
  * Base class for tests that use a single workspace as a fixture. The expectation is that
- * the workspace setup & destruction are all that neeeds to hapen in setup() nad cleanup(), although
+ * the workspace setup & destruction are all that needs to happen in setup() and cleanup(), although
  * doSetup() and doCleanup() can still be overridden, provided the caller calls super().
  *
  * No doUserJourney() implementation is provided, and this must be overridden by inheriting classes.
@@ -36,7 +36,7 @@ public abstract class WorkspaceFixtureTestScriptBase extends WorkspaceTestScript
   }
 
   /**
-   * Create a workspace as a test fixture (i.e. not specidfically the code under test).
+   * Create a workspace as a test fixture (i.e. not specifically the code under test).
    * @param testUsers - test user configurations
    * @param workspaceApi - API with workspace methods
    * @throws ApiException

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceFixtureTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceFixtureTestScriptBase.java
@@ -1,0 +1,66 @@
+package scripts.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.CreateWorkspaceRequestBody;
+import bio.terra.workspace.model.CreatedWorkspace;
+import bio.terra.workspace.model.WorkspaceDescription;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scripts.testscripts.GetWorkspace;
+
+/**
+ * Base class for tests that use a single workspace as a fixture. The expectation is that
+ * the workspace setup & destruction are all that neeeds to hapen in setup() nad cleanup(), although
+ * doSetup() and doCleanup() can still be overridden, provided the caller calls super().
+ *
+ * No doUserJourney() implementation is provided, and this must be overridden by inheriting classes.
+ */
+public abstract class WorkspaceFixtureTestScriptBase extends WorkspaceTestScriptBase {
+  private static final Logger logger = LoggerFactory.getLogger(GetWorkspace.class);
+
+  private UUID workspaceId;
+
+  /**
+   * Allow inheriting classes to obtain the workspace ID for the fixture.
+   * @return
+   */
+  public UUID getWorkspaceId() {
+    return workspaceId;
+  }
+
+  /**
+   * Create a workspace as a test fixture (i.e. not specidfically the code under test).
+   * @param testUsers - test user configurations
+   * @param workspaceApi - API with workspace methods
+   * @throws ApiException
+   */
+  @Override
+  public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws ApiException {
+    workspaceId = UUID.randomUUID();
+    final var requestBody = new CreateWorkspaceRequestBody()
+        .id(workspaceId);
+    final CreatedWorkspace workspace = workspaceApi.createWorkspace(requestBody);
+    assertThat(workspace.getId(), equalTo(workspaceId));
+  }
+
+  /**
+   * Clean up workspace only.
+   * @param testUsers
+   * @param workspaceApi
+   * @throws ApiException
+   */
+  @Override
+  public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws ApiException {
+    workspaceApi.deleteWorkspace(workspaceId);
+  }
+
+}


### PR DESCRIPTION
Frequently, we need to set up just one workspace and tear it down as part of a related test. This intermediate base class allows us to do this. With it, the `GetWorkspace` test script becomes a 2-liner.