### PR TITLE
[PF-641] Serialize UUID and enums as strings in flightmap

### DIFF
--- a/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -17,6 +17,7 @@ import bio.terra.workspace.service.stage.StageService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,8 +105,8 @@ public class ControlledResourceService {
                 DeleteControlledResourceGcsBucketFlight.class,
                 null,
                 userRequest)
-            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId)
-            .addParameter(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_ID, resourceId)
+            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString())
+            .addParameter(ResourceKeys.RESOURCE_ID, resourceId.toString())
             .addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath);
 
     return jobBuilder.submit();

--- a/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -72,7 +72,8 @@ public class CreateGcsBucketStep implements Step {
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
     FlightMap inputMap = flightContext.getInputParameters();
-    UUID workspaceId = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    UUID workspaceId =
+        UUID.fromString(inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     String projectId = workspaceService.getRequiredGcpProject(workspaceId);
     final StorageCow storageCow = crlService.createStorageCow(projectId);
     storageCow.delete(resource.getBucketName());

--- a/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceGcsBucketFlight.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceGcsBucketFlight.java
@@ -42,9 +42,11 @@ public class DeleteControlledResourceGcsBucketFlight extends Flight {
     super(inputParameters, beanBag);
     final FlightBeanBag flightBeanBag = FlightBeanBag.getFromObject(beanBag);
 
-    final UUID workspaceId = inputParameters.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    final UUID workspaceId =
+        UUID.fromString(inputParameters.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     final UUID resourceId =
-        inputParameters.get(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_ID, UUID.class);
+        UUID.fromString(
+            inputParameters.get(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_ID, String.class));
     final AuthenticatedUserRequest userRequest =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 

--- a/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
+++ b/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
@@ -61,7 +61,8 @@ public class ReferencedResourceService {
                 resource,
                 userReq)
             .addParameter(
-                WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE, resource.getResourceType());
+                WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE,
+                resource.getResourceType().name());
 
     UUID resourceIdResult = createJob.submitAndWait(UUID.class);
     if (!resourceIdResult.equals(resource.getResourceId())) {

--- a/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/CreateReferenceMetadataStep.java
+++ b/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/CreateReferenceMetadataStep.java
@@ -44,7 +44,8 @@ public class CreateReferenceMetadataStep implements Step {
   private ReferencedResource getReferenceResource(FlightContext flightContext) {
     FlightMap inputMap = flightContext.getInputParameters();
     WsmResourceType resourceType =
-        inputMap.get(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE, WsmResourceType.class);
+        WsmResourceType.valueOf(
+            inputMap.get(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE, String.class));
 
     // Use the resource type to deserialize the right class
     return inputMap.get(JobMapKeys.REQUEST.getKeyName(), resourceType.getReferenceClass());

--- a/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/CreateReferenceResourceFlight.java
+++ b/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/CreateReferenceResourceFlight.java
@@ -16,8 +16,8 @@ public class CreateReferenceResourceFlight extends Flight {
 
     // Perform access verification separately by resource type
     WsmResourceType resourceType =
-        inputParameters.get(
-            WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE, WsmResourceType.class);
+        WsmResourceType.valueOf(
+            inputParameters.get(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE, String.class));
     switch (resourceType) {
       case BIG_QUERY_DATASET:
         addStep(new CreateReferenceVerifyAccessBigQueryDatasetStep(appContext.getCrlService()));

--- a/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -74,14 +74,15 @@ public class WorkspaceService {
         jobService
             .newJob(
                 description, workspaceRequest.jobId(), WorkspaceCreateFlight.class, null, userReq)
-            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceRequest.workspaceId());
+            .addParameter(
+                WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceRequest.workspaceId().toString());
     if (workspaceRequest.spendProfileId().isPresent()) {
       createJob.addParameter(
           WorkspaceFlightMapKeys.SPEND_PROFILE_ID, workspaceRequest.spendProfileId().get().id());
     }
 
     createJob.addParameter(
-        WorkspaceFlightMapKeys.WORKSPACE_STAGE, workspaceRequest.workspaceStage());
+        WorkspaceFlightMapKeys.WORKSPACE_STAGE, workspaceRequest.workspaceStage().name());
 
     createJob.addParameter(
         WorkspaceFlightMapKeys.DISPLAY_NAME_ID, workspaceRequest.displayName().orElse(""));
@@ -168,8 +169,9 @@ public class WorkspaceService {
                 WorkspaceDeleteFlight.class,
                 null, // Delete does not have a useful request body
                 userReq)
-            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, id)
-            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_STAGE, workspace.getWorkspaceStage());
+            .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, id.toString())
+            .addParameter(
+                WorkspaceFlightMapKeys.WORKSPACE_STAGE, workspace.getWorkspaceStage().name());
     deleteJob.submitAndWait(null);
   }
 
@@ -213,7 +215,7 @@ public class WorkspaceService {
             CreateGcpContextFlight.class,
             /* request= */ null,
             userReq)
-        .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId)
+        .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString())
         .addParameter(
             WorkspaceFlightMapKeys.BILLING_ACCOUNT_ID, spendProfile.billingAccountId().get())
         .addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath)
