### PR TITLE
[PF-356] Move memberEmail from url to request body on grantRole endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 
 allprojects {
 	group = "bio.terra"
-	version = "0.8.0-SNAPSHOT"
+	version = "0.9.0-SNAPSHOT"
 	ext {
 		artifactGroup = "${group}.workspace"
 		swaggerOutputDir = "${buildDir}/swagger-code"

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -276,13 +276,13 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<Void> grantRole(
       @PathVariable("id") UUID id,
       @PathVariable("role") IamRole role,
-      @PathVariable("memberEmail") String memberEmail) {
-    ControllerValidationUtils.validateEmail(memberEmail);
+      @RequestBody GrantRoleRequestBody body) {
+    ControllerValidationUtils.validateEmail(body.getMemberEmail());
     samService.grantWorkspaceRole(
         id,
         getAuthenticatedInfo(),
         bio.terra.workspace.service.iam.model.IamRole.fromApiModel(role),
-        memberEmail);
+        body.getMemberEmail());
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -235,15 +235,20 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{id}/roles/{role}/members/{memberEmail}:
+  /api/workspaces/v1/{id}/roles/{role}/members:
     parameters:
     - $ref: '#/components/parameters/Id'
     - $ref: '#/components/parameters/Role'
-    - $ref: '#/components/parameters/MemberEmail'
     post:
       summary: Grant an IAM role to a user or group.
       operationId: grantRole
       tags: [Workspace]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GrantRoleRequestBody'
       responses:
         '204':
           description: Role granted successfully
@@ -253,6 +258,11 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/workspaces/v1/{id}/roles/{role}/members/{memberEmail}:
+    parameters:
+    - $ref: '#/components/parameters/Id'
+    - $ref: '#/components/parameters/Role'
+    - $ref: '#/components/parameters/MemberEmail'
     delete:
       summary: Remove an IAM role from a user or group.
       operationId: removeRole
@@ -701,6 +711,14 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/RoleBinding'
+
+    GrantRoleRequestBody:
+      description: The body for a request to grant a role to a single user.
+      type: object
+      required: [memberEmail]
+      properties:
+        memberEmail:
+          type: string
 
   responses:
     CreatedWorkspaceResponse:


### PR DESCRIPTION
Previously in #184, I changed the `grantRole` endpoint from PUT to POST, leaving all parameters in the URL. This is allowed by both the server and client, but GCP automatically rejects POST requests without a `Content-length` header (which Jersey does not include for empty bodies).

This change moves the `memberEmail` parameter from the URL to the request body for `grantRole`. The `removeRole` endpoint is unchanged, as DELETE requests should not have bodies.

From an API design standpoint this makes the most sense to me: we are adding one member to a role's collection of members. This endpoint is not creating a new role, so I did not want to move role to the request body.

While this does mean our POST and DELETE endpoints are no longer symmetrical, this is the same approach we've taken for creating/deleting workspaces and data references.

In addition to testing this with a locally built client and server, I verified this against my preview environment to ensure there were no complaints from the proxy or GCP ingress.