### PR TITLE
[PF-597] Update client library publishing documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -125,7 +125,7 @@ http://localhost:8080/swagger-ui.html
 
 New versions of the WSM client library need to be published manually. You should
  publish a new version of the client library alongside any changes to WSM's 
- visible interface (generally, any changes to [our Swagger API specification](src/main/resources/api/service_openapi.yaml)).
+ visible interface (generally, any changes to [our API specification](src/main/resources/api/service_openapi.yaml)).
  Until you follow these steps, API changes may cause failures in automated client tests that run against your PR.
 
 To publish a new version of the client library:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -120,6 +120,28 @@ To run the application:
 Then navigate to the Swagger:  
 http://localhost:8080/swagger-ui.html
 
+
+## Publishing
+
+New versions of the WSM client library need to be published manually. You should
+ publish a new version of the client library alongside any changes to WSM's 
+ visible interface (generally, any changes to [our Swagger API specification](src/main/resources/api/service_openapi.yaml)).
+ Until you follow these steps, API changes may cause failures in automated client tests that run against your PR.
+
+To publish a new version of the client library:
+1. Make your changes locally. Verify that client tests run using a local client 
+JAR and local server pass ([see client test README](workspace-manager-clienttests/README.md#local-testing)). If your changes are part of a PR, have the PR reviewed.
+1. Bump the version number in the `allprojects.version` field of [build.gradle](build.gradle).
+Compatible changes should be a change to the minor or patch version. 
+Backwards-incompatible changes should change the major version. Try to avoid 
+backwards incompatible changes.
+1. Publish the new client library to Artifactory ([instructions here](workspace-manager-client/README.md)). This requires
+Vault access.
+1. Update the client tests to use the newly-published version by modifying the 
+`dependencies.ext.workspaceManagerClient` field of the [Test Runner buildfile](workspace-manager-clienttests/build.gradle).
+1. After the previous step, automated client tests on your PR should pass. Once 
+they do, and you have approvals, merge your changes.
+
 ### Other
 
 You may also want to periodically rebuild and refresh any auto-generated code:

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Workspace Manager publishes an API client library based on the OpenAPI Spec v3.
 ```gradle
 implementation(group: 'bio.terra', name: 'terra-workspace-manager-client', version: 'x.x.x')
 ```
-See [build.gradle](build.gradle) for current version information, which should be available via Artifactory.
+See [build.gradle](build.gradle) for current version information.
 
 Note that the publishing of this artifact is currently manual. Whenever the OpenAPI definitions change,
 we should publish a new version of this library to artifactory. Backwards compatible changes should

--- a/README.md
+++ b/README.md
@@ -167,18 +167,13 @@ Workspace Manager publishes an API client library based on the OpenAPI Spec v3.
 
 ### Usage (Gradle)
 ```gradle
-implementation(group: 'bio.terra', name: 'terra-workspace-manager-client', version: '0.11.0-SNAPSHOT')
+implementation(group: 'bio.terra', name: 'terra-workspace-manager-client', version: 'x.x.x')
 ```
+See [build.gradle](build.gradle) for current version information, which should be available via Artifactory.
 
 Note that the publishing of this artifact is currently manual. Whenever the OpenAPI definitions change,
 we should publish a new version of this library to artifactory. Backwards compatible changes should
 have a minor version bump, and breaking changes should have a major version bump. We will try to avoid
 breaking changes at all costs.
 
-### Publishing
-
-To publish, you will need to export the `ARTIFACTORY_USERNAME` and `ARTIFACTORY_PASSWORD` environment variables for the Broad artifactory. To build and publish:
-
-```sh
-./gradlew workspace-manager-client:artifactoryPublish
-```
+See the Publishing section of [DEVELOPMENT.md](DEVELOPMENT.md#publishing) for more information on publishing new releases.

--- a/workspace-manager-clienttests/README.md
+++ b/workspace-manager-clienttests/README.md
@@ -174,3 +174,7 @@ you can run client tests against that server, e.g.
 export TEST_RUNNER_SERVER_SPECIFICATION_FILE="workspace-local.json" 
 ./gradlew runTest --args="configs/integration/BasicAuthenticated.json /tmp/TR"
 ```
+
+All current WSM configurations are stored in the [`servers` dir](src/main/resources/servers).
+See [TestRunner repo README](https://github.com/DataBiosphere/terra-test-runner/blob/main/README.md#Override-the-server-from-the-command-line)
+ for more information about this and other available env vars.

--- a/workspace-manager-clienttests/README.md
+++ b/workspace-manager-clienttests/README.md
@@ -138,6 +138,7 @@ For example,
 
 NB: A Google Bucket name has a limit of up to 63 characters.
 
+## Local testing
 #### Use a local Workspace Manager client JAR file
 The version of the Workspace Manager client JAR file is specified in the build.gradle file in this sub-project. This JAR file is
 fetched from the Broad Institute Maven repository. You can override this to use a local version of the Workspace Manager client
@@ -160,4 +161,16 @@ Please refer to `test-runner-integration.yml` for an example use case.
 cd ~/terra-workspace-manager/workspace-manager-client
 ../gradlew clean assemble
 ls -la ./build/libs/*jar
+```
+
+#### Use a local Workspace Manager server
+See [DEVELOPMENT.md](../DEVELOPMENT.md#running-workspace-manager) to start a
+local Workspace Manager server.
+
+Workspace Manager has a [pre-defined configuration file](src/main/resources/servers/workspace-local.json) 
+for running against a local server. Once you have a local server running separately,
+you can run client tests against that server, e.g.
+```
+export TEST_RUNNER_SERVER_SPECIFICATION_FILE="workspace-local.json" 
+./gradlew runTest --args="configs/integration/BasicAuthenticated.json /tmp/TR"
 ```


### PR DESCRIPTION
Updating documentation on how to publish new versions of the WSM client library