### PR TITLE
slack notifications for alpha/staging tests [AS-694]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,5 +155,4 @@ jobs:
         status: ${{ job.status }}
         channel: "#dsde-qa"
         username: "Workspace Manager tests"
-        text: "Integration tests"
         fields: repo,job,workflow,commit,eventName,author,took

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,12 +144,10 @@ jobs:
         path: build/reports/tests
 
     - name: "Notify QA Slack"
-#      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
-      if: ${{ always() }}
+      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
       uses: broadinstitute/action-slack@v3.8.0
       # see https://github.com/broadinstitute/action-slack
       env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,6 +151,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
         channel: "#dsde-qa"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,3 +142,18 @@ jobs:
       with:
         name: Test Reports
         path: build/reports/tests
+
+    - name: "Notify QA Slack"
+      if: ${{ always() }}
+      # if:  steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
+      uses: broadinstitute/action-slack@v3.8.0
+      # see https://github.com/broadinstitute/action-slack
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        status: ${{ job.status }}
+        channel: "#dsde-qa"
+        username: "Workspace Manager tests"
+        text: "Integration tests"
+        fields: repo,job,workflow,action,commit,message,author,took

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,4 +157,4 @@ jobs:
         channel: "#dsde-qa"
         username: "Workspace Manager tests"
         text: "Integration tests"
-        fields: repo,job,workflow,action,commit,message,author,took
+        fields: repo,job,workflow,commit,eventName,author,took

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,8 +144,7 @@ jobs:
         path: build/reports/tests
 
     - name: "Notify QA Slack"
-      if: ${{ always() }}
-      # if:  steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
+      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
       uses: broadinstitute/action-slack@v3.8.0
       # see https://github.com/broadinstitute/action-slack
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,11 +144,12 @@ jobs:
         path: build/reports/tests
 
     - name: "Notify QA Slack"
-      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
+#      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
+      if: ${{ always() }}
       uses: broadinstitute/action-slack@v3.8.0
       # see https://github.com/broadinstitute/action-slack
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -95,7 +95,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     workspaceService.createWorkspace(request, USER_REQUEST);
 
     assertEquals(
-        request.workspaceId(),
+//        request.workspaceId(),
+            java.util.UUID.randomUUID(),
         workspaceService.getWorkspace(request.workspaceId(), USER_REQUEST).getWorkspaceId());
   }
 

--- a/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -95,8 +95,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     workspaceService.createWorkspace(request, USER_REQUEST);
 
     assertEquals(
-//        request.workspaceId(),
-            java.util.UUID.randomUUID(),
+        request.workspaceId(),
         workspaceService.getWorkspace(request.workspaceId(), USER_REQUEST).getWorkspaceId());
   }
 


### PR DESCRIPTION
add Slack notifications to #dsde-qa, using https://github.com/broadinstitute/action-slack. Code shamelessly copied from data repo.

Tested by manually changing the `if:` clause in the job to `if: always()` and seeing the notifications arrive in #dsde-qa. The [Jenkins job](https://fc-jenkins.dsp-techops.broadinstitute.org/job/workspacemanager-integration-test-trigger/configure) that triggers the alpha and staging tests is hardcoded to use the `dev` branch of this repo, so I can't test the real thing easily; I don't want to edit the Jenkins job.

if you don't like the :mariostar: emoji I can change that :)
![Screen Shot 2021-03-21 at 5 58 34 PM](https://user-images.githubusercontent.com/6041577/111922247-2adc0f80-8a6f-11eb-87ce-423b216f5aaa.png)


