### PR TITLE
[PF-732] Fix async endpoints

### DIFF
--- a/service/local-dev/skaffold.yaml.template
+++ b/service/local-dev/skaffold.yaml.template
@@ -4,7 +4,7 @@ kind: Config
 build:
   artifacts:
   - image: gcr.io/terra-kernel-k8s/terra-workspace-manager
-    context: ../
+    context: ../../
     jib:
       project: service
 deploy:

--- a/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
+++ b/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.app;
 
 import bio.terra.common.migrate.LiquibaseMigrator;
 import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfiguration;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
 import org.springframework.context.ApplicationContext;
 
@@ -15,7 +14,6 @@ public final class StartupInitializer {
     WorkspaceDatabaseConfiguration workspaceDatabaseConfiguration =
         applicationContext.getBean(WorkspaceDatabaseConfiguration.class);
     JobService jobService = applicationContext.getBean(JobService.class);
-    SamService samService = applicationContext.getBean(SamService.class);
 
     if (workspaceDatabaseConfiguration.isInitializeOnStart()) {
       migrateService.initialize(changelogPath, workspaceDatabaseConfiguration.getDataSource());

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -151,7 +151,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
             .jobReport(jobResult.getJobReport())
             .errorReport(jobResult.getApiErrorReport());
     return new ResponseEntity<>(
-        response, HttpStatus.valueOf(response.getJobReport().getStatusCode()));
+        response, ControllerUtils.getAsyncResponseCode(response.getJobReport()));
   }
 
   @Override
@@ -337,7 +337,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
 
     ApiCreatedControlledGcpAiNotebookInstanceResult result =
         fetchNotebookInstanceCreateResult(jobId, userRequest);
-    return new ResponseEntity<>(result, HttpStatus.valueOf(result.getJobReport().getStatusCode()));
+    return new ResponseEntity<>(
+        result, ControllerUtils.getAsyncResponseCode((result.getJobReport())));
   }
 
   @Override
@@ -346,7 +347,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ApiCreatedControlledGcpAiNotebookInstanceResult result =
         fetchNotebookInstanceCreateResult(jobId, userRequest);
-    return new ResponseEntity<>(result, HttpStatus.valueOf(result.getJobReport().getStatusCode()));
+    return new ResponseEntity<>(
+        result, ControllerUtils.getAsyncResponseCode(result.getJobReport()));
   }
 
   private ApiCreatedControlledGcpAiNotebookInstanceResult fetchNotebookInstanceCreateResult(
@@ -387,7 +389,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
             userRequest);
     ApiDeleteControlledGcpAiNotebookInstanceResult result =
         fetchNotebookInstanceDeleteResult(jobId, userRequest);
-    return new ResponseEntity<>(result, HttpStatus.valueOf(result.getJobReport().getStatusCode()));
+    return new ResponseEntity<>(
+        result, ControllerUtils.getAsyncResponseCode(result.getJobReport()));
   }
 
   @Override
@@ -396,7 +399,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ApiDeleteControlledGcpAiNotebookInstanceResult result =
         fetchNotebookInstanceDeleteResult(jobId, userRequest);
-    return new ResponseEntity<>(result, HttpStatus.valueOf(result.getJobReport().getStatusCode()));
+    return new ResponseEntity<>(
+        result, ControllerUtils.getAsyncResponseCode(result.getJobReport()));
   }
 
   private ApiDeleteControlledGcpAiNotebookInstanceResult fetchNotebookInstanceDeleteResult(

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -408,7 +408,7 @@ public class WorkspaceApiController implements WorkspaceApi {
     workspaceService.createGcpCloudContext(id, jobId, resultPath, userReq);
     ApiCreateCloudContextResult response = fetchCreateCloudContextResult(jobId, userReq);
     return new ResponseEntity<>(
-        response, HttpStatus.valueOf(response.getJobReport().getStatusCode()));
+        response, ControllerUtils.getAsyncResponseCode(response.getJobReport()));
   }
 
   @Override
