### PR TITLE
[PF-306] Add nightly integration tests, make client tests run locally

### DIFF
--- a/.github/workflows/test-runner-nightly-integration.yml
+++ b/.github/workflows/test-runner-nightly-integration.yml
@@ -6,25 +6,12 @@ name: Test Runner Nightly Integration Tests
 on:
   workflow_dispatch: {}
   schedule:
-  - cron: '0 6 * * *' # run at 6 AM UTC, 1 AM ET.
+  - cron: '0 7 * * *' # run at 7 AM UTC, 2 AM ET.
 
 jobs:
   test-runner-integration:
 
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:12.3
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-runner-nightly-integration.yml
+++ b/.github/workflows/test-runner-nightly-integration.yml
@@ -4,10 +4,9 @@
 name: Test Runner Nightly Integration Tests
 
 on:
-  push:
-    branches: [ dev ]
-  pull_request:
-      branches: [ '**' ]
+  workflow_dispatch: {}
+  schedule:
+  - cron: '0 6 * * *' # run at 6 AM UTC, 1 AM ET.
 
 jobs:
   test-runner-integration:
@@ -29,11 +28,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      # This step is needed when running test using a local server.
-      - name: Initialize Postgres DB
-        env:
-          PGPASSWORD: postgres
-        run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
       - name: Set up AdoptOpenJDK 11
         uses: joschi/setup-jdk@v2
         with:
@@ -49,8 +43,6 @@ jobs:
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-
-      # These steps aren't needed for unit tests
       - name: Get Vault token
         id: vault-token-step
         env:
@@ -69,22 +61,6 @@ jobs:
           chmod +x render_config.sh
           ./render_config.sh dev ${{ steps.vault-token-step.outputs.vault-token }}
           chmod +r rendered
-
-      # Spin up a local server.
-      - name: Run local server (in background)
-        run: ./gradlew bootRun &
-      - name: Wait for local server to start
-        # With a timeout of 60 seconds, try to connect to localhost:8080 every 1 second.
-        run: timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
-
-      - name: Build the WSM client
-        run: |
-          echo "Building WSM client library"
-          ./gradlew :workspace-manager-client:clean :workspace-manager-client:assemble
-          cd workspace-manager-clienttests
-          export ORG_GRADLE_PROJECT_workspacemanagerclientjar=$(find .. -type f -name "workspace-manager-client*.jar")
-          echo "ORG_GRADLE_PROJECT_workspacemanagerclientjar = ${ORG_GRADLE_PROJECT_workspacemanagerclientjar}"
-
       # We can also set the env var in the GH action script to specify which server we are testing against.
       # This will be particularly helpful once we switch over to testing against any test env -- then it's just a change to the env var.
       # Please refer to https://github.com/DataBiosphere/terra-test-runner#override-the-server-from-the-command-line for more information.

