### PR TITLE
[PF-728] Add BQ dataset client tests, fix reader permissions

### DIFF
--- a/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
@@ -45,7 +45,8 @@ public class CustomGcpIamRoleMapping {
           "bigquery.routines.list",
           "bigquery.tables.export",
           "bigquery.tables.getData",
-          "bigquery.tables.list");
+          "bigquery.tables.list",
+          "bigquery.tables.get");
 
   static final ImmutableList<String> BIG_QUERY_DATASET_WRITER_PERMISSIONS =
       new ImmutableList.Builder<String>()

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -190,7 +190,7 @@ public class ControlledBigQueryDatasetLifecycle extends WorkspaceAllocateTestScr
 
   /**
    * Create and return a table with a single column in this test's dataset. Unlike createDataset,
-   * this talks directly on the BigQuery and does not go through WSM.
+   * this talks directly to BigQuery and does not go through WSM.
    */
   private Table createTable(BigQuery bigQueryClient, String projectId) {
     var tableId = TableId.of(projectId, DATASET_NAME, TABLE_NAME);

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -54,6 +54,11 @@ public class ControlledBigQueryDatasetLifecycle extends WorkspaceAllocateTestScr
 
   private TestUserSpecification writer;
   private TestUserSpecification reader;
+  // We require a reader, writer, and owner for this test. Arbitrarily, user 0 in the provided list
+  // will be the workspace owner (handled in base class), user 1 will be the writer, and user 2 will
+  // be the reader.
+  private static final int WRITER_USER_INDEX = 1;
+  private static final int READER_USER_INDEX = 2;
 
   @Override
   protected void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
@@ -63,8 +68,8 @@ public class ControlledBigQueryDatasetLifecycle extends WorkspaceAllocateTestScr
     assertThat(
         "There must be at least three test users defined for this test.",
         testUsers != null && testUsers.size() > 2);
-    this.writer = testUsers.get(1);
-    this.reader = testUsers.get(2);
+    this.writer = testUsers.get(WRITER_USER_INDEX);
+    this.reader = testUsers.get(READER_USER_INDEX);
   }
 
   @Override
@@ -203,16 +208,14 @@ public class ControlledBigQueryDatasetLifecycle extends WorkspaceAllocateTestScr
     return bigQueryClient.create(tableInfo);
   }
 
