### PR TITLE
[PF-363] Handle calls to create duplicate context better

### DIFF
--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.spendprofile.SpendProfile;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.spendprofile.SpendProfileService;
+import bio.terra.workspace.service.workspace.exceptions.DuplicateGoogleContextException;
 import bio.terra.workspace.service.workspace.exceptions.MissingSpendProfileException;
 import bio.terra.workspace.service.workspace.exceptions.NoBillingAccountException;
 import bio.terra.workspace.service.workspace.flight.*;
@@ -106,7 +107,7 @@ public class WorkspaceService {
     samService.workspaceAuthz(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
     workspaceDao.assertMcWorkspace(workspaceId, "createGoogleContext");
     if (!workspaceDao.getCloudContext(workspaceId).googleProjectId().isEmpty()) {
-      throw new
+      throw new DuplicateGoogleContextException(workspaceId);
     }
     Optional<SpendProfileId> spendProfileId =
         workspaceDao.getWorkspace(workspaceId).spendProfileId();

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -105,6 +105,9 @@ public class WorkspaceService {
   public String createGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     samService.workspaceAuthz(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
     workspaceDao.assertMcWorkspace(workspaceId, "createGoogleContext");
+    if (!workspaceDao.getCloudContext(workspaceId).googleProjectId().isEmpty()) {
+      throw new
+    }
     Optional<SpendProfileId> spendProfileId =
         workspaceDao.getWorkspace(workspaceId).spendProfileId();
     if (spendProfileId.isEmpty()) {

--- a/src/main/java/bio/terra/workspace/service/workspace/exceptions/DuplicateGoogleContextException.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/exceptions/DuplicateGoogleContextException.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.workspace.exceptions;
+
+import bio.terra.workspace.common.exception.BadRequestException;
+import bio.terra.workspace.common.exception.ErrorReportException;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exception thrown when attempting to create a Google context in a workspace which already
+ * has one.
+ */
+public class DuplicateGoogleContextException extends ErrorReportException {
+  private static final HttpStatus thisStatus = HttpStatus.BAD_REQUEST;
+  public DuplicateGoogleContextException(UUID workspaceId) {
+    super(
+        String.format(
+            "Spend profile id required, but none found on workspace %s", workspaceId.toString()));
+  }
+}

--- a/src/main/java/bio/terra/workspace/service/workspace/exceptions/DuplicateGoogleContextException.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/exceptions/DuplicateGoogleContextException.java
@@ -1,19 +1,13 @@
 package bio.terra.workspace.service.workspace.exceptions;
 
-import bio.terra.workspace.common.exception.BadRequestException;
-import bio.terra.workspace.common.exception.ErrorReportException;
+import bio.terra.workspace.common.exception.ConflictException;
 import java.util.UUID;
-import org.springframework.http.HttpStatus;
 
 /**
- * Exception thrown when attempting to create a Google context in a workspace which already
- * has one.
+ * Exception thrown when attempting to create a Google context in a workspace which already has one.
  */
-public class DuplicateGoogleContextException extends ErrorReportException {
-  private static final HttpStatus thisStatus = HttpStatus.BAD_REQUEST;
+public class DuplicateGoogleContextException extends ConflictException {
   public DuplicateGoogleContextException(UUID workspaceId) {
-    super(
-        String.format(
-            "Spend profile id required, but none found on workspace %s", workspaceId.toString()));
+    super(String.format("Workspace %s already has a Google context.", workspaceId.toString()));
   }
 }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -206,6 +206,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
@@ -746,6 +748,12 @@ components:
             $ref: '#/components/schemas/ErrorReport'
     NotFound:
       description: Not found (or unauthorized)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorReport'
+    Conflict:
+      description: Request conflicts with current state
       content:
         application/json:
           schema:


### PR DESCRIPTION
Currently, making a call to create a google context on a workspace which already has one will result in partially executing the stairway flight (including allocating a new GCP project) before failing (and deleting the new GCP project). This is a waste of time and projects, and we can avoid it and provide a more useful error code with a simple check.