### PR TITLE
[PF-418] Update version and publish new client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 def useMavenLocal = false
 allprojects {
 	group = "bio.terra"
-	version = "0.21.0-SNAPSHOT"
+	version = "0.22.0-SNAPSHOT"
 	ext {
 		artifactGroup = "${group}.workspace"
 		swaggerOutputDir = "${buildDir}/swagger-code"

--- a/workspace-manager-clienttests/build.gradle
+++ b/workspace-manager-clienttests/build.gradle
@@ -37,7 +37,7 @@ dependencies {
         googleOauth2 = "0.20.0"
         googleContainer = "v1-rev93-1.25.0"
 
-        workspacemanagerClient = "0.21.0-SNAPSHOT"
+        workspacemanagerClient = "0.22.0-SNAPSHOT"
         datarepoClient = "1.0.155-SNAPSHOT"
         testRunner = "0.0.3-SNAPSHOT"
     }


### PR DESCRIPTION
Small change to update WSM version and publish an updated client library with the "create controlled BQ dataset" endpoint available (#307). I had originally planned to publish once delete/update/get were also available, but making this available now is easier for CLI development.