--- a/.github/workflows/test-runner-pr-integration.yml
+++ b/.github/workflows/test-runner-pr-integration.yml
@@ -1,0 +1,103 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Test Runner Nightly Integration Tests
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  test-runner-integration:
+
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:12.3
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+        - 5432:5432
+
+    steps:
+    - uses: actions/checkout@v2
+    # This step is needed when running test using a local server.
+    - name: Initialize Postgres DB
+      env:
+        PGPASSWORD: postgres
+      run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
+    - name: Set up AdoptOpenJDK 11
+      uses: joschi/setup-jdk@v2
+      with:
+        java-version: 11
+    # This step caches Gradle packages for reuse in the same VM instance.
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Get Vault token
+      id: vault-token-step
+      env:
+        VAULT_ADDR: https://clotho.broadinstitute.org:8200
+      run: |
+        VAULT_TOKEN=$(docker run --rm --cap-add IPC_LOCK \
+          -e "VAULT_ADDR=${VAULT_ADDR}" \
+          vault:1.1.0 \
+          vault write -field token \
+            auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
+            secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+        echo ::set-output name=vault-token::$VAULT_TOKEN
+        echo ::add-mask::$VAULT_TOKEN
+    - name: Set permissions and render test configurations
+      run: |
+        chmod +x render_config.sh
+        ./render_config.sh dev ${{ steps.vault-token-step.outputs.vault-token }}
+        chmod +r rendered
+
+    # Spin up a local server.
+    - name: Run local server (in background)
+      run: ./gradlew bootRun &
+    - name: Wait for local server to start
+      # With a timeout of 60 seconds, try to connect to localhost:8080 every 1 second.
+      run: timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+
+    # We can also set the env var in the GH action script to specify which server we are testing against.
+    # This will be particularly helpful once we switch over to testing against any test env -- then it's just a change to the env var.
+    # Please refer to https://github.com/DataBiosphere/terra-test-runner#override-the-server-from-the-command-line for more information.
+    - name: Run the Basic Integration test suite
+      run: |
+        cd workspace-manager-clienttests
+        echo "Test Runner config"
+        ./render-config.sh ${{ steps.vault-token-step.outputs.vault-token }}
+        echo "Running test suite"
+        export TEST_RUNNER_SERVER_SPECIFICATION_FILE="workspace-local.json"
+        ./gradlew runTest --args="suites/BasicIntegration.json /tmp/TestRunnerResults"
+
+    - name: Upload test results to Google Bucket
+      if: ${{ always() }}
+      run: |
+        cd workspace-manager-clienttests
+        echo "Upload test results to Google Bucket"
+        ./gradlew uploadResults --args="CompressDirectoryToBucket.json /tmp/TestRunnerResults"
+
+    - name: Upload test results to BigQuery Test Runner Dataset
+      if: ${{ always() }}
+      run: |
+        cd workspace-manager-clienttests
+        echo "Upload test results to BigQuery Test Runner Dataset"
+        ./gradlew uploadResults --args="SummariesToBigQuery.json /tmp/TestRunnerResults"

--- a/.github/workflows/test-runner-pr-integration.yml
+++ b/.github/workflows/test-runner-pr-integration.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Test Runner Nightly Integration Tests
+name: Test Runner PR Integration Tests
 
 on:
   push:

--- a/.github/workflows/test-runner-pr-integration.yml
+++ b/.github/workflows/test-runner-pr-integration.yml
@@ -1,8 +1,11 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Test Runner PR Integration Tests
-
+name: PR Client Library Integration Tests
+description: >-
+  Action for running client integration tests against PRs. This test uses local
+  server changes but runs a published version of the client, so it will not pick
+  up local client changes.
 on:
   push:
     branches: [ dev ]
@@ -10,7 +13,7 @@ on:
     branches: [ '**' ]
 
 jobs:
-  test-runner-integration:
+  integration-test:
 
     runs-on: ubuntu-latest
 
@@ -76,9 +79,6 @@ jobs:
       # With a timeout of 60 seconds, try to connect to localhost:8080 every 1 second.
       run: timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
 
-    # We can also set the env var in the GH action script to specify which server we are testing against.
-    # This will be particularly helpful once we switch over to testing against any test env -- then it's just a change to the env var.
-    # Please refer to https://github.com/DataBiosphere/terra-test-runner#override-the-server-from-the-command-line for more information.
     - name: Run the Basic Integration test suite
       run: |
         cd workspace-manager-clienttests


### PR DESCRIPTION
The current setup for TestRunner integration tests runs on commits to a PR and builds a local client, but runs against the `wsmtest` environment server, meaning server-side changes are not captured in these PR checks. They also don't run nightly like the perf tests, which we want.

This change switches the existing `test-runner-nightly-integration` action to run the nightly integration tests in the wsmtest environment. It also switches to using the currently specified version of the client library, rather than building a client with potentially unpublished changes from head. The tests will run at 7 AM UTC since the perf tests also use the `wsmtest` environment and run at 6 AM UTC.

Additionally, I added a new `test-runner-pr-integration` action. On push to a PR, this action will run client tests against a local server (with local changes) using the currently specified client version. It will **not** build a local client with unpublished changes. Publishing is currently manual, and letting the test pass with unpublished changes could lead to failing releases.
(Side note: we might want to consider automatically publishing new versions of the client library on merge to dev. I believe TDR does this already, so there may be shared actions we can use).