### PR TITLE
PF-341 Temporarily add 'roles/notebooks.admin' for workspace owners and writers

### DIFF
--- a/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -13,12 +13,16 @@ public class CloudSyncRoleMapping {
                   "roles/viewer",
                   "roles/bigquery.dataEditor",
                   "roles/lifesciences.editor",
+                  // TODO(wchambers): Revise notebooks permissions when there are controlled resources for notebooks.
+                  "roles/notebooks.admin",
                   "roles/storage.objectAdmin"),
           IamRole.WRITER,
               ImmutableList.of(
                   "roles/viewer",
                   "roles/bigquery.dataEditor",
                   "roles/lifesciences.editor",
+                  // TODO(wchambers): Revise notebooks permissions when there are controlled resources for notebooks.
+                  "roles/notebooks.admin",
                   "roles/storage.objectAdmin"),
           IamRole.READER, ImmutableList.of("roles/viewer"));
 }


### PR DESCRIPTION
Add a notebooks admin role for workspace owners and writers for the Enterprise alpha. When we introduce controlled resources for notebooks, we will revise the permissions. This initial role allows users to demo notebooks.