### PR TITLE
AS-592: return 404 from workspace-specific APIs if the workspace doesn't exist [risk: low]

### DIFF
--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -124,6 +124,17 @@ public class WorkspaceDao {
     return WorkspaceStage.valueOf(jdbcTemplate.queryForObject(sql, params, String.class));
   }
 
+  // TODO: do all three variants of assertMcWorkspace belong in WorkspaceDAO?
+  private void assertMcWorkspace(WorkspaceStage stage, UUID workspaceId, String action) {
+    if (!WorkspaceStage.MC_WORKSPACE.equals(stage)) {
+      throw new StageDisabledException(workspaceId, stage, action);
+    }
+  }
+
+  public void assertMcWorkspace(Workspace workspace, String action) {
+    assertMcWorkspace(workspace.workspaceStage(), workspace.workspaceId(), action);
+  }
+
   /**
    * Check that the given workspace has stage MC_WORKSPACE, and throw an exception otherwise.
    *
@@ -132,9 +143,7 @@ public class WorkspaceDao {
    */
   public void assertMcWorkspace(UUID workspaceId, String action) {
     WorkspaceStage stage = getWorkspaceStage(workspaceId);
-    if (!WorkspaceStage.MC_WORKSPACE.equals(stage)) {
-      throw new StageDisabledException(workspaceId, stage, action);
-    }
+    assertMcWorkspace(stage, workspaceId, action);
   }
 
   /** Retrieves the cloud context of the workspace. */

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -124,26 +124,32 @@ public class WorkspaceDao {
     return WorkspaceStage.valueOf(jdbcTemplate.queryForObject(sql, params, String.class));
   }
 
