### PR TITLE
[PF-826] Fix test.yml when run with dev environment

### DIFF
--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -94,7 +94,7 @@ jobs:
           test: ${{ steps.set-config-files-step.outputs.test }}
 
       - name: "Notify QA Slack"
-        if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
+        if: always() && (steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging')
         uses: broadinstitute/action-slack@v3.8.0
         # see https://github.com/broadinstitute/action-slack
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       testEnv:
-        description: 'Environment in which tests should be run. Known to work for local, alpha and staging.'
+        description: 'Environment in which tests should be run. Regardless of how this is set, the tests run against a local Postgres and development Sam'
         required: true
 
 jobs:
@@ -111,7 +111,9 @@ jobs:
       id: config
       uses: ./.github/actions/write-config
       with:
-        target: ${{ steps.set-env-step.outputs.test-env }}
+        # Note that unit and connected tests run with local configuration regardless of
+        # the test-env specified on the workflow-dispatch input.
+        target: local
         vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
 
       # Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,7 @@ jobs:
         path: service/build/reports/tests
 
     - name: "Notify QA Slack"
-      if: steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging'
+      if: always() && (steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging')
       uses: broadinstitute/action-slack@v3.8.0
       # see https://github.com/broadinstitute/action-slack
       env:

--- a/service/src/test/java/bio/terra/workspace/common/BaseConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseConnectedTest.java
@@ -13,5 +13,5 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("connected-test")
 public class BaseConnectedTest extends BaseTest {
 
-  public static final String BUFFER_SERVICE_DISABLED_ENVS_REG_EX = "alpha|staging|prod";
+  public static final String BUFFER_SERVICE_DISABLED_ENVS_REG_EX = "dev|alpha|staging|prod";
 }

--- a/service/src/test/java/bio/terra/workspace/service/status/WorkspaceManagerStatusServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/status/WorkspaceManagerStatusServiceTest.java
@@ -57,5 +57,4 @@ public class WorkspaceManagerStatusServiceTest extends BaseUnitTest {
     statusService.checkStatus();
     assertFalse(statusService.getCurrentStatus());
   }
-
 }


### PR DESCRIPTION
Whether we should even run this test is being tracked separate in [AS-789](https://broadworkbench.atlassian.net/browse/AS-789?atlOrigin=eyJpIjoiNDlkYmZjNzY0NjIwNGMwYzk3MDE3MzIxYzM5MDk3ODkiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

This change makes the dev environment work in the same was as the alpha and staging environments.
There are three small fixes:
1. Add `dev` to the environments that skip tests that require Buffer/Janitor configuration
2. Change workflow logic so `alpha` and `staging` results will always get reported to QA via slack
3. Set the `write-config` to be `local` always for these tests, since they always are running against a local WSM service and local postgres.

