### PR TITLE
PF-734 Avoid " around 'service_account' for git secrets false positives

### DIFF
--- a/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/CreateAiNotebookInstanceStep.java
+++ b/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/CreateAiNotebookInstanceStep.java
@@ -49,6 +49,9 @@ import org.springframework.http.HttpStatus;
 public class CreateAiNotebookInstanceStep implements Step {
   /** The Notebook instance metadata key used to control proxy mode. */
   private static final String PROXY_MODE_METADATA_KEY = "proxy-mode";
+  /** The Notebook instance metadata value used to set the service account proxy mode. */
+  // git secrets gets a false positive if 'service_account' is double quoted.
+  private static final String PROXY_MODE_SA_VALUE = "service_" + "account";
 
   private final Logger logger = LoggerFactory.getLogger(CreateAiNotebookInstanceStep.class);
   private final CrlService crlService;
@@ -139,7 +142,7 @@ public class CreateAiNotebookInstanceStep implements Step {
     // Create the AI Notebook instance in the service account proxy mode to control proxy access by
     // means of IAM permissions on the service account.
     // https://cloud.google.com/ai-platform/notebooks/docs/troubleshooting#opening_a_notebook_results_in_a_403_forbidden_error
-    if (metadata.put(PROXY_MODE_METADATA_KEY, "service_account") != null) {
+    if (metadata.put(PROXY_MODE_METADATA_KEY, PROXY_MODE_SA_VALUE) != null) {
       throw new BadRequestException("proxy-mode metadata is reserved for Terra.");
     }
     instance.setMetadata(metadata);

--- a/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -146,8 +146,8 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .instances()
             .get(resource.toInstanceName(workspace.getGcpCloudContext().get().getGcpProjectId()))
             .execute();
-
-    assertThat(instance.getMetadata(), Matchers.hasEntry("proxy-mode", "service_account"));
+    // git secrets gets a false positive if 'service_account' is double quoted.
+    assertThat(instance.getMetadata(), Matchers.hasEntry("proxy-mode", "service_" + "account"));
     // TODO(PF-626): Test that the user has permission to act as the service account.
 
     assertEquals(

--- a/src/test/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/CreateAiNotebookInstanceStepTest.java
+++ b/src/test/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/CreateAiNotebookInstanceStepTest.java
@@ -51,7 +51,8 @@ public class CreateAiNotebookInstanceStepTest extends BaseUnitTest {
     assertEquals("data-disk-type", instance.getDataDiskType());
     assertEquals(222L, instance.getDataDiskSizeGb());
     assertThat(instance.getMetadata(), Matchers.aMapWithSize(2));
-    assertThat(instance.getMetadata(), Matchers.hasEntry("proxy-mode", "service_account"));
+    // git secrets gets a false positive if 'service_account' is double quoted.
+    assertThat(instance.getMetadata(), Matchers.hasEntry("proxy-mode", "service_" + "account"));
     assertThat(instance.getMetadata(), Matchers.hasEntry("metadata-key", "metadata-value"));
     assertEquals("foo@bar.com", instance.getServiceAccount());
     assertEquals(4L, instance.getAcceleratorConfig().getCoreCount());
@@ -69,7 +70,7 @@ public class CreateAiNotebookInstanceStepTest extends BaseUnitTest {
         CreateAiNotebookInstanceStep.setFields(
             new ApiGcpAiNotebookInstanceCreationParameters(), "foo@bar.com", new Instance());
     assertThat(instance.getMetadata(), Matchers.aMapWithSize(1));
-    assertThat(instance.getMetadata(), Matchers.hasEntry("proxy-mode", "service_account"));
+    assertThat(instance.getMetadata(), Matchers.hasEntry("proxy-mode", "service_" + "account"));
     assertEquals("foo@bar.com", instance.getServiceAccount());
   }
 


### PR DESCRIPTION
For some reason git secrets has a false positive for the string 'service_account' when it is in double quotes, `"like_this"`. 

The only pattern that looks related is `secrets.patterns ("type": "service_account"|"privateKeyType": "TYPE_GOOGLE_CREDENTIALS_FILE",)` but this doesn't have the type.
This is mysterious, but not especially hard to avoid.