### PR TITLE
Tidy up [post- AS-512]

### DIFF
--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -83,8 +83,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<CreatedWorkspace> createWorkspace(
       @RequestBody CreateWorkspaceRequestBody body) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    logger.info(
-        String.format("Creating workspace %s for %s", body.getId().toString(), userReq.getEmail()));
+    logger.info("Creating workspace {} for {}", body.getId(), userReq.getEmail());
 
     // Existing client libraries should not need to know about the stage, as they won't use any of
     // the features it gates. If stage isn't specified in a create request, we default to
@@ -107,9 +106,7 @@ public class WorkspaceApiController implements WorkspaceApi {
     UUID createdId = workspaceService.createWorkspace(internalRequest, userReq);
 
     CreatedWorkspace responseWorkspace = new CreatedWorkspace().id(createdId);
-    logger.info(
-        String.format(
-            "Created workspace %s for %s", responseWorkspace.toString(), userReq.getEmail()));
+    logger.info("Created workspace {} for {}", responseWorkspace, userReq.getEmail());
 
     return new ResponseEntity<>(responseWorkspace, HttpStatus.OK);
   }
@@ -117,7 +114,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   @Override
   public ResponseEntity<WorkspaceDescription> getWorkspace(@PathVariable("id") UUID id) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    logger.info(String.format("Getting workspace %s for %s", id.toString(), userReq.getEmail()));
+    logger.info("Getting workspace {} for {}", id, userReq.getEmail());
     Workspace workspace = workspaceService.getWorkspace(id, userReq);
     WorkspaceCloudContext cloudContext = workspaceService.getCloudContext(id, userReq);
 
@@ -131,7 +128,7 @@ public class WorkspaceApiController implements WorkspaceApi {
             .spendProfile(workspace.spendProfileId().map(SpendProfileId::id).orElse(null))
             .stage(workspace.workspaceStage().toApiModel())
             .googleContext(googleContext);
-    logger.info(String.format("Got workspace %s for %s", desc.toString(), userReq.getEmail()));
+    logger.info("Got workspace {} for {}", desc, userReq.getEmail());
 
     return new ResponseEntity<>(desc, HttpStatus.OK);
   }
@@ -139,9 +136,9 @@ public class WorkspaceApiController implements WorkspaceApi {
   @Override
   public ResponseEntity<Void> deleteWorkspace(@PathVariable("id") UUID id) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    logger.info(String.format("Deleting workspace %s for %s", id.toString(), userReq.getEmail()));
+    logger.info("Deleting workspace {} for {}", id, userReq.getEmail());
     workspaceService.deleteWorkspace(id, userReq);
-    logger.info(String.format("Deleted workspace %s for %s", id.toString(), userReq.getEmail()));
+    logger.info("Deleted workspace {} for {}", id, userReq.getEmail());
 
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
@@ -151,9 +148,10 @@ public class WorkspaceApiController implements WorkspaceApi {
       @PathVariable("id") UUID id, @RequestBody CreateDataReferenceRequestBody body) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     logger.info(
-        String.format(
-            "Creating data reference in workspace %s for %s with body %s",
-            id.toString(), userReq.getEmail(), body.toString()));
+        "Creating data reference in workspace {} for {} with body {}",
+        id,
+        userReq.getEmail(),
+        body);
 
     ControllerValidationUtils.validate(body);
     DataReferenceValidationUtils.validateReferenceName(body.getName());
@@ -175,9 +173,7 @@ public class WorkspaceApiController implements WorkspaceApi {
             .build();
     DataReference reference = dataReferenceService.createDataReference(referenceRequest, userReq);
     logger.info(
-        String.format(
-            "Created data reference %s in workspace %s for %s ",
-            reference.toString(), id.toString(), userReq.getEmail()));
+        "Created data reference {} in workspace {} for {} ", reference, id, userReq.getEmail());
 
     return new ResponseEntity<>(reference.toApiModel(), HttpStatus.OK);
   }
@@ -187,14 +183,13 @@ public class WorkspaceApiController implements WorkspaceApi {
       @PathVariable("id") UUID workspaceId, @PathVariable("referenceId") UUID referenceId) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     logger.info(
-        String.format(
-            "Getting data reference by id %s in workspace %s for %s",
-            referenceId.toString(), workspaceId.toString(), userReq.getEmail()));
+        "Getting data reference by id {} in workspace {} for {}",
+        referenceId,
+        workspaceId,
+        userReq.getEmail());
     DataReference ref = dataReferenceService.getDataReference(workspaceId, referenceId, userReq);
     logger.info(
-        String.format(
-            "Got data reference %s in workspace %s for %s",
-            ref.toString(), workspaceId.toString(), userReq.getEmail()));
+        "Got data reference {} in workspace {} for {}", ref, workspaceId, userReq.getEmail());
 
     return new ResponseEntity<>(ref.toApiModel(), HttpStatus.OK);
   }
@@ -206,17 +201,21 @@ public class WorkspaceApiController implements WorkspaceApi {
       @PathVariable("name") String name) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     logger.info(
-        String.format(
-            "Getting data reference by name %s and reference type %s in workspace %s for %s",
-            name, referenceType, workspaceId.toString(), userReq.getEmail()));
+        "Getting data reference by name {} and reference type {} in workspace {} for {}",
+        name,
+        referenceType,
+        workspaceId,
+        userReq.getEmail());
     DataReferenceValidationUtils.validateReferenceName(name);
     DataReference ref =
         dataReferenceService.getDataReferenceByName(
             workspaceId, DataReferenceType.fromApiModel(referenceType), name, userReq);
     logger.info(
-        String.format(
-            "Got data reference %s of type %s in workspace %s for %s",
-            ref.toString(), referenceType.toString(), workspaceId.toString(), userReq.getEmail()));
+        "Got data reference {} of type {} in workspace {} for {}",
+        ref,
+        referenceType,
+        workspaceId,
+        userReq.getEmail());
 
     return new ResponseEntity<>(ref.toApiModel(), HttpStatus.OK);
   }
