### PR TITLE
AS-723 - (First Pass) Migrate WSM integration tests from JUnit to TestRunner

### DIFF
--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/DataReferenceLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/DataReferenceLifecycle.java
@@ -64,6 +64,6 @@ public class DataReferenceLifecycle extends DataRepoTestScriptBase {
     assertThat(
         dataReferenceDescription.getReference().getSnapshot(), equalTo(getDataRepoSnapshotId()));
     assertThat(
-        dataReferenceDescription.getReference().getInstanceName(), equalTo(getDataRepoInstance()));
+        dataReferenceDescription.getReference().getInstanceName(), equalTo(getDataRepoInstanceName()));
   }
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/DataReferenceLifecycle.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/DataReferenceLifecycle.java
@@ -11,17 +11,16 @@ import bio.terra.workspace.model.CreateDataReferenceRequestBody;
 import bio.terra.workspace.model.DataReferenceDescription;
 import bio.terra.workspace.model.ReferenceTypeEnum;
 import org.apache.http.HttpStatus;
-import scripts.utils.ClientTestUtils;
-import scripts.utils.WorkspaceAllocateTestScriptBase;
+import scripts.utils.DataRepoTestScriptBase;
 
-public class DataReferenceLifecycle extends WorkspaceAllocateTestScriptBase {
+public class DataReferenceLifecycle extends DataRepoTestScriptBase {
 
   @Override
   public void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
       throws ApiException {
     // Create a data reference
-    final CreateDataReferenceRequestBody body =
-        ClientTestUtils.getTestCreateDataReferenceRequestBody();
+    final CreateDataReferenceRequestBody body = getTestCreateDataReferenceRequestBody();
+
     final String referenceName = body.getName();
 
     final DataReferenceDescription newReference =
@@ -63,10 +62,8 @@ public class DataReferenceLifecycle extends WorkspaceAllocateTestScriptBase {
     assertThat(
         dataReferenceDescription.getReferenceType(), equalTo(ReferenceTypeEnum.DATA_REPO_SNAPSHOT));
     assertThat(
-        dataReferenceDescription.getReference().getSnapshot(),
-        equalTo(ClientTestUtils.TEST_SNAPSHOT));
+        dataReferenceDescription.getReference().getSnapshot(), equalTo(getDataRepoSnapshotId()));
     assertThat(
-        dataReferenceDescription.getReference().getInstanceName(),
-        equalTo(ClientTestUtils.TERRA_DATA_REPO_INSTANCE));
+        dataReferenceDescription.getReference().getInstanceName(), equalTo(getDataRepoInstance()));
   }
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateDataReferences.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateDataReferences.java
@@ -20,10 +20,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scripts.utils.ClientTestUtils;
-import scripts.utils.WorkspaceAllocateTestScriptBase;
+import scripts.utils.DataRepoTestScriptBase;
 
-public class EnumerateDataReferences extends WorkspaceAllocateTestScriptBase {
+public class EnumerateDataReferences extends DataRepoTestScriptBase {
 
   private static final Logger logger = LoggerFactory.getLogger(EnumerateDataReferences.class);
 
@@ -44,7 +43,7 @@ public class EnumerateDataReferences extends WorkspaceAllocateTestScriptBase {
     // create 10 data references
     final List<CreateDataReferenceRequestBody> createBodies =
         IntStream.range(0, DATA_REFERENCE_COUNT)
-            .mapToObj(i -> ClientTestUtils.getTestCreateDataReferenceRequestBody())
+            .mapToObj(i -> getTestCreateDataReferenceRequestBody())
             .collect(Collectors.toList());
 
     logger.debug("Creating references for workspace {}", getWorkspaceId());
@@ -71,8 +70,7 @@ public class EnumerateDataReferences extends WorkspaceAllocateTestScriptBase {
 
     // fetch all
     final List<DataReferenceDescription> referenceDescriptions =
-        ClientTestUtils.getDataReferenceDescriptions(
-            getWorkspaceId(), workspaceApi, 0, DATA_REFERENCE_COUNT);
+        getDataReferenceDescriptions(getWorkspaceId(), workspaceApi, 0, DATA_REFERENCE_COUNT);
     assertThat(referenceDescriptions.size(), equalTo(DATA_REFERENCE_COUNT));
 
     final String allIdString =
@@ -92,7 +90,7 @@ public class EnumerateDataReferences extends WorkspaceAllocateTestScriptBase {
 
     // fetch first page
     final List<DataReferenceDescription> referenceDescriptionsPage0 =
-        ClientTestUtils.getDataReferenceDescriptions(getWorkspaceId(), workspaceApi, 0, PAGE_SIZE);
+        getDataReferenceDescriptions(getWorkspaceId(), workspaceApi, 0, PAGE_SIZE);
     assertThat(referenceDescriptionsPage0.size(), equalTo(PAGE_SIZE));
     final ImmutableSet<UUID> referenceIdsPage0 =
         ImmutableSet.copyOf(
@@ -103,8 +101,7 @@ public class EnumerateDataReferences extends WorkspaceAllocateTestScriptBase {
 
     // fetch second page
     final List<DataReferenceDescription> referenceDescriptionsPage1 =
-        ClientTestUtils.getDataReferenceDescriptions(
-            getWorkspaceId(), workspaceApi, PAGE_SIZE, PAGE_SIZE);
+        getDataReferenceDescriptions(getWorkspaceId(), workspaceApi, PAGE_SIZE, PAGE_SIZE);
     assertThat(referenceDescriptionsPage1.size(), equalTo(PAGE_SIZE));
     final ImmutableSet<UUID> referenceIdsPage1 =
         ImmutableSet.copyOf(
@@ -122,8 +119,7 @@ public class EnumerateDataReferences extends WorkspaceAllocateTestScriptBase {
 
     // final partial page
     final List<DataReferenceDescription> referenceDescriptionsPage2 =
-        ClientTestUtils.getDataReferenceDescriptions(
-            getWorkspaceId(), workspaceApi, 2 * PAGE_SIZE, PAGE_SIZE);
+        getDataReferenceDescriptions(getWorkspaceId(), workspaceApi, 2 * PAGE_SIZE, PAGE_SIZE);
     assertThat(referenceDescriptionsPage2.size(), equalTo(DATA_REFERENCE_COUNT - 2 * PAGE_SIZE));
     final ImmutableSet<UUID> referenceIdsPage2 =
         ImmutableSet.copyOf(
@@ -142,8 +138,7 @@ public class EnumerateDataReferences extends WorkspaceAllocateTestScriptBase {
 
     // Assure no results if offset is too high
     final List<DataReferenceDescription> referencesBeyondUpperBound =
-        ClientTestUtils.getDataReferenceDescriptions(
-            getWorkspaceId(), workspaceApi, 10 * PAGE_SIZE, PAGE_SIZE);
+        getDataReferenceDescriptions(getWorkspaceId(), workspaceApi, 10 * PAGE_SIZE, PAGE_SIZE);
     assertThat(referencesBeyondUpperBound, is(empty()));
   }
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateResources.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateResources.java
@@ -29,10 +29,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
+import scripts.utils.DataRepoTestScriptBase;
 import scripts.utils.ResourceMaker;
-import scripts.utils.WorkspaceAllocateTestScriptBase;
 
-public class EnumerateResources extends WorkspaceAllocateTestScriptBase {
+public class EnumerateResources extends DataRepoTestScriptBase {
   private static final Logger logger = LoggerFactory.getLogger(EnumerateResources.class);
 
   // TODO: make these parameters in the test description?
@@ -249,7 +249,11 @@ public class EnumerateResources extends WorkspaceAllocateTestScriptBase {
           {
             DataRepoSnapshotResource resource =
                 ResourceMaker.makeDataRepoSnapshotReference(
-                    referencedGcpResourceApi, workspaceId, name);
+                    referencedGcpResourceApi,
+                    workspaceId,
+                    name,
+                    getDataRepoSnapshotId(),
+                    getDataRepoInstance());
             resourceList.add(resource.getMetadata());
             break;
           }

--- a/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateResources.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/testscripts/EnumerateResources.java
@@ -253,7 +253,7 @@ public class EnumerateResources extends DataRepoTestScriptBase {
                     workspaceId,
                     name,
                     getDataRepoSnapshotId(),
-                    getDataRepoInstance());
+                    getDataRepoInstanceName());
             resourceList.add(resource.getMetadata());
             break;
           }

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/ClientTestUtils.java
@@ -11,15 +11,8 @@ import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.ResourceApi;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiClient;
-import bio.terra.workspace.client.ApiException;
-import bio.terra.workspace.model.CloningInstructionsEnum;
-import bio.terra.workspace.model.CreateDataReferenceRequestBody;
-import bio.terra.workspace.model.DataReferenceDescription;
-import bio.terra.workspace.model.DataReferenceList;
-import bio.terra.workspace.model.DataRepoSnapshot;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.JobReport;
-import bio.terra.workspace.model.ReferenceTypeEnum;
 import bio.terra.workspace.model.RoleBindingList;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
@@ -36,9 +29,6 @@ import org.slf4j.LoggerFactory;
 
 public class ClientTestUtils {
 
-  public static final String DATA_REFERENCE_NAME_PREFIX = "REF_";
-  public static final String TEST_SNAPSHOT = "97b5559a-2f8f-4df3-89ae-5a249173ee0c";
-  public static final String TERRA_DATA_REPO_INSTANCE = "terra";
   public static final String TEST_BUCKET_NAME = "terra_wsm_test_resource";
   public static final String TEST_BQ_DATASET_NAME = "terra_wsm_test_dataset";
   public static final String TEST_BQ_DATASET_PROJECT = "terra-kernel-k8s";
@@ -181,38 +171,6 @@ public class ClientTestUtils {
     int httpCode = workspaceApi.getApiClient().getStatusCode();
     logger.debug("{} HTTP code: {}", label, httpCode);
     assertThat(HttpStatusCodes.isSuccess(httpCode), equalTo(true));
-  }
-
-  /**
-   * Return a globally unique data reference name starting with the constant prefix. This will
-   * include a UUID reformatted to meet the rules for data reference names (just replacing hyphens
-   * with underscores). This method is useful when creating references on the same workspace from
-   * multiple threads.
-   *
-   * @return unique data reference name
-   */
-  public static String getUniqueDataReferenceName() {
-    String name = DATA_REFERENCE_NAME_PREFIX + UUID.randomUUID().toString();
-    return name.replace("-", "_");
-  }
-
-  public static DataRepoSnapshot getTestDataRepoSnapshot() {
-    return new DataRepoSnapshot().snapshot(TEST_SNAPSHOT).instanceName(TERRA_DATA_REPO_INSTANCE);
-  }
-
-  public static CreateDataReferenceRequestBody getTestCreateDataReferenceRequestBody() {
-    return new CreateDataReferenceRequestBody()
-        .name(getUniqueDataReferenceName())
-        .cloningInstructions(CloningInstructionsEnum.REFERENCE)
-        .referenceType(ReferenceTypeEnum.DATA_REPO_SNAPSHOT)
-        .reference(getTestDataRepoSnapshot());
-  }
-
-  public static List<DataReferenceDescription> getDataReferenceDescriptions(
-      UUID workspaceId, WorkspaceApi workspaceApi, int offset, int limit) throws ApiException {
-    final DataReferenceList dataReferenceListFirstPage =
-        workspaceApi.enumerateReferences(workspaceId, offset, limit);
-    return dataReferenceListFirstPage.getResources();
   }
 
   /**

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/DataRepoTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/DataRepoTestScriptBase.java
@@ -32,8 +32,7 @@ public abstract class DataRepoTestScriptBase extends WorkspaceAllocateTestScript
 
   @Override
   public void setParameters(List<String> parameters) throws Exception {
-    // TODO: Refactor this function to use parameterMap when the ticket below is done
-    // TODO: https://broadworkbench.atlassian.net/browse/QA-1460
+    // TODO: Refactor this function when TestRunner starts supporting parameterMap
     super.setParameters(parameters);
     if (parameters == null || parameters.size() < 3) {
       throw new IllegalArgumentException(
@@ -62,9 +61,7 @@ public abstract class DataRepoTestScriptBase extends WorkspaceAllocateTestScript
   }
 
   /**
-   * Util method that enumerates data references.
-   * TODO: This method is currently being used only in {@link scripts.testscripts.EnumerateDataReferences} test.
-   *  If the method is not needed by other tests, we could move it into the test above as a private method
+   * Enumerate data references
    *
    * @return A list of data references
    */

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/DataRepoTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/DataRepoTestScriptBase.java
@@ -1,0 +1,90 @@
+package scripts.utils;
+
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.*;
+import java.util.List;
+import java.util.UUID;
+
+public abstract class DataRepoTestScriptBase extends WorkspaceAllocateTestScriptBase {
+  private static final String DATA_REFERENCE_NAME_PREFIX = "REF_";
+
+  private String dataRepoSnapshotId;
+  private String dataRepoInstance;
+
+  /**
+   * Allow inheriting classes to obtain the Data Repo snapshot ID
+   *
+   * @return Data Repo Snapshot string
+   */
+  protected String getDataRepoSnapshotId() {
+    return dataRepoSnapshotId;
+  }
+
+  /**
+   * Allow inheriting classes to obtain the Data Repo Instance
+   *
+   * @return Data Repo Instance string
+   */
+  protected String getDataRepoInstance() {
+    return dataRepoInstance;
+  }
+
+  @Override
+  public void setParameters(List<String> parameters) throws Exception {
+    // TODO: Refactor this function to use parameterMap when the ticket below is done
+    // TODO: https://broadworkbench.atlassian.net/browse/QA-1460
+    super.setParameters(parameters);
+    if (parameters == null || parameters.size() < 3) {
+      throw new IllegalArgumentException(
+          "Must provide Spend Profile ID, Data Repo snapshot ID, and Data Repo Instance in the parameters list");
+    } else {
+      // "spendProfileId = parameters.get(0);" fetches Spend Profile ID and is already implemented
+      // in the super class
+      dataRepoSnapshotId = parameters.get(1);
+      dataRepoInstance = parameters.get(2);
+    }
+  }
+
+  /**
+   * Generate and return a CreateDataReferenceRequestBody. The returned object consists of a unique
+   * name for the data reference, standard cloning instructions, standard reference type, and a
+   * reference using the snapshot ID and Data Repo Instance arguments defined in the test config.
+   *
+   * @return Request body for creating a data reference
+   */
+  protected CreateDataReferenceRequestBody getTestCreateDataReferenceRequestBody() {
+    return new CreateDataReferenceRequestBody()
+        .name(getUniqueDataReferenceName())
+        .cloningInstructions(CloningInstructionsEnum.REFERENCE)
+        .referenceType(ReferenceTypeEnum.DATA_REPO_SNAPSHOT)
+        .reference(getTestDataRepoSnapshot());
+  }
+
+  /**
+   * Util method that enumerates data references. // TODO: The method is currently being used only
+   * in {@link scripts.testscripts.EnumerateDataReferences} test // TODO: If not needed by other
+   * tests, we could move this method into that test as a private method
+   *
+   * @return A list of data references
+   */
+  protected List<DataReferenceDescription> getDataReferenceDescriptions(
+      UUID workspaceId, WorkspaceApi workspaceApi, int offset, int limit) throws ApiException {
+    final DataReferenceList dataReferenceListFirstPage =
+        workspaceApi.enumerateReferences(workspaceId, offset, limit);
+    return dataReferenceListFirstPage.getResources();
+  }
+
+  private String getUniqueDataReferenceName() {
+    String name = DATA_REFERENCE_NAME_PREFIX + UUID.randomUUID().toString();
+    // Reformat the UUID (replace hyphens with underscores) in order to meet the rules for data
+    // reference names
+    return name.replace("-", "_");
+  }
+
+  private DataRepoSnapshot getTestDataRepoSnapshot() {
+    return new DataRepoSnapshot()
+        .snapshot(getDataRepoSnapshotId())
+        .instanceName(getDataRepoInstance());
+  }
+}

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/DataRepoTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/DataRepoTestScriptBase.java
@@ -10,24 +10,24 @@ public abstract class DataRepoTestScriptBase extends WorkspaceAllocateTestScript
   private static final String DATA_REFERENCE_NAME_PREFIX = "REF_";
 
   private String dataRepoSnapshotId;
-  private String dataRepoInstance;
+  private String dataRepoInstanceName;
 
   /**
    * Allow inheriting classes to obtain the Data Repo snapshot ID
    *
-   * @return Data Repo Snapshot string
+   * @return Data Repo Snapshot ID string
    */
   protected String getDataRepoSnapshotId() {
     return dataRepoSnapshotId;
   }
 
   /**
-   * Allow inheriting classes to obtain the Data Repo Instance
+   * Allow inheriting classes to obtain the Data Repo Instance Name
    *
-   * @return Data Repo Instance string
+   * @return Data Repo Instance Name string
    */
-  protected String getDataRepoInstance() {
-    return dataRepoInstance;
+  protected String getDataRepoInstanceName() {
+    return dataRepoInstanceName;
   }
 
   @Override
@@ -37,19 +37,19 @@ public abstract class DataRepoTestScriptBase extends WorkspaceAllocateTestScript
     super.setParameters(parameters);
     if (parameters == null || parameters.size() < 3) {
       throw new IllegalArgumentException(
-          "Must provide Spend Profile ID, Data Repo snapshot ID, and Data Repo Instance in the parameters list");
+          "Must provide Spend Profile ID, Data Repo snapshot ID, and Data Repo Instance Name in the parameters list");
     } else {
       // "spendProfileId = parameters.get(0);" fetches Spend Profile ID and is already implemented
       // in the super class
       dataRepoSnapshotId = parameters.get(1);
-      dataRepoInstance = parameters.get(2);
+      dataRepoInstanceName = parameters.get(2);
     }
   }
 
   /**
    * Generate and return a CreateDataReferenceRequestBody. The returned object consists of a unique
    * name for the data reference, standard cloning instructions, standard reference type, and a
-   * reference using the snapshot ID and Data Repo Instance arguments defined in the test config.
+   * reference using the Data Repo Snapshot ID and Instance Name arguments defined in the test config.
    *
    * @return Request body for creating a data reference
    */
@@ -85,6 +85,6 @@ public abstract class DataRepoTestScriptBase extends WorkspaceAllocateTestScript
   private DataRepoSnapshot getTestDataRepoSnapshot() {
     return new DataRepoSnapshot()
         .snapshot(getDataRepoSnapshotId())
-        .instanceName(getDataRepoInstance());
+        .instanceName(getDataRepoInstanceName());
   }
 }

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/DataRepoTestScriptBase.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/DataRepoTestScriptBase.java
@@ -62,9 +62,9 @@ public abstract class DataRepoTestScriptBase extends WorkspaceAllocateTestScript
   }
 
   /**
-   * Util method that enumerates data references. // TODO: The method is currently being used only
-   * in {@link scripts.testscripts.EnumerateDataReferences} test // TODO: If not needed by other
-   * tests, we could move this method into that test as a private method
+   * Util method that enumerates data references.
+   * TODO: This method is currently being used only in {@link scripts.testscripts.EnumerateDataReferences} test.
+   *  If the method is not needed by other tests, we could move it into the test above as a private method
    *
    * @return A list of data references
    */

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/ResourceMaker.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/ResourceMaker.java
@@ -65,7 +65,12 @@ public class ResourceMaker {
   }
 
   public static DataRepoSnapshotResource makeDataRepoSnapshotReference(
-      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name) throws ApiException {
+      ReferencedGcpResourceApi resourceApi,
+      UUID workspaceId,
+      String name,
+      String snapshotId,
+      String dataRepoInstance)
+      throws ApiException {
 
     var body =
         new CreateDataRepoSnapshotReferenceRequestBody()
@@ -76,8 +81,8 @@ public class ResourceMaker {
                     .name(name))
             .snapshot(
                 new DataRepoSnapshotAttributes()
-                    .snapshot(ClientTestUtils.TEST_SNAPSHOT)
-                    .instanceName(ClientTestUtils.TERRA_DATA_REPO_INSTANCE));
+                    .snapshot(snapshotId)
+                    .instanceName(dataRepoInstance));
 
     return resourceApi.createDataRepoSnapshotReference(body, workspaceId);
   }

--- a/workspace-manager-clienttests/src/main/java/scripts/utils/ResourceMaker.java
+++ b/workspace-manager-clienttests/src/main/java/scripts/utils/ResourceMaker.java
@@ -68,8 +68,8 @@ public class ResourceMaker {
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceId,
       String name,
-      String snapshotId,
-      String dataRepoInstance)
+      String dataRepoSnapshotId,
+      String dataRepoInstanceName)
       throws ApiException {
 
     var body =
@@ -81,8 +81,8 @@ public class ResourceMaker {
                     .name(name))
             .snapshot(
                 new DataRepoSnapshotAttributes()
-                    .snapshot(snapshotId)
-                    .instanceName(dataRepoInstance));
+                    .snapshot(dataRepoSnapshotId)
+                    .instanceName(dataRepoInstanceName));
 
     return resourceApi.createDataRepoSnapshotReference(body, workspaceId);
   }

--- a/workspace-manager-clienttests/src/main/resources/configs/integration/DataReferenceLifecycle.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/integration/DataReferenceLifecycle.json
@@ -11,7 +11,7 @@
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
-      "parameters": ["wm-default-spend-profile"]
+      "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
   "testUserFiles": ["william.json"]

--- a/workspace-manager-clienttests/src/main/resources/configs/integration/EnumerateDataReferences.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/integration/EnumerateDataReferences.json
@@ -11,7 +11,7 @@
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
-      "parameters": ["wm-default-spend-profile"]
+      "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
   "testUserFiles": ["william.json"]

--- a/workspace-manager-clienttests/src/main/resources/configs/integration/EnumerateResources.json
+++ b/workspace-manager-clienttests/src/main/resources/configs/integration/EnumerateResources.json
@@ -11,7 +11,7 @@
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "MINUTES",
-      "parameters": ["wm-default-spend-profile"]
+      "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
   "testUserFiles": ["bella.json"]


### PR DESCRIPTION
This is the first PR (more iterations to come) for migrating WSM integration tests form JUnit to TestRunner. I'm breaking the work down into different PR's in order to get early feedback and also make the changes easier to review.

This PR:
- Parameterizes the arguments used in creating data references
- Creates a base test script (`DataRepoTestScriptBase.java`) that's tailored towards tests that work with data references
- Moves the data references util code from `ClientTestUtils.java` to `DataRepoTestScriptBase.java`
- Updates related files/tests

The next set of PRs will address running the tests in other environments, and updating the GitHub workflows accordingly.