### PR TITLE
[PF-638] Fix broken client tests for controlled resources

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,7 @@ server:
 
 spring:
   application.name: workspace
+  profiles.active: human-readable-logging
   web:
     resources:
       cache:
@@ -69,6 +70,21 @@ workspace:
     upgrade-on-start: true
     uri: ${env.db.host}/${env.db.ws.name}
     username: ${env.db.ws.user}
+
+  # Local servers will point to Tools RBS by default.
+  # These values may be overridden by Helm.
+  buffer:
+    enabled: true
+    client-credential-file-path: rendered/buffer-client-sa-account.json
+    instanceUrl: https://buffer.tools.integ.envs.broadinstitute.org
+    poolId: workspace_manager_v6
+
+  spend:
+    spend-profiles:
+    - # A default spend profile available in dev Sam.
+      id: wm-default-spend-profile
+      # The billing account workspace-dev has access to.
+      billing-account-id: 01A82E-CA8A14-367457
 
 terra.common:
   kubernetes:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,6 @@ server:
 
 spring:
   application.name: workspace
-  profiles.active: human-readable-logging
   web:
     resources:
       cache:
@@ -70,21 +69,6 @@ workspace:
     upgrade-on-start: true
     uri: ${env.db.host}/${env.db.ws.name}
     username: ${env.db.ws.user}
-
-  # Local servers will point to Tools RBS by default.
-  # These values may be overridden by Helm.
-  buffer:
-    enabled: true
-    client-credential-file-path: rendered/buffer-client-sa-account.json
-    instanceUrl: https://buffer.tools.integ.envs.broadinstitute.org
-    poolId: workspace_manager_v6
-
-  spend:
-    spend-profiles:
-    - # A default spend profile available in dev Sam.
-      id: wm-default-spend-profile
-      # The billing account workspace-dev has access to.
-      billing-account-id: 01A82E-CA8A14-367457
 
 terra.common:
   kubernetes:

--- a/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import bio.terra.common.sam.exception.SamBadRequestException;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/CreateGetDeleteControlledGcsBucket.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/CreateGetDeleteControlledGcsBucket.java
@@ -36,6 +36,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/CreateGetDeleteControlledGcsBucket.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/CreateGetDeleteControlledGcsBucket.java
@@ -165,7 +165,7 @@ public class CreateGetDeleteControlledGcsBucket extends WorkspaceAllocateTestScr
 
     // TODO(PF-643): this should happen inside WSM.
     logger.info("Waiting 15s for permissions to propagate");
-    Thread.sleep(15000);
+    TimeUnit.SECONDS.sleep(15);
 
     // Second user can now read the blob
     Blob readerRetrievedFile = readerStorageClient.get(blobId);

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -83,26 +83,10 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
 
     String projectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
 
-    ControlledGcpResourceApi resourceApi =
+    ControlledGcpResourceApi workspaceOwnerResourceApi =
         ClientTestUtils.getControlledGcpResourceClient(testUser, server);
