### PR TITLE
postgres 12->13 [AS-650]

### DIFF
--- a/.github/workflows/test-runner-pr-integration.yml
+++ b/.github/workflows/test-runner-pr-integration.yml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12.3
+        image: postgres:13.1
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12.3
+        image: postgres:13.1
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ Note: this document is being written during a time when code is rapidly evolving
 
 ### Prerequisites:
 
-- Install Postgres 12.3: https://www.postgresql.org/download/
+- Install Postgres 13.1: https://www.postgresql.org/download/
   - [The app](https://postgresapp.com/downloads.html) may be easier, just make sure to download the right version. It'll manage things for you and has a useful menulet where the server can be turned on and off. Don't forget to create a server if you go this route.
 - Install AdoptOpenJDK Java 11 (Hotspot). Here's an easy way on Mac, using [jEnv](https://www.jenv.be/) to manage the active version:
 

--- a/local-dev/run_postgres.sh
+++ b/local-dev/run_postgres.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Start up a postgres container with initial user/database setup.
-POSTGRES_VERSION=12.3
+POSTGRES_VERSION=13.1
 
 start() {
     echo "attempting to remove old $CONTAINER container..."


### PR DESCRIPTION
Update tests, readme, and local-dev script to use Postgres 13 instead of 12. This reflects our production deployment.