### PR TITLE
replace static fixtures with methods that generate unique bucket names

### DIFF
--- a/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -55,14 +55,17 @@ public class ControlledResourceFixtures {
   // list must not be immutable if deserialization is to work
   static final List<ApiGcpGcsBucketLifecycleRule> LIFECYCLE_RULES =
       new ArrayList<>(List.of(LIFECYCLE_RULE_1, LIFECYCLE_RULE_2));
-  public static final String BUCKET_NAME = "my-bucket";
+  public static final String BUCKET_NAME_PREFIX = "my-bucket";
   public static final String BUCKET_LOCATION = "US-CENTRAL1";
-  public static final ApiGcpGcsBucketCreationParameters GOOGLE_BUCKET_CREATION_PARAMETERS =
-      new ApiGcpGcsBucketCreationParameters()
-          .name(BUCKET_NAME)
-          .location(BUCKET_LOCATION)
-          .defaultStorageClass(ApiGcpGcsBucketDefaultStorageClass.STANDARD)
-          .lifecycle(new ApiGcpGcsBucketLifecycle().rules(LIFECYCLE_RULES));
+
+  /** Construct a parameter object with a unique bucket name to avoid unintended clashes. */
+  public static ApiGcpGcsBucketCreationParameters getGoogleBucketCreationParameters() {
+    return new ApiGcpGcsBucketCreationParameters()
+        .name(uniqueName(BUCKET_NAME_PREFIX))
+        .location(BUCKET_LOCATION)
+        .defaultStorageClass(ApiGcpGcsBucketDefaultStorageClass.STANDARD)
+        .lifecycle(new ApiGcpGcsBucketLifecycle().rules(LIFECYCLE_RULES));
+  }
 
   public static ApiGcpAiNotebookInstanceCreationParameters defaultNotebookCreationParameters() {
     return new ApiGcpAiNotebookInstanceCreationParameters()
@@ -80,17 +83,19 @@ public class ControlledResourceFixtures {
   public static final String RESOURCE_DESCRIPTION =
       "A bucket that had beer in it, briefly. \uD83C\uDF7B";
   public static final CloningInstructions CLONING_INSTRUCTIONS = CloningInstructions.COPY_REFERENCE;
-  public static final ControlledGcsBucketResource BUCKET_RESOURCE =
-      new ControlledGcsBucketResource(
-          WORKSPACE_ID,
-          RESOURCE_ID,
-          RESOURCE_NAME,
-          RESOURCE_DESCRIPTION,
-          CLONING_INSTRUCTIONS,
-          OWNER_EMAIL,
-          AccessScopeType.ACCESS_SCOPE_PRIVATE,
-          ManagedByType.MANAGED_BY_USER,
-          BUCKET_NAME);
+
+  public static ControlledGcsBucketResource getBucketResource() {
+    return new ControlledGcsBucketResource(
+        WORKSPACE_ID,
+        RESOURCE_ID,
+        RESOURCE_NAME,
+        RESOURCE_DESCRIPTION,
+        CLONING_INSTRUCTIONS,
+        OWNER_EMAIL,
+        AccessScopeType.ACCESS_SCOPE_PRIVATE,
+        ManagedByType.MANAGED_BY_USER,
+        uniqueName(BUCKET_NAME_PREFIX));
+      }
 
   private ControlledResourceFixtures() {}
 
@@ -111,7 +116,7 @@ public class ControlledResourceFixtures {
         .assignedUser(null)
         .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
         .managedBy(ManagedByType.MANAGED_BY_USER)
-        .bucketName(BUCKET_NAME);
+        .bucketName(uniqueName(BUCKET_NAME_PREFIX));
   }
 
   /**
@@ -133,6 +138,10 @@ public class ControlledResourceFixtures {
         .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
         .managedBy(ManagedByType.MANAGED_BY_USER)
         .datasetName("test_dataset");
+  }
+
+  private static String uniqueName(String prefix) {
+    return prefix + "-" + UUID.randomUUID().toString();
   }
 
   /**

--- a/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -84,7 +84,7 @@ public class ControlledResourceFixtures {
       "A bucket that had beer in it, briefly. \uD83C\uDF7B";
   public static final CloningInstructions CLONING_INSTRUCTIONS = CloningInstructions.COPY_REFERENCE;
 
-  public static ControlledGcsBucketResource getBucketResource() {
+  public static ControlledGcsBucketResource getBucketResource(String bucketName) {
     return new ControlledGcsBucketResource(
         WORKSPACE_ID,
         RESOURCE_ID,
@@ -94,7 +94,7 @@ public class ControlledResourceFixtures {
         OWNER_EMAIL,
         AccessScopeType.ACCESS_SCOPE_PRIVATE,
         ManagedByType.MANAGED_BY_USER,
-        uniqueName(BUCKET_NAME_PREFIX));
+        bucketName);
       }
 
   private ControlledResourceFixtures() {}

--- a/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.db;
 
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.BUCKET_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -84,11 +83,12 @@ public class ResourceDaoTest extends BaseUnitTest {
 
   @Test
   public void duplicateControlledBucketNameRejected() {
+    final String clashingBucketName = "not-a-pail";
     final UUID workspaceId1 = createGcpWorkspace();
     final ControlledGcsBucketResource initialResource =
         ControlledResourceFixtures.makeDefaultControlledGcsBucketResource()
             .workspaceId(workspaceId1)
-            .bucketName(BUCKET_NAME)
+            .bucketName(clashingBucketName)
             .build();
 
     resourceDao.createControlledResource(initialResource);
@@ -98,7 +98,7 @@ public class ResourceDaoTest extends BaseUnitTest {
         ControlledResourceFixtures.makeDefaultControlledGcsBucketResource()
             .workspaceId(workspaceId2)
             .name("another-bucket-resource")
-            .bucketName(BUCKET_NAME)
+            .bucketName(clashingBucketName)
             .build();
 
     assertThrows(

--- a/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
+++ b/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.flight;
 
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.getGoogleBucketCreationParameters;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -15,6 +16,7 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateGcsBucketStep;
@@ -51,7 +53,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
   public void testCreatesBucket() throws RetryException, InterruptedException {
     CreateGcsBucketStep createGcsBucketStep =
         new CreateGcsBucketStep(
-            mockCrlService, ControlledResourceFixtures.BUCKET_RESOURCE, mockWorkspaceService);
+            mockCrlService, ControlledResourceFixtures.getBucketResource(), mockWorkspaceService);
 
     when(mockCrlService.createStorageCow(FAKE_PROJECT_ID, mockUserRequest))
         .thenReturn(mockStorageCow);
@@ -59,9 +61,10 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
     when(mockStorageCow.create(bucketInfoCaptor.capture())).thenReturn(mockBucketCow);
 
     final FlightMap inputFlightMap = new FlightMap();
+    final ApiGcpGcsBucketCreationParameters creationParameters =
+        getGoogleBucketCreationParameters();
     inputFlightMap.put(
-        WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS,
-        ControlledResourceFixtures.GOOGLE_BUCKET_CREATION_PARAMETERS);
+        WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
     inputFlightMap.makeImmutable();
     doReturn(inputFlightMap).when(mockFlightContext).getInputParameters();
 
@@ -69,7 +72,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
     assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
 
     final BucketInfo info = bucketInfoCaptor.getValue();
-    assertThat(info.getName(), equalTo(ControlledResourceFixtures.BUCKET_NAME));
+    assertThat(info.getName(), equalTo(creationParameters.getName()));
     assertThat(info.getLocation(), equalTo(ControlledResourceFixtures.BUCKET_LOCATION));
     assertThat(info.getStorageClass(), equalTo(StorageClass.STANDARD));
 

--- a/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
+++ b/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
@@ -51,9 +51,12 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
 
   @Test
   public void testCreatesBucket() throws RetryException, InterruptedException {
+    final ApiGcpGcsBucketCreationParameters creationParameters =
+        getGoogleBucketCreationParameters();
+
     CreateGcsBucketStep createGcsBucketStep =
         new CreateGcsBucketStep(
-            mockCrlService, ControlledResourceFixtures.getBucketResource(), mockWorkspaceService);
+            mockCrlService, ControlledResourceFixtures.getBucketResource(creationParameters.getName()), mockWorkspaceService);
 
     when(mockCrlService.createStorageCow(FAKE_PROJECT_ID, mockUserRequest))
         .thenReturn(mockStorageCow);
@@ -61,8 +64,6 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
     when(mockStorageCow.create(bucketInfoCaptor.capture())).thenReturn(mockBucketCow);
 
     final FlightMap inputFlightMap = new FlightMap();
-    final ApiGcpGcsBucketCreationParameters creationParameters =
-        getGoogleBucketCreationParameters();
     inputFlightMap.put(
         WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
     inputFlightMap.makeImmutable();


### PR DESCRIPTION
Reports of flakkiness when unit tests are run simultaneously in the same DB point to the bucket name uniqueness check. Hence, using unique bucket names everywhere.