### PR TITLE
jobid should not be empty string/whitespace [AS-679]

### DIFF
--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -29,6 +29,7 @@ import bio.terra.workspace.service.iam.exception.InvalidRoleException;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.JobService.AsyncJobResult;
+import bio.terra.workspace.service.job.exception.InvalidJobIdException;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -113,8 +114,11 @@ public class WorkspaceApiController implements WorkspaceApi {
     WorkspaceStage internalStage = WorkspaceStage.fromApiModel(requestStage);
     Optional<SpendProfileId> spendProfileId =
         Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::create);
-    // If clients do not provide a usable job ID, we generate one instead.
-    String jobId = StringUtils.isNotBlank(body.getJobId()) ? body.getJobId() : UUID.randomUUID().toString();
+    // If clients provide a job ID, it cannot be whitespace-only
+    if (StringUtils.isWhitespace(body.getJobId()))
+      throw new InvalidJobIdException("jobId cannot be whitespace-only.");
+    // If clients do not provide a job ID, we generate one instead.
+    String jobId = body.getJobId() != null ? body.getJobId() : UUID.randomUUID().toString();
 
     WorkspaceRequest internalRequest =
         WorkspaceRequest.builder()

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -29,7 +29,6 @@ import bio.terra.workspace.service.iam.exception.InvalidRoleException;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.JobService.AsyncJobResult;
-import bio.terra.workspace.service.job.exception.InvalidJobIdException;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -49,8 +48,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -114,9 +111,6 @@ public class WorkspaceApiController implements WorkspaceApi {
     WorkspaceStage internalStage = WorkspaceStage.fromApiModel(requestStage);
     Optional<SpendProfileId> spendProfileId =
         Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::create);
-    // If clients provide a job ID, it cannot be whitespace-only
-    if (StringUtils.isWhitespace(body.getJobId()))
-      throw new InvalidJobIdException("jobId cannot be whitespace-only.");
     // If clients do not provide a job ID, we generate one instead.
     String jobId = body.getJobId() != null ? body.getJobId() : UUID.randomUUID().toString();
 

--- a/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -48,6 +48,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -111,8 +113,8 @@ public class WorkspaceApiController implements WorkspaceApi {
     WorkspaceStage internalStage = WorkspaceStage.fromApiModel(requestStage);
     Optional<SpendProfileId> spendProfileId =
         Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::create);
-    // If clients do not provide a job ID, we generate one instead.
-    String jobId = body.getJobId() != null ? body.getJobId() : UUID.randomUUID().toString();
+    // If clients do not provide a usable job ID, we generate one instead.
+    String jobId = StringUtils.isNotBlank(body.getJobId()) ? body.getJobId() : UUID.randomUUID().toString();
 
     WorkspaceRequest internalRequest =
         WorkspaceRequest.builder()

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -24,7 +24,14 @@ import bio.terra.workspace.generated.model.ApiErrorReport;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.job.exception.*;
+import bio.terra.workspace.service.job.exception.DuplicateJobIdException;
+import bio.terra.workspace.service.job.exception.InternalStairwayException;
+import bio.terra.workspace.service.job.exception.InvalidJobIdException;
+import bio.terra.workspace.service.job.exception.InvalidResultStateException;
+import bio.terra.workspace.service.job.exception.JobNotCompleteException;
+import bio.terra.workspace.service.job.exception.JobNotFoundException;
+import bio.terra.workspace.service.job.exception.JobResponseException;
+import bio.terra.workspace.service.job.exception.JobUnauthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -154,8 +161,9 @@ public class JobService {
       AuthenticatedUserRequest userReq) {
 
     // If clients provide a non-null job ID, it cannot be whitespace-only
-    if (StringUtils.isWhitespace(jobId))
+    if (StringUtils.isWhitespace(jobId)) {
       throw new InvalidJobIdException("jobId cannot be whitespace-only.");
+    }
 
     return new JobBuilder(description, jobId, flightClass, request, userReq, this)
         .addParameter(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext())

--- a/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -24,13 +24,7 @@ import bio.terra.workspace.generated.model.ApiErrorReport;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.job.exception.DuplicateJobIdException;
-import bio.terra.workspace.service.job.exception.InternalStairwayException;
-import bio.terra.workspace.service.job.exception.InvalidResultStateException;
-import bio.terra.workspace.service.job.exception.JobNotCompleteException;
-import bio.terra.workspace.service.job.exception.JobNotFoundException;
-import bio.terra.workspace.service.job.exception.JobResponseException;
-import bio.terra.workspace.service.job.exception.JobUnauthorizedException;
+import bio.terra.workspace.service.job.exception.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -158,6 +152,11 @@ public class JobService {
       Class<? extends Flight> flightClass,
       Object request,
       AuthenticatedUserRequest userReq) {
+
+    // If clients provide a non-null job ID, it cannot be whitespace-only
+    if (StringUtils.isWhitespace(jobId))
+      throw new InvalidJobIdException("jobId cannot be whitespace-only.");
+
     return new JobBuilder(description, jobId, flightClass, request, userReq, this)
         .addParameter(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext())
         .addParameter(

--- a/src/main/java/bio/terra/workspace/service/job/exception/InvalidJobIdException.java
+++ b/src/main/java/bio/terra/workspace/service/job/exception/InvalidJobIdException.java
@@ -1,0 +1,18 @@
+package bio.terra.workspace.service.job.exception;
+
+import bio.terra.workspace.common.exception.BadRequestException;
+
+/** An exception indicating an invalid jobId string value. Error code is 400 Bad Request. */
+public class InvalidJobIdException extends BadRequestException {
+  public InvalidJobIdException(String message) {
+    super(message);
+  }
+
+  public InvalidJobIdException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InvalidJobIdException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -1025,6 +1025,8 @@ components:
             unique requests. Sending different requests with the same jobId
             will lead to all but one of the request bodies being ignored.
             This will be randomly generated if not provided in a request.
+            Best practice is for job identifier to be a UUID, a ShortUUID,
+            or other globally unique identifier.
           type: string
         stage:
           $ref: '#/components/schemas/WorkspaceStageModel'

--- a/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.job.exception.InvalidJobIdException;
 import bio.terra.workspace.service.job.exception.JobNotFoundException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
@@ -43,6 +44,26 @@ class JobServiceTest extends BaseUnitTest {
     } catch (Exception e) {
       // How does a mock even throw an exception?
     }
+  }
+
+  @Test
+  void emptyStringJobIdTest() {
+    String testJobId = "";
+    assertThrows(
+        InvalidJobIdException.class,
+        () ->
+            jobService.newJob(
+                "description", testJobId, JobServiceTestFlight.class, null, testUser));
+  }
+
+  @Test
+  void whitespaceStringJobIdTest() {
+    String testJobId = "\t ";
+    assertThrows(
+        InvalidJobIdException.class,
+        () ->
+            jobService.newJob(
+                "description", testJobId, JobServiceTestFlight.class, null, testUser));
   }
 
   @Test

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -160,24 +160,21 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void emptyJobIdRequestRejected() {
-    WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID())
-            .jobId("")
-            .build();
+    WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).jobId("").build();
+
+    assertEquals("", request.jobId());
     // create-workspace request specifies the empty string for jobId
     assertThrows(
-            InvalidJobIdException.class,
-            () -> workspaceService.createWorkspace(request, USER_REQUEST));
+        InvalidJobIdException.class, () -> workspaceService.createWorkspace(request, USER_REQUEST));
   }
 
   @Test
   void whitespaceJobIdRequestRejected() {
-    WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID())
-            .jobId("  \t  ")
-            .build();
+    WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID()).jobId("  \t  ").build();
     // create-workspace request specifies a whitespace-only string for jobId
     assertThrows(
-            InvalidJobIdException.class,
-            () -> workspaceService.createWorkspace(request, USER_REQUEST));  }
+        InvalidJobIdException.class, () -> workspaceService.createWorkspace(request, USER_REQUEST));
+  }
 
   @Test
   void duplicateOperationSharesFailureResponse() {

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -163,7 +163,6 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID())
             .jobId("")
             .build();
