### PR TITLE
AS-723 follow-up: Create integration suite for dev env

### DIFF
--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           if ${{ steps.set-env-step.outputs.test-env == 'dev' }}; then
             TEST_SERVER=workspace-dev.json
-            TEST=suites/FullIntegration.json
+            TEST=suites/dev/FullIntegration.json
           elif ${{ steps.set-env-step.outputs.test-env == 'alpha' }}; then
             TEST_SERVER=workspace-alpha.json
             TEST=suites/alpha/FullIntegration.json

--- a/integration/src/main/resources/suites/dev/FullIntegration.json
+++ b/integration/src/main/resources/suites/dev/FullIntegration.json
@@ -1,0 +1,13 @@
+{
+  "name": "FullIntegration",
+  "description": "Integration tests (not including context/control-related tests) - to be run on dev",
+  "serverSpecificationFile": "workspace-dev.json",
+  "testConfigurationFiles": [
+    "integration/BasicAuthenticated.json",
+    "integration/BasicUnauthenticated.json",
+    "integration/GetRoles.json",
+    "integration/WorkspaceLifecycle.json",
+    "integration/DataReferenceLifecycle.json",
+    "integration/EnumerateDataReferences.json"
+  ]
+}


### PR DESCRIPTION
Create dedicated test suite for dev environment. I had set it up earlier to use the [generic test suite](https://github.com/DataBiosphere/terra-workspace-manager/blob/dev/integration/src/main/resources/suites/FullIntegration.json) which is more targeted towards wsmtest environment.
This provides consistency by running the same tests that we run on alpha and staging during release promotion.