### PR TITLE
[PF-633][PF-735] Remove bucket and BQ project level permissions

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -202,18 +202,23 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
     assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, readerCannotDeleteBucket.getCode());
     logger.info("Failed to delete bucket {} directly as reader as expected", bucketName);
 
-    // TODO(PF-633): Owners and writers can actually delete buckets due to workspace-level roles
-    //  included as a temporary workaround. This needs to be removed as we transition onto WSM
-    //  controlled resources.
+    // Writer also cannot delete the bucket directly
+    StorageException writerCannotDeleteBucket =
+        assertThrows(
+            StorageException.class,
+            () -> readerStorageClient.get(bucketName).delete(),
+            "Workspace writer was able to delete a bucket directly!");
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, writerCannotDeleteBucket.getCode());
+    logger.info("Failed to delete bucket {} directly as writer as expected", bucketName);
 
-    // // Owner also cannot delete the bucket directly
-    // StorageException ownerCannotDeleteBucket =
-    //     assertThrows(
-    //         StorageException.class,
-    //         () -> ownerStorageClient.get(bucketName).delete(),
-    //         "Workspace owner was able to delete a bucket directly!");
-    // assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, ownerCannotDeleteBucket.getCode());
-    // logger.info("Failed to delete bucket {} directly as owner as expected", bucketName);
+    // Owner also cannot delete the bucket directly
+    StorageException ownerCannotDeleteBucket =
+        assertThrows(
+            StorageException.class,
+            () -> ownerStorageClient.get(bucketName).delete(),
+            "Workspace owner was able to delete a bucket directly!");
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, ownerCannotDeleteBucket.getCode());
+    logger.info("Failed to delete bucket {} directly as owner as expected", bucketName);
 
     // Owner can delete the bucket through WSM
     ResourceMaker.deleteControlledGcsBucket(resourceId, getWorkspaceId(), resourceApi);

--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -202,15 +202,6 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
     assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, readerCannotDeleteBucket.getCode());
     logger.info("Failed to delete bucket {} directly as reader as expected", bucketName);
 