-
-    // Create a private bucket
-    CreatedControlledGcpGcsBucket bucket = createPrivateBucket(resourceApi);
-    UUID resourceId = bucket.getResourceId();
-
-    // Retrieve the bucket resource from WSM
-    logger.info("Retrieving bucket resource id {}", resourceId.toString());
-    GcpGcsBucketResource gotBucket = resourceApi.getBucket(getWorkspaceId(), resourceId);
-    assertEquals(
-        gotBucket.getAttributes().getBucketName(),
-        bucket.getGcpBucket().getAttributes().getBucketName());
-    assertEquals(gotBucket.getAttributes().getBucketName(), bucketName);
-
-    Storage ownerStorageClient = ClientTestUtils.getGcpStorageClient(testUser, projectId);
-    Storage privateUserStorageClient =
-        ClientTestUtils.getGcpStorageClient(privateResourceUser, projectId);
-    Storage workspaceReaderStorageClient =
-        ClientTestUtils.getGcpStorageClient(workspaceReader, projectId);
+    ControlledGcpResourceApi privateUserResourceApi =
+        ClientTestUtils.getControlledGcpResourceClient(privateResourceUser, server);
 
     workspaceApi.grantRole(
         new GrantRoleRequestBody().memberEmail(workspaceReader.userEmail),
@@ -113,13 +97,31 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     workspaceApi.grantRole(
         new GrantRoleRequestBody().memberEmail(privateResourceUser.userEmail),
         getWorkspaceId(),
-        IamRole.READER);
+        IamRole.WRITER);
     logger.info(
-        "Added {} as a reader to workspace {}", privateResourceUser.userEmail, getWorkspaceId());
+        "Added {} as a writer to workspace {}", privateResourceUser.userEmail, getWorkspaceId());
 
     // TODO(PF-643): this should happen inside WSM.
     logger.info("Waiting 15s for permissions to propagate");
     Thread.sleep(15000);
+
+    // Create a private bucket, which privateResourceUser assigns to themself.
+    CreatedControlledGcpGcsBucket bucket = createPrivateBucket(privateUserResourceApi);
+    UUID resourceId = bucket.getResourceId();
+
+    // Retrieve the bucket resource from WSM
+    logger.info("Retrieving bucket resource id {}", resourceId.toString());
+    GcpGcsBucketResource gotBucket = privateUserResourceApi.getBucket(getWorkspaceId(), resourceId);
+    assertEquals(
+        gotBucket.getAttributes().getBucketName(),
+        bucket.getGcpBucket().getAttributes().getBucketName());
+    assertEquals(gotBucket.getAttributes().getBucketName(), bucketName);
+
+    Storage ownerStorageClient = ClientTestUtils.getGcpStorageClient(testUser, projectId);
+    Storage privateUserStorageClient =
+        ClientTestUtils.getGcpStorageClient(privateResourceUser, projectId);
+    Storage workspaceReaderStorageClient =
+        ClientTestUtils.getGcpStorageClient(workspaceReader, projectId);
 
     BlobId blobId = BlobId.of(bucketName, GCS_BLOB_NAME);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
@@ -177,19 +179,8 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     privateUserStorageClient.delete(blobId);
     logger.info("Private resource user successfully deleted blob {}", blobId.getName());
 
-    // Private resource user cannot delete bucket, as they are not an editor
-    ControlledGcpResourceApi privateResourceUserWsmClient =
-        ClientTestUtils.getControlledGcpResourceClient(privateResourceUser, server);
-    ApiException userCannotDeleteBucket =
-        assertThrows(
-            ApiException.class,
-            () -> deleteBucket(privateResourceUserWsmClient, resourceId),
-            "Non-editor private resource user was able to delete bucket");
-    assertEquals(userCannotDeleteBucket.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
-    logger.info("Private resource user cannot to delete bucket");
-
     // Owner can delete the bucket through WSM
-    var ownerDeleteResult = deleteBucket(resourceApi, resourceId);
+    var ownerDeleteResult = deleteBucket(workspaceOwnerResourceApi, resourceId);
     logger.info(
         "For owner, delete bucket status is {}",
         ownerDeleteResult.getJobReport().getStatus().toString());
@@ -199,7 +190,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     ApiException bucketIsMissing =
         assertThrows(
             ApiException.class,
-            () -> resourceApi.getBucket(getWorkspaceId(), resourceId),
+            () -> workspaceOwnerResourceApi.getBucket(getWorkspaceId(), resourceId),
             "Incorrectly found a deleted bucket!");
     assertEquals(bucketIsMissing.getCode(), HttpStatusCodes.STATUS_CODE_NOT_FOUND);
 

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -103,7 +103,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
 
     // TODO(PF-643): this should happen inside WSM.
     logger.info("Waiting 15s for permissions to propagate");
-    Thread.sleep(15000);
+    TimeUnit.SECONDS.sleep(15);
 
     // Create a private bucket, which privateResourceUser assigns to themself.
     CreatedControlledGcpGcsBucket bucket = createPrivateBucket(privateUserResourceApi);

--- a/workspace-manager-clienttests/src/main/resources/configs/integration/CreateGetDeleteControlledGcsBucket.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/integration/CreateGetDeleteControlledGcsBucket.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile"]
     }
   ],
