### PR TITLE
[PF-356] Move memberEmail to request body for grantRole

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 
 allprojects {
 	group = "bio.terra"
-	version = "0.7.0-SNAPSHOT"
+	version = "0.8.0-SNAPSHOT"
 	ext {
 		artifactGroup = "${group}.workspace"
 		swaggerOutputDir = "${buildDir}/swagger-code"

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -276,7 +276,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<Void> grantRole(
       @PathVariable("id") UUID id,
       @PathVariable("role") IamRole role,
-      @PathVariable("memberEmail") String memberEmail) {
+      @RequestBody String memberEmail) {
     ControllerValidationUtils.validateEmail(memberEmail);
     samService.grantWorkspaceRole(
         id,

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -276,7 +276,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<Void> grantRole(
       @PathVariable("id") UUID id,
       @PathVariable("role") IamRole role,
-      @RequestBody String memberEmail) {
+      @PathVariable("memberEmail") String memberEmail) {
     ControllerValidationUtils.validateEmail(memberEmail);
     samService.grantWorkspaceRole(
         id,

--- a/src/main/java/bio/terra/workspace/service/workspace/exceptions/RetryableCrlException.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/exceptions/RetryableCrlException.java
@@ -2,9 +2,10 @@ package bio.terra.workspace.service.workspace.exceptions;
 
 import bio.terra.stairway.exception.RetryException;
 
-/** Exception for retryable errors thrown by the Cloud Resource Library (CRL).
+/**
+ * Exception for retryable errors thrown by the Cloud Resource Library (CRL).
  *
- * This extends Stairway's RetryException, which will signal Stairway to retry any step this is
+ * <p>This extends Stairway's RetryException, which will signal Stairway to retry any step this is
  * thrown from (modulo a retry rule).
  */
 public class RetryableCrlException extends RetryException {

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/GoogleCloudSyncStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/GoogleCloudSyncStep.java
@@ -19,10 +19,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * A {@link Step} that grants GCP IAM permissions to Sam policy groups.
@@ -60,9 +58,12 @@ public class GoogleCloudSyncStep implements Step {
       List<Binding> existingBindings = currentPolicy.getBindings();
 
       // GCP IAM always prefixes groups with the literal "group:"
-      String readerGroup = "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_READER_GROUP_EMAIL, String.class);
-      String writerGroup = "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_WRITER_GROUP_EMAIL, String.class);
-      String ownerGroup = "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_OWNER_GROUP_EMAIL, String.class);
+      String readerGroup =
+          "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_READER_GROUP_EMAIL, String.class);
+      String writerGroup =
+          "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_WRITER_GROUP_EMAIL, String.class);
+      String ownerGroup =
+          "group:" + workingMap.get(WorkspaceFlightMapKeys.IAM_OWNER_GROUP_EMAIL, String.class);
       List<Binding> newBindings = new ArrayList<>();
       newBindings.addAll(bindingsForRole(IamRole.READER, readerGroup));
       newBindings.addAll(bindingsForRole(IamRole.WRITER, writerGroup));
@@ -84,16 +85,17 @@ public class GoogleCloudSyncStep implements Step {
     return StepResult.getStepResultSuccess();
   }
 
-  /** Build a list of role bindings for a given group, using CloudSyncRoleMapping.
+  /**
+   * Build a list of role bindings for a given group, using CloudSyncRoleMapping.
    *
    * @param role The role granted to this user. Translated to GCP roles using CloudSyncRoleMapping.
-   * @param group The group being granted a role. Should be prefixed with the literal "group:" for GCP.
-   * */
+   * @param group The group being granted a role. Should be prefixed with the literal "group:" for
+   *     GCP.
+   */
   private List<Binding> bindingsForRole(IamRole role, String group) {
     List<Binding> bindings = new ArrayList<>();
     for (String gcpRole : CloudSyncRoleMapping.cloudSyncRoleMap.get(role)) {
-      bindings.add(
-          new Binding().setRole(gcpRole).setMembers(Collections.singletonList(group)));
+      bindings.add(new Binding().setRole(gcpRole).setMembers(Collections.singletonList(group)));
     }
     return bindings;
   }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -714,7 +714,7 @@ components:
         $ref: '#/components/schemas/RoleBinding'
 
     MemberEmail:
-      description: A user or group's email. Used for adding or removing IAM permissions
+      description: A user or group's email.
       type: string
 
   responses:

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -235,15 +235,20 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{id}/roles/{role}/members/{memberEmail}:
+  /api/workspaces/v1/{id}/roles/{role}/members:
     parameters:
     - $ref: '#/components/parameters/Id'
     - $ref: '#/components/parameters/Role'
-    - $ref: '#/components/parameters/MemberEmail'
     put:
       summary: Grant an IAM role to a user or group.
       operationId: grantRole
       tags: [Workspace]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MemberEmail'
       responses:
         '204':
           description: Role granted successfully
@@ -253,6 +258,12 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+
+  /api/workspaces/v1/{id}/roles/{role}/members/{memberEmail}:
+    parameters:
+    - $ref: '#/components/parameters/Id'
+    - $ref: '#/components/parameters/Role'
+    - $ref: '#/components/parameters/MemberEmail'
     delete:
       summary: Remove an IAM role from a user or group.
       operationId: removeRole
@@ -393,7 +404,7 @@ components:
     MemberEmail:
       name: memberEmail
       in: path
-      description: A user or group's email. Used for adding or removing IAM permissions
+      description: A user or group's email.
       required: true
       schema:
         type: string
@@ -701,6 +712,10 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/RoleBinding'
+
+    MemberEmail:
+      description: A user or group's email. Used for adding or removing IAM permissions
+      type: string
 
   responses:
     CreatedWorkspaceResponse:

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -235,20 +235,15 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{id}/roles/{role}/members:
+  /api/workspaces/v1/{id}/roles/{role}/members/{memberEmail}:
     parameters:
     - $ref: '#/components/parameters/Id'
     - $ref: '#/components/parameters/Role'
-    put:
+    - $ref: '#/components/parameters/MemberEmail'
+    post:
       summary: Grant an IAM role to a user or group.
       operationId: grantRole
       tags: [Workspace]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MemberEmail'
       responses:
         '204':
           description: Role granted successfully
@@ -258,12 +253,6 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-
-  /api/workspaces/v1/{id}/roles/{role}/members/{memberEmail}:
-    parameters:
-    - $ref: '#/components/parameters/Id'
-    - $ref: '#/components/parameters/Role'
-    - $ref: '#/components/parameters/MemberEmail'
     delete:
       summary: Remove an IAM role from a user or group.
       operationId: removeRole
@@ -404,7 +393,7 @@ components:
     MemberEmail:
       name: memberEmail
       in: path
-      description: A user or group's email.
+      description: A user or group's email. Used for adding or removing IAM permissions
       required: true
       schema:
         type: string
@@ -712,10 +701,6 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/RoleBinding'
-
-    MemberEmail:
-      description: A user or group's email.
-      type: string
 
   responses:
     CreatedWorkspaceResponse:


### PR DESCRIPTION
Currently, the `grantRole` endpoint is at `PUT /api/workspaces/v1/{id}/roles/{role}/members/{memberEmail}` and does not take a body. The swagger generated client (using Jersey2) enforces its own rules about HTTP requests and disallows PUT requests with an empty body, which means we can't call this endpoint from the client.

This changes PUT to POST, which may have empty request bodies.

As this is a change to the API, I've bumped the project version to 0.8.0 and will publish a new client library when this change is merged.

This also includes unrelated lint changes to `RetryableCrlException` and `GoogleCloudSyncStep` because I pushed without linting in #172. Sorry!