### PR TITLE
PF-469 Give controlled bucket creation its own method on ControlledResourceService.

### DIFF
--- a/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -96,9 +96,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     }
 
     final ControlledGcsBucketResource createdBucket =
-        controlledResourceService
-            .syncCreateControlledResource(resource, body.getGcsBucket(), privateRoles, userRequest)
-            .castToGcsBucketResource();
+        controlledResourceService.syncCreateBucket(
+            resource, body.getGcsBucket(), privateRoles, userRequest);
     var response =
         new ApiCreatedControlledGcpGcsBucket()
             .resourceId(createdBucket.getResourceId())

--- a/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -102,14 +102,7 @@ public class ControlledResourceService {
         commonCreationJobBuilder(
                 resource, privateResourceIamRoles, UUID.randomUUID().toString(), null, userRequest)
             .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
-    String jobId = jobBuilder.submit();
-    jobService.waitForJob(jobId);
-    JobResultOrException<ControlledGcsBucketResource> jobResult =
-        jobService.retrieveJobResult(jobId, ControlledGcsBucketResource.class, userRequest);
-    if (jobResult.getException() != null) {
-      throw jobResult.getException();
-    }
-    return jobResult.getResult();
+    return jobBuilder.submitAndWait(ControlledGcsBucketResource.class);
   }
 
   /** Create a JobBuilder for creating controlled resources with the common parameters populated. */

--- a/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -10,7 +10,6 @@ import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceA
 import bio.terra.workspace.service.job.JobBuilder;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.job.JobService.JobResultOrException;
 import bio.terra.workspace.service.resource.WsmResource;
 import bio.terra.workspace.service.resource.controlled.exception.InvalidControlledResourceException;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
@@ -100,7 +99,11 @@ public class ControlledResourceService {
       AuthenticatedUserRequest userRequest) {
     JobBuilder jobBuilder =
         commonCreationJobBuilder(
-                resource, privateResourceIamRoles, UUID.randomUUID().toString(), null, userRequest)
+                resource,
+                privateResourceIamRoles,
+                new ApiJobControl().id(UUID.randomUUID().toString()),
+                null,
+                userRequest)
             .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
     return jobBuilder.submitAndWait(ControlledGcsBucketResource.class);
   }
@@ -109,7 +112,7 @@ public class ControlledResourceService {
   private JobBuilder commonCreationJobBuilder(
       ControlledResource resource,
       List<ControlledResourceIamRole> privateResourceIamRoles,
-      String jobId,
+      ApiJobControl jobControl,
       String resultPath,
       AuthenticatedUserRequest userRequest) {
     stageService.assertMcWorkspace(resource.getWorkspaceId(), "createControlledResource");
@@ -125,7 +128,11 @@ public class ControlledResourceService {
     final JobBuilder jobBuilder =
         jobService
             .newJob(
-                jobDescription, jobId, CreateControlledResourceFlight.class, resource, userRequest)
+                jobDescription,
+                jobControl.getId(),
+                CreateControlledResourceFlight.class,
+                resource,
+                userRequest)
             .addParameter(
                 ControlledResourceKeys.PRIVATE_RESOURCE_IAM_ROLES, privateResourceIamRoles)
             .addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath);

--- a/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -92,34 +92,31 @@ public class ControlledResourceService {
     return controlledResource;
   }
 
-  public ControlledResource syncCreateControlledResource(
-      ControlledResource resource,
+  /** Starts a create controlled bucket resource, blocking until its job is finished. */
+  public ControlledGcsBucketResource syncCreateBucket(
+      ControlledGcsBucketResource resource,
       ApiGcpGcsBucketCreationParameters creationParameters,
       List<ControlledResourceIamRole> privateResourceIamRoles,
       AuthenticatedUserRequest userRequest) {
-    ApiJobControl syncJobControl = new ApiJobControl().id(UUID.randomUUID().toString());
-    String jobId =
-        createControlledResource(
-            resource,
-            creationParameters,
-            privateResourceIamRoles,
-            syncJobControl,
-            null,
-            userRequest);
+    JobBuilder jobBuilder =
+        commonCreationJobBuilder(
+                resource, privateResourceIamRoles, UUID.randomUUID().toString(), null, userRequest)
+            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
+    String jobId = jobBuilder.submit();
     jobService.waitForJob(jobId);
-    JobResultOrException<ControlledResource> jobResult =
-        jobService.retrieveJobResult(jobId, ControlledResource.class, userRequest);
+    JobResultOrException<ControlledGcsBucketResource> jobResult =
+        jobService.retrieveJobResult(jobId, ControlledGcsBucketResource.class, userRequest);
     if (jobResult.getException() != null) {
       throw jobResult.getException();
     }
     return jobResult.getResult();
   }
 
-  public String createControlledResource(
+  /** Create a JobBuilder for creating controlled resources with the common parameters populated. */
+  private JobBuilder commonCreationJobBuilder(
       ControlledResource resource,
-      ApiGcpGcsBucketCreationParameters creationParameters,
       List<ControlledResourceIamRole> privateResourceIamRoles,
-      ApiJobControl jobControl,
+      String jobId,
       String resultPath,
       AuthenticatedUserRequest userRequest) {
     stageService.assertMcWorkspace(resource.getWorkspaceId(), "createControlledResource");
@@ -135,16 +132,11 @@ public class ControlledResourceService {
     final JobBuilder jobBuilder =
         jobService
             .newJob(
-                jobDescription,
-                jobControl.getId(),
-                CreateControlledResourceFlight.class,
-                resource,
-                userRequest)
-            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters)
+                jobDescription, jobId, CreateControlledResourceFlight.class, resource, userRequest)
             .addParameter(
                 ControlledResourceKeys.PRIVATE_RESOURCE_IAM_ROLES, privateResourceIamRoles)
             .addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath);
-    return jobBuilder.submit();
+    return jobBuilder;
   }
 
   public ControlledResource getControlledResource(


### PR DESCRIPTION
Creating controlled buckets requires its own set of parameters (`ApiGcpGcsBucketCreationParameters`). Other controlled resource types will have their own creation parameters. Rather than trying to make a single "create controlled resource" function on ControlledResourceService, make creating buckets its own method, paving the way for adding other resource overloads.

This matches the bucket specific method for deletion.

I'd like to make this tiny change to avoid further merge conflicts on AI notebook instances & bigQuery data set controlled resources.