-  // TODO: do all three variants of assertMcWorkspace belong in WorkspaceDAO?
-  private void assertMcWorkspace(WorkspaceStage stage, UUID workspaceId, String action) {
+  // underlying implementation for the two public assertMcWorkspace() methods
+  private void assertMcWorkspace(WorkspaceStage stage, UUID workspaceId, String actionMessage) {
     if (!WorkspaceStage.MC_WORKSPACE.equals(stage)) {
-      throw new StageDisabledException(workspaceId, stage, action);
+      throw new StageDisabledException(workspaceId, stage, actionMessage);
     }
-  }
-
-  public void assertMcWorkspace(Workspace workspace, String action) {
-    assertMcWorkspace(workspace.workspaceStage(), workspace.workspaceId(), action);
   }
 
   /**
    * Check that the given workspace has stage MC_WORKSPACE, and throw an exception otherwise.
    *
-   * @param workspaceId ID of the workspace to check
-   * @param action The action being performed, used in the exception message if needed
+   * @param workspace the workspace to check
+   * @param actionMessage The action being performed, used only in the exception message if needed
    */
-  public void assertMcWorkspace(UUID workspaceId, String action) {
+  public void assertMcWorkspace(Workspace workspace, String actionMessage) {
+    assertMcWorkspace(workspace.workspaceStage(), workspace.workspaceId(), actionMessage);
+  }
+
+  /**
+   * Check that the given workspace id has stage MC_WORKSPACE, and throw an exception otherwise.
+   *
+   * @param workspaceId ID of the workspace to check
+   * @param actionMessage The action being performed, used only in the exception message if needed
+   */
+  public void assertMcWorkspace(UUID workspaceId, String actionMessage) {
     WorkspaceStage stage = getWorkspaceStage(workspaceId);
-    assertMcWorkspace(stage, workspaceId, action);
+    assertMcWorkspace(stage, workspaceId, actionMessage);
   }
 
   /** Retrieves the cloud context of the workspace. */

--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -53,7 +53,7 @@ public class DataReferenceService {
   public DataReference getDataReference(
       UUID workspaceId, UUID referenceId, AuthenticatedUserRequest userReq) {
 
-    samService.workspaceAuthz(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    samService.authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
 
     return dataReferenceDao.getDataReference(workspaceId, referenceId);
   }
@@ -68,7 +68,7 @@ public class DataReferenceService {
       DataReferenceType referenceType,
       String name,
       AuthenticatedUserRequest userReq) {
-    samService.workspaceAuthz(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    samService.authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
 
     return dataReferenceDao.getDataReferenceByName(workspaceId, referenceType, name);
   }
@@ -78,7 +78,7 @@ public class DataReferenceService {
   public DataReference createDataReference(
       DataReferenceRequest referenceRequest, AuthenticatedUserRequest userReq) {
 
-    samService.workspaceAuthz(
+    samService.authorizedGetWorkspace(
         userReq, referenceRequest.workspaceId(), SamConstants.SAM_WORKSPACE_WRITE_ACTION);
 
     String description = "Create data reference in workspace " + referenceRequest.workspaceId();
@@ -116,7 +116,7 @@ public class DataReferenceService {
   @Traced
   public List<DataReference> enumerateDataReferences(
       UUID workspaceId, int offset, int limit, AuthenticatedUserRequest userReq) {
-    samService.workspaceAuthz(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    samService.authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     return dataReferenceDao.enumerateDataReferences(workspaceId, offset, limit);
   }
 
@@ -125,7 +125,7 @@ public class DataReferenceService {
   public void deleteDataReference(
       UUID workspaceId, UUID referenceId, AuthenticatedUserRequest userReq) {
 
-    samService.workspaceAuthz(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
+    samService.authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
 
     if (dataReferenceDao.isControlled(workspaceId, referenceId)) {
       throw new ControlledResourceNotImplementedException(

--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -54,7 +54,7 @@ public class DataReferenceService {
   public DataReference getDataReference(
       UUID workspaceId, UUID referenceId, AuthenticatedUserRequest userReq) {
 
-    workspaceService.authorizedGetWorkspace(
+    workspaceService.validateWorkspaceAndAction(
         userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
 
     return dataReferenceDao.getDataReference(workspaceId, referenceId);
@@ -71,7 +71,7 @@ public class DataReferenceService {
       DataReferenceType referenceType,
       String name,
       AuthenticatedUserRequest userReq) {
-    workspaceService.authorizedGetWorkspace(
+    workspaceService.validateWorkspaceAndAction(
         userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
 
     return dataReferenceDao.getDataReferenceByName(workspaceId, referenceType, name);
@@ -85,7 +85,7 @@ public class DataReferenceService {
   public DataReference createDataReference(
       DataReferenceRequest referenceRequest, AuthenticatedUserRequest userReq) {
 
-    workspaceService.authorizedGetWorkspace(
+    workspaceService.validateWorkspaceAndAction(
         userReq, referenceRequest.workspaceId(), SamConstants.SAM_WORKSPACE_WRITE_ACTION);
 
     String description = "Create data reference in workspace " + referenceRequest.workspaceId();
@@ -125,7 +125,7 @@ public class DataReferenceService {
   @Traced
   public List<DataReference> enumerateDataReferences(
       UUID workspaceId, int offset, int limit, AuthenticatedUserRequest userReq) {
-    workspaceService.authorizedGetWorkspace(
+    workspaceService.validateWorkspaceAndAction(
         userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     return dataReferenceDao.enumerateDataReferences(workspaceId, offset, limit);
   }
@@ -138,7 +138,7 @@ public class DataReferenceService {
   public void deleteDataReference(
       UUID workspaceId, UUID referenceId, AuthenticatedUserRequest userReq) {
 
-    workspaceService.authorizedGetWorkspace(
+    workspaceService.validateWorkspaceAndAction(
         userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
 
     if (dataReferenceDao.isControlled(workspaceId, referenceId)) {

--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -47,7 +47,7 @@ public class DataReferenceService {
 
   /**
    * Retrieve a data reference from the database by ID. References are always contained inside a
-   * single workspace.
+   * single workspace. Verifies workspace existence and read permission before retrieving the reference.
    */
   @Traced
   public DataReference getDataReference(
@@ -61,7 +61,7 @@ public class DataReferenceService {
 
   /**
    * Retrieve a data reference from the database by name. Names are unique per workspace, per data
-   * reference type.
+   * reference type. Verifies workspace existence and read permission before retrieving the reference.
    */
   @Traced
   public DataReference getDataReferenceByName(
@@ -75,7 +75,10 @@ public class DataReferenceService {
     return dataReferenceDao.getDataReferenceByName(workspaceId, referenceType, name);
   }
 
-  /** Create a data reference and return the newly created object. */
+  /**
+   * Create a data reference and return the newly created object.  Verifies workspace existence
+   * and write permission before creating the reference.
+   * */
   @Traced
   public DataReference createDataReference(
       DataReferenceRequest referenceRequest, AuthenticatedUserRequest userReq) {
@@ -114,6 +117,8 @@ public class DataReferenceService {
    *
    * <p>References are in ascending order by reference ID. At most {@Code limit} results will be
    * returned, with the first being {@Code offset} entries from the start of the database.
+   *
+   * <p>Verifies workspace existence and read permission before listing the references.
    */
   @Traced
   public List<DataReference> enumerateDataReferences(
@@ -123,7 +128,10 @@ public class DataReferenceService {
     return dataReferenceDao.enumerateDataReferences(workspaceId, offset, limit);
   }
 
-  /** Delete a data reference, or throw an exception if the specified reference does not exist. */
+  /**
+   * Delete a data reference, or throw an exception if the specified reference does not exist.  Verifies
+   * workspace existence and write permission before deleting the reference.
+   * */
   @Traced
   public void deleteDataReference(
       UUID workspaceId, UUID referenceId, AuthenticatedUserRequest userReq) {

--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -47,7 +47,8 @@ public class DataReferenceService {
 
   /**
    * Retrieve a data reference from the database by ID. References are always contained inside a
-   * single workspace. Verifies workspace existence and read permission before retrieving the reference.
+   * single workspace. Verifies workspace existence and read permission before retrieving the
+   * reference.
    */
   @Traced
   public DataReference getDataReference(
@@ -61,7 +62,8 @@ public class DataReferenceService {
 
   /**
    * Retrieve a data reference from the database by name. Names are unique per workspace, per data
-   * reference type. Verifies workspace existence and read permission before retrieving the reference.
+   * reference type. Verifies workspace existence and read permission before retrieving the
+   * reference.
    */
   @Traced
   public DataReference getDataReferenceByName(
@@ -76,9 +78,9 @@ public class DataReferenceService {
   }
 
   /**
-   * Create a data reference and return the newly created object.  Verifies workspace existence
-   * and write permission before creating the reference.
-   * */
+   * Create a data reference and return the newly created object. Verifies workspace existence and
+   * write permission before creating the reference.
+   */
   @Traced
   public DataReference createDataReference(
       DataReferenceRequest referenceRequest, AuthenticatedUserRequest userReq) {
@@ -129,9 +131,9 @@ public class DataReferenceService {
   }
 
   /**
-   * Delete a data reference, or throw an exception if the specified reference does not exist.  Verifies
-   * workspace existence and write permission before deleting the reference.
-   * */
+   * Delete a data reference, or throw an exception if the specified reference does not exist.
+   * Verifies workspace existence and write permission before deleting the reference.
+   */
   @Traced
   public void deleteDataReference(
       UUID workspaceId, UUID referenceId, AuthenticatedUserRequest userReq) {

--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -9,10 +9,10 @@ import bio.terra.workspace.service.datareference.model.DataReference;
 import bio.terra.workspace.service.datareference.model.DataReferenceRequest;
 import bio.terra.workspace.service.datareference.model.DataReferenceType;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.job.JobBuilder;
 import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.util.List;
@@ -29,19 +29,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class DataReferenceService {
   private final DataReferenceDao dataReferenceDao;
-  private final SamService samService;
   private final JobService jobService;
+  private final WorkspaceService workspaceService;
   private final ObjectMapper objectMapper;
 
   @Autowired
   public DataReferenceService(
       DataReferenceDao dataReferenceDao,
-      SamService samService,
       JobService jobService,
+      WorkspaceService workspaceService,
       ObjectMapper objectMapper) {
     this.dataReferenceDao = dataReferenceDao;
-    this.samService = samService;
     this.jobService = jobService;
+    this.workspaceService = workspaceService;
     this.objectMapper = objectMapper;
   }
 
@@ -53,7 +53,8 @@ public class DataReferenceService {
   public DataReference getDataReference(
       UUID workspaceId, UUID referenceId, AuthenticatedUserRequest userReq) {
 
-    samService.authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    workspaceService.authorizedGetWorkspace(
+        userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
 
     return dataReferenceDao.getDataReference(workspaceId, referenceId);
   }
@@ -68,7 +69,8 @@ public class DataReferenceService {
       DataReferenceType referenceType,
       String name,
       AuthenticatedUserRequest userReq) {
-    samService.authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    workspaceService.authorizedGetWorkspace(
+        userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
 
     return dataReferenceDao.getDataReferenceByName(workspaceId, referenceType, name);
   }
@@ -78,7 +80,7 @@ public class DataReferenceService {
   public DataReference createDataReference(
       DataReferenceRequest referenceRequest, AuthenticatedUserRequest userReq) {
 
-    samService.authorizedGetWorkspace(
+    workspaceService.authorizedGetWorkspace(
         userReq, referenceRequest.workspaceId(), SamConstants.SAM_WORKSPACE_WRITE_ACTION);
 
     String description = "Create data reference in workspace " + referenceRequest.workspaceId();
@@ -116,7 +118,8 @@ public class DataReferenceService {
   @Traced
   public List<DataReference> enumerateDataReferences(
       UUID workspaceId, int offset, int limit, AuthenticatedUserRequest userReq) {
-    samService.authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    workspaceService.authorizedGetWorkspace(
+        userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     return dataReferenceDao.enumerateDataReferences(workspaceId, offset, limit);
   }
 
@@ -125,7 +128,8 @@ public class DataReferenceService {
   public void deleteDataReference(
       UUID workspaceId, UUID referenceId, AuthenticatedUserRequest userReq) {
 
-    samService.authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
+    workspaceService.authorizedGetWorkspace(
+        userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
 
     if (dataReferenceDao.isControlled(workspaceId, referenceId)) {
       throw new ControlledResourceNotImplementedException(

--- a/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -9,7 +9,6 @@ import bio.terra.workspace.generated.model.SystemStatusSystems;
 import bio.terra.workspace.service.iam.model.IamRole;
 import bio.terra.workspace.service.iam.model.RoleBinding;
 import bio.terra.workspace.service.iam.model.SamConstants;
-import bio.terra.workspace.service.workspace.model.Workspace;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -139,31 +138,6 @@ public class SamService {
               String.format(
                       "User %s is authorized to %s workspace %s",
                       userReq.getEmail(), action, workspaceId.toString()));
-  }
-
-  /**
-   * Convenience function that checks existence of a workspace, followed by an authorization check
-   * against that workspace.
-   *
-   * Throws WorkspaceNotFoundException from getWorkspace if the workspace does not exist, regardless
-   * of the user's permission.
-   *
-   * Throws SamUnauthorizedException if the user is not permitted to perform the specified action
-   * on the workspace in question.
-   *
-   * Returns the Workspace object if it exists and the user is permitted to perform the specified action.
-   *
-   * @param userReq the user's authenticated request
-   * @param workspaceId id of the workspace in question
-   * @param action the action to authorize against the workspace
-   * @return the workspace, if it exists and the user is permitted to perform the specified action.
-   */
-  @Traced
-  // TODO: this doesn't belong in SamService; it should move to ... where? WorkspaceService?
-  public Workspace authorizedGetWorkspace(AuthenticatedUserRequest userReq, UUID workspaceId, String action) {
-    Workspace workspace = workspaceDao.getWorkspace(workspaceId);
-    workspaceAuthzOnly(userReq, workspaceId, action);
-    return workspace;
   }
 
   /**

--- a/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -132,7 +132,7 @@ public class SamService {
     if (!isAuthorized)
       throw new SamUnauthorizedException(
           String.format(
-              "User %s is not authorized to %s workspace %s or it does not exist",
+              "User %s is not authorized to %s workspace %s",
               userReq.getEmail(), action, workspaceId));
     else
       logger.info(

--- a/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -121,23 +121,24 @@ public class SamService {
   }
 
   @Traced
-  public void workspaceAuthzOnly(AuthenticatedUserRequest userReq, UUID workspaceId, String action) {
+  public void workspaceAuthzOnly(
+      AuthenticatedUserRequest userReq, UUID workspaceId, String action) {
     boolean isAuthorized =
-            isAuthorized(
-                    userReq.getRequiredToken(),
-                    SamConstants.SAM_WORKSPACE_RESOURCE,
-                    workspaceId.toString(),
-                    action);
+        isAuthorized(
+            userReq.getRequiredToken(),
+            SamConstants.SAM_WORKSPACE_RESOURCE,
+            workspaceId.toString(),
+            action);
     if (!isAuthorized)
       throw new SamUnauthorizedException(
-              String.format(
-                      "User %s is not authorized to %s workspace %s or it does not exist",
-                      userReq.getEmail(), action, workspaceId));
+          String.format(
+              "User %s is not authorized to %s workspace %s or it does not exist",
+              userReq.getEmail(), action, workspaceId));
     else
       logger.info(
-              String.format(
-                      "User %s is authorized to %s workspace %s",
-                      userReq.getEmail(), action, workspaceId.toString()));
+          String.format(
+              "User %s is authorized to %s workspace %s",
+              userReq.getEmail(), action, workspaceId.toString()));
   }
 
   /**

--- a/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.generated.model.SystemStatusSystems;
 import bio.terra.workspace.service.iam.model.IamRole;
 import bio.terra.workspace.service.iam.model.RoleBinding;
 import bio.terra.workspace.service.iam.model.SamConstants;
+import bio.terra.workspace.service.workspace.model.Workspace;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -121,23 +122,48 @@ public class SamService {
   }
 
   @Traced
-  public void workspaceAuthz(AuthenticatedUserRequest userReq, UUID workspaceId, String action) {
+  public void workspaceAuthzOnly(AuthenticatedUserRequest userReq, UUID workspaceId, String action) {
     boolean isAuthorized =
-        isAuthorized(
-            userReq.getRequiredToken(),
-            SamConstants.SAM_WORKSPACE_RESOURCE,
-            workspaceId.toString(),
-            action);
+            isAuthorized(
+                    userReq.getRequiredToken(),
+                    SamConstants.SAM_WORKSPACE_RESOURCE,
+                    workspaceId.toString(),
+                    action);
     if (!isAuthorized)
       throw new SamUnauthorizedException(
-          String.format(
-              "User %s is not authorized to %s workspace %s or it does not exist",
-              userReq.getEmail(), action, workspaceId));
+              String.format(
+                      "User %s is not authorized to %s workspace %s or it does not exist",
+                      userReq.getEmail(), action, workspaceId));
     else
       logger.info(
-          String.format(
-              "User %s is authorized to %s workspace %s",
-              userReq.getEmail(), action, workspaceId.toString()));
+              String.format(
+                      "User %s is authorized to %s workspace %s",
+                      userReq.getEmail(), action, workspaceId.toString()));
+  }
+
+  /**
+   * Convenience function that checks existence of a workspace, followed by an authorization check
+   * against that workspace.
+   *
+   * Throws WorkspaceNotFoundException from getWorkspace if the workspace does not exist, regardless
+   * of the user's permission.
+   *
+   * Throws SamUnauthorizedException if the user is not permitted to perform the specified action
+   * on the workspace in question.
+   *
+   * Returns the Workspace object if it exists and the user is permitted to perform the specified action.
+   *
+   * @param userReq the user's authenticated request
+   * @param workspaceId id of the workspace in question
+   * @param action the action to authorize against the workspace
+   * @return the workspace, if it exists and the user is permitted to perform the specified action.
+   */
+  @Traced
+  // TODO: this doesn't belong in SamService; it should move to ... where? WorkspaceService?
+  public Workspace authorizedGetWorkspace(AuthenticatedUserRequest userReq, UUID workspaceId, String action) {
+    Workspace workspace = workspaceDao.getWorkspace(workspaceId);
+    workspaceAuthzOnly(userReq, workspaceId, action);
+    return workspace;
   }
 
   /**

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -16,7 +16,6 @@ import bio.terra.workspace.service.workspace.flight.*;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceRequest;
 import io.opencensus.contrib.spring.aop.Traced;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -134,13 +133,11 @@ public class WorkspaceService {
     if (!workspaceDao.getCloudContext(workspaceId).googleProjectId().isEmpty()) {
       throw new DuplicateGoogleContextException(workspaceId);
     }
-    Optional<SpendProfileId> spendProfileId = workspace.spendProfileId();
-    if (spendProfileId.isEmpty()) {
-      throw new MissingSpendProfileException(workspaceId);
-    }
-    SpendProfile spendProfile = spendProfileService.authorizeLinking(spendProfileId.get(), userReq);
+    SpendProfileId spendProfileId =
+        workspace.spendProfileId().orElseThrow(() -> new MissingSpendProfileException(workspaceId));
+    SpendProfile spendProfile = spendProfileService.authorizeLinking(spendProfileId, userReq);
     if (spendProfile.billingAccountId().isEmpty()) {
-      throw new NoBillingAccountException(spendProfileId.get());
+      throw new NoBillingAccountException(spendProfileId);
     }
 
     String jobId = UUID.randomUUID().toString();

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -117,14 +117,20 @@ public class WorkspaceService {
     deleteJob.submitAndWait(null, false);
   }
 
-  /** Retrieves the cloud context of a workspace. */
+  /**
+   * Retrieves the cloud context of a workspace.  Verifies workspace existence and
+   * read permission before retrieving the cloud context.
+   * */
   @Traced
   public WorkspaceCloudContext getCloudContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     return workspaceDao.getCloudContext(workspaceId);
   }
 
-  /** Start a job to create a Google cloud context for the workspace. Returns the job id. */
+  /**
+   * Start a job to create a Google cloud context for the workspace. Returns the job id.  Verifies
+   * workspace existence and write permission before starting the job.
+   * */
   @Traced
   public String createGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     Workspace workspace =
@@ -155,7 +161,10 @@ public class WorkspaceService {
     return jobId;
   }
 
-  /** Delete the Google cloud context for the workspace. */
+  /**
+   * Delete the Google cloud context for the workspace.  Verifies workspace existence and
+   * write permission before deleting the cloud context.
+   * */
   @Traced
   public void deleteGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     Workspace workspace =

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -71,13 +71,16 @@ public class WorkspaceService {
   /** Retrieves an existing workspace by ID */
   @Traced
   public Workspace getWorkspace(UUID id, AuthenticatedUserRequest userReq) {
+    Workspace workspace = workspaceDao.getWorkspace(id);
     samService.workspaceAuthz(userReq, id, SamConstants.SAM_WORKSPACE_READ_ACTION);
-    return workspaceDao.getWorkspace(id);
+    return workspace;
   }
 
   /** Delete an existing workspace by ID. */
   @Traced
   public void deleteWorkspace(UUID id, AuthenticatedUserRequest userReq) {
+    // getWorkspace will throw WorkspaceNotFoundException if it doesn't exist
+    workspaceDao.getWorkspace(id);
 
     samService.workspaceAuthz(userReq, id, SamConstants.SAM_WORKSPACE_DELETE_ACTION);
 

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -86,7 +86,7 @@ public class WorkspaceService {
    * @return the workspace, if it exists and the user is permitted to perform the specified action.
    */
   @Traced
-  public Workspace authorizedGetWorkspace(
+  public Workspace validateWorkspaceAndAction(
       AuthenticatedUserRequest userReq, UUID workspaceId, String action) {
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
     samService.workspaceAuthzOnly(userReq, workspaceId, action);
@@ -96,13 +96,13 @@ public class WorkspaceService {
   /** Retrieves an existing workspace by ID */
   @Traced
   public Workspace getWorkspace(UUID id, AuthenticatedUserRequest userReq) {
-    return authorizedGetWorkspace(userReq, id, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    return validateWorkspaceAndAction(userReq, id, SamConstants.SAM_WORKSPACE_READ_ACTION);
   }
 
   /** Delete an existing workspace by ID. */
   @Traced
   public void deleteWorkspace(UUID id, AuthenticatedUserRequest userReq) {
-    authorizedGetWorkspace(userReq, id, SamConstants.SAM_WORKSPACE_DELETE_ACTION);
+    validateWorkspaceAndAction(userReq, id, SamConstants.SAM_WORKSPACE_DELETE_ACTION);
 
     String description = "Delete workspace " + id;
     JobBuilder deleteJob =
@@ -123,7 +123,7 @@ public class WorkspaceService {
    */
   @Traced
   public WorkspaceCloudContext getCloudContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
-    authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    validateWorkspaceAndAction(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     return workspaceDao.getCloudContext(workspaceId);
   }
 
@@ -134,7 +134,7 @@ public class WorkspaceService {
   @Traced
   public String createGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     Workspace workspace =
-        authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
+        validateWorkspaceAndAction(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
     workspaceDao.assertMcWorkspace(workspace, "createGoogleContext");
     if (!workspaceDao.getCloudContext(workspaceId).googleProjectId().isEmpty()) {
       throw new DuplicateGoogleContextException(workspaceId);
@@ -168,7 +168,7 @@ public class WorkspaceService {
   @Traced
   public void deleteGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     Workspace workspace =
-        authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
+        validateWorkspaceAndAction(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
     workspaceDao.assertMcWorkspace(workspace, "deleteGoogleContext");
     jobService
         .newJob(

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -87,7 +87,8 @@ public class WorkspaceService {
    * @return the workspace, if it exists and the user is permitted to perform the specified action.
    */
   @Traced
-  public Workspace authorizedGetWorkspace(AuthenticatedUserRequest userReq, UUID workspaceId, String action) {
+  public Workspace authorizedGetWorkspace(
+      AuthenticatedUserRequest userReq, UUID workspaceId, String action) {
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
     samService.workspaceAuthzOnly(userReq, workspaceId, action);
     return workspace;
@@ -127,7 +128,8 @@ public class WorkspaceService {
   /** Start a job to create a Google cloud context for the workspace. Returns the job id. */
   @Traced
   public String createGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
-    Workspace workspace = authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
+    Workspace workspace =
+        authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
     workspaceDao.assertMcWorkspace(workspace, "createGoogleContext");
     if (!workspaceDao.getCloudContext(workspaceId).googleProjectId().isEmpty()) {
       throw new DuplicateGoogleContextException(workspaceId);
@@ -159,7 +161,8 @@ public class WorkspaceService {
   /** Delete the Google cloud context for the workspace. */
   @Traced
   public void deleteGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
-    Workspace workspace = authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
+    Workspace workspace =
+        authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
     workspaceDao.assertMcWorkspace(workspace, "deleteGoogleContext");
     jobService
         .newJob(

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -118,9 +118,9 @@ public class WorkspaceService {
   }
 
   /**
-   * Retrieves the cloud context of a workspace.  Verifies workspace existence and
-   * read permission before retrieving the cloud context.
-   * */
+   * Retrieves the cloud context of a workspace. Verifies workspace existence and read permission
+   * before retrieving the cloud context.
+   */
   @Traced
   public WorkspaceCloudContext getCloudContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     authorizedGetWorkspace(userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
@@ -128,9 +128,9 @@ public class WorkspaceService {
   }
 
   /**
-   * Start a job to create a Google cloud context for the workspace. Returns the job id.  Verifies
+   * Start a job to create a Google cloud context for the workspace. Returns the job id. Verifies
    * workspace existence and write permission before starting the job.
-   * */
+   */
   @Traced
   public String createGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     Workspace workspace =
@@ -162,9 +162,9 @@ public class WorkspaceService {
   }
 
   /**
-   * Delete the Google cloud context for the workspace.  Verifies workspace existence and
-   * write permission before deleting the cloud context.
-   * */
+   * Delete the Google cloud context for the workspace. Verifies workspace existence and write
+   * permission before deleting the cloud context.
+   */
   @Traced
   public void deleteGoogleContext(UUID workspaceId, AuthenticatedUserRequest userReq) {
     Workspace workspace =

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -77,6 +77,8 @@ paths:
                 $ref: '#/components/schemas/WorkspaceDescription'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
@@ -90,6 +92,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -118,6 +118,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
     get:
@@ -134,6 +136,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 
@@ -150,6 +154,8 @@ paths:
           $ref: '#/components/responses/DataReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
@@ -161,6 +167,8 @@ paths:
           description: OK
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 
@@ -178,6 +186,8 @@ paths:
           $ref: '#/components/responses/DataReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 

--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -123,7 +123,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
     String samMessage = "Fake Sam unauthorized message";
     doThrow(new SamUnauthorizedException(samMessage))
         .when(mockSamService)
-        .authorizedGetWorkspace(any(), any(), any());
+        .workspaceAuthzOnly(any(), any(), any());
     UUID workspaceId = createDefaultWorkspace();
     assertThrows(
         SamUnauthorizedException.class,

--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -123,7 +123,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
     String samMessage = "Fake Sam unauthorized message";
     doThrow(new SamUnauthorizedException(samMessage))
         .when(mockSamService)
-        .workspaceAuthz(any(), any(), any());
+        .authorizedGetWorkspace(any(), any(), any());
     UUID workspaceId = createDefaultWorkspace();
     assertThrows(
         SamUnauthorizedException.class,

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -81,14 +81,6 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   public void testGetExistingWorkspace() {
-    Mockito.when(
-            mockSamService.isAuthorized(
-                Mockito.any(),
-                Mockito.eq(SamConstants.SAM_WORKSPACE_RESOURCE),
-                Mockito.any(),
-                Mockito.eq(SamConstants.SAM_WORKSPACE_READ_ACTION)))
-        .thenReturn(true);
-
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
 
@@ -113,8 +105,8 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
     workspaceService.createWorkspace(request, USER_REQUEST);
 
     doThrow(new SamUnauthorizedException("forbid!"))
-            .when(mockSamService)
-            .workspaceAuthzOnly(any(), any(), any());
+        .when(mockSamService)
+        .workspaceAuthzOnly(any(), any(), any());
     assertThrows(
         SamUnauthorizedException.class,
         () -> workspaceService.getWorkspace(request.workspaceId(), USER_REQUEST));
@@ -220,12 +212,12 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   @Test
   public void deleteForbiddenMissingWorkspace() {
     doThrow(new SamUnauthorizedException("forbid!"))
-            .when(mockSamService)
-            .workspaceAuthzOnly(any(), any(), any());
+        .when(mockSamService)
+        .workspaceAuthzOnly(any(), any(), any());
 
     assertThrows(
-            WorkspaceNotFoundException.class,
-            () -> workspaceService.deleteWorkspace(UUID.randomUUID(), USER_REQUEST));
+        WorkspaceNotFoundException.class,
+        () -> workspaceService.deleteWorkspace(UUID.randomUUID(), USER_REQUEST));
   }
 
   @Test
@@ -234,12 +226,12 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
     workspaceService.createWorkspace(request, USER_REQUEST);
 
     doThrow(new SamUnauthorizedException("forbid!"))
-            .when(mockSamService)
-            .workspaceAuthzOnly(any(), any(), any());
+        .when(mockSamService)
+        .workspaceAuthzOnly(any(), any(), any());
 
     assertThrows(
-            SamUnauthorizedException.class,
-            () -> workspaceService.deleteWorkspace(request.workspaceId(), USER_REQUEST));
+        SamUnauthorizedException.class,
+        () -> workspaceService.deleteWorkspace(request.workspaceId(), USER_REQUEST));
   }
 
   @Test

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -90,6 +90,29 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
+  public void testGetForbiddenMissingWorkspace() {
+    doThrow(new SamUnauthorizedException("forbid!"))
+        .when(mockSamService)
+        .workspaceAuthz(any(), any(), any());
+    assertThrows(
+        WorkspaceNotFoundException.class,
+        () -> workspaceService.getWorkspace(UUID.randomUUID(), USER_REQUEST));
+  }
+
+  @Test
+  public void testGetForbiddenExistingWorkspace() {
+    WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
+    workspaceService.createWorkspace(request, USER_REQUEST);
+
+    doThrow(new SamUnauthorizedException("forbid!"))
+            .when(mockSamService)
+            .workspaceAuthz(any(), any(), any());
+    assertThrows(
+        SamUnauthorizedException.class,
+        () -> workspaceService.getWorkspace(request.workspaceId(), USER_REQUEST));
+  }
+
+  @Test
   public void testWorkspaceStagePersists() {
     WorkspaceRequest mcWorkspaceRequest =
         defaultRequestBuilder(UUID.randomUUID())

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -210,6 +210,31 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
+  public void deleteForbiddenMissingWorkspace() {
+    doThrow(new SamUnauthorizedException("forbid!"))
+            .when(mockSamService)
+            .workspaceAuthz(any(), any(), any());
+
+    assertThrows(
+            WorkspaceNotFoundException.class,
+            () -> workspaceService.deleteWorkspace(UUID.randomUUID(), USER_REQUEST));
+  }
+
+  @Test
+  public void deleteForbiddenExistingWorkspace() {
+    WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
+    workspaceService.createWorkspace(request, USER_REQUEST);
+
+    doThrow(new SamUnauthorizedException("forbid!"))
+            .when(mockSamService)
+            .workspaceAuthz(any(), any(), any());
+
+    assertThrows(
+            SamUnauthorizedException.class,
+            () -> workspaceService.deleteWorkspace(request.workspaceId(), USER_REQUEST));
+  }
+
+  @Test
   public void deleteWorkspaceWithDataReference() {
     // First, create a workspace.
     UUID workspaceId = UUID.randomUUID();

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -93,7 +93,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void testGetForbiddenMissingWorkspace() {
     doThrow(new SamUnauthorizedException("forbid!"))
         .when(mockSamService)
-        .workspaceAuthz(any(), any(), any());
+        .authorizedGetWorkspace(any(), any(), any());
     assertThrows(
         WorkspaceNotFoundException.class,
         () -> workspaceService.getWorkspace(UUID.randomUUID(), USER_REQUEST));
@@ -106,7 +106,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
 
     doThrow(new SamUnauthorizedException("forbid!"))
             .when(mockSamService)
-            .workspaceAuthz(any(), any(), any());
+            .authorizedGetWorkspace(any(), any(), any());
     assertThrows(
         SamUnauthorizedException.class,
         () -> workspaceService.getWorkspace(request.workspaceId(), USER_REQUEST));
@@ -213,7 +213,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   public void deleteForbiddenMissingWorkspace() {
     doThrow(new SamUnauthorizedException("forbid!"))
             .when(mockSamService)
-            .workspaceAuthz(any(), any(), any());
+            .authorizedGetWorkspace(any(), any(), any());
 
     assertThrows(
             WorkspaceNotFoundException.class,
@@ -227,7 +227,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
 
     doThrow(new SamUnauthorizedException("forbid!"))
             .when(mockSamService)
-            .workspaceAuthz(any(), any(), any());
+            .authorizedGetWorkspace(any(), any(), any());
 
     assertThrows(
             SamUnauthorizedException.class,


### PR DESCRIPTION
This would eliminate the need for broadinstitute/rawls#1347.

In this PR, we change workspace- and data reference-related APIs, which all operate in the context of a single workspace, to always return a 404 if the workspace doesn't exist. It still returns a 403 if the workspace exists but you don't have permission; and returns an appropriate code (generally 200/204) if you do have permission.

In the case of 403,  it changes the error message from "User %s is not authorized to %s workspace %s or it does not exist" to "User %s is not authorized to %s workspace %s". 

For those who haven't followed all the conversation, we realize the 403/404 differentiation leaks existence of a workspace to those who don't have permission to see it. Because Workspace Manager is a low-level service, this is ok; we obscure  error messages at higher layers of the stack.

Do I need to duplicate the new tests using testrunner syntaxes?