### PR TITLE
PF-421: Add serviceusage.serviceUsageConsumer role.

### DIFF
--- a/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -13,9 +13,10 @@ public class CloudSyncRoleMapping {
                   "roles/viewer",
                   "roles/bigquery.dataEditor",
                   // TODO(wchambers): Revise service account permissions when there are controlled
-                  // resources for service accounts.
+                  // resources for service accounts. (Also used by NextFlow)
                   "roles/iam.serviceAccountUser",
                   "roles/lifesciences.editor",
+                  "roles/serviceusage.serviceUsageConsumer",
                   // TODO(wchambers): Revise notebooks permissions when there are controlled
                   // resources for notebooks.
                   "roles/notebooks.admin",
@@ -27,9 +28,10 @@ public class CloudSyncRoleMapping {
                   "roles/viewer",
                   "roles/bigquery.dataEditor",
                   // TODO(wchambers): Revise service account permissions when there are controlled
-                  // resources for service accounts.
+                  // resources for service accounts. (Also used by NextFlow)
                   "roles/iam.serviceAccountUser",
                   "roles/lifesciences.editor",
+                  "roles/serviceusage.serviceUsageConsumer",
                   // TODO(wchambers): Revise notebooks permissions when there are controlled
                   // resources for notebooks.
                   "roles/notebooks.admin",


### PR DESCRIPTION
Add the serviceusage.serviceUsageConsumer role to workspace owners and writers.

The goal of this change is to resolve the 403 error I get when trying run a Nextflow workflow inside a workspace project.
`"pet-110017243614237806241@terra-wsm-test-8a063ae7.iam.gserviceaccount.com does not have serviceusage.services.use access to the Google Cloud project."`

The roles that [GCP says to use](https://cloud.google.com/life-sciences/docs/tutorials/nextflow#create_a_service_account_and_add_roles) for running Nextflow are:
1. Cloud Life Sciences Workflows Runner = roles/lifesciences.workflowsRunner
 This has the same permissions as roles/lifesciences.editor, which is already granted.
2. Service Account User = roles/iam.serviceAccountUser
  This was already granted for AIP notebooks, per the comment in the code.
3. Service Usage Consumer = roles/serviceusage.serviceUsageConsumer
  This is added in this PR.
4. Storage Object Admin = roles/storage.objectAdmin
  This is superceded by roles/storage.admin, which is already granted so that the CLI can create buckets manually. 