-  /**
-   * Insert a single String value into the column/table/dataset specified by constant values.
-   */
+  /** Insert a single String value into the column/table/dataset specified by constant values. */
   private void insertValueIntoTable(BigQuery bigQueryClient, String value) throws Exception {
     String query =
-        String.format(
-            "INSERT %s.%s (%s) VALUES(@value)", DATASET_NAME, TABLE_NAME, COLUMN_NAME);
-    QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query)
-        .addNamedParameter("value", QueryParameterValue.string(value))
-        .build();
+        String.format("INSERT %s.%s (%s) VALUES(@value)", DATASET_NAME, TABLE_NAME, COLUMN_NAME);
+    QueryJobConfiguration queryConfig =
+        QueryJobConfiguration.newBuilder(query)
+            .addNamedParameter("value", QueryParameterValue.string(value))
+            .build();
     runBigQueryJob(bigQueryClient, queryConfig);
   }
 

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -1,0 +1,181 @@
+package scripts.testscripts;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.ControlledGcpResourceApi;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.model.AccessScope;
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import bio.terra.workspace.model.ControlledResourceCommonFields;
+import bio.terra.workspace.model.CreateControlledGcpBigQueryDatasetRequestBody;
+import bio.terra.workspace.model.CreatedControlledGcpBigQueryDataset;
+import bio.terra.workspace.model.GcpBigQueryDatasetCreationParameters;
+import bio.terra.workspace.model.GcpBigQueryDatasetResource;
+import bio.terra.workspace.model.GrantRoleRequestBody;
+import bio.terra.workspace.model.IamRole;
+import bio.terra.workspace.model.ManagedBy;
+import bio.terra.workspace.model.UpdateControlledResourceRequestBody;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scripts.utils.ClientTestUtils;
+import scripts.utils.CloudContextMaker;
+import scripts.utils.WorkspaceAllocateTestScriptBase;
+
+public class ControlledBigQueryDatasetLifecycle extends WorkspaceAllocateTestScriptBase {
+  private static final Logger logger = LoggerFactory.getLogger(ControlledGcsBucketLifecycle.class);
+
+  private static final String DATASET_LOCATION = "US-CENTRAL1";
+  private static final String DATASET_NAME = "wsmtest_dataset";
+  private static final String TABLE_NAME = "wsmtest_table";
+  private static final String RESOURCE_NAME = "wsmtestresource";
+
+  private TestUserSpecification writer;
+  private TestUserSpecification reader;
+
+  @Override
+  protected void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doSetup(testUsers, workspaceApi);
+    // Note the 0th user is the owner of the workspace, pulled out in the super class.
+    assertThat(
+        "There must be at least three test users defined for this test.",
+        testUsers != null && testUsers.size() > 2);
+    this.writer = testUsers.get(1);
+    this.reader = testUsers.get(2);
+  }
+
+  @Override
+  protected void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
+      throws Exception {
+
+    ControlledGcpResourceApi ownerResourceApi =
+        ClientTestUtils.getControlledGcpResourceClient(testUser, server);
+
+    // Add a writer and reader to this workspace
+    logger.info(
+        "Adding {} as writer and {} as reader to workspace {}",
+        writer.userEmail,
+        reader.userEmail,
+        getWorkspaceId());
+    workspaceApi.grantRole(
+        new GrantRoleRequestBody().memberEmail(writer.userEmail), getWorkspaceId(), IamRole.WRITER);
+    workspaceApi.grantRole(
+        new GrantRoleRequestBody().memberEmail(reader.userEmail), getWorkspaceId(), IamRole.READER);
+
+    logger.info("Waiting 15s for permissions to propagate");
+    TimeUnit.SECONDS.sleep(15);
+
+    // Create a cloud context
+    String projectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
+    logger.info("Created project {}", projectId);
+
+    // Create a shared BigQuery dataset
+    CreatedControlledGcpBigQueryDataset createdDataset = createDataset(ownerResourceApi);
+    UUID resourceId = createdDataset.getResourceId();
+
+    // Retrieve the dataset resource
+    logger.info("Retrieving dataset resource id {}", resourceId.toString());
+    GcpBigQueryDatasetResource fetchedResource =
+        ownerResourceApi.getBigQueryDataset(getWorkspaceId(), resourceId);
+    assertEquals(createdDataset.getBigQueryDataset(), fetchedResource);
+
+    BigQuery ownerBqClient = ClientTestUtils.getGcpBigQueryClient(testUser, projectId);
+    BigQuery writerBqClient = ClientTestUtils.getGcpBigQueryClient(writer, projectId);
+    BigQuery readerBqClient = ClientTestUtils.getGcpBigQueryClient(reader, projectId);
+
+    // Workspace owner can create a table in this dataset
+    Table table = createTable(ownerBqClient, projectId);
+    String tableName = table.getTableId().getTable();
+
+    // Workspace reader can read the table
+    var readTable = readerBqClient.getTable(table.getTableId());
+    assertEquals(table, readTable);
+    logger.info("Read table {} as workspace reader", tableName);
+
+    // Workspace reader cannot modify tables
+    Table readerUpdatedTable = table.toBuilder().setDescription("A new table description").build();
+    assertThrows(
+        BigQueryException.class,
+        () -> readerBqClient.update(readerUpdatedTable),
+        "Workspace reader was able to modify a table");
+    logger.info("Workspace reader could not modify table {} as expected", tableName);
+
+    // Workspace writer can update the table
+    String newDescription = "Another new table description";
+    Table writerUpdatedTable = table.toBuilder().setDescription(newDescription).build();
+    Table updatedTable = writerBqClient.update(writerUpdatedTable);
+    assertEquals(newDescription, updatedTable.getDescription());
+    logger.info("Workspace writer modified table {}", tableName);
+
+    // Workspace owner can update the dataset resource through WSM
+    String resourceDescription = "a description for WSM";
+    var updateDatasetRequest =
+        new UpdateControlledResourceRequestBody().description(resourceDescription);
+    ownerResourceApi.updateBigQueryDataset(updateDatasetRequest, getWorkspaceId(), resourceId);
+    var datasetAfterUpdate = ownerResourceApi.getBigQueryDataset(getWorkspaceId(), resourceId);
+    assertEquals(datasetAfterUpdate.getMetadata().getDescription(), resourceDescription);
+    logger.info("Workspace owner updated resource {}", resourceId);
+
+    // Workspace writer can delete the table we created earlier
+    logger.info("Deleting table {} from dataset {}", table.getTableId().getTable(), DATASET_NAME);
+    assertTrue(
+        writerBqClient.delete(TableId.of(projectId, DATASET_NAME, table.getTableId().getTable())));
+
+    // TODO(PF-735): test that neither owners or writers can directly delete the BQ dataset. They
+    // can because of the broad project-level permissions we grant.
+
+    // Workspace owner can delete the dataset through WSM
+    ownerResourceApi.deleteBigQueryDataset(getWorkspaceId(), resourceId);
+  }
+
+  /** Create and return a controlled BigQuery dataset resource. */
+  private CreatedControlledGcpBigQueryDataset createDataset(ControlledGcpResourceApi resourceApi)
+      throws Exception {
+    var creationParameters =
+        new GcpBigQueryDatasetCreationParameters()
+            .datasetId(DATASET_NAME)
+            .location(DATASET_LOCATION);
+    var commonParameters =
+        new ControlledResourceCommonFields()
+            .name(RESOURCE_NAME)
+            .cloningInstructions(CloningInstructionsEnum.NOTHING)
+            .accessScope(AccessScope.SHARED_ACCESS)
+            .managedBy(ManagedBy.USER);
+    var requestBody =
+        new CreateControlledGcpBigQueryDatasetRequestBody()
+            .dataset(creationParameters)
+            .common(commonParameters);
+    logger.info("Creating dataset {} in workspace {}", DATASET_NAME, getWorkspaceId());
+    return resourceApi.createBigQueryDataset(requestBody, getWorkspaceId());
+  }
+  /**
+   * Create and return a table with a single column in this test's dataset. Unlike createDataset,
+   * this talks directly on the BigQuery and does not go through WSM.
+   */
+  private Table createTable(BigQuery bigQueryClient, String projectId) {
+    var tableId = TableId.of(projectId, DATASET_NAME, TABLE_NAME);
+    var tableField = Field.of("myFieldName", StandardSQLTypeName.STRING);
+    var schema = Schema.of(tableField);
+    var tableDefinition = StandardTableDefinition.of(schema);
+    var tableInfo = TableInfo.of(tableId, tableDefinition);
+
+    logger.info("Creating table {} in dataset {}", TABLE_NAME, DATASET_NAME);
+    return bigQueryClient.create(tableInfo);
+  }
+}

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -44,12 +44,8 @@ import scripts.utils.CloudContextMaker;
 import scripts.utils.ResourceMaker;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
