### PR TITLE
[PF-530] Bump version and publish new client library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 
 allprojects {
 	group = "bio.terra"
-	version = "0.14.0-SNAPSHOT"
+	version = "0.15.0-SNAPSHOT"
 	ext {
 		artifactGroup = "${group}.workspace"
 		swaggerOutputDir = "${buildDir}/swagger-code"


### PR DESCRIPTION
We need to publish a new version of the client library for the new `listWorkspaces` endpoint added in #251, but I forgot to bump the app version in that PR. sorry!