### PR TITLE
[PF-772] assertEquals argument order

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -110,7 +110,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
     // Create a user-shared controlled GCS bucket - should fail due to no cloud context
     ApiException createBucketFails =
         assertThrows(ApiException.class, () -> createBucketAttempt(resourceApi));
-    assertEquals(createBucketFails.getCode(), HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, createBucketFails.getCode());
     logger.info("Failed to create bucket, as expected");
 
     // Create the cloud context
@@ -125,9 +125,8 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
     logger.info("Retrieving bucket resource id {}", resourceId.toString());
     GcpGcsBucketResource gotBucket = resourceApi.getBucket(getWorkspaceId(), resourceId);
     assertEquals(
-        gotBucket.getAttributes().getBucketName(),
-        bucket.getGcpBucket().getAttributes().getBucketName());
-    assertEquals(gotBucket.getAttributes().getBucketName(), bucketName);
+        bucket.getGcpBucket().getAttributes().getBucketName(), gotBucket.getAttributes().getBucketName());
+    assertEquals(bucketName, gotBucket.getAttributes().getBucketName());
 
     Storage ownerStorageClient = ClientTestUtils.getGcpStorageClient(testUser, projectId);
 
@@ -139,7 +138,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
 
     // Owner can read the object they created
     Blob retrievedFile = ownerStorageClient.get(blobId);
-    assertEquals(retrievedFile.getBlobId(), createdFile.getBlobId());
+    assertEquals(createdFile.getBlobId(), retrievedFile.getBlobId());
     logger.info("Read existing blob {} from bucket as owner", retrievedFile.getBlobId());
 
     // Second user has not yet been added to the workspace, so calls will be rejected.
@@ -151,7 +150,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
             StorageException.class,
             () -> readerStorageClient.get(blobId),
             "User accessed a controlled workspace bucket without being a workspace member");
-    assertEquals(userCannotRead.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, userCannotRead.getCode());
     logger.info(
         "User {} outside of workspace could not access bucket as expected", reader.userEmail);
 
@@ -166,7 +165,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
 
     // Second user can now read the blob
     Blob readerRetrievedFile = readerStorageClient.get(blobId);
-    assertEquals(readerRetrievedFile.getBlobId(), createdFile.getBlobId());
+    assertEquals(createdFile.getBlobId(), readerRetrievedFile.getBlobId());
     logger.info("Read existing blob {} from bucket as reader", retrievedFile.getBlobId());
 
     // Reader cannot write an object
@@ -178,7 +177,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
             StorageException.class,
             () -> readerStorageClient.create(readerBlobInfo, GCS_BLOB_CONTENT.getBytes()),
             "Workspace reader was able to write a file to a bucket!");
-    assertEquals(readerCannotWrite.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, readerCannotWrite.getCode());
     logger.info("Failed to write new blob {} as reader as expected", readerBlobId.getName());
 
     // Reader cannot delete the blob the owner created.
@@ -187,7 +186,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
             StorageException.class,
             () -> readerStorageClient.delete(blobId),
             "Workspace reader was able to delete bucket contents!");
-    assertEquals(readerCannotDeleteBlob.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, readerCannotDeleteBlob.getCode());
     logger.info("Reader failed to delete blob {} as expected", blobId);
 
     // Owner can delete the blob they created earlier.
@@ -200,7 +199,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
             StorageException.class,
             () -> readerStorageClient.get(bucketName).delete(),
             "Workspace reader was able to delete a bucket directly!");
-    assertEquals(readerCannotDeleteBucket.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, readerCannotDeleteBucket.getCode());
     logger.info("Failed to delete bucket {} directly as reader as expected", bucketName);
 
     // TODO(PF-633): Owners and writers can actually delete buckets due to workspace-level roles
@@ -213,7 +212,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
     //         StorageException.class,
     //         () -> ownerStorageClient.get(bucketName).delete(),
     //         "Workspace owner was able to delete a bucket directly!");
-    // assertEquals(ownerCannotDeleteBucket.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    // assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, ownerCannotDeleteBucket.getCode());
     // logger.info("Failed to delete bucket {} directly as owner as expected", bucketName);
 
     // Owner can delete the bucket through WSM
@@ -225,7 +224,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
             ApiException.class,
             () -> resourceApi.getBucket(getWorkspaceId(), resourceId),
             "Incorrectly found a deleted bucket!");