@@ -236,7 +238,7 @@ public class WorkspaceService {
             DeleteGcpContextFlight.class,
             /* request= */ null,
             userReq)
-        .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId)
+        .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString())
         .submitAndWait(null);
   }
 

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CheckSamWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CheckSamWorkspaceAuthzStep.java
@@ -29,7 +29,10 @@ public class CheckSamWorkspaceAuthzStep implements Step {
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
     UUID workspaceID =
-        flightContext.getInputParameters().get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+        UUID.fromString(
+            flightContext
+                .getInputParameters()
+                .get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     if (!canReadExistingWorkspace(workspaceID)) {
       throw new WorkspaceNotFoundException(
           String.format(

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
@@ -33,7 +33,8 @@ public class CreateWorkspaceAuthzStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
-    UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    UUID workspaceID =
+        UUID.fromString(inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     // Even though WSM should own this resource, Stairway steps can run multiple times, so it's
     // possible this step already created the resource. If WSM can either read the existing Sam
     // resource or create a new one, this is considered successful.
@@ -46,7 +47,8 @@ public class CreateWorkspaceAuthzStep implements Step {
   @Override
   public StepResult undoStep(FlightContext flightContext) {
     FlightMap inputMap = flightContext.getInputParameters();
-    UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    UUID workspaceID =
+        UUID.fromString(inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     try {
       samService.deleteWorkspace(userReq.getRequiredToken(), workspaceID);
     } catch (SamApiException ex) {

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -30,7 +30,8 @@ public class CreateWorkspaceStep implements Step {
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
 
-    UUID workspaceId = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    UUID workspaceId =
+        UUID.fromString(inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
 
     String spendProfileIdString =
         inputMap.get(WorkspaceFlightMapKeys.SPEND_PROFILE_ID, String.class);
@@ -41,7 +42,7 @@ public class CreateWorkspaceStep implements Step {
     String description = inputMap.get(WorkspaceFlightMapKeys.DESCRIPTION_ID, String.class);
 
     WorkspaceStage workspaceStage =
-        inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, WorkspaceStage.class);
+        WorkspaceStage.valueOf(inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, String.class));
     Workspace workspaceToCreate =
         Workspace.builder()
             .workspaceId(workspaceId)
@@ -62,7 +63,8 @@ public class CreateWorkspaceStep implements Step {
   @Override
   public StepResult undoStep(FlightContext flightContext) {
     FlightMap inputMap = flightContext.getInputParameters();
-    UUID workspaceId = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    UUID workspaceId =
+        UUID.fromString(inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     // Ignore return value, as we don't care whether a workspace was deleted or just not found.
     workspaceDao.deleteWorkspace(workspaceId);
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextStep.java
@@ -21,7 +21,10 @@ public class DeleteGcpContextStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) {
     UUID workspaceId =
-        flightContext.getInputParameters().get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+        UUID.fromString(
+            flightContext
+                .getInputParameters()
+                .get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     workspaceDao.deleteGcpCloudContext(workspaceId);
     return StepResult.getStepResultSuccess();
   }
@@ -31,7 +34,10 @@ public class DeleteGcpContextStep implements Step {
     // Right now, we don't attempt to undo DAO deletion. This is expected to happen infrequently and
     // not before steps that are likely to fail.
     UUID workspaceId =
-        flightContext.getInputParameters().get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+        UUID.fromString(
+            flightContext
+                .getInputParameters()
+                .get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     logger.error("Unable to undo DAO deletion of google context [{}]", workspaceId);
     return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL);
   }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteProjectStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteProjectStep.java
@@ -64,7 +64,10 @@ public class DeleteProjectStep implements Step {
 
   private Optional<GcpCloudContext> getContext(FlightContext flightContext) {
     UUID workspaceId =
-        flightContext.getInputParameters().get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+        UUID.fromString(
+            flightContext
+                .getInputParameters()
+                .get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     return workspaceDao.getGcpCloudContext(workspaceId);
   }
 }

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
@@ -25,7 +25,8 @@ public class DeleteWorkspaceAuthzStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
-    UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    UUID workspaceID =
+        UUID.fromString(inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     try {
       samService.deleteWorkspace(userReq.getRequiredToken(), workspaceID);
     } catch (SamApiException e) {

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
@@ -22,7 +22,8 @@ public class DeleteWorkspaceStateStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws RetryException {
     FlightMap inputMap = flightContext.getInputParameters();
-    UUID workspaceID = inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+    UUID workspaceID =
+        UUID.fromString(inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     // WorkspaceDao.deleteWorkspace returns true if a delete succeeds or false if the workspace is
     // not found, but the user-facing delete operation should return a 204 even if the workspace is
     // not found.

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/StoreGcpContextStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/StoreGcpContextStep.java
@@ -23,7 +23,10 @@ public class StoreGcpContextStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) {
     UUID workspaceId =
-        flightContext.getInputParameters().get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+        UUID.fromString(
+            flightContext
+                .getInputParameters()
+                .get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     String projectId = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
 
     // Create the cloud context; throws if the context already exists. We let
@@ -35,7 +38,10 @@ public class StoreGcpContextStep implements Step {
   @Override
   public StepResult undoStep(FlightContext flightContext) {
     UUID workspaceId =
-        flightContext.getInputParameters().get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+        UUID.fromString(
+            flightContext
+                .getInputParameters()
+                .get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     String projectId = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
 
     // Delete the cloud context, but only if it is the one with our project id

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/SyncSamGroupsStep.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/SyncSamGroupsStep.java
@@ -29,7 +29,10 @@ public class SyncSamGroupsStep implements Step {
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
     UUID workspaceId =
-        flightContext.getInputParameters().get(WorkspaceFlightMapKeys.WORKSPACE_ID, UUID.class);
+        UUID.fromString(
+            flightContext
+                .getInputParameters()
+                .get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
     AuthenticatedUserRequest userReq =
         flightContext
             .getInputParameters()

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceCreateFlight.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceCreateFlight.java
@@ -19,7 +19,8 @@ public class WorkspaceCreateFlight extends Flight {
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
     WorkspaceStage workspaceStage =
-        inputParameters.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, WorkspaceStage.class);
+        WorkspaceStage.valueOf(
+            inputParameters.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, String.class));
 
     // Workspace authz is handled differently depending on whether WSM owns the underlying Sam
     // resource or not, as indicated by the workspace stage enum.

--- a/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
+++ b/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
@@ -23,7 +23,8 @@ public class WorkspaceDeleteFlight extends Flight {
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
     WorkspaceStage workspaceStage =
-        inputParameters.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, WorkspaceStage.class);
+        WorkspaceStage.valueOf(
+            inputParameters.get(WorkspaceFlightMapKeys.WORKSPACE_STAGE, String.class));
     // TODO: we still need the following steps once their features are supported:
     // 1. delete controlled resources using the Cloud Resource Manager library
     // 2. Notify all registered applications of deletion, once applications are supported

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -132,7 +132,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
   private static FlightMap createInputParameters(
       UUID workspaceId, String billingAccountId, AuthenticatedUserRequest userReq) {
     FlightMap inputs = new FlightMap();
-    inputs.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
+    inputs.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString());
     inputs.put(WorkspaceFlightMapKeys.BILLING_ACCOUNT_ID, billingAccountId);
     inputs.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), userReq);
     return inputs;

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -49,7 +49,7 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
     UUID workspaceId = createWorkspace();
     FlightMap createParameters = new FlightMap();
     AuthenticatedUserRequest userReq = userAccessUtils.defaultUserAuthRequest();
-    createParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
+    createParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString());
     createParameters.put(
         WorkspaceFlightMapKeys.BILLING_ACCOUNT_ID, spendUtils.defaultBillingAccountId());
     createParameters.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), userReq);
@@ -73,7 +73,7 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
 
     // Delete the google context.
     FlightMap deleteParameters = new FlightMap();
-    deleteParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
+    deleteParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString());
     flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
             jobService.getStairway(),
@@ -97,7 +97,7 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
     assertTrue(workspace.getGcpCloudContext().isEmpty());
 
     FlightMap inputParameters = new FlightMap();
-    inputParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId);
+    inputParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString());
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
             jobService.getStairway(),


### PR DESCRIPTION
Currently, WSM serializes UUIDs and enums directly to Stairway flightmaps. This works fine normally, but causes issues when flights are dropped and recovered. As a short-term workaround, I've moved all direct serialization of enums and final classes (currently just UUID) to Strings instead. In the longer term, there's more work to be done on Stairway ser/des.