-  "testUserFiles": ["bella.json", "neville.json"]
+  "testUserFiles": ["bella.json", "elijah.json"]
 }

--- a/workspace-manager-clienttests/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile"]
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "neville.json"]
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"]
 }

--- a/workspace-manager-clienttests/src/main/resources/configs/perf/BasicAuthenticated.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/perf/BasicAuthenticated.json
@@ -10,7 +10,8 @@
       "numberOfUserJourneyThreadsToRun": 10,
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
-      "expectedTimeForEachUnit": "SECONDS"
+      "expectedTimeForEachUnit": "SECONDS",
+      "parameters": ["wm-default-spend-profile"]
     }
   ],
   "testUserFiles": ["william.json"]

--- a/workspace-manager-clienttests/src/main/resources/configs/perf/DataReferenceLifecycle.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/perf/DataReferenceLifecycle.json
@@ -10,7 +10,8 @@
       "numberOfUserJourneyThreadsToRun": 10,
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
-      "expectedTimeForEachUnit": "SECONDS"
+      "expectedTimeForEachUnit": "SECONDS",
+      "parameters": ["wm-default-spend-profile"]
     }
   ],
   "testUserFiles": ["william.json"]

--- a/workspace-manager-clienttests/src/main/resources/configs/perf/EnumerateDataReferences.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/perf/EnumerateDataReferences.json
@@ -10,7 +10,8 @@
       "numberOfUserJourneyThreadsToRun": 10,
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
-      "expectedTimeForEachUnit": "SECONDS"
+      "expectedTimeForEachUnit": "SECONDS",
+      "parameters": ["wm-default-spend-profile"]
     }
   ],
   "testUserFiles": ["william.json"]

--- a/workspace-manager-clienttests/src/main/resources/configs/perf/GetRoles.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/perf/GetRoles.json
@@ -10,7 +10,8 @@
       "numberOfUserJourneyThreadsToRun": 10,
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
-      "expectedTimeForEachUnit": "SECONDS"
+      "expectedTimeForEachUnit": "SECONDS",
+      "parameters": ["wm-default-spend-profile"]
     }
   ],
   "testUserFiles": ["william.json"]

--- a/workspace-manager-clienttests/src/main/resources/testusers/liam.json
+++ b/workspace-manager-clienttests/src/main/resources/testusers/liam.json
@@ -1,0 +1,5 @@
+{
+  "name": "liam",
+  "userEmail": "liam.dragonmaw@test.firecloud.org",
+  "delegatorServiceAccountFile": "delegate-user-sa.json"
+}

--- a/workspace-manager-clienttests/src/main/resources/testusers/neville.json
+++ b/workspace-manager-clienttests/src/main/resources/testusers/neville.json
@@ -1,5 +1,0 @@
-{
-  "name": "neville",
-  "userEmail": "neville.temp@test.firecloud.org",
-  "delegatorServiceAccountFile": "delegate-user-sa.json"
-}


### PR DESCRIPTION
A number of controlled resource related client tests do not run regularly through GitHub actions, and they've been broken by other changes recently. This PR fixes the following:

- Adds a new user, `liam`. This is to replace `neville`, who is no longer listed in Sam.
- Adds a spendprofile parameter to the perf tests which need it. These tests have been failing since creation due to this missing parameter.
- Refactors `PrivateControlledGcsBucketLifecycle` to reflect the requirement that users assign private resources to themselves. Previously, this test had a workspace owner assign a resource to a workspace reader.