### PR TITLE
PF-669 Minimal fix for status endpoint

### DIFF
--- a/src/main/java/bio/terra/workspace/app/Main.java
+++ b/src/main/java/bio/terra/workspace/app/Main.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(
     exclude = {
@@ -27,7 +26,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
       // Scan all service-specific packages beneath the current package
       "bio.terra.workspace"
     })
-@EnableScheduling
 public class Main {
   public static void main(String[] args) {
     new SpringApplicationBuilder(Main.class).initializers(new LoggingInitializer()).run(args);

--- a/src/main/java/bio/terra/workspace/common/utils/BaseStatusService.java
+++ b/src/main/java/bio/terra/workspace/common/utils/BaseStatusService.java
@@ -42,7 +42,7 @@ public class BaseStatusService {
 
   @PostConstruct
   public void startStatusChecking() {
-    scheduler.scheduleAtFixedRate(this::checkSubsystems, 1, 1, TimeUnit.MINUTES);
+    scheduler.scheduleAtFixedRate(this::checkSubsystems, 5, 60, TimeUnit.SECONDS);
   }
 
   protected void registerSubsystem(String name, StatusSubsystem subsystem) {

--- a/src/main/java/bio/terra/workspace/common/utils/BaseStatusService.java
+++ b/src/main/java/bio/terra/workspace/common/utils/BaseStatusService.java
@@ -4,10 +4,13 @@ import bio.terra.workspace.generated.model.ApiSystemStatus;
 import bio.terra.workspace.generated.model.ApiSystemStatusSystems;
 import java.util.Date;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
 
 /*
  BaseStatusService is a Spring replacement for workbench-libs' HealthMonitor utilities. It checks
@@ -25,6 +28,7 @@ public class BaseStatusService {
   private long lastUpdatedTimestampMillis;
   private final ApiSystemStatus currentStatus;
   private final long staleThresholdMillis;
+  private final ScheduledExecutorService scheduler;
 
   private static final Logger logger = LoggerFactory.getLogger(BaseStatusService.class);
 
@@ -33,13 +37,18 @@ public class BaseStatusService {
     currentStatus = new ApiSystemStatus().ok(false);
     lastUpdatedTimestampMillis = 0;
     this.staleThresholdMillis = staleThresholdMillis;
+    this.scheduler = Executors.newScheduledThreadPool(1);
+  }
+
+  @PostConstruct
+  public void startStatusChecking() {
+    scheduler.scheduleAtFixedRate(this::checkSubsystems, 1, 1, TimeUnit.MINUTES);
   }
 
   protected void registerSubsystem(String name, StatusSubsystem subsystem) {
     subsystems.put(name, subsystem);
   }
 
-  @Scheduled(cron = "${workspace.status-check.cron}")
   public void checkSubsystems() {
     // SystemStatus uses the thread-unsafe HashMap to hold ApiSystemStatusSystems objects by
     // default.

--- a/src/main/java/bio/terra/workspace/service/status/WorkspaceManagerStatusService.java
+++ b/src/main/java/bio/terra/workspace/service/status/WorkspaceManagerStatusService.java
@@ -52,6 +52,6 @@ public class WorkspaceManagerStatusService extends BaseStatusService {
   }
 
   private Boolean isConnectionValid(Connection connection) throws SQLException {
-    return connection.isValid(0);
+    return connection.isValid(30);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,7 +61,6 @@ workspace:
     username: ${env.db.stairway.user}
 
   status-check:
-    cron: "0 * * * * *" # Every minute.
     staleness-threshold-ms: 600000
 
   workspace-database:


### PR DESCRIPTION
This is a small PR to try to address the likely issues with the stuck /status endpoint. I made two changes:
1. Put a timeout on the database connection check
2. Allocate a single thread scheduled executor just for the status check.

In thinking about the problem, I realized I want to understand why we are bothering doing all of this. I wrote [Status Checking Reconsidered](https://docs.google.com/document/d/1UqEZ0UsnSvv0E_bWfMuSYAZiCQFVIgNUDmWIGHNXxG0/edit#heading=h.jl83h28nja15l)

When MC Terra Arch Council has figured out the system level view, we can come back to elaborating or eliminating this endpoint. In the meantime, I am hoping this will get us by!