@@ -238,15 +237,19 @@ public class WorkspaceApiController implements WorkspaceApi {
     }
 
     logger.info(
-        String.format(
-            "Updating data reference by id %s in workspace %s for %s with body %s",
-            referenceId.toString(), id.toString(), userReq.getEmail(), body.toString()));
+        "Updating data reference by id {} in workspace {} for {} with body {}",
+        referenceId,
+        id,
+        userReq.getEmail(),
+        body);
 
     dataReferenceService.updateDataReference(id, referenceId, body, userReq);
     logger.info(
-        String.format(
-            "Updating data reference by id %s in workspace %s for %s with body %s",
-            referenceId.toString(), id.toString(), userReq.getEmail(), body.toString()));
+        "Updating data reference by id {} in workspace {} for {} with body {}",
+        referenceId,
+        id,
+        userReq.getEmail(),
+        body);
 
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
@@ -256,14 +259,16 @@ public class WorkspaceApiController implements WorkspaceApi {
       @PathVariable("id") UUID workspaceId, @PathVariable("referenceId") UUID referenceId) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     logger.info(
-        String.format(
-            "Deleting data reference by id %s in workspace %s for %s",
-            referenceId.toString(), workspaceId.toString(), userReq.getEmail()));
+        "Deleting data reference by id {} in workspace {} for {}",
+        referenceId,
+        workspaceId,
+        userReq.getEmail());
     dataReferenceService.deleteDataReference(workspaceId, referenceId, userReq);
     logger.info(
-        String.format(
-            "Deleted data reference by id %s in workspace %s for %s",
-            referenceId.toString(), workspaceId.toString(), userReq.getEmail()));
+        "Deleted data reference by id {} in workspace {} for {}",
+        referenceId,
+        workspaceId,
+        userReq.getEmail());
 
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
@@ -274,15 +279,11 @@ public class WorkspaceApiController implements WorkspaceApi {
       @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
       @Valid @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    logger.info(
-        String.format(
-            "Getting data references in workspace %s for %s", id.toString(), userReq.getEmail()));
+    logger.info("Getting data references in workspace {} for {}", id, userReq.getEmail());
     ControllerValidationUtils.validatePaginationParams(offset, limit);
     List<DataReference> enumerateResult =
         dataReferenceService.enumerateDataReferences(id, offset, limit, userReq);
-    logger.info(
-        String.format(
-            "Got data references in workspace %s for %s", id.toString(), userReq.getEmail()));
+    logger.info("Got data references in workspace {} for {}", id, userReq.getEmail());
     DataReferenceList responseList = new DataReferenceList();
     for (DataReference ref : enumerateResult) {
       responseList.addResourcesItem(ref.toApiModel());

--- a/src/main/java/bio/terra/workspace/db/DataReferenceDao.java
+++ b/src/main/java/bio/terra/workspace/db/DataReferenceDao.java
@@ -61,9 +61,9 @@ public class DataReferenceDao {
     try {
       jdbcTemplate.update(sql, params);
       logger.info(
-          String.format(
-              "Inserted record for data reference %s for workspace %s",
-              referenceId, request.workspaceId()));
+          "Inserted record for data reference {} for workspace {}",
+          referenceId,
+          request.workspaceId());
       return referenceId.toString();
     } catch (DuplicateKeyException e) {
       throw new DuplicateDataReferenceException(
@@ -84,9 +84,9 @@ public class DataReferenceDao {
     try {
       DataReference ref = jdbcTemplate.queryForObject(sql, params, DATA_REFERENCE_ROW_MAPPER);
       logger.info(
-          String.format(
-              "Retrieved record for data reference by id %s for workspace %s",
-              referenceId, workspaceId));
+          "Retrieved record for data reference by id {} for workspace {}",
+          referenceId,
+          workspaceId);
       return ref;
     } catch (EmptyResultDataAccessException e) {
       throw new DataReferenceNotFoundException("Data Reference not found.");
@@ -111,9 +111,10 @@ public class DataReferenceDao {
     try {
       DataReference ref = jdbcTemplate.queryForObject(sql, params, DATA_REFERENCE_ROW_MAPPER);
       logger.info(
-          String.format(
-              "Retrieved record for data reference by name %s and reference type %s for workspace %s",
-              name, type, workspaceId));
+          "Retrieved record for data reference by name {} and reference type {} for workspace {}",
+          name,
+          type,
+          workspaceId);
       return ref;
     } catch (EmptyResultDataAccessException e) {
       throw new DataReferenceNotFoundException("Data Reference not found.");
@@ -167,16 +168,14 @@ public class DataReferenceDao {
     int rowsAffected = jdbcTemplate.update(updateStatement.toString(), params);
     boolean updated = rowsAffected > 0;
 
-    if (updated)
+    if (updated) {
+      logger.info("Updated record for data reference {} in workspace {}", referenceId, workspaceId);
+    } else {
       logger.info(
-          String.format(
-              "Updated record for data reference %s in workspace %s",
-              referenceId.toString(), workspaceId.toString()));
-    else
-      logger.info(
-          String.format(
-              "Failed to update record for data reference %s in workspace %s",
-              referenceId.toString(), workspaceId.toString()));
+          "Failed to update record for data reference {} in workspace {}",
+          referenceId,
+          workspaceId);
+    }
 
     return updated;
   }
@@ -192,16 +191,14 @@ public class DataReferenceDao {
             params);
     boolean deleted = rowsAffected > 0;
 
-    if (deleted)
+    if (deleted) {
+      logger.info("Deleted record for data reference {} in workspace {}", referenceId, workspaceId);
+    } else {
       logger.info(
-          String.format(
-              "Deleted record for data reference %s in workspace %s",
-              referenceId.toString(), workspaceId.toString()));
-    else
-      logger.info(
-          String.format(
-              "Failed to delete record for data reference %s in workspace %s",
-              referenceId.toString(), workspaceId.toString()));
+          "Failed to delete record for data reference {} in workspace {}",
+          referenceId,
+          workspaceId);
+    }
 
     return deleted;
   }
@@ -222,7 +219,7 @@ public class DataReferenceDao {
             .addValue("offset", offset)
             .addValue("limit", limit);
     List<DataReference> resultList = jdbcTemplate.query(sql, params, DATA_REFERENCE_ROW_MAPPER);
-    logger.info(String.format("Retrieved data references in workspace %s", workspaceId.toString()));
+    logger.info("Retrieved data references in workspace {}", workspaceId);
     return resultList;
   }
 

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -60,8 +60,7 @@ public class WorkspaceDao {
             .addValue("workspace_stage", workspace.workspaceStage().toString());
     try {
       jdbcTemplate.update(sql, params);
-      logger.info(
-          String.format("Inserted record for workspace %s", workspace.workspaceId().toString()));
+      logger.info("Inserted record for workspace {}", workspace.workspaceId());
     } catch (DuplicateKeyException e) {
       throw new DuplicateWorkspaceException(
           "Workspace " + workspace.workspaceId().toString() + " already exists.", e);
@@ -80,11 +79,11 @@ public class WorkspaceDao {
 
     boolean deleted = rowsAffected > 0;
 
-    if (deleted)
-      logger.info(String.format("Deleted record for workspace %s", workspaceId.toString()));
-    else
-      logger.info(
-          String.format("Failed to delete record for workspace %s", workspaceId.toString()));
+    if (deleted) {
+      logger.info("Deleted record for workspace {}", workspaceId);
+    } else {
+      logger.info("Failed to delete record for workspace {}", workspaceId);
+    }
 
     return deleted;
   }
@@ -107,7 +106,7 @@ public class WorkspaceDao {
                                   .map(SpendProfileId::create))
                           .workspaceStage(WorkspaceStage.valueOf(rs.getString("workspace_stage")))
                           .build()));
-      logger.info(String.format("Retrieved workspace record %s", result.toString()));
+      logger.info("Retrieved workspace record {}", result);
       return result;
     } catch (EmptyResultDataAccessException e) {
       throw new WorkspaceNotFoundException(String.format("Workspace %s not found.", id.toString()));

--- a/src/main/java/bio/terra/workspace/service/buffer/BufferService.java
+++ b/src/main/java/bio/terra/workspace/service/buffer/BufferService.java
@@ -65,9 +65,9 @@ public class BufferService {
       BufferApi bufferApi = bufferApi(bufferServiceConfiguration.getInstanceUrl());
       PoolInfo info = bufferApi.getPoolInfo(bufferServiceConfiguration.getPoolId());
       logger.info(
-          String.format(
-              "Retrieved pool %s on Buffer Service instance %s",
-              bufferServiceConfiguration.getPoolId(), bufferServiceConfiguration.getInstanceUrl()));
+          "Retrieved pool {} on Buffer Service instance {}",
+          bufferServiceConfiguration.getPoolId(),
+          bufferServiceConfiguration.getInstanceUrl());
       return info;
     } catch (IOException e) {
       throw new BufferServiceAuthorizationException(
@@ -95,9 +95,9 @@ public class BufferService {
       ResourceInfo info =
           bufferApi.handoutResource(requestBody, bufferServiceConfiguration.getPoolId());
       logger.info(
-          String.format(
-              "Retrieved resource from pool %s on Buffer Service instance %s",
-              bufferServiceConfiguration.getPoolId(), bufferServiceConfiguration.getInstanceUrl()));
+          "Retrieved resource from pool {} on Buffer Service instance {}",
+          bufferServiceConfiguration.getPoolId(),
+          bufferServiceConfiguration.getInstanceUrl());
       return info;
     } catch (IOException e) {
       throw new BufferServiceAuthorizationException(

--- a/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/DataReferenceService.java
@@ -119,8 +119,8 @@ public class DataReferenceService {
   /**
    * List data references in a workspace.
    *
-   * <p>References are in ascending order by reference ID. At most {@Code limit} results will be
-   * returned, with the first being {@Code offset} entries from the start of the database.
+   * <p>References are in ascending order by reference ID. At most {@code limit} results will be
+   * returned, with the first being {@code offset} entries from the start of the database.
    *
    * <p>Verifies workspace existence and read permission before listing the references.
    */

--- a/src/main/java/bio/terra/workspace/service/datareference/model/DataReferenceType.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/model/DataReferenceType.java
@@ -7,7 +7,7 @@ import com.google.common.collect.EnumHashBiMap;
 
 /** Enum describing the type of object a data reference is pointing to. */
 public enum DataReferenceType {
-  /** A snapshot stored in Data Repo. Corresponds to a {@Code SnapshotReference} object. */
+  /** A snapshot stored in Data Repo. Corresponds to a {@code SnapshotReference} object. */
   DATA_REPO_SNAPSHOT;
 
   private static final BiMap<DataReferenceType, ReferenceTypeEnum> typeMap =

--- a/src/main/java/bio/terra/workspace/service/datareference/model/ReferenceObject.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/model/ReferenceObject.java
@@ -16,8 +16,8 @@ import org.slf4j.LoggerFactory;
  * rules. ReferenceObject implementations must be fully serializable by the output of getProperties.
  *
  * <p>In order to properly deserialize implementations of this class, the implementation classes
- * must be added to the list inside the {@Code JsonSubTypes} annotation below. The implementation
- * class should specify a name using the {@Code JsonTypeName} annotation so that changes to the
+ * must be added to the list inside the {@code JsonSubTypes} annotation below. The implementation
+ * class should specify a name using the {@code JsonTypeName} annotation so that changes to the
  * class name do not break backwards compatibility.
  */
 @JsonTypeInfo(use = Id.NAME)
@@ -43,8 +43,8 @@ public interface ReferenceObject {
    * Method for deserializing a ReferenceObject from a json string.
    *
    * <p>This method is used for Stairway and database deserialization. This makes use of type
-   * information stored via the {@Code JsonTypeInfo} annotation, and parses that information using
-   * the {@Code JsonSubTypes} annotation.
+   * information stored via the {@code JsonTypeInfo} annotation, and parses that information using
+   * the {@code JsonSubTypes} annotation.
    */
   static ReferenceObject fromJson(String jsonString) {
     try {

--- a/src/main/java/bio/terra/workspace/service/datareference/model/SnapshotReference.java
+++ b/src/main/java/bio/terra/workspace/service/datareference/model/SnapshotReference.java
@@ -14,8 +14,8 @@ import com.google.auto.value.AutoValue;
  * instance this reference is stored in. The list of allowed names is a configuration property)
  * snapshot (the ID of the snapshot inside Data Repo)
  *
- * <p>The {@Code JsonTypeName} annotation specifies the class name used for serialization (see the
- * {@Code JsonSubTypes} annotation in {@Code ReferenceObject} for corresponding deserialization). By
+ * <p>The {@code JsonTypeName} annotation specifies the class name used for serialization (see the
+ * {@code JsonSubTypes} annotation in {@code ReferenceObject} for corresponding deserialization). By
  * using a constant string instead of the actual class name, changing the name of this class will
  * not break backwards compatibility with existing serialized objects. This string does not need to
  * match the class name - it only matches for clarity.

--- a/src/main/java/bio/terra/workspace/service/datarepo/DataRepoService.java
+++ b/src/main/java/bio/terra/workspace/service/datarepo/DataRepoService.java
@@ -67,9 +67,7 @@ public class DataRepoService {
 
     try {
       repositoryApi.retrieveSnapshot(snapshotId);
-      logger.info(
-          String.format(
-              "Retrieved snapshot %s on Data Repo instance %s", snapshotId, instanceName));
+      logger.info("Retrieved snapshot {} on Data Repo instance {}", snapshotId, instanceName);
       return true;
     } catch (ApiException e) {
       if (e.getCode() == HttpStatus.NOT_FOUND.value()) {

--- a/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -95,7 +95,7 @@ public class SamService {
             .policies(defaultWorkspacePolicies(callerEmail));
     try {
       resourceApi.createResource(SamConstants.SAM_WORKSPACE_RESOURCE, workspaceRequest);
-      logger.info(String.format("Created Sam resource for workspace %s", id.toString()));
+      logger.info("Created Sam resource for workspace {}", id);
     } catch (ApiException apiException) {
       throw new SamApiException(apiException);
     }
@@ -106,7 +106,7 @@ public class SamService {
     ResourcesApi resourceApi = samResourcesApi(authToken);
     try {
       resourceApi.deleteResource(SamConstants.SAM_WORKSPACE_RESOURCE, id.toString());
-      logger.info(String.format("Deleted Sam resource for workspace %s", id.toString()));
+      logger.info("Deleted Sam resource for workspace {}", id);
     } catch (ApiException apiException) {
       throw new SamApiException(apiException);
     }
@@ -139,9 +139,7 @@ public class SamService {
               userReq.getEmail(), action, workspaceId));
     else
       logger.info(
-          String.format(
-              "User %s is authorized to %s workspace %s",
-              userReq.getEmail(), action, workspaceId.toString()));
+          "User {} is authorized to {} workspace {}", userReq.getEmail(), action, workspaceId);
   }
 
   /**
@@ -166,9 +164,7 @@ public class SamService {
       resourceApi.addUserToPolicy(
           SamConstants.SAM_WORKSPACE_RESOURCE, workspaceId.toString(), role.toSamRole(), email);
       logger.info(
-          String.format(
-              "Granted role %s to user %s in workspace %s",
-              role.toSamRole(), email, workspaceId.toString()));
+          "Granted role {} to user {} in workspace {}", role.toSamRole(), email, workspaceId);
     } catch (ApiException e) {
       throw new SamApiException(e);
     }
@@ -191,9 +187,7 @@ public class SamService {
       resourceApi.removeUserFromPolicy(
           SamConstants.SAM_WORKSPACE_RESOURCE, workspaceId.toString(), role.toSamRole(), email);
       logger.info(
-          String.format(
-              "Removed role %s from user %s in workspace %s",
-              role.toSamRole(), email, workspaceId.toString()));
+          "Removed role {} from user {} in workspace {}", role.toSamRole(), email, workspaceId);
     } catch (ApiException e) {
       throw new SamApiException(e);
     }
@@ -247,9 +241,10 @@ public class SamService {
                   SamConstants.SAM_WORKSPACE_RESOURCE, workspaceId.toString(), role.toSamRole())
               .getEmail();
       logger.info(
-          String.format(
-              "Synced role %s to google group %s in workspace %s",
-              role.toSamRole(), groupEmail, workspaceId.toString()));
+          "Synced role {} to google group {} in workspace {}",
+          role.toSamRole(),
+          groupEmail,
+          workspaceId);
       return groupEmail;
     } catch (ApiException e) {
       throw new SamApiException(e);

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -173,7 +173,7 @@ public class JobService {
       // DuplicateFlightIdSubmittedException is a more specific StairwayException, and so needs to
       // be checked separately. Allowing duplicate FlightIds is useful for ensuring idempotent
       // behavior of flights.
-      logger.warn(String.format("Received duplicate job ID: %s", jobId));
+      logger.warn("Received duplicate job ID: {}", jobId);
       throw new DuplicateJobIdException("Received duplicate jobId, see logs for details", ex);
     } catch (StairwayException | InterruptedException stairwayEx) {
       throw new InternalStairwayException(stairwayEx);

--- a/src/main/java/bio/terra/workspace/service/migrate/MigrateService.java
+++ b/src/main/java/bio/terra/workspace/service/migrate/MigrateService.java
@@ -57,9 +57,11 @@ public class MigrateService {
       DatabaseChangeLogLock[] locks = liquibase.listLocks();
       for (DatabaseChangeLogLock lock : locks) {
         logger.info(
-            String.format(
-                "DatabaseChangeLogLock changeSet: %s, id: %s, lockedBy: %s, granted: %s",
-                changesetFile, lock.getId(), lock.getLockedBy(), lock.getLockGranted()));
+            "DatabaseChangeLogLock changeSet: {}, id: {}, lockedBy: {}, granted: {}",
+            changesetFile,
+            lock.getId(),
+            lock.getLockedBy(),
+            lock.getLockGranted());
 
         // We can get into this state where one of the APIs is running migrations and gets shut down
         // so that another API container can run. It will result in a lock that doesn't get

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -47,7 +47,7 @@ public class CreateWorkspaceStep implements Step {
     workspaceDao.createWorkspace(workspaceToCreate);
 
     FlightUtils.setResponse(flightContext, workspaceId, HttpStatus.OK);
-    logger.info(String.format("Workspace created with id %s", workspaceId));
+    logger.info("Workspace created with id {}", workspaceId);
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/SyncSamGroupsStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/SyncSamGroupsStep.java
@@ -12,7 +12,7 @@ import bio.terra.workspace.service.job.JobMapKeys;
 import java.util.UUID;
 
 /**
- * A {@Code Step} which synchronizes Sam policies with google groups and stores the group names in
+ * A {@code Step} which synchronizes Sam policies with google groups and stores the group names in
  * the Stairway working map.
  */
 public class SyncSamGroupsStep implements Step {

--- a/src/test/java/bio/terra/workspace/common/BaseStatusServiceTest.java
+++ b/src/test/java/bio/terra/workspace/common/BaseStatusServiceTest.java
@@ -23,7 +23,7 @@ public class BaseStatusServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void testSingleComponent() {
+  void testSingleComponent() {
     List<StatusSubsystem> subsystems = new ArrayList<>();
     subsystems.add(new StatusSubsystem(() -> new SystemStatusSystems().ok(true), true));
 
@@ -33,7 +33,7 @@ public class BaseStatusServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void testPassesWithNonCriticalFailure() throws Exception {
+  void testPassesWithNonCriticalFailure() {
     List<StatusSubsystem> subsystems = new ArrayList<>();
     subsystems.add(new StatusSubsystem(() -> new SystemStatusSystems().ok(true), true));
     subsystems.add(new StatusSubsystem(() -> new SystemStatusSystems().ok(false), false));
@@ -44,7 +44,7 @@ public class BaseStatusServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void testNotOkWithCriticalFailure() throws Exception {
+  void testNotOkWithCriticalFailure() {
     List<StatusSubsystem> subsystems = new ArrayList<>();
     subsystems.add(new StatusSubsystem(() -> new SystemStatusSystems().ok(false), true));
     subsystems.add(new StatusSubsystem(() -> new SystemStatusSystems().ok(true), false));
@@ -55,7 +55,7 @@ public class BaseStatusServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void testNotOkWithCriticalException() throws Exception {
+  void testNotOkWithCriticalException() {
     List<StatusSubsystem> subsystems = new ArrayList<>();
     Supplier<SystemStatusSystems> exceptionSupplier =
         () -> {
@@ -69,7 +69,7 @@ public class BaseStatusServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void testOkWithNonCriticalException() throws Exception {
+  void testOkWithNonCriticalException() {
     List<StatusSubsystem> subsystems = new ArrayList<>();
     Supplier<SystemStatusSystems> exceptionSupplier =
         () -> {

--- a/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
+++ b/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
@@ -12,12 +12,12 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class MdcHookTest extends BaseUnitTest {
+class MdcHookTest extends BaseUnitTest {
   @Autowired private MdcHook mdcHook;
   @Autowired private JobService jobService;
 
   @Test
-  public void initialContextPropagated_Do() throws Exception {
+  void initialContextPropagated_Do() throws Exception {
     Stairway stairway = jobService.getStairway();
 
     MDC.clear();
@@ -33,7 +33,7 @@ public class MdcHookTest extends BaseUnitTest {
   }
 
   @Test
-  public void initialContextPropagated_Undo() throws Exception {
+  void initialContextPropagated_Undo() throws Exception {
     Stairway stairway = jobService.getStairway();
 
     MDC.clear();
@@ -52,7 +52,7 @@ public class MdcHookTest extends BaseUnitTest {
   }
 
   @Test
-  public void noInitialContextOk() throws Exception {
+  void noInitialContextOk() throws Exception {
     Stairway stairway = jobService.getStairway();
 
     MDC.clear();
@@ -67,7 +67,7 @@ public class MdcHookTest extends BaseUnitTest {
   }
 
   @Test
-  public void inputParametersNotSetOk() throws Exception {
+  void inputParametersNotSetOk() throws Exception {
     Stairway stairway = jobService.getStairway();
 
     String flightId = stairway.createFlightId();
@@ -80,7 +80,7 @@ public class MdcHookTest extends BaseUnitTest {
 
   /** Test that the CheckMdc Step will fail the flight as expected by the rest of the tests. */
   @Test
-  public void testCheckMdc() throws Exception {
+  void testCheckMdc() throws Exception {
     Stairway stairway = jobService.getStairway();
 
     String flightId = stairway.createFlightId();

--- a/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 
-public class DataReferenceDaoTest extends BaseUnitTest {
+class DataReferenceDaoTest extends BaseUnitTest {
 
   @Autowired private WorkspaceDatabaseConfiguration workspaceDatabaseConfiguration;
 
@@ -58,12 +58,12 @@ public class DataReferenceDaoTest extends BaseUnitTest {
   class CreateDataReference {
 
     @Test
-    public void verifyCreatedDataReferenceExists() {
+    void verifyCreatedDataReferenceExists() {
       assertThat(currentReference.get().referenceId(), equalTo(referenceId));
     }
 
     @Test
-    public void createReferenceWithoutWorkspaceFails() {
+    void createReferenceWithoutWorkspaceFails() {
       // This reference uses a random workspaceID, so the corresponding workspace does not exist.
       DataReferenceRequest referenceRequest = defaultReferenceRequest(UUID.randomUUID()).build();
       assertThrows(
@@ -72,7 +72,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
     }
 
     @Test
-    public void verifyCreateDuplicateNameFails() {
+    void verifyCreateDuplicateNameFails() {
       assertThrows(
           DuplicateDataReferenceException.class,
           () -> dataReferenceDao.createDataReference(referenceRequest, referenceId));
@@ -83,7 +83,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
   class GetDataReference {
 
     @Test
-    public void verifyGetDataReferenceByName() {
+    void verifyGetDataReferenceByName() {
       DataReference ref =
           dataReferenceDao.getDataReferenceByName(
               workspaceId, referenceRequest.referenceType(), referenceRequest.name());
@@ -91,7 +91,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
     }
 
     @Test
-    public void verifyGetDataReference() {
+    void verifyGetDataReference() {
       DataReference result = currentReference.get();
 
       assertThat(result.workspaceId(), equalTo(workspaceId));
@@ -102,7 +102,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
     }
 
     @Test
-    public void verifyGetDataReferenceNotInWorkspaceNotFound() {
+    void verifyGetDataReferenceNotInWorkspaceNotFound() {
       Workspace decoyWorkspace =
           Workspace.builder()
               .workspaceId(UUID.randomUUID())
@@ -123,7 +123,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
             dataReferenceDao.updateDataReference(workspaceId, referenceId, name, description);
 
     @Test
-    public void verifyUpdateName() {
+    void verifyUpdateName() {
       String updatedName = "rename";
 
       updateReference.apply(updatedName, null);
@@ -134,7 +134,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
     }
 
     @Test
-    public void verifyUpdateReferenceDescription() {
+    void verifyUpdateReferenceDescription() {
       String updatedDescription = "updated description";
 
       updateReference.apply(null, updatedDescription);
@@ -143,7 +143,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
     }
 
     @Test
-    public void verifyUpdateAllFields() {
+    void verifyUpdateAllFields() {
       String updatedName2 = "rename_again";
       String updatedDescription2 = "updated description again";
 
@@ -153,7 +153,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
     }
 
     @Test
-    public void updateNothingFails() {
+    void updateNothingFails() {
       assertThrows(InvalidDaoRequestException.class, () -> updateReference.apply(null, null));
     }
   }
@@ -162,7 +162,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
   class DeleteDataReference {
 
     @Test
-    public void verifyDeleteDataReference() {
+    void verifyDeleteDataReference() {
       assertTrue(dataReferenceDao.deleteDataReference(workspaceId, referenceId));
 
       // try to delete again to make sure it's not there
@@ -170,7 +170,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
     }
 
     @Test
-    public void deleteNonExistentWorkspaceFails() {
+    void deleteNonExistentWorkspaceFails() {
       assertFalse(dataReferenceDao.deleteDataReference(UUID.randomUUID(), UUID.randomUUID()));
     }
   }
@@ -179,7 +179,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
   class EnumerateDataReferences {
 
     @Test
-    public void enumerateWorkspaceReferences() {
+    void enumerateWorkspaceReferences() {
       // Create two references in the same workspace.
       DataReference firstReference = currentReference.get();
 
@@ -199,7 +199,7 @@ public class DataReferenceDaoTest extends BaseUnitTest {
     }
 
     @Test
-    public void enumerateEmptyReferenceList() {
+    void enumerateEmptyReferenceList() {
       UUID newWorkspaceId = createDefaultWorkspace();
 
       List<DataReference> result = dataReferenceDao.enumerateDataReferences(newWorkspaceId, 0, 10);

--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-public class WorkspaceIntegrationTest extends BaseIntegrationTest {
+class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   // TODO: As this class grows, consider if it's worth breaking down these workspace tests into
   //  different class files based on the the type of workspace action (Create, Get, Delete, etc).
@@ -57,7 +57,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
    *  Doc: https://docs.google.com/document/d/13mYVJML_fOLsX1gxQxRJgECUNT27dAMKzEJxUEvtQqM/edit#heading=h.x06ofvfgp7wt
    */
   @AfterEach
-  public void tearDown(TestInfo testInfo) throws Exception {
+  void tearDown(TestInfo testInfo) throws Exception {
     Set<String> tags = testInfo.getTags();
     if (tags != null && tags.contains(TAG_NEEDS_CLEANUP)) {
       List<UUID> uuidList = testToWorkspaceIdsMap.get(testInfo.getDisplayName());
@@ -69,7 +69,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @Tag(TAG_NEEDS_CLEANUP)
-  public void createWorkspace(TestInfo testInfo) throws Exception {
+  void createWorkspace(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
 
@@ -83,7 +83,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @Tag(TAG_NEEDS_CLEANUP)
-  public void getWorkspace(TestInfo testInfo) throws Exception {
+  void getWorkspace(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
 
@@ -103,7 +103,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @Tag(TAG_NEEDS_CLEANUP)
-  public void deleteWorkspace(TestInfo testInfo) throws Exception {
+  void deleteWorkspace(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
     WorkspaceResponse<CreatedWorkspace> workspaceResponse = createDefaultWorkspace(workspaceId);
@@ -131,7 +131,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @Tag(TAG_NEEDS_CLEANUP)
-  public void createDataReference(TestInfo testInfo) throws Exception {
+  void createDataReference(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
 
@@ -151,7 +151,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @Tag(TAG_NEEDS_CLEANUP)
-  public void deleteDataReference(TestInfo testInfo) throws Exception {
+  void deleteDataReference(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
 
@@ -171,7 +171,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @Tag(TAG_NEEDS_CLEANUP)
-  public void listDataReference(TestInfo testInfo) throws Exception {
+  void listDataReference(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
 
@@ -204,7 +204,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @Tag(TAG_NEEDS_CLEANUP)
-  public void getDataReferenceById(TestInfo testInfo) throws Exception {
+  void getDataReferenceById(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
 
@@ -233,7 +233,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @Tag(TAG_NEEDS_CLEANUP)
-  public void getDataReferenceByNameAndType(TestInfo testInfo) throws Exception {
+  void getDataReferenceByNameAndType(TestInfo testInfo) throws Exception {
     UUID workspaceId = UUID.randomUUID();
     testToWorkspaceIdsMap.put(testInfo.getDisplayName(), Collections.singletonList(workspaceId));
 
@@ -266,7 +266,7 @@ public class WorkspaceIntegrationTest extends BaseIntegrationTest {
 
   @Test
   @Tag(TAG_NEEDS_CLEANUP)
-  public void testDefaultWorkspaceStageIsRawls() throws Exception {
+  void testDefaultWorkspaceStageIsRawls() throws Exception {
     UUID workspaceId = UUID.randomUUID();
     createDefaultWorkspace(workspaceId);
 

--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class DataReferenceServiceTest extends BaseUnitTest {
+class DataReferenceServiceTest extends BaseUnitTest {
 
   @Autowired private WorkspaceService workspaceService;
   @Autowired private DataReferenceService dataReferenceService;
@@ -60,7 +60,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
           dataReferenceService.getDataReference(workspaceId, reference.referenceId(), USER_REQUEST);
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     doReturn(true).when(mockDataRepoService).snapshotExists(any(), any(), any());
 
     workspaceId = createDefaultWorkspace();
@@ -69,7 +69,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void testCreateDataReference() {
+  void testCreateDataReference() {
     assertThat(reference.workspaceId(), equalTo(workspaceId));
     assertThat(reference.name(), equalTo(request.name()));
   }
@@ -78,7 +78,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
   class GetDataReference {
 
     @Test
-    public void testGetDataReference() {
+    void testGetDataReference() {
       DataReference ref = currentReference.get();
 
       assertThat(ref.workspaceId(), equalTo(workspaceId));
@@ -86,7 +86,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
     }
 
     @Test
-    public void testGetDataReferenceByName() {
+    void testGetDataReferenceByName() {
       DataReference ref =
           dataReferenceService.getDataReferenceByName(
               workspaceId, request.referenceType(), request.name(), USER_REQUEST);
@@ -96,7 +96,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
     }
 
     @Test
-    public void testGetMissingDataReference() {
+    void testGetMissingDataReference() {
       assertThrows(
           DataReferenceNotFoundException.class,
           () ->
@@ -108,7 +108,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
   class EnumerateDataReferences {
 
     @Test
-    public void enumerateDataReferences() {
+    void enumerateDataReferences() {
       // Uses a different name because names are unique per reference type, per workspace.
       DataReferenceRequest secondRequest =
           defaultReferenceRequest(workspaceId).name("different_name").build();
@@ -123,7 +123,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
     }
 
     @Test
-    public void enumerateFailsUnauthorized() {
+    void enumerateFailsUnauthorized() {
       String samMessage = "Fake Sam unauthorized message";
       doThrow(new SamUnauthorizedException(samMessage))
           .when(mockSamService)
@@ -144,7 +144,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
                 workspaceId, reference.referenceId(), updateBody, USER_REQUEST);
 
     @Test
-    public void testUpdateName() {
+    void testUpdateName() {
       String updatedName = "rename";
 
       updateReference.accept(new UpdateDataReferenceRequestBody().name(updatedName));
@@ -188,7 +188,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
   class DeleteDataReference {
 
     @Test
-    public void testDeleteDataReference() {
+    void testDeleteDataReference() {
       // Validate the reference exists and is readable.
       assertThat(currentReference.get(), equalTo(reference));
 
@@ -198,7 +198,7 @@ public class DataReferenceServiceTest extends BaseUnitTest {
     }
 
     @Test
-    public void testDeleteMissingDataReference() {
+    void testDeleteMissingDataReference() {
       assertThrows(
           DataReferenceNotFoundException.class,
           () ->

--- a/src/test/java/bio/terra/workspace/service/datareference/DataRepoServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataRepoServiceTest.java
@@ -9,18 +9,18 @@ import bio.terra.workspace.service.datarepo.DataRepoService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class DataRepoServiceTest extends BaseUnitTest {
+class DataRepoServiceTest extends BaseUnitTest {
 
   @Autowired private DataRepoService dataRepoService;
 
   @Test
-  public void testValidateInvalidDataRepoInstance() throws Exception {
+  void testValidateInvalidDataRepoInstance() {
     assertThrows(
         ValidationException.class, () -> dataRepoService.getInstanceUrl("fake-invalid-test"));
   }
 
   @Test
-  public void testValidateValidDataRepoInstance() throws Exception {
+  void testValidateValidDataRepoInstance() {
     try {
       // the valid k/v is set in test/resources/application.properties
       // we trim and toLowerCase the string, so this verifies that too

--- a/src/test/java/bio/terra/workspace/service/datareference/model/ReferenceObjectTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/model/ReferenceObjectTest.java
@@ -5,14 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import bio.terra.workspace.common.BaseUnitTest;
 import org.junit.jupiter.api.Test;
 
-public class ReferenceObjectTest extends BaseUnitTest {
+class ReferenceObjectTest extends BaseUnitTest {
 
   /**
    * This is a simple test for verifying that SnapshotReference's toJson() and fromJson() are
    * compatible. If this failing, you've likely broken one or both of those methods.
    */
   @Test
-  public void SnapshotReferenceSerializationWorks() {
+  void SnapshotReferenceSerializationWorks() {
     SnapshotReference snapshot =
         SnapshotReference.create(/* instanceName= */ "foo", /* snapshot= */ "bar");
     assertEquals(snapshot, ReferenceObject.fromJson(snapshot.toJson()));
@@ -23,7 +23,7 @@ public class ReferenceObjectTest extends BaseUnitTest {
    * stored JSON values. If this test fails, your change may not work with existing databases.
    */
   @Test
-  public void SnapshotReferenceSerializationBackwardsCompatible() {
+  void SnapshotReferenceSerializationBackwardsCompatible() {
     SnapshotReference snapshotReference =
         (SnapshotReference)
             ReferenceObject.fromJson(

--- a/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class SamServiceTest extends BaseConnectedTest {
+class SamServiceTest extends BaseConnectedTest {
 
   @Autowired private SamService samService;
   @Autowired private WorkspaceService workspaceService;
@@ -51,7 +51,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void AddedReaderCanRead() {
+  void AddedReaderCanRead() {
     UUID workspaceId = createWorkspaceDefaultUser();
     // Before being granted permission, secondary user should be rejected.
     assertThrows(
@@ -65,7 +65,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void AddedWriterCanWrite() {
+  void AddedWriterCanWrite() {
     UUID workspaceId = createWorkspaceDefaultUser();
     DataReferenceRequest referenceRequest =
         DataReferenceRequest.builder()
@@ -89,7 +89,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void RemovedReaderCannotRead() {
+  void RemovedReaderCannotRead() {
     UUID workspaceId = createWorkspaceDefaultUser();
     // Before being granted permission, secondary user should be rejected.
     assertThrows(
@@ -109,7 +109,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void NonOwnerCannotAddReader() {
+  void NonOwnerCannotAddReader() {
     UUID workspaceId = createWorkspaceDefaultUser();
     // Note that this request uses the secondary user's authentication token, when only the first
     // user is an owner.
@@ -124,7 +124,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void PermissionsApiFailsInRawlsWorkspace() {
+  void PermissionsApiFailsInRawlsWorkspace() {
     WorkspaceRequest rawlsRequest =
         WorkspaceRequest.builder()
             .workspaceId(UUID.randomUUID())
@@ -143,7 +143,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void InvalidUserEmailRejected() {
+  void InvalidUserEmailRejected() {
     UUID workspaceId = createWorkspaceDefaultUser();
     assertThrows(
         SamApiException.class,
@@ -153,7 +153,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void ListPermissionsIncludesAddedUsers() {
+  void ListPermissionsIncludesAddedUsers() {
     UUID workspaceId = createWorkspaceDefaultUser();
     samService.grantWorkspaceRole(
         workspaceId, defaultUserRequest(), IamRole.READER, userAccessUtils.getSecondUserEmail());
@@ -180,7 +180,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void WriterCannotListPermissions() {
+  void WriterCannotListPermissions() {
     UUID workspaceId = createWorkspaceDefaultUser();
     samService.grantWorkspaceRole(
         workspaceId, defaultUserRequest(), IamRole.WRITER, userAccessUtils.getSecondUserEmail());
@@ -190,7 +190,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void GrantRoleInMissingWorkspaceThrows() {
+  void GrantRoleInMissingWorkspaceThrows() {
     UUID fakeId = UUID.randomUUID();
     assertThrows(
         WorkspaceNotFoundException.class,
@@ -203,7 +203,7 @@ public class SamServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void ReadRolesInMissingWorkspaceThrows() {
+  void ReadRolesInMissingWorkspaceThrows() {
     UUID fakeId = UUID.randomUUID();
     assertThrows(
         WorkspaceNotFoundException.class,

--- a/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
-import bio.terra.stairway.exception.StairwayException;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.generated.model.JobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -24,7 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 
-public class JobServiceTest extends BaseUnitTest {
+class JobServiceTest extends BaseUnitTest {
   private final AuthenticatedUserRequest testUser =
       new AuthenticatedUserRequest()
           .subjectId("StairwayUnit")
@@ -36,7 +35,7 @@ public class JobServiceTest extends BaseUnitTest {
   @MockBean private SamService mockSamService;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     try {
       Mockito.doReturn(true).when(mockSamService.isAuthorized(any(), any(), any(), any()));
     } catch (Exception e) {
@@ -45,7 +44,7 @@ public class JobServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void retrieveTest() throws Exception {
+  void retrieveTest() throws Exception {
     // We perform 7 flights and then retrieve and enumerate them.
     // The fids list should be in exactly the same order as the database ordered by submit time.
 
@@ -113,12 +112,12 @@ public class JobServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void testBadIdRetrieveJob() {
+  void testBadIdRetrieveJob() {
     assertThrows(JobNotFoundException.class, () -> jobService.retrieveJob("abcdef", testUser));
   }
 
   @Test
-  public void testBadIdRetrieveResult() {
+  void testBadIdRetrieveResult() {
     assertThrows(
         JobNotFoundException.class,
         () -> jobService.retrieveJobResult("abcdef", Object.class, testUser));
@@ -132,7 +131,7 @@ public class JobServiceTest extends BaseUnitTest {
   }
 
   // Submit a flight; wait for it to finish; return the flight id
-  private String runFlight(String description) throws StairwayException {
+  private String runFlight(String description) {
     String jobId = UUID.randomUUID().toString();
     jobService.newJob(description, jobId, JobServiceTestFlight.class, null, testUser).submit();
     jobService.waitForJob(jobId);

--- a/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileServiceTest.java
@@ -12,14 +12,14 @@ import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class SpendProfileServiceTest extends BaseConnectedTest {
+class SpendProfileServiceTest extends BaseConnectedTest {
   @Autowired SamService samService;
   @Autowired SpendProfileConfiguration spendProfileConfiguration;
   @Autowired SpendConnectedTestUtils spendUtils;
   @Autowired UserAccessUtils userAccessUtils;
 
   @Test
-  public void authorizeLinkingSuccess() {
+  void authorizeLinkingSuccess() {
     SpendProfileId id = spendUtils.defaultSpendId();
     SpendProfile profile = SpendProfile.builder().id(id).build();
     SpendProfileService service = new SpendProfileService(samService, ImmutableList.of(profile));
@@ -28,7 +28,7 @@ public class SpendProfileServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void authorizeLinkingSamUnauthorizedThrowsUnauthorized() {
+  void authorizeLinkingSamUnauthorizedThrowsUnauthorized() {
     SpendProfileId id = spendUtils.defaultSpendId();
     SpendProfile profile = SpendProfile.builder().id(id).build();
     SpendProfileService service = new SpendProfileService(samService, ImmutableList.of(profile));
@@ -39,7 +39,7 @@ public class SpendProfileServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void authorizeLinkingUnknownIdThrowsUnauthorized() {
+  void authorizeLinkingUnknownIdThrowsUnauthorized() {
     SpendProfileService service = new SpendProfileService(samService, ImmutableList.of());
     assertThrows(
         SpendUnauthorizedException.class,
@@ -49,7 +49,7 @@ public class SpendProfileServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void parseSpendProfileConfiguration() {
+  void parseSpendProfileConfiguration() {
     SpendProfileService service = new SpendProfileService(samService, spendProfileConfiguration);
     assertEquals(
         SpendProfile.builder()

--- a/src/test/java/bio/terra/workspace/service/status/WorkspaceManagerStatusServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/status/WorkspaceManagerStatusServiceTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class WorkspaceManagerStatusServiceTest extends BaseUnitTest {
+class WorkspaceManagerStatusServiceTest extends BaseUnitTest {
 
   @MockBean private DataRepoService mockDataRepoService;
   @MockBean private DataRepoConfiguration mockDataRepoConfiguration;
@@ -39,14 +39,14 @@ public class WorkspaceManagerStatusServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void testStatusWithWorkingEndpoints() throws Exception {
+  void testStatusWithWorkingEndpoints() {
     // Manually check subsystems, since @Scheduled doesn't work nicely in unit tests.
     statusService.checkSubsystems();
     assertTrue(statusService.getCurrentStatus().isOk());
   }
 
   @Test
-  public void testCriticalFailureNotOk() throws Exception {
+  void testCriticalFailureNotOk() {
     doReturn(new SystemStatusSystems().ok(false).addMessagesItem("Sam is kill"))
         .when(mockSamService)
         .status();
@@ -59,7 +59,7 @@ public class WorkspaceManagerStatusServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void testBufferCriticalFailureNotOk() throws Exception {
+  void testBufferCriticalFailureNotOk() {
     doReturn(new SystemStatusSystems().ok(false).addMessagesItem("Buffer down"))
         .when(mockBufferService)
         .status();

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -1,9 +1,9 @@
 package bio.terra.workspace.service.workspace;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -45,7 +45,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class WorkspaceServiceTest extends BaseConnectedTest {
+class WorkspaceServiceTest extends BaseConnectedTest {
   @Autowired private WorkspaceService workspaceService;
   @Autowired private DataReferenceService dataReferenceService;
   @Autowired private JobService jobService;
@@ -66,7 +66,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
           .subjectId("fakeID123");
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     doReturn(true).when(dataRepoService).snapshotExists(any(), any(), any());
     // By default, allow all spend link calls as authorized. (All other isAuthorized calls return
     // false by Mockito default.
@@ -83,14 +83,14 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void testGetMissingWorkspace() {
+  void testGetMissingWorkspace() {
     assertThrows(
         WorkspaceNotFoundException.class,
         () -> workspaceService.getWorkspace(UUID.randomUUID(), USER_REQUEST));
   }
 
   @Test
-  public void testGetExistingWorkspace() {
+  void testGetExistingWorkspace() {
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
 
@@ -100,7 +100,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void testGetForbiddenMissingWorkspace() {
+  void testGetForbiddenMissingWorkspace() {
     doThrow(new SamUnauthorizedException("forbid!"))
         .when(mockSamService)
         .workspaceAuthzOnly(any(), any(), any());
@@ -110,7 +110,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void testGetForbiddenExistingWorkspace() {
+  void testGetForbiddenExistingWorkspace() {
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
 
@@ -123,7 +123,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void testWorkspaceStagePersists() {
+  void testWorkspaceStagePersists() {
     WorkspaceRequest mcWorkspaceRequest =
         defaultRequestBuilder(UUID.randomUUID())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
@@ -136,7 +136,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void duplicateWorkspaceIdRequestsRejected() {
+  void duplicateWorkspaceIdRequestsRejected() {
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
     // Note that the two calls use different jobIds for the same Workspace ID, making them
@@ -148,7 +148,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void duplicateJobIdRequestRejected() {
+  void duplicateJobIdRequestRejected() {
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
     // Because these calls share the same jobId they're treated as duplicate requests, rather
@@ -159,7 +159,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void duplicateOperationSharesFailureResponse() {
+  void duplicateOperationSharesFailureResponse() {
     String errorMsg = "fake SAM error message";
     doThrow(new SamApiException(errorMsg))
         .when(mockSamService)
@@ -180,7 +180,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void testWithSpendProfile() {
+  void testWithSpendProfile() {
     Optional<SpendProfileId> spendProfileId = Optional.of(SpendProfileId.create("foo"));
     WorkspaceRequest request =
         defaultRequestBuilder(UUID.randomUUID()).spendProfileId(spendProfileId).build();
@@ -192,7 +192,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void testHandlesSamError() {
+  void testHandlesSamError() {
     String errorMsg = "fake SAM error message";
 
     doThrow(new SamApiException(errorMsg))
@@ -209,7 +209,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void createAndDeleteWorkspace() {
+  void createAndDeleteWorkspace() {
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
 
@@ -220,7 +220,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void deleteForbiddenMissingWorkspace() {
+  void deleteForbiddenMissingWorkspace() {
     doThrow(new SamUnauthorizedException("forbid!"))
         .when(mockSamService)
         .workspaceAuthzOnly(any(), any(), any());
@@ -231,7 +231,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void deleteForbiddenExistingWorkspace() {
+  void deleteForbiddenExistingWorkspace() {
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
 
@@ -245,7 +245,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void deleteWorkspaceWithDataReference() {
+  void deleteWorkspaceWithDataReference() {
     // First, create a workspace.
     UUID workspaceId = UUID.randomUUID();
     WorkspaceRequest request = defaultRequestBuilder(workspaceId).build();
@@ -287,7 +287,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void deleteWorkspaceWithGoogleContext() throws Exception {
+  void deleteWorkspaceWithGoogleContext() throws Exception {
     WorkspaceRequest request =
         defaultRequestBuilder(UUID.randomUUID())
             .spendProfileId(Optional.of(spendUtils.defaultSpendId()))
@@ -302,17 +302,17 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
         workspaceService.getCloudContext(request.workspaceId(), USER_REQUEST).googleProjectId();
 
     // Verify project exists by retrieving it.
-    Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
+    crl.getCloudResourceManagerCow().projects().get(projectId).execute();
 
     workspaceService.deleteWorkspace(request.workspaceId(), USER_REQUEST);
 
     // Check that project is now being deleted.
-    project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
+    Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
     assertEquals("DELETE_REQUESTED", project.getLifecycleState());
   }
 
   @Test
-  public void createGetDeleteGoogleContext() {
+  void createGetDeleteGoogleContext() {
     WorkspaceRequest request =
         defaultRequestBuilder(UUID.randomUUID())
             .spendProfileId(Optional.of(spendUtils.defaultSpendId()))
@@ -324,9 +324,8 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
     workspaceService.createGoogleContext(request.workspaceId(), jobId, "/fake/value", USER_REQUEST);
     jobService.waitForJob(jobId);
     assertNull(jobService.retrieveJobResult(jobId, Object.class, USER_REQUEST).getException());
-    assertTrue(
-        workspaceService.getCloudContext(request.workspaceId(), USER_REQUEST).googleProjectId()
-            != null);
+    assertNotNull(
+        workspaceService.getCloudContext(request.workspaceId(), USER_REQUEST).googleProjectId());
 
     workspaceService.deleteGoogleContext(request.workspaceId(), USER_REQUEST);
     assertEquals(
@@ -335,7 +334,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void createGoogleContextRawlsStageThrows() {
+  void createGoogleContextRawlsStageThrows() {
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
     String jobId = UUID.randomUUID().toString();
@@ -348,7 +347,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void createGoogleContextNoSpendProfileIdThrows() {
+  void createGoogleContextNoSpendProfileIdThrows() {
     WorkspaceRequest request =
         defaultRequestBuilder(UUID.randomUUID())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
@@ -364,7 +363,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void createGoogleContextSpendLinkingUnauthorizedThrows() {
+  void createGoogleContextSpendLinkingUnauthorizedThrows() {
     WorkspaceRequest request =
         defaultRequestBuilder(UUID.randomUUID())
             .spendProfileId(Optional.of(spendUtils.defaultSpendId()))
@@ -388,7 +387,7 @@ public class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  public void createGoogleContextSpendWithoutBillingAccountThrows() {
+  void createGoogleContextSpendWithoutBillingAccountThrows() {
     WorkspaceRequest request =
         defaultRequestBuilder(UUID.randomUUID())
             .spendProfileId(Optional.of(spendUtils.noBillingAccount()))

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class CreateGoogleContextFlightTest extends BaseConnectedTest {
+class CreateGoogleContextFlightTest extends BaseConnectedTest {
   /** How long to wait for a Stairway flight to complete before timing out the test. */
   private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(3);
 
@@ -47,7 +47,7 @@ public class CreateGoogleContextFlightTest extends BaseConnectedTest {
   @Autowired private UserAccessUtils userAccessUtils;
 
   @Test
-  public void successCreatesProjectAndContext() throws Exception {
+  void successCreatesProjectAndContext() throws Exception {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userReq = userAccessUtils.defaultUserAuthRequest();
     assertEquals(
@@ -80,7 +80,7 @@ public class CreateGoogleContextFlightTest extends BaseConnectedTest {
   }
 
   @Test
-  public void errorRevertsChanges() throws Exception {
+  void errorRevertsChanges() throws Exception {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userReq = userAccessUtils.defaultUserAuthRequest();
     assertEquals(

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class DeleteGoogleContextFlightTest extends BaseConnectedTest {
+class DeleteGoogleContextFlightTest extends BaseConnectedTest {
   /**
    * How long to wait for a delete context Stairway flight to complete before timing out the test.
    */
@@ -40,7 +40,7 @@ public class DeleteGoogleContextFlightTest extends BaseConnectedTest {
   @Autowired private UserAccessUtils userAccessUtils;
 
   @Test
-  public void deleteContext() throws Exception {
+  void deleteContext() throws Exception {
     UUID workspaceId = createWorkspace();
     FlightMap createParameters = new FlightMap();
     AuthenticatedUserRequest userReq = userAccessUtils.defaultUserAuthRequest();
@@ -80,7 +80,7 @@ public class DeleteGoogleContextFlightTest extends BaseConnectedTest {
   }
 
   @Test
-  public void deleteNonExistentContextIsOk() throws Exception {
+  void deleteNonExistentContextIsOk() throws Exception {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userReq = userAccessUtils.defaultUserAuthRequest();
     assertEquals(


### PR DESCRIPTION
- removed `String.format` nested in a logger
- fixed a javadoc tag (`@Code` -> `@code`)
- normalized tests
  - removed `public`, matching JUnit docs
  - removed some unthrown exceptions
  - also added a bit of nesting, so **better reviewed with whitespace hidden**