-    // Writer also cannot delete the bucket directly
-    StorageException writerCannotDeleteBucket =
-        assertThrows(
-            StorageException.class,
-            () -> readerStorageClient.get(bucketName).delete(),
-            "Workspace writer was able to delete a bucket directly!");
-    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, writerCannotDeleteBucket.getCode());
-    logger.info("Failed to delete bucket {} directly as writer as expected", bucketName);
-
     // Owner also cannot delete the bucket directly
     StorageException ownerCannotDeleteBucket =
         assertThrows(

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -124,7 +124,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     BlobId blobId = BlobId.of(bucketName, GCS_BLOB_NAME);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
 
-    // Owner cannot write object to bucket
+    // Workspace owner cannot write object to bucket, this is not their private resource
     StorageException ownerCannotWritePrivateBucket =
         assertThrows(
             StorageException.class,
@@ -151,7 +151,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     assertEquals(createdBlob, retrievedBlob);
     logger.info("Private resource user can read {} from bucket", retrievedBlob.getName());
 
-    // Owner cannot read the bucket contents
+    // Workspace owner cannot read the bucket contents, because it is not their bucket
     StorageException ownerCannotReadPrivateBucket =
         assertThrows(
             StorageException.class,
@@ -173,7 +173,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     privateUserStorageClient.delete(blobId);
     logger.info("Private resource user successfully deleted blob {}", blobId.getName());
 
-    // Owner can delete the bucket through WSM
+    // Workspace owner can delete the bucket through WSM
     var ownerDeleteResult = deleteBucket(workspaceOwnerResourceApi, resourceId);
     logger.info(
         "For owner, delete bucket status is {}",

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -124,15 +124,14 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     BlobId blobId = BlobId.of(bucketName, GCS_BLOB_NAME);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
 
-    // TODO(PF-633): workspace owners can write to private buckets via "roles/storage.admin".
-    // // Owner cannot write object to bucket
-    // StorageException ownerCannotWritePrivateBucket =
-    //     assertThrows(
-    //         StorageException.class,
-    //         () -> ownerStorageClient.create(blobInfo, GCS_BLOB_CONTENT.getBytes()),
-    //         "Workspace owner was able to write to private bucket");
-    // assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, ownerCannotWritePrivateBucket.getCode());
-    // logger.info("Workspace owner cannot write to private resource as expected");
+    // Owner cannot write object to bucket
+    StorageException ownerCannotWritePrivateBucket =
+        assertThrows(
+            StorageException.class,
+            () -> ownerStorageClient.create(blobInfo, GCS_BLOB_CONTENT.getBytes()),
+            "Workspace owner was able to write to private bucket");
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, ownerCannotWritePrivateBucket.getCode());
+    logger.info("Workspace owner cannot write to private resource as expected");
 
     // Workspace reader cannot write object to bucket
     StorageException readerCannotWriteBucket =
@@ -152,26 +151,23 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     assertEquals(createdBlob, retrievedBlob);
     logger.info("Private resource user can read {} from bucket", retrievedBlob.getName());
 
-    // TODO(PF-633): workspace owners can read from private buckets via "roles/storage.admin" and
-    //  "roles/viewer"
-    // // Owner cannot read the bucket contents
-    // StorageException ownerCannotReadPrivateBucket =
-    //     assertThrows(
-    //         StorageException.class,
-    //         () -> ownerStorageClient.get(blobId),
-    //         "Workspace owner was able to read private bucket");
-    // assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, ownerCannotReadPrivateBucket.getCode());
-    // logger.info("Workspace owner cannot read from private bucket as expected");
+    // Owner cannot read the bucket contents
+    StorageException ownerCannotReadPrivateBucket =
+        assertThrows(
+            StorageException.class,
+            () -> ownerStorageClient.get(blobId),
+            "Workspace owner was able to read private bucket");
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, ownerCannotReadPrivateBucket.getCode());
+    logger.info("Workspace owner cannot read from private bucket as expected");
 
-    // TODO(PF-633): workspace readers can read from private buckets via "roles/viewer".
-    // // Workspace reader also cannot read private bucket contents
-    // StorageException readerCannotReadPrivateBucket =
-    //     assertThrows(
-    //         StorageException.class,
-    //         () -> workspaceReaderStorageClient.get(blobId),
-    //         "Workspace reader was able to read private bucket");
-    // assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, readerCannotReadPrivateBucket.getCode());
-    // logger.info("Workspace reader cannot read from private bucket as expected");
+    // Workspace reader also cannot read private bucket contents
+    StorageException readerCannotReadPrivateBucket =
+        assertThrows(
+            StorageException.class,
+            () -> workspaceReaderStorageClient.get(blobId),
+            "Workspace reader was able to read private bucket");
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, readerCannotReadPrivateBucket.getCode());
+    logger.info("Workspace reader cannot read from private bucket as expected");
 
     // Private resource user can delete the blob they created earlier.
     privateUserStorageClient.delete(blobId);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -14,20 +14,22 @@ import java.util.List;
  * CustomGcpIamRoleMapping}), and should be removed from this list.
  */
 public class CloudSyncRoleMapping {
-  private static final List<String> READER_PERMISSIONS = ImmutableList.of("roles/viewer");
+  // Note that bigquery.jobUser is required at the project level, unlike other permissions which can
+  // be per-dataset.
+  private static final List<String> READER_PERMISSIONS =
+      ImmutableList.of(
+          "roles/bigquery.jobUser",
+          "roles/lifesciences.viewer",
+          "roles/serviceusage.serviceUsageViewer");
   private static final List<String> WRITER_PERMISSIONS =
       new ImmutableList.Builder<String>()
           .addAll(READER_PERMISSIONS)
           .add(
-              "roles/bigquery.dataEditor",
               // TODO(wchambers): Revise service account permissions when there are controlled
               // resources for service accounts. (Also used by NextFlow)
               "roles/iam.serviceAccountUser",
               "roles/lifesciences.editor",
-              "roles/serviceusage.serviceUsageConsumer",
-              // TODO(marikomedlock): Revise storage permissions when there are controlled
-              // resources for buckets.
-              "roles/storage.admin")
+              "roles/serviceusage.serviceUsageConsumer")
           .build();
   // Currently, workspace editors, applications and owners have the sam cloud permissions as
   // writers. If that changes, create a new list and modify the map below.


### PR DESCRIPTION
This change will make WSM stop granting most project level permissions for GCS buckets and BigQuery datasets in new projects. The major exception is `roles/bigquery.jobUser`. This grants permission to run BigQuery jobs, which was previously included with `roles/viewer`. This role must be granted at the project level, rather than the individual dataset level.

Removing `roles/viewer` will remove a ton of over-granted permissions across GCP. All controlled resources have appropriate READER roles and I think the remaining lifescience and serviceusage roles should cover existing usecases, but we should keep an eye out if this causes unexpected breakage for users.

As always there is no backfill mechanism, so users in existing projects will still be overpermissioned.

Leaving this as a draft until we have a green light on not breaking early users.