### PR TITLE
PF-338 Add the service account user role temporarily for owners & writers

### DIFF
--- a/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -12,29 +12,29 @@ public class CloudSyncRoleMapping {
               ImmutableList.of(
                   "roles/viewer",
                   "roles/bigquery.dataEditor",
-                  // TODO(wchambers): Revise notebooks permissions when there are controlled
-                  // resources for notebooks.
+                  // TODO(wchambers): Revise service account permissions when there are controlled
+                  // resources for service accounts.
                   "roles/iam.serviceAccountUser",
                   "roles/lifesciences.editor",
                   // TODO(wchambers): Revise notebooks permissions when there are controlled
                   // resources for notebooks.
                   "roles/notebooks.admin",
                   // TODO(marikomedlock): Revise storage permissions when there are controlled
-                  // resources for notebooks
+                  // resources for buckets.
                   "roles/storage.admin"),
           IamRole.WRITER,
               ImmutableList.of(
                   "roles/viewer",
                   "roles/bigquery.dataEditor",
-                  // TODO(wchambers): Revise notebooks permissions when there are controlled
-                  // resources for notebooks.
+                  // TODO(wchambers): Revise service account permissions when there are controlled
+                  // resources for service accounts.
                   "roles/iam.serviceAccountUser",
                   "roles/lifesciences.editor",
                   // TODO(wchambers): Revise notebooks permissions when there are controlled
                   // resources for notebooks.
                   "roles/notebooks.admin",
                   // TODO(marikomedlock): Revise storage permissions when there are controlled
-                  // resources for notebooks
+                  // resources for buckets.
                   "roles/storage.admin"),
           IamRole.READER, ImmutableList.of("roles/viewer"));
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -12,6 +12,9 @@ public class CloudSyncRoleMapping {
               ImmutableList.of(
                   "roles/viewer",
                   "roles/bigquery.dataEditor",
+                  // TODO(wchambers): Revise notebooks permissions when there are controlled
+                  // resources for notebooks.
+                  "roles/iam.serviceAccountUser",
                   "roles/lifesciences.editor",
                   // TODO(wchambers): Revise notebooks permissions when there are controlled
                   // resources for notebooks.
@@ -23,6 +26,9 @@ public class CloudSyncRoleMapping {
               ImmutableList.of(
                   "roles/viewer",
                   "roles/bigquery.dataEditor",
+                  // TODO(wchambers): Revise notebooks permissions when there are controlled
+                  // resources for notebooks.
+                  "roles/iam.serviceAccountUser",
                   "roles/lifesciences.editor",
                   // TODO(wchambers): Revise notebooks permissions when there are controlled
                   // resources for notebooks.


### PR DESCRIPTION
This role enables all owners and writers to "use" any service account in the project.
This is a temporary measure to enable AI Notebooks while we build APIs for controlled service accounts. Until then, to create AI Notebooks, a user needs to have the user role on a service account.