### PR TITLE
[PF-387] Explicitly track Sam workspace resource ownership

### DIFF
--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -90,6 +90,8 @@ public class WorkspaceApiController implements WorkspaceApi {
     // RAWLS_WORKSPACE.
     WorkspaceStageModel requestStage = body.getStage();
     requestStage = (requestStage == null ? WorkspaceStageModel.RAWLS_WORKSPACE : requestStage);
+    boolean isSamResourceOwner =
+        (body.isSamResourceOwner() == null ? false : body.isSamResourceOwner());
     WorkspaceStage internalStage = WorkspaceStage.fromApiModel(requestStage);
     Optional<SpendProfileId> spendProfileId =
         Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::create);
@@ -102,6 +104,7 @@ public class WorkspaceApiController implements WorkspaceApi {
             .jobId(jobId)
             .spendProfileId(spendProfileId)
             .workspaceStage(internalStage)
+            .isSamResourceOwner(isSamResourceOwner)
             .build();
     UUID createdId = workspaceService.createWorkspace(internalRequest, userReq);
 

--- a/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -49,15 +49,16 @@ public class WorkspaceDao {
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public UUID createWorkspace(Workspace workspace) {
     String sql =
-        "INSERT INTO workspace (workspace_id, spend_profile, profile_settable, workspace_stage) values "
-            + "(:id, :spend_profile, :spend_profile_settable, :workspace_stage)";
+        "INSERT INTO workspace (workspace_id, spend_profile, profile_settable, workspace_stage, is_sam_resource_owner) values "
+            + "(:id, :spend_profile, :spend_profile_settable, :workspace_stage, :is_sam_resource_owner)";
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("id", workspace.workspaceId().toString())
             .addValue(
                 "spend_profile", workspace.spendProfileId().map(SpendProfileId::id).orElse(null))
             .addValue("spend_profile_settable", workspace.spendProfileId().isEmpty())
-            .addValue("workspace_stage", workspace.workspaceStage().toString());
+            .addValue("workspace_stage", workspace.workspaceStage().toString())
+            .addValue("is_sam_resource_owner", workspace.isSamResourceOwner());
     try {
       jdbcTemplate.update(sql, params);
       logger.info("Inserted record for workspace {}", workspace.workspaceId());
@@ -105,6 +106,7 @@ public class WorkspaceDao {
                               Optional.ofNullable(rs.getString("spend_profile"))
                                   .map(SpendProfileId::create))
                           .workspaceStage(WorkspaceStage.valueOf(rs.getString("workspace_stage")))
+                          .isSamResourceOwner(rs.getBoolean("is_sam_resource_owner"))
                           .build()));
       logger.info("Retrieved workspace record {}", result);
       return result;

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -68,6 +68,8 @@ public class WorkspaceService {
 
     createJob.addParameter(
         WorkspaceFlightMapKeys.WORKSPACE_STAGE, workspaceRequest.workspaceStage());
+    createJob.addParameter(
+        WorkspaceFlightMapKeys.IS_SAM_RESOURCE_OWNER, workspaceRequest.isSamResourceOwner());
 
     return createJob.submitAndWait(UUID.class);
   }
@@ -107,7 +109,8 @@ public class WorkspaceService {
   /** Delete an existing workspace by ID. */
   @Traced
   public void deleteWorkspace(UUID id, AuthenticatedUserRequest userReq) {
-    validateWorkspaceAndAction(userReq, id, SamConstants.SAM_WORKSPACE_DELETE_ACTION);
+    Workspace workspace =
+        validateWorkspaceAndAction(userReq, id, SamConstants.SAM_WORKSPACE_DELETE_ACTION);
 
     String description = "Delete workspace " + id;
     JobBuilder deleteJob =
@@ -118,7 +121,9 @@ public class WorkspaceService {
                 WorkspaceDeleteFlight.class,
                 null, // Delete does not have a useful request body
                 userReq)
-            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, id);
+            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, id)
+            .addParameter(
+                WorkspaceFlightMapKeys.IS_SAM_RESOURCE_OWNER, workspace.isSamResourceOwner());
     deleteJob.submitAndWait(null);
   }
 

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -37,11 +37,14 @@ public class CreateWorkspaceStep implements Step {
             .map(SpendProfileId::create);
     WorkspaceStage workspaceStage =
         inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, WorkspaceStage.class);
+    boolean isSamResourceOwner =
+        inputMap.get(WorkspaceFlightMapKeys.IS_SAM_RESOURCE_OWNER, Boolean.class);
     Workspace workspaceToCreate =
         Workspace.builder()
             .workspaceId(workspaceId)
             .spendProfileId(spendProfileId)
             .workspaceStage(workspaceStage)
+            .isSamResourceOwner(isSamResourceOwner)
             .build();
 
     workspaceDao.createWorkspace(workspaceToCreate);

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
@@ -26,6 +26,13 @@ public class DeleteWorkspaceAuthzStep implements Step {
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
     UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    boolean isSamResourceOwner =
+        inputMap.get(WorkspaceFlightMapKeys.IS_SAM_RESOURCE_OWNER, Boolean.class);
+    // Nothing required for this step if this Sam resource is not owned by WSM.
+    if (!isSamResourceOwner) {
+      return StepResult.getStepResultSuccess();
+    }
+
     try {
       samService.deleteWorkspace(userReq.getRequiredToken(), workspaceID);
     } catch (SamApiException e) {

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -5,6 +5,7 @@ public final class WorkspaceFlightMapKeys {
   public static final String SPEND_PROFILE_ID = "spendProfileId";
   public static final String GOOGLE_PROJECT_ID = "googleProjectId";
   public static final String WORKSPACE_STAGE = "workspaceStage";
+  public static final String IS_SAM_RESOURCE_OWNER = "samResourceOwner";
   public static final String BILLING_ACCOUNT_ID = "billingAccountId";
   public static final String IAM_OWNER_GROUP_EMAIL = "iamOwnerGroupEmail";
   public static final String IAM_WRITER_GROUP_EMAIL = "iamWriterGroupEmail";

--- a/src/main/java/bio/terra/workspace/service/workspace/model/Workspace.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/model/Workspace.java
@@ -30,6 +30,12 @@ public abstract class Workspace {
   /** Temporary feature flag indicating whether this workspace uses MC Terra features. */
   public abstract WorkspaceStage workspaceStage();
 
+  /**
+   * Whether this workspace owns its Sam resource or not. Used for compatibility with Rawls
+   * workspaces, where Rawls owns the Sam resource rather than WSM.
+   */
+  public abstract boolean isSamResourceOwner();
+
   public static Builder builder() {
     return new AutoValue_Workspace.Builder();
   }
@@ -41,6 +47,8 @@ public abstract class Workspace {
     public abstract Builder spendProfileId(Optional<SpendProfileId> value);
 
     public abstract Builder workspaceStage(WorkspaceStage value);
+
+    public abstract Builder isSamResourceOwner(boolean value);
 
     public abstract Workspace build();
   }

--- a/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceRequest.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceRequest.java
@@ -36,6 +36,12 @@ public abstract class WorkspaceRequest {
   /** Temporary feature flag indicating whether this workspace uses MC Terra features. */
   public abstract WorkspaceStage workspaceStage();
 
+  /**
+   * Whether this workspace owns its Sam resource or not. Used for compatibility with Rawls
+   * workspaces, where Rawls owns the Sam resource rather than WSM.
+   */
+  public abstract boolean isSamResourceOwner();
+
   public static WorkspaceRequest.Builder builder() {
     return new AutoValue_WorkspaceRequest.Builder();
   }
@@ -49,6 +55,8 @@ public abstract class WorkspaceRequest {
     public abstract WorkspaceRequest.Builder spendProfileId(Optional<SpendProfileId> value);
 
     public abstract WorkspaceRequest.Builder workspaceStage(WorkspaceStage value);
+
+    public abstract WorkspaceRequest.Builder isSamResourceOwner(boolean value);
 
     public abstract WorkspaceRequest build();
   }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -837,6 +837,13 @@ components:
           type: string
         stage:
           $ref: '#/components/schemas/WorkspaceStageModel'
+        samResourceOwner:
+          description: |
+            Whether this workspace should attempt to create its own Sam workspace
+            resource, or use one that already exists. Defaults to false. This is used solely for compatibility with
+            Rawls workspaces, and should be deleted when WSM manages workspaces
+            instead.
+          type: boolean
 
     CreatedWorkspace:
       type: object

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -7,4 +7,5 @@
     <include file="changesets/20201104_reference_index.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20201204_json_to_jsonb.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20210205_add_description.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20210212_add_sam_resource_owner.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20210212_add_sam_resource_owner.yaml
+++ b/src/main/resources/db/changesets/20210212_add_sam_resource_owner.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+- changeSet:
+    id: addSamResourceOwner
+    author: zloery
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: is_sam_resource_owner
+            type: boolean
+            value: true
+        tableName: workspace

--- a/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/DataReferenceDaoTest.java
@@ -107,6 +107,7 @@ class DataReferenceDaoTest extends BaseUnitTest {
           Workspace.builder()
               .workspaceId(UUID.randomUUID())
               .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+              .isSamResourceOwner(true)
               .build();
       UUID decoyId = workspaceDao.createWorkspace(decoyWorkspace);
       assertThrows(
@@ -217,6 +218,7 @@ class DataReferenceDaoTest extends BaseUnitTest {
             .workspaceId(UUID.randomUUID())
             .spendProfileId(Optional.empty())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .isSamResourceOwner(true)
             .build();
     return workspaceDao.createWorkspace(workspace);
   }

--- a/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -47,6 +47,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
             .workspaceId(workspaceId)
             .spendProfileId(spendProfileId)
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .isSamResourceOwner(true)
             .build();
     workspaceDao.createWorkspace(workspace);
 
@@ -103,6 +104,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
           Workspace.builder()
               .workspaceId(workspaceId)
               .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+              .isSamResourceOwner(true)
               .build();
       workspaceDao.createWorkspace(mcWorkspace);
     }
@@ -225,6 +227,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
     return Workspace.builder()
         .workspaceId(workspaceId)
         .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+        .isSamResourceOwner(true)
         .build();
   }
 }

--- a/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -287,7 +287,8 @@ class WorkspaceIntegrationTest extends BaseIntegrationTest {
       throws Exception {
     String path = testConfig.getWsmWorkspacesBaseUrl();
     String userEmail = testConfig.getUserEmail();
-    CreateWorkspaceRequestBody body = new CreateWorkspaceRequestBody().id(workspaceId);
+    CreateWorkspaceRequestBody body =
+        new CreateWorkspaceRequestBody().id(workspaceId).samResourceOwner(true);
     String jsonBody = testUtils.mapToJson(body);
 
     return workspaceManagerTestClient.post(userEmail, path, jsonBody, CreatedWorkspace.class);

--- a/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/datareference/DataReferenceServiceTest.java
@@ -276,6 +276,7 @@ class DataReferenceServiceTest extends BaseUnitTest {
             .jobId(UUID.randomUUID().toString())
             .spendProfileId(Optional.empty())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .isSamResourceOwner(true)
             .build();
     return workspaceService.createWorkspace(request, USER_REQUEST);
   }

--- a/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -129,7 +129,7 @@ class SamServiceTest extends BaseConnectedTest {
         WorkspaceRequest.builder()
             .workspaceId(UUID.randomUUID())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .isSamResourceOwner(false)
+            .isSamResourceOwner(true)
             .jobId(UUID.randomUUID().toString())
             .build();
     UUID workspaceId = workspaceService.createWorkspace(rawlsRequest, defaultUserRequest());

--- a/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -129,6 +129,7 @@ class SamServiceTest extends BaseConnectedTest {
         WorkspaceRequest.builder()
             .workspaceId(UUID.randomUUID())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .isSamResourceOwner(false)
             .jobId(UUID.randomUUID().toString())
             .build();
     UUID workspaceId = workspaceService.createWorkspace(rawlsRequest, defaultUserRequest());
@@ -236,6 +237,7 @@ class SamServiceTest extends BaseConnectedTest {
         WorkspaceRequest.builder()
             .workspaceId(UUID.randomUUID())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+            .isSamResourceOwner(true)
             .jobId(UUID.randomUUID().toString())
             .build();
     return workspaceService.createWorkspace(request, defaultUserRequest());

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -414,6 +414,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .workspaceId(workspaceId)
         .jobId(UUID.randomUUID().toString())
         .spendProfileId(Optional.empty())
-        .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE);
+        .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+        .isSamResourceOwner(true);
   }
 }

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -115,6 +115,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
             .workspaceId(UUID.randomUUID())
             .jobId(UUID.randomUUID().toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+            .isSamResourceOwner(true)
             .build();
     return workspaceService.createWorkspace(request, userAccessUtils.defaultUserAuthRequest());
   }

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -107,6 +107,7 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
             .workspaceId(UUID.randomUUID())
             .jobId(UUID.randomUUID().toString())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
+            .isSamResourceOwner(true)
             .build();
     return workspaceService.createWorkspace(request, userAccessUtils.defaultUserAuthRequest());
   }

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/CreateGetDeleteWorkspace.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/CreateGetDeleteWorkspace.java
@@ -24,6 +24,7 @@ public class CreateGetDeleteWorkspace extends WorkspaceTestScriptBase {
     UUID workspaceId = UUID.randomUUID();
     CreateWorkspaceRequestBody requestBody = new CreateWorkspaceRequestBody();
     requestBody.setId(workspaceId);
+    requestBody.setSamResourceOwner(true);
     workspaceApi.createWorkspace(requestBody);
     ClientTestUtils.assertHttpSuccess(workspaceApi, "CREATE workspace");
 

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceFixtureTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/WorkspaceFixtureTestScriptBase.java
@@ -47,7 +47,8 @@ public abstract class WorkspaceFixtureTestScriptBase extends WorkspaceTestScript
     workspaceId = UUID.randomUUID();
     final var requestBody = new CreateWorkspaceRequestBody()
         .id(workspaceId)
-        .stage(getStageModel());
+        .stage(getStageModel())
+        .samResourceOwner(true);
     final CreatedWorkspace workspace = workspaceApi.createWorkspace(requestBody);
     assertThat(workspace.getId(), equalTo(workspaceId));
   }


### PR DESCRIPTION
This change adds a new field to our workspace representation indicating whether WSM owns the corresponding Sam resource or not. This is specified at creation time (defaulting to "not owned", Rawls' behavior for compatibility) and is used during workspace deletion to know whether we need to delete the Sam resource or not. As this is a temporary field used for Rawls integration, it is not returned on calls to retrieve a workspace.

I'm also looking for more opinions on whether this change is beneficial or not. It adds an additional integration wart that will eventually need to be removed, but it also helps prevent corrupt resource layouts. Specifically, we currently assume Rawls will always delete its workspace Sam resource before calling delete workspace on WSM. If this assumption is violated, WSM will delete a Rawls-managed Sam resource, which could lead to unexpected behavior. This assumption holds for the current Rawls implementation, but we may not want to rely on this assumption.