-    workspaceService.createWorkspace(request, USER_REQUEST);
     // create-workspace request specifies the empty string for jobId
     assertThrows(
             InvalidJobIdException.class,
@@ -175,7 +174,6 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID())
             .jobId("  \t  ")
             .build();
-    workspaceService.createWorkspace(request, USER_REQUEST);
     // create-workspace request specifies a whitespace-only string for jobId
     assertThrows(
             InvalidJobIdException.class,

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.exception.DuplicateJobIdException;
+import bio.terra.workspace.service.job.exception.InvalidJobIdException;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.referenced.ReferencedDataRepoSnapshotResource;
@@ -156,6 +157,29 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         DuplicateJobIdException.class,
         () -> workspaceService.createWorkspace(request, USER_REQUEST));
   }
+
+  @Test
+  void emptyJobIdRequestRejected() {
+    WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID())
+            .jobId("")
+            .build();
+    workspaceService.createWorkspace(request, USER_REQUEST);
+    // create-workspace request specifies the empty string for jobId
+    assertThrows(
+            InvalidJobIdException.class,
+            () -> workspaceService.createWorkspace(request, USER_REQUEST));
+  }
+
+  @Test
+  void whitespaceJobIdRequestRejected() {
+    WorkspaceRequest request = defaultRequestBuilder(UUID.randomUUID())
+            .jobId("  \t  ")
+            .build();
+    workspaceService.createWorkspace(request, USER_REQUEST);
+    // create-workspace request specifies a whitespace-only string for jobId
+    assertThrows(
+            InvalidJobIdException.class,
+            () -> workspaceService.createWorkspace(request, USER_REQUEST));  }
 
   @Test
   void duplicateOperationSharesFailureResponse() {


### PR DESCRIPTION
The `jobId` field, part of the create-workspace request, is too easy for an end user to get wrong by specifying the empty string.

to use a system-generated jobid, the caller must omit the jobId entirely:
```
{
  "id": "123e4567-e89b-12d3-a456-426614174000",
  "stage": "RAWLS_WORKSPACE"
}
```

but a common mistake is to leave the jobId key in the payload but blank out its value:
```
{
  "id": "123e4567-e89b-12d3-a456-426614174000",
  "jobId": "",
  "stage": "RAWLS_WORKSPACE"
}
```

which could result in many jobs attempting to have the same jobId of "", leading to conflicts.

This PR changes the behavior to validate that iif a caller specifies a jobId, its value is not the empty string nor is whitespace-only. This validation happens fairly low in `JobService`, so it affects any code using `JobService`, not just create-workspace.

