### PR TITLE
PF-746 Avoid william.thunderlord as the test user in connected tests.

### DIFF
--- a/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -242,11 +242,9 @@ class SamServiceTest extends BaseConnectedTest {
 
   @Test
   void listWorkspacesIncludesWsmWorkspace() throws Exception {
-    // This call cannot use william.thunderlord's account in dev Sam. Sam will return 500, as it
-    // cannot handle his tens of thousands of workspaces.
-    UUID workspaceId = createWorkspaceSecondaryUser();
+    UUID workspaceId = createWorkspaceDefaultUser();
     List<UUID> samWorkspaceIdList =
-        samService.listWorkspaceIds(userAccessUtils.secondUserAuthRequest());
+        samService.listWorkspaceIds(userAccessUtils.defaultUserAuthRequest());
     assertTrue(samWorkspaceIdList.contains(workspaceId));
   }
 
@@ -351,10 +349,6 @@ class SamServiceTest extends BaseConnectedTest {
   /** Create a workspace using the default test user for connected tests, return its ID. */
   private UUID createWorkspaceDefaultUser() {
     return createWorkspaceForUser(defaultUserRequest());
-  }
-
-  private UUID createWorkspaceSecondaryUser() {
-    return createWorkspaceForUser(secondaryUserRequest());
   }
 
   private UUID createWorkspaceForUser(AuthenticatedUserRequest userReq) {

--- a/src/test/resources/application-connected-test.yml
+++ b/src/test/resources/application-connected-test.yml
@@ -4,7 +4,7 @@ workspace:
 
   connected-test:
     user-delegated-service-account-path: rendered/user-delegated-service-account.json
-    default-user-email: william.thunderlord@test.firecloud.org
+    default-user-email: elijah.thunderlord@test.firecloud.org
     second-user-email: liam.dragonmaw@test.firecloud.org
 
   crl:

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -16,6 +16,8 @@ workspace:
       alpha: d56f4db5-b6c6-4a7e-8be2-ff6aa21c4fa6
       staging: 3e858a77-ea11-4f55-96f4-e6e45b71b7bf
     user-emails:
+      # TODO(PF-746): william.thunderlord has GCP permissions issue and should be avoided, but
+      # he is authorized to do Data Repo operations.
       local: william.thunderlord@test.firecloud.org
       dev: william.thunderlord@test.firecloud.org
       alpha: hermione.owner@test.firecloud.org


### PR DESCRIPTION
`william.thunderlord@test.firecloud.org` has problems getting more GCP permissions. Avoid using him in connected tests and leave a TODO for the integration tests that are being ported in AS-723.
More details on william.thunderlord's affliction in PF-746.

It is not simple to remove him everywhere because he has special Data Repo permissions not given to all test users. I'm doing a limited change at this time for the kinds of tests that he currently breaks.