-    assertEquals(bucketNotFound.getCode(), HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, bucketNotFound.getCode());
 
     // also verify it was deleted from GCP
     Bucket maybeBucket = ownerStorageClient.get(bucketName);

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -112,10 +112,8 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     // Retrieve the bucket resource from WSM
     logger.info("Retrieving bucket resource id {}", resourceId.toString());
     GcpGcsBucketResource gotBucket = privateUserResourceApi.getBucket(getWorkspaceId(), resourceId);
-    assertEquals(
-        gotBucket.getAttributes().getBucketName(),
-        bucket.getGcpBucket().getAttributes().getBucketName());
-    assertEquals(gotBucket.getAttributes().getBucketName(), bucketName);
+    assertEquals(bucket.getGcpBucket().getAttributes().getBucketName(), gotBucket.getAttributes().getBucketName());
+    assertEquals(bucketName, gotBucket.getAttributes().getBucketName());
 
     Storage ownerStorageClient = ClientTestUtils.getGcpStorageClient(testUser, projectId);
     Storage privateUserStorageClient =
@@ -133,7 +131,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     //         StorageException.class,
     //         () -> ownerStorageClient.create(blobInfo, GCS_BLOB_CONTENT.getBytes()),
     //         "Workspace owner was able to write to private bucket");
-    // assertEquals(ownerCannotWritePrivateBucket.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    // assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, ownerCannotWritePrivateBucket.getCode());
     // logger.info("Workspace owner cannot write to private resource as expected");
 
     // Workspace reader cannot write object to bucket
@@ -142,7 +140,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             StorageException.class,
             () -> workspaceReaderStorageClient.create(blobInfo, GCS_BLOB_CONTENT.getBytes()),
             "Workspace reader was able to write to private bucket");
-    assertEquals(readerCannotWriteBucket.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, readerCannotWriteBucket.getCode());
     logger.info("Workspace reader cannot write to private resource as expected");
 
     // Private resource user can write object to bucket
@@ -151,7 +149,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
 
     // Private user can read their bucket
     Blob retrievedBlob = privateUserStorageClient.get(blobId);
-    assertEquals(retrievedBlob, createdBlob);
+    assertEquals(createdBlob, retrievedBlob);
     logger.info("Private resource user can read {} from bucket", retrievedBlob.getName());
 
     // TODO(PF-633): workspace owners can read from private buckets via "roles/storage.admin" and
@@ -162,7 +160,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     //         StorageException.class,
     //         () -> ownerStorageClient.get(blobId),
     //         "Workspace owner was able to read private bucket");
-    // assertEquals(ownerCannotReadPrivateBucket.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    // assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, ownerCannotReadPrivateBucket.getCode());
     // logger.info("Workspace owner cannot read from private bucket as expected");
 
     // TODO(PF-633): workspace readers can read from private buckets via "roles/viewer".
@@ -172,7 +170,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     //         StorageException.class,
     //         () -> workspaceReaderStorageClient.get(blobId),
     //         "Workspace reader was able to read private bucket");
-    // assertEquals(readerCannotReadPrivateBucket.getCode(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    // assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, readerCannotReadPrivateBucket.getCode());
     // logger.info("Workspace reader cannot read from private bucket as expected");
 
     // Private resource user can delete the blob they created earlier.
@@ -184,7 +182,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     logger.info(
         "For owner, delete bucket status is {}",
         ownerDeleteResult.getJobReport().getStatus().toString());
-    assertEquals(ownerDeleteResult.getJobReport().getStatus(), JobReport.StatusEnum.SUCCEEDED);
+    assertEquals(JobReport.StatusEnum.SUCCEEDED, ownerDeleteResult.getJobReport().getStatus());
 
     // verify the bucket was deleted from WSM metadata
     ApiException bucketIsMissing =
@@ -192,7 +190,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             ApiException.class,
             () -> workspaceOwnerResourceApi.getBucket(getWorkspaceId(), resourceId),
             "Incorrectly found a deleted bucket!");
-    assertEquals(bucketIsMissing.getCode(), HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+    assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, bucketIsMissing.getCode());
 
     // also verify it was deleted from GCP
     Bucket maybeBucket = ownerStorageClient.get(bucketName);

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -96,7 +96,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
 
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
 
