### PR TITLE
Add data reference info in perf config files

### DIFF
--- a/integration/src/main/resources/configs/perf/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/perf/DataReferenceLifecycle.json
@@ -11,7 +11,7 @@
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
-      "parameters": ["wm-default-spend-profile"]
+      "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
   "testUserFiles": ["william.json"]

--- a/integration/src/main/resources/configs/perf/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/perf/EnumerateDataReferences.json
@@ -11,7 +11,7 @@
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
-      "parameters": ["wm-default-spend-profile"]
+      "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
   "testUserFiles": ["william.json"]


### PR DESCRIPTION
This PR fixes the snapshot-related error in perf tests
`java.lang.IllegalArgumentException: Must provide Spend Profile ID, Data Repo snapshot ID, and Data Repo Instance Name in the parameters list`