### PR TITLE
[PF-457] Only depend on Buffer Service status if Buffer Service integration is enabled

### DIFF
--- a/src/main/java/bio/terra/workspace/app/configuration/external/BufferServiceConfiguration.java
+++ b/src/main/java/bio/terra/workspace/app/configuration/external/BufferServiceConfiguration.java
@@ -16,12 +16,22 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "workspace.buffer")
 public class BufferServiceConfiguration {
 
+  // TODO(PF-302): Clean up once fully using Buffer Service in all environments.
+  private boolean enabled = false;
   private String instanceUrl;
   private String poolId;
   private String clientCredentialFilePath;
 
   private static final ImmutableList<String> BUFFER_SCOPES =
       ImmutableList.of("openid", "email", "profile");
+
+  public boolean getEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
 
   public String getInstanceUrl() {
     return instanceUrl;

--- a/src/main/java/bio/terra/workspace/service/status/WorkspaceManagerStatusService.java
+++ b/src/main/java/bio/terra/workspace/service/status/WorkspaceManagerStatusService.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.status;
 
+import bio.terra.workspace.app.configuration.external.BufferServiceConfiguration;
 import bio.terra.workspace.app.configuration.external.DataRepoConfiguration;
 import bio.terra.workspace.common.utils.BaseStatusService;
 import bio.terra.workspace.common.utils.StatusSubsystem;
@@ -25,6 +26,7 @@ public class WorkspaceManagerStatusService extends BaseStatusService {
       DataRepoConfiguration dataRepoConfiguration,
       NamedParameterJdbcTemplate jdbcTemplate,
       SamService samService,
+      BufferServiceConfiguration bufferServiceConfiguration,
       BufferService bufferService,
       @Value("${workspace.status-check.staleness-threshold-ms}") long staleThresholdMillis) {
     super(staleThresholdMillis);
@@ -43,7 +45,9 @@ public class WorkspaceManagerStatusService extends BaseStatusService {
           new StatusSubsystem(checkDataRepoInstanceFn, /*isCritical=*/ false));
     }
 
-    registerSubsystem("Buffer", new StatusSubsystem(bufferService::status, /*isCritical=*/ true));
+    if (bufferServiceConfiguration.getEnabled()) {
+      registerSubsystem("Buffer", new StatusSubsystem(bufferService::status, /*isCritical=*/ true));
+    }
     registerSubsystem("Sam", new StatusSubsystem(samService::status, /*isCritical=*/ true));
   }
 

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -11,9 +11,11 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.spendprofile.SpendProfile;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.spendprofile.SpendProfileService;
+import bio.terra.workspace.service.workspace.exceptions.BufferServiceDisabledException;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateGoogleContextException;
 import bio.terra.workspace.service.workspace.exceptions.MissingSpendProfileException;
 import bio.terra.workspace.service.workspace.exceptions.NoBillingAccountException;
+import bio.terra.workspace.service.workspace.exceptions.StageDisabledException;
 import bio.terra.workspace.service.workspace.flight.*;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceRequest;
@@ -139,6 +141,10 @@ public class WorkspaceService {
   @Traced
   public String createGoogleContext(
       UUID workspaceId, String jobId, String resultPath, AuthenticatedUserRequest userReq) {
+    if (!bufferServiceConfiguration.getEnabled()) {
+      throw new BufferServiceDisabledException(
+          "Cannot create a google context in an environment where buffer service is disabled or not configured.");
+    }
     Workspace workspace =
         validateWorkspaceAndAction(userReq, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
     workspaceDao.assertMcWorkspace(workspace, "createGoogleContext");

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -15,7 +15,6 @@ import bio.terra.workspace.service.workspace.exceptions.BufferServiceDisabledExc
 import bio.terra.workspace.service.workspace.exceptions.DuplicateGoogleContextException;
 import bio.terra.workspace.service.workspace.exceptions.MissingSpendProfileException;
 import bio.terra.workspace.service.workspace.exceptions.NoBillingAccountException;
-import bio.terra.workspace.service.workspace.exceptions.StageDisabledException;
 import bio.terra.workspace.service.workspace.flight.*;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceRequest;

--- a/src/main/java/bio/terra/workspace/service/workspace/exceptions/BufferServiceDisabledException.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/exceptions/BufferServiceDisabledException.java
@@ -4,9 +4,11 @@ import bio.terra.workspace.common.exception.BadRequestException;
 
 /**
  * Exception thrown when a user attempts to use Buffer Service in an environment where it's disabled
- * or not configured.
- * TODO(PF-302): Remove this exception when buffer is enabled and used in all environments.
+ * or not configured. TODO(PF-302): Remove this exception when buffer is enabled and used in all
+ * environments.
  */
 public class BufferServiceDisabledException extends BadRequestException {
-  public BufferServiceDisabledException(String message) {super(message);}
+  public BufferServiceDisabledException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/exceptions/BufferServiceDisabledException.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/exceptions/BufferServiceDisabledException.java
@@ -1,0 +1,12 @@
+package bio.terra.workspace.service.workspace.exceptions;
+
+import bio.terra.workspace.common.exception.BadRequestException;
+
+/**
+ * Exception thrown when a user attempts to use Buffer Service in an environment where it's disabled
+ * or not configured.
+ * TODO(PF-302): Remove this exception when buffer is enabled and used in all environments.
+ */
+public class BufferServiceDisabledException extends BadRequestException {
+  public BufferServiceDisabledException(String message) {super(message);}
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,5 +1,6 @@
 workspace:
   buffer:
+    enabled: true
     pool-id: workspace_manager_v3
     instance-url: https://buffer.tools.integ.envs.broadinstitute.org
     client-credential-file-path: rendered/buffer-client-sa-account.json


### PR DESCRIPTION
This re-adds the `workspace.buffer.enabled` flag that was removed in #215, and checks that it is true before adding Buffer Service as a dependency to check for WSM's status endpoint.

Without this check, WSM's status endpoint is broken in environments where it does not have a Buffer service configuration. With this change those environments still will not have access to Buffer Service functionality, but this is acceptable as it is gated behind the workspace stage feature flag.

This change depends on a [corresponding Helm change](https://github.com/broadinstitute/terra-helm/pull/293) to actually provide this configuration value. In any environment where it is not provided, it will default to `false` and WSM's status endpoint will not depend on Buffer service.