-    assertEquals(workspace, createdWorkspace);
+    assertEquals(createdWorkspace, workspace);
 
     assertTrue(workspaceDao.deleteWorkspace(workspaceId));
   }
@@ -176,7 +176,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
     void createAndGetMcWorkspace() {
       Workspace workspace = workspaceDao.getWorkspace(mcWorkspaceId);
 
-      assertEquals(workspace, mcWorkspace);
+      assertEquals(mcWorkspace, workspace);
       assertTrue(workspaceDao.deleteWorkspace(mcWorkspaceId));
     }
 

--- a/service/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
+++ b/service/src/test/java/bio/terra/workspace/integration/WorkspaceIntegrationTest.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.integration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -193,7 +194,7 @@ class WorkspaceIntegrationTest extends BaseIntegrationTest {
     assertEquals(HttpStatus.OK, listResponse.getStatusCode());
     assertTrue(listResponse.isResponseObject());
     DataReferenceList referenceList = listResponse.getResponseObject();
-    assertEquals(referenceList.getResources().size(), 2);
+    assertThat(referenceList.getResources(), hasSize(2));
 
     DataReferenceDescription[] expectedResults = {
       firstPostResponse.getResponseObject(), secondPostResponse.getResponseObject()

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -235,7 +235,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             duplicateResourceJobId,
             ControlledAiNotebookInstanceResource.class,
             user.getAuthenticatedRequest());
-    assertEquals(duplicateJobResult.getException().getClass(), DuplicateResourceException.class);
+    assertEquals(DuplicateResourceException.class, duplicateJobResult.getException().getClass());
   }
 
   @Test
@@ -560,7 +560,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     BigQueryCow bqCow = crlService.createWsmSaBigQueryCow();
     Dataset cloudDataset =
         bqCow.datasets().get(projectId, createdDataset.getDatasetName()).execute();
-    assertEquals(cloudDataset.getLocation(), location);
+    assertEquals(location, cloudDataset.getLocation());
 
     assertEquals(
         resource,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleTest.java
@@ -17,45 +17,45 @@ public class CustomGcpIamRoleTest extends BaseUnitTest {
   @Test
   public void validateCustomIamRoleNames() {
     assertEquals(
+        "GCS_BUCKET_READER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
             .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.READER)
-            .getRoleName(),
-        "GCS_BUCKET_READER");
+            .getRoleName());
     assertEquals(
+        "GCS_BUCKET_WRITER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
             .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.WRITER)
-            .getRoleName(),
-        "GCS_BUCKET_WRITER");
+            .getRoleName());
     assertEquals(
+        "GCS_BUCKET_EDITOR",
         CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
             .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.EDITOR)
-            .getRoleName(),
-        "GCS_BUCKET_EDITOR");
+            .getRoleName());
     assertEquals(
+        "GCS_BUCKET_ASSIGNER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
             .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.ASSIGNER)
-            .getRoleName(),
-        "GCS_BUCKET_ASSIGNER");
+            .getRoleName());
 
     assertEquals(
+        "BIG_QUERY_DATASET_READER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
             .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.READER)
-            .getRoleName(),
-        "BIG_QUERY_DATASET_READER");
+            .getRoleName());
     assertEquals(
+        "BIG_QUERY_DATASET_WRITER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
             .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.WRITER)
-            .getRoleName(),
-        "BIG_QUERY_DATASET_WRITER");
+            .getRoleName());
     assertEquals(
+        "BIG_QUERY_DATASET_EDITOR",
         CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
             .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.EDITOR)
-            .getRoleName(),
-        "BIG_QUERY_DATASET_EDITOR");
+            .getRoleName());
     assertEquals(
+        "BIG_QUERY_DATASET_ASSIGNER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
             .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.ASSIGNER)
-            .getRoleName(),
-        "BIG_QUERY_DATASET_ASSIGNER");
+            .getRoleName());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -80,7 +80,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
     assertTrue(workspace.getGcpCloudContext().isPresent());
 
     String contextProjectId = workspace.getGcpCloudContext().get().getGcpProjectId();
-    assertEquals(contextProjectId, projectId);
+    assertEquals(projectId, contextProjectId);
 
     Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
     assertEquals(projectId, project.getProjectId());


### PR DESCRIPTION
Expected value should come first. In almost all cases it's clear which is which. It might  be good to have another set of eyes search for "assertEquals" and scan for anomalies.