### PR TITLE
[PF-853] Explicitly set the artifact id for publishing

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -80,6 +80,7 @@ java {
 publishing {
     publications {
         workspaceManagerClientLibrary(MavenPublication) {
+            artifactId = "workspace-manager-client"
             from components.java
             versionMapping {
                 usage("java-runtime") {


### PR DESCRIPTION
We have been publishing the client to the wrong place ever since I re-org's the build.
The reason is that the `artifactId` is taken by default from the project name. I changed the project name to `client`.
This change explicitly sets the artifactId which, the docs say, will do the right thing.

The only way I can think of to test this is to do a tag-publish action on the branch. If that works, I then merge right away and get a proper tag-publish on the mainline.