### PR TITLE
PF-621 Make ErrorReportException status and causes always have non-null values.

### DIFF
--- a/src/main/java/bio/terra/workspace/common/exception/ErrorReportException.java
+++ b/src/main/java/bio/terra/workspace/common/exception/ErrorReportException.java
@@ -2,14 +2,15 @@ package bio.terra.workspace.common.exception;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.springframework.http.HttpStatus;
 
 /**
- * This base class has data that corresponds to the ApiErrorReport model generated from the
- * OpenAPI yaml. The global exception handler auto-magically converts exceptions of this base class
- * into the appropriate ApiErrorReport REST response.
+ * This base class has data that corresponds to the ApiErrorReport model generated from the OpenAPI
+ * yaml. The global exception handler auto-magically converts exceptions of this base class into the
+ * appropriate ApiErrorReport REST response.
  */
 public abstract class ErrorReportException extends RuntimeException {
   private static final HttpStatus DEFAULT_STATUS = HttpStatus.INTERNAL_SERVER_ERROR;
@@ -38,8 +39,8 @@ public abstract class ErrorReportException extends RuntimeException {
   public ErrorReportException(
       String message, @Nullable List<String> causes, @Nullable HttpStatus statusCode) {
     super(message);
-    this.causes = causes != null ? causes : Collections.emptyList();
-    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
+    this.causes = Optional.ofNullable(causes).orElse(Collections.emptyList());
+    this.statusCode = Optional.ofNullable(statusCode).orElse(DEFAULT_STATUS);
   }
 
   public ErrorReportException(
@@ -48,8 +49,8 @@ public abstract class ErrorReportException extends RuntimeException {
       @Nullable List<String> causes,
       @Nullable HttpStatus statusCode) {
     super(message, cause);
-    this.causes = causes != null ? causes : Collections.emptyList();
-    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
+    this.causes = Optional.ofNullable(causes).orElse(Collections.emptyList());
+    this.statusCode = Optional.ofNullable(statusCode).orElse(DEFAULT_STATUS);
   }
 
   public List<String> getCauses() {

--- a/src/main/java/bio/terra/workspace/common/exception/ErrorReportException.java
+++ b/src/main/java/bio/terra/workspace/common/exception/ErrorReportException.java
@@ -1,46 +1,55 @@
 package bio.terra.workspace.common.exception;
 
-// This base class has data that corresponds to the ApiErrorReport model generated from
-// the OpenAPI yaml. The global exception handler auto-magically converts exceptions
-// of this base class into the appropriate ApiErrorReport REST response.
-
+import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.springframework.http.HttpStatus;
 
+/**
+ * This base class has data that corresponds to the ApiErrorReport model generated from the
+ * OpenAPI yaml. The global exception handler auto-magically converts exceptions of this base class
+ * into the appropriate ApiErrorReport REST response.
+ */
 public abstract class ErrorReportException extends RuntimeException {
+  private static final HttpStatus DEFAULT_STATUS = HttpStatus.INTERNAL_SERVER_ERROR;
+
   private final List<String> causes;
   private final HttpStatus statusCode;
 
   public ErrorReportException(String message) {
     super(message);
-    this.causes = null;
-    this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+    this.causes = Collections.emptyList();
+    this.statusCode = DEFAULT_STATUS;
   }
 
   public ErrorReportException(String message, Throwable cause) {
     super(message, cause);
-    this.causes = null;
-    this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+    this.causes = Collections.emptyList();
+    this.statusCode = DEFAULT_STATUS;
   }
 
   public ErrorReportException(Throwable cause) {
     super(cause);
-    this.causes = null;
-    this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
-  }
-
-  public ErrorReportException(String message, List<String> causes, HttpStatus statusCode) {
-    super(message);
-    this.causes = causes;
-    this.statusCode = statusCode;
+    this.causes = Collections.emptyList();
+    this.statusCode = DEFAULT_STATUS;
   }
 
   public ErrorReportException(
-      String message, Throwable cause, List<String> causes, HttpStatus statusCode) {
+      String message, @Nullable List<String> causes, @Nullable HttpStatus statusCode) {
+    super(message);
+    this.causes = causes != null ? causes : Collections.emptyList();
+    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
+  }
+
+  public ErrorReportException(
+      String message,
+      Throwable cause,
+      @Nullable List<String> causes,
+      @Nullable HttpStatus statusCode) {
     super(message, cause);
-    this.causes = causes;
-    this.statusCode = statusCode;
+    this.causes = causes != null ? causes : Collections.emptyList();
+    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
   }
 
   public List<String> getCauses() {


### PR DESCRIPTION
While many of the ErrorReportException's constructors have default HttpStatus values, the constructors that explicitly take a  HttpStatus allow the value to be null. Change these constructors so that HttpStatus is never null.

When there's a non http-status Sam ApiException, Stairway serialization of the wrapping ErrorReportException fails because it expects a non-null statusCode. 
https://github.com/DataBiosphere/terra-workspace-manager/blob/894e24101da748254297a95fbb30cd29a24c3053/src/main/java/bio/terra/workspace/service/job/StairwayExceptionSerializer.java#L45

Do a similar change with causes so that the default value for the collection is an empty list instead of null so that clients can skip a null check.

I will also make the corresponding change in terra-common-libs.