-// This test does not use GcpCloudContextTestScriptBase as it also tests the interaction between
-// controlled resources and context creation.
-public class CreateGetDeleteControlledGcsBucket extends WorkspaceAllocateTestScriptBase {
-  private static final Logger logger =
-      LoggerFactory.getLogger(CreateGetDeleteControlledGcsBucket.class);
-  private static final long CREATE_BUCKET_POLL_SECONDS = 5;
+public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBase {
+  private static final Logger logger = LoggerFactory.getLogger(ControlledGcsBucketLifecycle.class);
 
   private static final GcpGcsBucketLifecycleRule LIFECYCLE_RULE_1 =
       new GcpGcsBucketLifecycleRule()

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateResources.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateResources.java
@@ -170,15 +170,29 @@ public class EnumerateResources extends WorkspaceAllocateTestScriptBase {
   @Override
   protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
       throws Exception {
-    // Delete the controlled buckets
+    // Delete the controlled resources
     for (ResourceMetadata metadata : resourceList) {
-      if (metadata.getStewardshipType() == StewardshipType.CONTROLLED
-          && metadata.getResourceType() == ResourceType.GCS_BUCKET) {
-        ResourceMaker.deleteControlledGcsBucket(
-            metadata.getResourceId(), getWorkspaceId(), controlledGcpResourceApi);
+      if (metadata.getStewardshipType() == StewardshipType.CONTROLLED) {
+        switch (metadata.getResourceType()) {
+          case GCS_BUCKET:
+            ResourceMaker.deleteControlledGcsBucket(
+                metadata.getResourceId(), getWorkspaceId(), controlledGcpResourceApi);
+            break;
+          case BIG_QUERY_DATASET:
+            controlledGcpResourceApi.deleteBigQueryDataset(
+                getWorkspaceId(), metadata.getResourceId());
+            break;
+          case AI_NOTEBOOK:
+          case DATA_REPO_SNAPSHOT:
+          default:
+            throw new IllegalStateException(
+                String.format(
+                    "No cleanup method specified for resource type %s in test EnumerateResources.",
+                    metadata.getResourceType()));
+        }
       }
     }
-    // Cleanup the workspace after we cleanup the the buckets!
+    // Cleanup the workspace after we cleanup the the resources!
     super.doCleanup(testUsers, workspaceApi);
   }
 
@@ -230,13 +244,13 @@ public class EnumerateResources extends WorkspaceAllocateTestScriptBase {
 
     List<ResourceMetadata> resourceList = new ArrayList<>();
 
-    // We have four kinds of resources right now, so we switch on the modulus
+    // We have five kinds of resources right now, so we switch on the modulus
     // of the counter to choose which kind to make. We make a random name so that
     // different runs will have different alphabetical order.
     for (int i = 0; i < RESOURCE_COUNT; i++) {
       String name = RandomStringUtils.random(6, true, false) + i;
 
-      switch (i % 4) {
+      switch (i % 5) {
         case 0:
           {
             GcpBigQueryDatasetResource resource =
@@ -266,6 +280,15 @@ public class EnumerateResources extends WorkspaceAllocateTestScriptBase {
           {
             GcpGcsBucketResource resource =
                 ResourceMaker.makeControlledGcsBucketUserShared(
+                    controlledGcpResourceApi, workspaceId, name);
+            resourceList.add(resource.getMetadata());
+            break;
+          }
+
+        case 4:
+          {
+            GcpBigQueryDatasetResource resource =
+                ResourceMaker.makeControlledBigQueryDatasetUserShared(
                     controlledGcpResourceApi, workspaceId, name);
             resourceList.add(resource.getMetadata());
             break;

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/ClientTestUtils.java
@@ -244,8 +244,8 @@ public class ClientTestUtils {
     return jobReport.getStatus().equals(JobReport.StatusEnum.RUNNING);
   }
 
-  /** @return unique resource name */
-  public static String generateTestResourceName() {
+  /** @return a generated unique resource name consisting of letters, numbers, and underscores. */
+  public static String generateCloudResourceName() {
     String name = RESOURCE_NAME_PREFIX + UUID.randomUUID().toString();
     return name.replace("-", "_");
   }

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/ClientTestUtils.java
@@ -24,6 +24,8 @@ import bio.terra.workspace.model.RoleBindingList;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Strings;
@@ -42,7 +44,7 @@ public class ClientTestUtils {
   public static final String TEST_BUCKET_NAME = "terra_wsm_test_resource";
   public static final String TEST_BQ_DATASET_NAME = "terra_wsm_test_dataset";
   public static final String TEST_BQ_DATASET_PROJECT = "terra-kernel-k8s";
-  public static final String BUCKET_NAME_PREFIX = "terratest";
+  public static final String RESOURCE_NAME_PREFIX = "terratest";
   private static final Logger logger = LoggerFactory.getLogger(ClientTestUtils.class);
 
   // Required scopes for client tests include the usual login scopes.
@@ -121,6 +123,15 @@ public class ClientTestUtils {
         AuthenticationUtils.getDelegatedUserCredential(testUser, TEST_USER_SCOPES);
     StorageOptions options =
         StorageOptions.newBuilder().setCredentials(userCredential).setProjectId(projectId).build();
+    return options.getService();
+  }
+
+  public static BigQuery getGcpBigQueryClient(TestUserSpecification testUser, String projectId)
+      throws IOException {
+    GoogleCredentials userCredential =
+        AuthenticationUtils.getDelegatedUserCredential(testUser, TEST_USER_SCOPES);
+    var options =
+        BigQueryOptions.newBuilder().setCredentials(userCredential).setProjectId(projectId).build();
     return options.getService();
   }
 
@@ -233,9 +244,9 @@ public class ClientTestUtils {
     return jobReport.getStatus().equals(JobReport.StatusEnum.RUNNING);
   }
 
-  /** @return unique test bucket name */
-  public static String getTestBucketName() {
-    String name = BUCKET_NAME_PREFIX + UUID.randomUUID().toString();
+  /** @return unique resource name */
+  public static String generateTestResourceName() {
+    String name = RESOURCE_NAME_PREFIX + UUID.randomUUID().toString();
     return name.replace("-", "_");
   }
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/ResourceMaker.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/ResourceMaker.java
@@ -120,7 +120,7 @@ public class ResourceMaker {
 
     List<GcpGcsBucketLifecycleRule> lifecycleRules = new ArrayList<>(List.of(lifecycleRule));
 
-    String bucketName = ClientTestUtils.generateTestResourceName();
+    String bucketName = ClientTestUtils.generateCloudResourceName();
     var body =
         new CreateControlledGcpGcsBucketRequestBody()
             .common(
@@ -162,7 +162,7 @@ public class ResourceMaker {
   public static GcpBigQueryDatasetResource makeControlledBigQueryDatasetUserShared(
       ControlledGcpResourceApi resourceApi, UUID workspaceId, String name) throws Exception {
 
-    String datasetId = ClientTestUtils.generateTestResourceName();
+    String datasetId = ClientTestUtils.generateCloudResourceName();
     var body =
         new CreateControlledGcpBigQueryDatasetRequestBody()
             .common(

--- a/workspace-manager-clienttests/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
@@ -1,12 +1,12 @@
 {
-  "name": "CreateGetDeleteControlledGcsBucket",
-  "description": "CRUD controlled GCS bucket tests.",
+  "name": "ControlledBigQueryDatasetLifecycle",
+  "description": "CRUD controlled BQ dataset tests.",
   "serverSpecificationFile": "workspace-dev.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
-      "name": "CreateGetDeleteControlledGcsBucket",
+      "name": "ControlledBigQueryDatasetLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile"]
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"]
 }

--- a/workspace-manager-clienttests/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
@@ -1,0 +1,18 @@
+{
+  "name": "ControlledGcsBucketLifecycle",
+  "description": "CRUD controlled GCS bucket tests.",
+  "serverSpecificationFile": "workspace-dev.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ControlledGcsBucketLifecycle",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 5,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parameters": ["wm-default-spend-profile"]
+    }
+  ],
+  "testUserFiles": ["bella.json", "elijah.json"]
+}

--- a/workspace-manager-clienttests/src/main/resources/suites/FullIntegration.json
+++ b/workspace-manager-clienttests/src/main/resources/suites/FullIntegration.json
@@ -9,7 +9,8 @@
     "integration/EnumerateDataReferences.json",
     "integration/GetRoles.json",
     "integration/WorkspaceLifecycle.json",
-    "integration/CreateGetDeleteControlledGcsBucket.json",
+    "integration/ControlledGcsBucketLifecycle.json",
+    "integration/ControlledBigQueryDatasetLifecycle.json",
     "integration/PrivateControlledGcsBucketLifecycle.json",
     "integration/EnumerateResources.json"
   ]


### PR DESCRIPTION
This change adds client testing to cover the new endpoints for controlled BigQuery datasets. It also modifies the existing EnumerateResources test to include controlled BigQuery datasets. While looking at the equivalent test for GCS buckets, I also renamed the test to be more consistent.

I've also added `bigquery.tables.get` permission to our custom BigQuery READER role. We already included `bigquery.tables.list`, and leaving `get` out was a small oversight.