### PR TITLE
tweak username and author_name for Slack notifications [AS-694]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,5 +156,5 @@ jobs:
         channel: "#dsp-appservices-notifications"
 #        channel: "#dsde-qa"
         username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
-        author_name: "${{ steps.set-env-step.outputs.test-env }} ${{ process.env.AS_JOB }}"
+        author_name: "${{ steps.set-env-step.outputs.test-env }} ${{ github.workflow }}"
         fields: repo,job,workflow,commit,eventName,author,took

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,8 +144,7 @@ jobs:
         path: build/reports/tests
 
     - name: "Notify QA Slack"
-      if: ${{ always() }}
-#      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
+      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
       uses: broadinstitute/action-slack@v3.8.0
       # see https://github.com/broadinstitute/action-slack
       env:
@@ -153,8 +152,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsp-appservices-notifications"
-#        channel: "#dsde-qa"
+        channel: "#dsde-qa"
         username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
         author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} ${{ matrix.gradleTask }}"
         fields: repo,job,workflow,commit,eventName,author,took

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,5 +156,5 @@ jobs:
         channel: "#dsp-appservices-notifications"
 #        channel: "#dsde-qa"
         username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
-        author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} ${{ github.job }}"
+        author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} ${{ matrix.gradleTask }}"
         fields: repo,job,workflow,commit,eventName,author,took

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,8 @@ jobs:
         path: build/reports/tests
 
     - name: "Notify QA Slack"
-      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
+      if: ${{ always() }}
+#      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
       uses: broadinstitute/action-slack@v3.8.0
       # see https://github.com/broadinstitute/action-slack
       env:
@@ -152,6 +153,8 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsde-qa"
-        username: "Workspace Manager tests"
+        channel: "#dsp-appservices-notifications"
+#        channel: "#dsde-qa"
+        username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
+        author_name: "${{ steps.set-env-step.outputs.test-env }} ${{ process.env.AS_JOB }}"
         fields: repo,job,workflow,commit,eventName,author,took

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,5 +156,5 @@ jobs:
         channel: "#dsp-appservices-notifications"
 #        channel: "#dsde-qa"
         username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
-        author_name: "${{ steps.set-env-step.outputs.test-env }} ${{ github.workflow }}"
+        author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} ${{ github.job }}"
         fields: repo,job,workflow,commit,eventName,author,took


### PR DESCRIPTION
Follow-on PR to #264 to tweak the contents of the Slack notifications. The notifications are working correctly, but I thought they could be more informative. This PR:
* Changes the author from the totally unhelpful "8398a7@action-slack" to "Workspace Manager ${ENV} (unitTest|connectedTest|integrationTest)"
* Changes the username to include the environment - from "Workspace Manager tests" to "Workspace Manager ${ENV} tests"

After:
![Screen Shot 2021-03-23 at 9 23 51 AM](https://user-images.githubusercontent.com/6041577/112154582-caf27f80-8bba-11eb-94dc-12c2abda306a.png)

Before:
![111922247-2adc0f80-8a6f-11eb-87ce-423b216f5aaa](https://user-images.githubusercontent.com/6041577/112154489-b615ec00-8bba-11eb-94ea-90c8bd7ccb58.png)


