### PR TITLE
[No ticket] Always upload test results on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,7 @@ jobs:
       run: ./gradlew ${{ matrix.gradleTask }} --scan
 
     - name: Upload Test Reports
+      if: ${{ always() }}
       uses: actions/upload-artifact@v1
       with:
         name: Test Reports


### PR DESCRIPTION
No ticket because this only affects test infrastructure.

Currently, when a test run fails the GHA workflow will skip steps after "run tests", and so the test report is not uploaded. We should always make the test report available to make debugging failed tests easier.