### PR TITLE
AS-695: Document hotfix procedure

### DIFF
--- a/HOTFIX.md
+++ b/HOTFIX.md
@@ -1,5 +1,13 @@
 # Hotfix Process
 
-See the [HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md) documentation in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) for the general MC-Terra hotfix procedure, which applies to Workspace Manager
+1) Build the image that you would like to use for your hotfix:
+
+`./gradlew jibDockerBuild --image=gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE> -Djib.console=plain`
+
+2) Push the image that you've created to GCR:
+
+`docker push gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>`
+
+3) To apply the hotfix, see the [HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md) documentation in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) for the general MC-Terra hotfix procedure, which applies to Workspace Manager. Use the image that you built above when applying the hotfix.
 
 Should the hotfix process deviate from the general procedure outlined in terra-helmfile, this document should be updated to highlight those differences.

--- a/HOTFIX.md
+++ b/HOTFIX.md
@@ -15,7 +15,7 @@ docker push gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>
 3) Follow Step 1 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md)
 
 
-4) Follow Step 2 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md), except instead of running ArgoCD to sync the deployment, run the [gke-deploy Jenkins job](https://fc-jenkins.dsp-techops.broadinstitute.org/job/gke-deploy/) with `project` set to `workspacemanager`. Do this for `dev` and `staging`. Using this Jenkins deploy job will enusre that the tests run against the hotfix.
+4) Follow Step 2 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md), except instead of running ArgoCD to sync the deployment, run the [gke-deploy Jenkins job](https://fc-jenkins.dsp-techops.broadinstitute.org/job/gke-deploy/) with `project` set to `workspacemanager`. Do this for `dev` and `staging`. Using this Jenkins deploy job will ensure that the tests run against the hotfix.
 
 
 5) Follow Step 3 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md)

--- a/HOTFIX.md
+++ b/HOTFIX.md
@@ -2,11 +2,15 @@
 
 1) Build the image that you would like to use for your hotfix:
 
-`./gradlew jibDockerBuild --image=gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE> -Djib.console=plain`
+```sh
+./gradlew jibDockerBuild --image=gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>
+```
 
 2) Push the image that you've created to GCR:
 
-`docker push gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>`
+```sh
+docker push gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>
+```
 
 3) To apply the hotfix, see the [HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md) documentation in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) for the general MC-Terra hotfix procedure, which applies to Workspace Manager. Use the image that you built above when applying the hotfix.
 

--- a/HOTFIX.md
+++ b/HOTFIX.md
@@ -12,6 +12,13 @@
 docker push gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>
 ```
 
-3) To apply the hotfix, see the [HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md) documentation in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) for the general MC-Terra hotfix procedure, which applies to Workspace Manager. Use the image that you built above when applying the hotfix.
+3) Follow Step 1 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md)
 
-Should the hotfix process deviate from the general procedure outlined in terra-helmfile, this document should be updated to highlight those differences.
+
+4) Follow Step 2 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md), except instead of running ArgoCD to sync the deployment, run the [gke-deploy Jenkins job](https://fc-jenkins.dsp-techops.broadinstitute.org/job/gke-deploy/) with `project` set to `workspacemanager`. Do this for `dev` and `staging`. Using this Jenkins deploy job will enusre that the tests run against the hotfix.
+
+
+5) Follow Step 3 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md)
+
+
+Should the hotfix process further deviate from the general procedure outlined in terra-helmfile, this document should be updated to highlight those differences.

--- a/HOTFIX.md
+++ b/HOTFIX.md
@@ -1,0 +1,5 @@
+# Hotfix Process
+
+See the [HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md) documentation in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) for the general MC-Terra hotfix procedure, which applies to Workspace Manager
+
+Should the hotfix process deviate from the general procedure outlined in terra-helmfile, this document should be updated to highlight those differences.

--- a/HOTFIX.md
+++ b/HOTFIX.md
@@ -1,24 +1,22 @@
 # Hotfix Process
 
-1) Build the image that you would like to use for your hotfix:
+1) `gcloud auth login` as an account that has push access to gcr.io/terra-kernel-k8s, likely your @broadinstitute.org account
+
+2) Run `gcloud auth configure-docker`
+
+3) Build and push the image that you would like to use for your hotfix:
 
 ```sh
-./gradlew jibDockerBuild --image=gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>
+./gradlew jib --image=gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>
 ```
 
-2) Push the image that you've created to GCR:
-
-```sh
-docker push gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>
-```
-
-3) Follow Step 1 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md)
+4) Follow Step 1 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md)
 
 
-4) Follow Step 2 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md), except instead of running ArgoCD to sync the deployment, run the [gke-deploy Jenkins job](https://fc-jenkins.dsp-techops.broadinstitute.org/job/gke-deploy/) with `project` set to `workspacemanager`. Do this for `dev` and `staging`. Using this Jenkins deploy job will ensure that the tests run against the hotfix.
+5) Follow Step 2 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md), except instead of running ArgoCD to sync the deployment, run the [gke-deploy Jenkins job](https://fc-jenkins.dsp-techops.broadinstitute.org/job/gke-deploy/) with `project` set to `workspacemanager`. Do this for `dev` and `staging`. Using this Jenkins deploy job will ensure that the tests run against the hotfix.
 
 
-5) Follow Step 3 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md)
+6) Follow Step 3 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md)
 
 
 Should the hotfix process further deviate from the general procedure outlined in terra-helmfile, this document should be updated to highlight those differences.

--- a/README.md
+++ b/README.md
@@ -162,10 +162,6 @@ There are sample tests for the ping service to illustrate two styles of unit tes
 3. This updates the default [version mapping for the app in question](https://github.com/broadinstitute/terra-helmfile/blob/master/versions.yaml).
 4. [Our deployment of ArgoCD](https://ap-argocd.dsp-devops.broadinstitute.org/applications) monitors the above repo, and any environments in which the app is set to auto-sync will immediately pick up the new version of the image. If the app is not set to auto-sync in an environment, it can be manually synced via the ArgoCD UI or API.
 
-### Hotfix Process
-
-See the [HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md) documentation in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) for the MC-Terra hotfix procedure.
-
 ## Api Client
 Workspace Manager publishes an API client library based on the OpenAPI Spec v3. 
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ There are sample tests for the ping service to illustrate two styles of unit tes
 3. This updates the default [version mapping for the app in question](https://github.com/broadinstitute/terra-helmfile/blob/master/versions.yaml).
 4. [Our deployment of ArgoCD](https://ap-argocd.dsp-devops.broadinstitute.org/applications) monitors the above repo, and any environments in which the app is set to auto-sync will immediately pick up the new version of the image. If the app is not set to auto-sync in an environment, it can be manually synced via the ArgoCD UI or API.
 
+### Hotfix Process
+
+See the [HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md) documentation in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) for the MC-Terra hotfix procedure.
+
 ## Api Client
 Workspace Manager publishes an API client library based on the OpenAPI Spec v3. 
 


### PR DESCRIPTION
I think the original ticket suggests to copy the HOTFIX.md file into this repo but I would rather defer to the common documentation in the terra-helmfile repo since I have a feeling that it's more likely to be kept up to date. I don't think the WSM process is different than what's in terra-helmfile, anyway.

I'm open to discussing disagreements :) 