### PR TITLE
PF-730 prework - add workflow tester

### DIFF
--- a/.github/workflows/workflow-tester.yml
+++ b/.github/workflows/workflow-tester.yml
@@ -1,0 +1,36 @@
+# Workflow for testing new actions and workflows
+#
+# Github does not provide a way to run workflows that are not already merged to the
+# default branch. Once a workflow that is configured for manual running is merged,
+# then when you change it in a branch and execute your changes.
+#
+# The purpose of this workflow is to be a scratch space for developing workflows.
+# Use it to prepare a workflow. When it is ready, you can copy the file to the
+# proper name and merge from there.
+
+name: Workflow Tester
+on:
+  workflow_dispatch: {}
+
+jobs:
+  workflow-test-job:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get Vault token
+      id: vault-token-step
+      env:
+        VAULT_ADDR: https://clotho.broadinstitute.org:8200
+      run: |
+        VAULT_TOKEN=$(docker run --rm --cap-add IPC_LOCK \
+          -e "VAULT_ADDR=${VAULT_ADDR}" \
+          vault:1.1.0 \
+          vault write -field token \
+            auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
+            secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+        echo ::set-output name=vault-token::$VAULT_TOKEN
+        echo ::add-mask::$VAULT_TOKEN
+


### PR DESCRIPTION
You cannot run a workflow that is on a branch unless the workflow already exists in the default branch.
So here is a test workflow that is manually triggered that we can use for testing workflows.
In particular, I will use it for testing the database cleaning.
