### PR TITLE
PF-618 Only log errors and fatal from the cloud profiler agent.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,7 +284,8 @@ jib {
 						"-cprof_service=bio.terra.workspace" +
 						",-cprof_service_version=" + version +
 						",-cprof_enable_heap_sampling=true" +
-						",-logtostderr"
+						",-logtostderr" +
+						",-minloglevel=2"
 		]
 	}
 }


### PR DESCRIPTION
Change the logging level for the profiler agent to be less spammy. Ref https://cloud.google.com/profiler/docs/profiling-java#agent_logging