### PR TITLE
[PF-372] Change 401 responses to 403

### DIFF
--- a/src/main/java/bio/terra/workspace/common/exception/ForbiddenException.java
+++ b/src/main/java/bio/terra/workspace/common/exception/ForbiddenException.java
@@ -7,26 +7,26 @@ package bio.terra.workspace.common.exception;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 
-public abstract class UnauthorizedException extends ErrorReportException {
-  private static final HttpStatus thisStatus = HttpStatus.UNAUTHORIZED;
+public abstract class ForbiddenException extends ErrorReportException {
+  private static final HttpStatus thisStatus = HttpStatus.FORBIDDEN;
 
-  public UnauthorizedException(String message) {
+  public ForbiddenException(String message) {
     super(message, null, thisStatus);
   }
 
-  public UnauthorizedException(String message, Throwable cause) {
+  public ForbiddenException(String message, Throwable cause) {
     super(message, cause, null, thisStatus);
   }
 
-  public UnauthorizedException(Throwable cause) {
+  public ForbiddenException(Throwable cause) {
     super(null, cause, null, thisStatus);
   }
 
-  public UnauthorizedException(String message, List<String> causes) {
+  public ForbiddenException(String message, List<String> causes) {
     super(message, causes, thisStatus);
   }
 
-  public UnauthorizedException(String message, Throwable cause, List<String> causes) {
+  public ForbiddenException(String message, Throwable cause, List<String> causes) {
     super(message, cause, causes, thisStatus);
   }
 }

--- a/src/main/java/bio/terra/workspace/common/exception/SamUnauthorizedException.java
+++ b/src/main/java/bio/terra/workspace/common/exception/SamUnauthorizedException.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.common.exception;
 
-public class SamUnauthorizedException extends UnauthorizedException {
+public class SamUnauthorizedException extends ForbiddenException {
 
   public SamUnauthorizedException(String message) {
     super(message);

--- a/src/main/java/bio/terra/workspace/service/buffer/exception/BufferServiceAuthorizationException.java
+++ b/src/main/java/bio/terra/workspace/service/buffer/exception/BufferServiceAuthorizationException.java
@@ -1,8 +1,8 @@
 package bio.terra.workspace.service.buffer.exception;
 
-import bio.terra.workspace.common.exception.UnauthorizedException;
+import bio.terra.workspace.common.exception.ForbiddenException;
 
-public class BufferServiceAuthorizationException extends UnauthorizedException {
+public class BufferServiceAuthorizationException extends ForbiddenException {
 
   public BufferServiceAuthorizationException(String message) {
     super(message);

--- a/src/main/java/bio/terra/workspace/service/datareference/exception/DataRepoAuthorizationException.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/exception/DataRepoAuthorizationException.java
@@ -1,8 +1,8 @@
 package bio.terra.workspace.service.datareference.exception;
 
-import bio.terra.workspace.common.exception.UnauthorizedException;
+import bio.terra.workspace.common.exception.ForbiddenException;
 
-public class DataRepoAuthorizationException extends UnauthorizedException {
+public class DataRepoAuthorizationException extends ForbiddenException {
   public DataRepoAuthorizationException(String message) {
     super(message);
   }

--- a/src/main/java/bio/terra/workspace/service/job/exception/JobUnauthorizedException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/JobUnauthorizedException.java
@@ -1,8 +1,8 @@
 package bio.terra.workspace.service.job.exception;
 
-import bio.terra.workspace.common.exception.UnauthorizedException;
+import bio.terra.workspace.common.exception.ForbiddenException;
 
-public class JobUnauthorizedException extends UnauthorizedException {
+public class JobUnauthorizedException extends ForbiddenException {
   public JobUnauthorizedException(String message) {
     super(message);
   }

--- a/src/main/java/bio/terra/workspace/service/spendprofile/exceptions/SpendUnauthorizedException.java
+++ b/src/main/java/bio/terra/workspace/service/spendprofile/exceptions/SpendUnauthorizedException.java
@@ -1,9 +1,9 @@
 package bio.terra.workspace.service.spendprofile.exceptions;
 
-import bio.terra.workspace.common.exception.UnauthorizedException;
+import bio.terra.workspace.common.exception.ForbiddenException;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 
-public class SpendUnauthorizedException extends UnauthorizedException {
+public class SpendUnauthorizedException extends ForbiddenException {
   public SpendUnauthorizedException(String message) {
     super(message);
   }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -56,7 +56,7 @@ paths:
           $ref: '#/components/responses/CreatedWorkspaceResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
-        '401':
+        '403':
           $ref: '#/components/responses/PermissionDenied'
         '500':
           $ref: '#/components/responses/NotFound'
@@ -75,12 +75,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceDescription'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
         '500':
-          description: Get request error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/ServerError'
     delete:
       summary: Delete a Workspace.
       operationId: deleteWorkspace
@@ -90,8 +88,8 @@ paths:
           description: Success
         '400':
           $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/NotFound'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
         '500':
           $ref: '#/components/responses/ServerError'
 
@@ -130,7 +128,7 @@ paths:
           $ref: '#/components/responses/ReferenceListResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
-        '401':
+        '403':
           $ref: '#/components/responses/PermissionDenied'
         '500':
           $ref: '#/components/responses/ServerError'
@@ -146,6 +144,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/DataReferenceResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
@@ -172,6 +172,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/DataReferenceResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
         '500':
           $ref: '#/components/responses/ServerError'
 


### PR DESCRIPTION
Currently, lots of things in WM return an HTTP 401 response to indicate a user does not have permission for an action. Technically [401 means authentication info is missing or unreadable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) while [403 means permission is denied](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403). 

Note that Sam does not distinguish between "resource not found" and "permission denied" in calls to its `resourcePermission` endpoint. While WM does not explicitly need to hide this difference, it uses that endpoint to check permissions. Because WM cannot distinguish between 403 and 404 responses from Sam, WM will return 403 in this case, with an error message indicating either case is possible.