### PR TITLE
[PF-328] data reference enumeration test

### DIFF
--- a/src/main/java/bio/terra/workspace/service/workspace/exceptions/RetryableCrlException.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/exceptions/RetryableCrlException.java
@@ -2,9 +2,10 @@ package bio.terra.workspace.service.workspace.exceptions;
 
 import bio.terra.stairway.exception.RetryException;
 
-/** Exception for retryable errors thrown by the Cloud Resource Library (CRL).
+/**
+ * Exception for retryable errors thrown by the Cloud Resource Library (CRL).
  *
- * This extends Stairway's RetryException, which will signal Stairway to retry any step this is
+ * <p>This extends Stairway's RetryException, which will signal Stairway to retry any step this is
  * thrown from (modulo a retry rule).
  */
 public class RetryableCrlException extends RetryException {

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/GoogleCloudSyncStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/GoogleCloudSyncStep.java
@@ -19,10 +19,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * A {@link Step} that grants GCP IAM permissions to Sam policy groups.
@@ -60,9 +58,12 @@ public class GoogleCloudSyncStep implements Step {
       List<Binding> existingBindings = currentPolicy.getBindings();
 
       // GCP IAM always prefixes groups with the literal "group:"
-      String readerGroup = "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_READER_GROUP_EMAIL, String.class);
-      String writerGroup = "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_WRITER_GROUP_EMAIL, String.class);
-      String ownerGroup = "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_OWNER_GROUP_EMAIL, String.class);
+      String readerGroup =
+          "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_READER_GROUP_EMAIL, String.class);
+      String writerGroup =
+          "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_WRITER_GROUP_EMAIL, String.class);
+      String ownerGroup =
+          "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_OWNER_GROUP_EMAIL, String.class);
       List<Binding> newBindings = new ArrayList<>();
       newBindings.addAll(bindingsForRole(IamRole.READER, readerGroup));
       newBindings.addAll(bindingsForRole(IamRole.WRITER, writerGroup));
@@ -84,16 +85,17 @@ public class GoogleCloudSyncStep implements Step {
     return StepResult.getStepResultSuccess();
   }
 
-  /** Build a list of role bindings for a given group, using CloudSyncRoleMapping.
+  /**
+   * Build a list of role bindings for a given group, using CloudSyncRoleMapping.
    *
    * @param role The role granted to this user. Translated to GCP roles using CloudSyncRoleMapping.
-   * @param group The group being granted a role. Should be prefixed with the literal "group:" for GCP.
-   * */
+   * @param group The group being granted a role. Should be prefixed with the literal "group:" for
+   *     GCP.
+   */
   private List<Binding> bindingsForRole(IamRole role, String group) {
     List<Binding> bindings = new ArrayList<>();
     for (String gcpRole : CloudSyncRoleMapping.cloudSyncRoleMap.get(role)) {
-      bindings.add(
-          new Binding().setRole(gcpRole).setMembers(Collections.singletonList(group)));
+      bindings.add(new Binding().setRole(gcpRole).setMembers(Collections.singletonList(group)));
     }
     return bindings;
   }

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/DataReferenceLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/DataReferenceLifecycle.java
@@ -1,0 +1,53 @@
+package scripts.testscripts;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import bio.terra.workspace.model.CreateDataReferenceRequestBody;
+import bio.terra.workspace.model.DataReferenceDescription;
+import bio.terra.workspace.model.ReferenceTypeEnum;
+import scripts.utils.WorkspaceFixtureTestScriptBase;
+import scripts.utils.ClientTestUtils;
+
+public class DataReferenceLifecycle extends WorkspaceFixtureTestScriptBase {
+
+  @Override
+  public void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
+      throws ApiException {
+    // Create a data reference
+    final CreateDataReferenceRequestBody body = ClientTestUtils.getTestCreateDataReferenceRequestBody();
+    final String referenceName = body.getName();
+
+    final DataReferenceDescription newReference = workspaceApi.createDataReference(body, getWorkspaceId());
+    assertDataReferenceDescription(newReference, referenceName);
+
+    // retrieve the data reference
+   final DataReferenceDescription retrievedById = workspaceApi.getDataReference(
+       getWorkspaceId(), newReference.getReferenceId());
+    assertDataReferenceDescription(retrievedById, referenceName);
+
+    // retrieve by name
+    final DataReferenceDescription retrievedByName = workspaceApi.getDataReferenceByName(
+        getWorkspaceId(), ReferenceTypeEnum.DATA_REPO_SNAPSHOT, referenceName);
+    assertDataReferenceDescription(retrievedByName, referenceName);
+
+    // remove reference
+    workspaceApi.deleteDataReference(getWorkspaceId(), newReference.getReferenceId());
+
+    // TODO: assert 404 when retrieving again. This may interfere with parent class checking of status.
+  }
+
+  private void assertDataReferenceDescription(DataReferenceDescription dataReferenceDescription, String dataReferenceName) {
+    assertThat(dataReferenceDescription.getCloningInstructions(), equalTo(CloningInstructionsEnum.REFERENCE));
+    assertThat(dataReferenceDescription.getName(), equalTo(dataReferenceName));
+    assertThat(dataReferenceDescription.getReferenceType(), equalTo(ReferenceTypeEnum.DATA_REPO_SNAPSHOT));
+    assertThat(dataReferenceDescription.getReference().getSnapshot(), equalTo(
+        ClientTestUtils.TEST_SNAPSHOT));
+    assertThat(dataReferenceDescription.getReference().getInstanceName(), equalTo(
+        ClientTestUtils.TERRA_DATA_REPO_INSTANCE));
+  }
+}

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/DataReferenceLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/DataReferenceLifecycle.java
@@ -2,6 +2,7 @@ package scripts.testscripts;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.WorkspaceApi;
@@ -10,6 +11,7 @@ import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.CreateDataReferenceRequestBody;
 import bio.terra.workspace.model.DataReferenceDescription;
 import bio.terra.workspace.model.ReferenceTypeEnum;
+import org.apache.http.HttpStatus;
 import scripts.utils.WorkspaceFixtureTestScriptBase;
 import scripts.utils.ClientTestUtils;
 
@@ -38,7 +40,15 @@ public class DataReferenceLifecycle extends WorkspaceFixtureTestScriptBase {
     // remove reference
     workspaceApi.deleteDataReference(getWorkspaceId(), newReference.getReferenceId());
 
-    // TODO: assert 404 when retrieving again. This may interfere with parent class checking of status.
+    // verify it's not there anymore
+    DataReferenceDescription dataReferenceDescription = null;
+    try {
+       dataReferenceDescription = workspaceApi.getDataReference(getWorkspaceId(), newReference.getReferenceId());
+    } catch (ApiException expected) {
+      assertThat(expected.getCode(), equalTo(HttpStatus.SC_NOT_FOUND));
+    }
+    assertThat(dataReferenceDescription, equalTo(null));
+    assertThat(workspaceApi.getApiClient().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
   }
 
   private void assertDataReferenceDescription(DataReferenceDescription dataReferenceDescription, String dataReferenceName) {

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateDataReferences.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateDataReferences.java
@@ -1,0 +1,152 @@
+package scripts.testscripts;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.CreateDataReferenceRequestBody;
+import bio.terra.workspace.model.DataReferenceDescription;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scripts.utils.ClientTestUtils;
+import scripts.utils.WorkspaceFixtureTestScriptBase;
+
+public class EnumerateDataReferences extends WorkspaceFixtureTestScriptBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(EnumerateDataReferences.class);
+
+  private static final int DATA_REFERENCE_COUNT = 10;
+  private static final int PAGE_SIZE = 4;
+  private List<UUID> dataReferenceIds;
+
+  @Override
+  public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws ApiException {
+
+    // initialize workspace
+    super.doSetup(testUsers, workspaceApi);
+
+    // static assumptions
+    assertThat(PAGE_SIZE * 2, lessThan(DATA_REFERENCE_COUNT));
+    assertThat(PAGE_SIZE * 3, greaterThan(DATA_REFERENCE_COUNT));
+
+    // create 10 data references
+    final List<CreateDataReferenceRequestBody> createBodies = IntStream.range(0, DATA_REFERENCE_COUNT)
+        .mapToObj(i -> ClientTestUtils.getTestCreateDataReferenceRequestBody())
+        .collect(Collectors.toList());
+
+    logger.debug("Creating references for workspace {}", getWorkspaceId());
+    final ImmutableList.Builder<UUID> referenceIdListBuilder = ImmutableList.builder();
+    for (CreateDataReferenceRequestBody body : createBodies) {
+      final DataReferenceDescription dataReferenceDescription = workspaceApi.createDataReference(body, getWorkspaceId());
+      referenceIdListBuilder.add(dataReferenceDescription.getReferenceId());
+      logger.debug("Created Data Reference Name: {}, ID: {}", dataReferenceDescription.getName(), dataReferenceDescription.getReferenceId().toString());
+    }
+
+    dataReferenceIds = referenceIdListBuilder.build();
+    assertThat(dataReferenceIds.size(), equalTo(DATA_REFERENCE_COUNT));
+
+    logger.info("Created {} data references", dataReferenceIds.size());
+  }
+
+  @Override
+  public void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
+      throws ApiException {
+
+
+    // fetch all
+    final List<DataReferenceDescription> referenceDescriptions = ClientTestUtils
+        .getDataReferenceDescriptions(
+        getWorkspaceId(), workspaceApi,0, DATA_REFERENCE_COUNT);
+    assertThat(referenceDescriptions.size(), equalTo(DATA_REFERENCE_COUNT));
+
+    final String allIdString = referenceDescriptions.stream()
+        .map(DataReferenceDescription::getReferenceId)
+        .map(UUID::toString)
+        .collect(Collectors.joining("\n\t"));
+    logger.info("Retrieved offset 0, limit {}, IDs:\n\t{}", DATA_REFERENCE_COUNT, allIdString);
+
+    // should have all unique ids
+    final ImmutableSet<UUID> referenceIds = ImmutableSet.copyOf(referenceDescriptions.stream()
+        .map(DataReferenceDescription::getReferenceId)
+        .collect(Collectors.toSet()));
+    assertThat(referenceIds.size(), equalTo(DATA_REFERENCE_COUNT));
+
+    // fetch first page
+    final List<DataReferenceDescription> referenceDescriptionsPage0 = ClientTestUtils
+        .getDataReferenceDescriptions(
+        getWorkspaceId(), workspaceApi, 0, PAGE_SIZE);
+    assertThat(referenceDescriptionsPage0.size(), equalTo(PAGE_SIZE));
+    final ImmutableSet<UUID> referenceIdsPage0 = ImmutableSet.copyOf(referenceDescriptionsPage0.stream()
+        .map(DataReferenceDescription::getReferenceId)
+        .collect(Collectors.toSet()));
+    assertThat(referenceIdsPage0.size(), equalTo(PAGE_SIZE));
+
+    // fetch second page
+    final List<DataReferenceDescription> referenceDescriptionsPage1 = ClientTestUtils
+        .getDataReferenceDescriptions(
+        getWorkspaceId(), workspaceApi, PAGE_SIZE, PAGE_SIZE);
+    assertThat(referenceDescriptionsPage1.size(), equalTo(PAGE_SIZE));
+    final ImmutableSet<UUID> referenceIdsPage1 = ImmutableSet.copyOf(referenceDescriptionsPage1.stream()
+        .map(DataReferenceDescription::getReferenceId)
+        .collect(Collectors.toSet()));
+    assertThat(referenceIdsPage1.size(), equalTo(PAGE_SIZE));
+
+    // Assure no repeats
+    final ImmutableSet.Builder<UUID> idsFromTwoPagesBuilder = ImmutableSet.builder();
+    idsFromTwoPagesBuilder.addAll(referenceIdsPage0);
+    idsFromTwoPagesBuilder.addAll(referenceIdsPage1);
+    final var idsFromTwoPages = idsFromTwoPagesBuilder.build();
+    assertThat(idsFromTwoPages.size(), equalTo(2 * PAGE_SIZE));
+
+    // final partial page
+    // fetch second page
+    final List<DataReferenceDescription> referenceDescriptionsPage2 = ClientTestUtils
+        .getDataReferenceDescriptions(
+        getWorkspaceId(), workspaceApi, 2 * PAGE_SIZE, PAGE_SIZE);
+    assertThat(referenceDescriptionsPage2.size(), equalTo(DATA_REFERENCE_COUNT - 2 * PAGE_SIZE));
+    final ImmutableSet<UUID> referenceIdsPage2 = ImmutableSet.copyOf(referenceDescriptionsPage2.stream()
+        .map(DataReferenceDescription::getReferenceId)
+        .collect(Collectors.toSet()));
+    assertThat(referenceIdsPage2.size(), equalTo(referenceDescriptionsPage2.size()));
+
+    // Assure no repeats
+    final ImmutableSet.Builder<UUID> allIdsBuilder = ImmutableSet.builder();
+    allIdsBuilder.addAll(referenceIdsPage0);
+    allIdsBuilder.addAll(referenceIdsPage1);
+    allIdsBuilder.addAll(referenceIdsPage2);
+    final var allIds = allIdsBuilder.build();
+    assertThat(allIds.size(), equalTo(DATA_REFERENCE_COUNT));
+
+    // Assure no results if offset is too high
+    final List<DataReferenceDescription> referencesBeyondUpperBound = ClientTestUtils
+        .getDataReferenceDescriptions(
+        getWorkspaceId(), workspaceApi, 10 * PAGE_SIZE, PAGE_SIZE);
+    assertThat(referencesBeyondUpperBound, is(empty()));
+  }
+
+  @Override
+  public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws ApiException {
+    for (UUID referenceId : dataReferenceIds) {
+      workspaceApi.deleteDataReference(getWorkspaceId(), referenceId);
+      logger.debug("deleted data reference with ID: {}", referenceId.toString());
+    }
+    // cleanup the workspace
+    super.doCleanup(testUsers, workspaceApi);
+  }
+}

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateDataReferences.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateDataReferences.java
@@ -138,15 +138,4 @@ public class EnumerateDataReferences extends WorkspaceFixtureTestScriptBase {
         getWorkspaceId(), workspaceApi, 10 * PAGE_SIZE, PAGE_SIZE);
     assertThat(referencesBeyondUpperBound, is(empty()));
   }
-
-  @Override
-  public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
-      throws ApiException {
-    for (UUID referenceId : dataReferenceIds) {
-      workspaceApi.deleteDataReference(getWorkspaceId(), referenceId);
-      logger.debug("deleted data reference with ID: {}", referenceId.toString());
-    }
-    // cleanup the workspace
-    super.doCleanup(testUsers, workspaceApi);
-  }
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/ServiceStatus.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/ServiceStatus.java
@@ -7,14 +7,14 @@ import bio.terra.workspace.client.ApiClient;
 import bio.terra.workspace.model.SystemStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scripts.utils.WorkspaceManagerServiceUtils;
+import scripts.utils.ClientTestUtils;
 
 public class ServiceStatus extends TestScript {
     private static final Logger logger = LoggerFactory.getLogger(ServiceStatus.class);
 
     @Override
     public void userJourney(TestUserSpecification testUser) throws Exception {
-        ApiClient apiClient = WorkspaceManagerServiceUtils.getClientWithoutAccessToken(server);
+        ApiClient apiClient = ClientTestUtils.getClientWithoutAccessToken(server);
         UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
         SystemStatus systemStatus = unauthenticatedApi.serviceStatus();
 

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceTestScriptBase.java
@@ -32,7 +32,6 @@ public abstract class WorkspaceTestScriptBase extends TestScript {
       logger.debug("Caught exception creating setup ", apiEx);
       throw(apiEx);
     }
-    ClientTestUtils.assertHttpOk(workspaceApi, "setup");
   }
 
   @Override
@@ -45,7 +44,6 @@ public abstract class WorkspaceTestScriptBase extends TestScript {
       logger.debug("Caught exception in userJourney ", apiEx);
       throw(apiEx);
     }
-    ClientTestUtils.assertHttpOk(workspaceApi, "userJourney");
   }
 
   @Override
@@ -60,7 +58,6 @@ public abstract class WorkspaceTestScriptBase extends TestScript {
       logger.debug("Caught exception during cleanup ", apiEx);
       throw(apiEx);
     }
-    ClientTestUtils.assertHttpOk(workspaceApi, "cleanup");
   }
 
   public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) throws ApiException {}

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceTestScriptBase.java
@@ -24,7 +24,7 @@ public abstract class WorkspaceTestScriptBase extends TestScript {
   public void setup(List<TestUserSpecification> testUsers) throws Exception {
     assertThat("There must be at least one test user in configs/testusers directory.",
         testUsers != null && testUsers.size() > 0);
-    final WorkspaceApi workspaceApi = WorkspaceManagerServiceUtils
+    final WorkspaceApi workspaceApi = ClientTestUtils
         .getWorkspaceClient(testUsers.get(0), server);
     try {
       doSetup(testUsers, workspaceApi);
@@ -32,12 +32,12 @@ public abstract class WorkspaceTestScriptBase extends TestScript {
       logger.debug("Caught exception creating setup ", apiEx);
       throw(apiEx);
     }
-    WorkspaceManagerServiceUtils.assertHttpOk(workspaceApi, "setup");
+    ClientTestUtils.assertHttpOk(workspaceApi, "setup");
   }
 
   @Override
   public void userJourney(TestUserSpecification testUser) throws Exception {
-    final WorkspaceApi workspaceApi = WorkspaceManagerServiceUtils
+    final WorkspaceApi workspaceApi = ClientTestUtils
         .getWorkspaceClient(testUser, server);
     try {
       doUserJourney(testUser, workspaceApi);
@@ -45,14 +45,14 @@ public abstract class WorkspaceTestScriptBase extends TestScript {
       logger.debug("Caught exception in userJourney ", apiEx);
       throw(apiEx);
     }
-    WorkspaceManagerServiceUtils.assertHttpOk(workspaceApi, "userJourney");
+    ClientTestUtils.assertHttpOk(workspaceApi, "userJourney");
   }
 
   @Override
   public void cleanup(List<TestUserSpecification> testUsers) throws Exception {
     assertThat("There must be at least one test user in configs/testusers directory.",
         testUsers != null && testUsers.size() > 0);
-    final WorkspaceApi workspaceApi = WorkspaceManagerServiceUtils
+    final WorkspaceApi workspaceApi = ClientTestUtils
         .getWorkspaceClient(testUsers.get(0), server);
     try {
       doCleanup(testUsers, workspaceApi);
@@ -60,7 +60,7 @@ public abstract class WorkspaceTestScriptBase extends TestScript {
       logger.debug("Caught exception during cleanup ", apiEx);
       throw(apiEx);
     }
-    WorkspaceManagerServiceUtils.assertHttpOk(workspaceApi, "cleanup");
+    ClientTestUtils.assertHttpOk(workspaceApi, "cleanup");
   }
 
   public void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) throws ApiException {}

--- a/workspace-manager-clienttests/src/main/resources/configs/BasicAuthenticated.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/BasicAuthenticated.json
@@ -1,12 +1,26 @@
 {
   "name": "BasicAuthenticated",
-  "description": "Get workspace repeatedly, concurrently. Authentication required.",
+  "description": "Concurrent tests. Authentication required.",
   "serverSpecificationFile": "workspace-dev.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "GetWorkspace",
+      "numberOfUserJourneyThreadsToRun": 10,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 5,
+      "expectedTimeForEachUnit": "SECONDS"
+    },
+    {
+      "name": "EnumerateDataReferences",
+      "numberOfUserJourneyThreadsToRun": 10,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 5,
+      "expectedTimeForEachUnit": "SECONDS"
+    },
+    {
+      "name": "DataReferenceLifecycle",
       "numberOfUserJourneyThreadsToRun": 10,
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,

--- a/workspace-manager-clienttests/src/main/resources/configs/DataReferenceLifecycle.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/DataReferenceLifecycle.json
@@ -1,12 +1,12 @@
 {
-  "name": "BasicAuthenticated",
-  "description": "Concurrent tests. Authentication required.",
+  "name": "DataReferenceLifecycle",
+  "description": "CRUD data reference tests.",
   "serverSpecificationFile": "workspace-dev.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
-      "name": "GetWorkspace",
+      "name": "DataReferenceLifecycle",
       "numberOfUserJourneyThreadsToRun": 10,
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,

--- a/workspace-manager-clienttests/src/main/resources/configs/EnumerateDataReferences.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/EnumerateDataReferences.json
@@ -1,12 +1,12 @@
 {
-  "name": "BasicAuthenticated",
-  "description": "Concurrent tests. Authentication required.",
+  "name": "EnumerateDataReferences",
+  "description": "Test the offset and limit logic for enumerating data references on a workspace.",
   "serverSpecificationFile": "workspace-dev.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
-      "name": "GetWorkspace",
+      "name": "EnumerateDataReferences",
       "numberOfUserJourneyThreadsToRun": 10,
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,


### PR DESCRIPTION
Create, read (two ways), and delete a data reference. Uses the new test-fixture version of the base class, which needs to be merged first. It's at #181.