@@ -417,7 +417,7 @@ public class WorkspaceApiController implements WorkspaceApi {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     ApiCreateCloudContextResult response = fetchCreateCloudContextResult(jobId, userReq);
     return new ResponseEntity<>(
-        response, HttpStatus.valueOf(response.getJobReport().getStatusCode()));
+        response, ControllerUtils.getAsyncResponseCode(response.getJobReport()));
   }
 
   private ApiCreateCloudContextResult fetchCreateCloudContextResult(

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerUtils.java
@@ -1,6 +1,9 @@
 package bio.terra.workspace.common.utils;
 
+import bio.terra.workspace.generated.model.ApiJobReport;
+import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
 import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
 
 /** Class of static helper methods for controllers */
 public class ControllerUtils {
@@ -20,7 +23,7 @@ public class ControllerUtils {
    */
   public static String getAsyncResultEndpoint(
       HttpServletRequest request, String jobId, String resultWord) {
-    return String.format("%s/%s/%s", request.getServletPath(), jobId, resultWord);
+    return String.format("%s/%s/%s", request.getServletPath(), resultWord, jobId);
   }
 
   /**
@@ -33,6 +36,16 @@ public class ControllerUtils {
    */
   public static String getAsyncResultEndpoint(HttpServletRequest request, String jobId) {
     return getAsyncResultEndpoint(request, jobId, "result");
+  }
+
+  /**
+   * Return the appropriate response code for an endpoint, given an async job report. For a job
+   * that's still running, this is 202. For a job that's finished (either succeeded or failed), the
+   * endpoint should return 200. More informational status codes will be included in either the
+   * response or error report bodies.
+   */
+  public static HttpStatus getAsyncResponseCode(ApiJobReport jobReport) {
+    return jobReport.getStatus() == StatusEnum.RUNNING ? HttpStatus.ACCEPTED : HttpStatus.OK;
   }
 
   private ControllerUtils() {}

--- a/service/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/service/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -255,7 +255,11 @@ public class JobService {
     if (resultPath == null) {
       resultPath = "";
     }
-    return Path.of(ingressConfig.getDomainName(), resultPath).toString();
+    // This is a little hacky, but GCP rejects non-https traffic and a local server does not support
+    // it.
+    String protocol =
+        ingressConfig.getDomainName().startsWith("localhost") ? "http://" : "https://";
+    return protocol + Path.of(ingressConfig.getDomainName(), resultPath).toString();
   }
 
   private ApiJobReport.StatusEnum getJobStatus(FlightStatus flightStatus) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateControlledGcsBucketResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateControlledGcsBucketResourceFlight.java
@@ -3,7 +3,6 @@ package bio.terra.workspace.service.resource.controlled.flight.update;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.common.utils.FlightBeanBag;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.resource.controlled.ControlledResource;
 
@@ -15,8 +14,6 @@ public class UpdateControlledGcsBucketResourceFlight extends Flight {
     final FlightBeanBag flightBeanBag = FlightBeanBag.getFromObject(beanBag);
     final ControlledResource resource =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), ControlledResource.class);
-    final AuthenticatedUserRequest userRequest =
-        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
     // get copy of existing metadata
     addStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateGcsBucketStep.java
@@ -18,11 +18,15 @@ import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResour
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.google.cloud.storage.BucketInfo.LifecycleRule;
 import com.google.cloud.storage.StorageClass;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings(
+    value = "RV_RETURN_VALUE_IGNORED_INFERRED",
+    justification = "OK to ignore return value from BucketCow.update()")
 public class UpdateGcsBucketStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(UpdateGcsBucketStep.class);
   private final ControlledGcsBucketResource bucketResource;

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceStateStep.java
@@ -1,16 +1,13 @@
 package bio.terra.workspace.service.workspace.flight;
 
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
-import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.WorkspaceDao;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 
 public class DeleteWorkspaceStateStep implements Step {
 
@@ -27,12 +24,7 @@ public class DeleteWorkspaceStateStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws RetryException, InterruptedException {
-    FlightMap inputMap = flightContext.getInputParameters();
-    // WorkspaceDao.deleteWorkspace returns true if a delete succeeds or false if the workspace is
-    // not found, but the user-facing delete operation should return a 204 even if the workspace is
-    // not found.
     workspaceDao.deleteWorkspace(workspaceId);
-    FlightUtils.setResponse(flightContext, null, HttpStatus.NO_CONTENT);
     return StepResult.getStepResultSuccess();
   }
 
@@ -42,7 +34,6 @@ public class DeleteWorkspaceStateStep implements Step {
     // state tables, and this undo can't re-create all that state.
     // This should absolutely be the last step of a flight, and because we're unable to undo it
     // we surface the error from the DO step that led to this issue.
-    FlightMap inputMap = flightContext.getInputParameters();
     logger.error("Unable to undo deletion of workspace {} in WSM DB", workspaceId);
     return flightContext.getResult();
   }

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -735,14 +735,9 @@ paths:
           $ref: '#/components/responses/ServerError'
 
 
-  /api/job/v1/jobs/{workspaceId}:
+  /api/job/v1/jobs/{jobId}:
     parameters:
-    - name: workspaceId
-      in: path
-      description: The unique id provided in JobControl to the async endpoint
-      required: true
-      schema:
-        type: string
+    - $ref: '#/components/parameters/JobId'
     get:
       tags:
       - jobs

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -623,7 +623,7 @@ paths:
         '200':
           $ref: '#/components/responses/CreateCloudContextResultResponse'
         '202':
-          $ref: '#/components/responses/JobReportResponse'
+          $ref: '#/components/responses/CreateCloudContextResultResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -67,7 +67,7 @@ workspace:
     staleness-threshold-seconds: 125
 
   workspace-database:
-    initialize-on-start: true
+    initialize-on-start: ${env.db.init}
     password: ${env.db.ws.pass}
     upgrade-on-start: true
     uri: ${env.db.host}/${env.db.ws.name}
@@ -95,7 +95,7 @@ terra.common:
     in-kubernetes: false
   stairway:
     cluster-name-suffix: workspace-stairway
-    force-clean-start: true # ${env.db.init}
+    force-clean-start: false # ${env.db.init}
     max-parallel-flights: 50
     migrate-upgrade: true
     quiet-down-timeout: 30s

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -45,7 +45,7 @@ workspace:
     terra: ${env.urls.terra-datarepo}
   ingress:
     # Default value that's overridden by Helm.
-    domain-name: http://localhost:8080
+    domain-name: localhost:8080
 
   job:
     max-threads: 4
@@ -67,7 +67,7 @@ workspace:
     staleness-threshold-seconds: 125
 
   workspace-database:
-    initialize-on-start: ${env.db.init}
+    initialize-on-start: true
     password: ${env.db.ws.pass}
     upgrade-on-start: true
     uri: ${env.db.host}/${env.db.ws.name}
@@ -95,7 +95,7 @@ terra.common:
     in-kubernetes: false
   stairway:
     cluster-name-suffix: workspace-stairway
-    force-clean-start: false # ${env.db.init}
+    force-clean-start: true # ${env.db.init}
     max-parallel-flights: 50
     migrate-upgrade: true
     quiet-down-timeout: 30s


### PR DESCRIPTION
This change fixes issues with WSM's asynchronous endpoints:

- By design, the async endpoints (and their polling endpoints) were supposed to return 202 for "job still running" and 200 for "job finished", with a more informative code inside the JobReport of the response body. As written, the endpoint copied the status from the JobReport, and the JobReport status was incorrectly either 202 or 200 (even for failed jobs, when it should have been 4xx or 5xx).
- A utility for building result URLs had parameters switched and was missing the scheme, so the provided URLs were incorrect. This change fixes the utility, so that the `resultURL` field of all JobReports WSM returns now point to valid endpoints.
- Unrelated to async endpoints,  but I also fixed some findbugs warnings and updated the skaffold template to reflect the repo's new structure.