### PR TITLE
PF-422: Temporarily expand workspace user storage permissions.

### DIFF
--- a/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -16,7 +16,9 @@ public class CloudSyncRoleMapping {
                   // TODO(wchambers): Revise notebooks permissions when there are controlled
                   // resources for notebooks.
                   "roles/notebooks.admin",
-                  "roles/storage.objectAdmin"),
+                  // TODO(marikomedlock): Revise storage permissions when there are controlled
+                  // resources for notebooks
+                  "roles/storage.admin"),
           IamRole.WRITER,
               ImmutableList.of(
                   "roles/viewer",
@@ -25,6 +27,8 @@ public class CloudSyncRoleMapping {
                   // TODO(wchambers): Revise notebooks permissions when there are controlled
                   // resources for notebooks.
                   "roles/notebooks.admin",
-                  "roles/storage.objectAdmin"),
+                  // TODO(marikomedlock): Revise storage permissions when there are controlled
+                  // resources for notebooks
+                  "roles/storage.admin"),
           IamRole.READER, ImmutableList.of("roles/viewer"));
 }


### PR DESCRIPTION
Changed the allowed permissions for a workspace WRITER and OWNER from storage.objectAdmin -> storage.admin. This will allow the CLI to create buckets, until the WSM controlled resource API for buckets is available.

Thanks to @gjuggler for finding this fix!