### PR TITLE
PF-614: use date-time instead of date

### DIFF
--- a/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -25,9 +25,7 @@ import com.google.cloud.storage.BucketInfo.LifecycleRule.LifecycleAction;
 import com.google.cloud.storage.BucketInfo.LifecycleRule.LifecycleCondition;
 import com.google.cloud.storage.StorageClass;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -141,10 +139,8 @@ public class CreateGcsBucketStep implements Step {
       return resultBuilder.build();
     }
 
-    private static DateTime toDateTime(@Nullable LocalDate localDate) {
-      return Optional.ofNullable(localDate)
-          .map(LocalDate::atStartOfDay)
-          .map(ldt -> ldt.atOffset(ZoneOffset.UTC))
+    private static DateTime toDateTime(@Nullable OffsetDateTime offsetDateTime) {
+      return Optional.ofNullable(offsetDateTime)
           .map(OffsetDateTime::toInstant)
           .map(Instant::toEpochMilli)
           .map(DateTime::new)

--- a/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -139,6 +139,7 @@ public class CreateGcsBucketStep implements Step {
       return resultBuilder.build();
     }
 
+    @Nullable
     private static DateTime toDateTime(@Nullable OffsetDateTime offsetDateTime) {
       return Optional.ofNullable(offsetDateTime)
           .map(OffsetDateTime::toInstant)

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -1548,13 +1548,13 @@ components:
         createdBefore:
           description: This condition is satisfied when an object is created before midnight of the specified date in UTC.
           type: string
-          format: date
+          format: date-time
         customTimeBefore:
           description: >-
             This condition is satisfied when the customTime metadata for the object is set to an
             earlier date than the date used in this lifecycle condition.
           type: string
-          format: date
+          format: date-time
         daysSinceCustomTime:
           description: >-
             Days since the date set in the customTime metadata for the object. This condition is
@@ -1584,7 +1584,7 @@ components:
             Relevant only for versioned objects. This condition is satisfied for objects that became
             noncurrent on a date prior to the one specified in this condition.
           type: string
-          format: date
+          format: date-time
         numNewerVersions:
           description: >-
             Relevant only for versioned objects. If the value is N, this condition is satisfied

--- a/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -12,10 +12,7 @@ import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInsta
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import java.time.Instant;
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -50,9 +47,7 @@ public class ControlledResourceFixtures {
                   .type(ApiGcsBucketLifecycleRuleActionType.SET_STORAGE_CLASS))
           .condition(
               new ApiGcsBucketLifecycleRuleCondition()
-                  .createdBefore(
-                      OffsetDateTime.ofInstant(
-                          Instant.parse("2007-01-03T00:00:00.00Z"), ZoneOffset.UTC))
+                  .createdBefore(OffsetDateTime.parse("2007-01-03T00:00:00.00Z"))
                   .addMatchesStorageClassItem(ApiGcsBucketDefaultStorageClass.STANDARD));
   // list must not be immutable if deserialization is to work
   static final List<ApiGcsBucketLifecycleRule> LIFECYCLE_RULES =

--- a/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -12,7 +12,10 @@ import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInsta
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -47,7 +50,9 @@ public class ControlledResourceFixtures {
                   .type(ApiGcsBucketLifecycleRuleActionType.SET_STORAGE_CLASS))
           .condition(
               new ApiGcsBucketLifecycleRuleCondition()
-                  .createdBefore(LocalDate.of(2017, 2, 18))
+                  .createdBefore(
+                      OffsetDateTime.ofInstant(
+                          Instant.parse("2007-01-03T00:00:00.00Z"), ZoneOffset.UTC))
                   .addMatchesStorageClassItem(ApiGcsBucketDefaultStorageClass.STANDARD));
   // list must not be immutable if deserialization is to work
   static final List<ApiGcsBucketLifecycleRule> LIFECYCLE_RULES =


### PR DESCRIPTION
I erroneously used a type that didn't support exact time or time zones due to misreading an example or some other documentation.