### PR TITLE
[no ticket] Bump WSM tests to use newer RBS pool

### DIFF
--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,7 @@
 workspace:
   buffer:
     enabled: true
-    pool-id: workspace_manager_v3
+    pool-id: workspace_manager_v6
     instance-url: https://buffer.tools.integ.envs.broadinstitute.org
     client-credential-file-path: rendered/buffer-client-sa-account.json
 


### PR DESCRIPTION
(No ticket, this only affects test configuration)

This points WSM tests (currently just connected tests) to a newer pool from RBS. The old v3 pool was deleted recently ([see PR](https://github.com/DataBiosphere/terra-resource-buffer/pull/141)), and all sources should use the new v6 pool instead.