### PR TITLE
QA-1504: Fix intermittent NPE in resiliency test.

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -10,7 +10,7 @@ plugins {
     //  fine in the service project.
     // id "com.diffplug.spotless" version "5.12.4"
     // Terra Test Runner Plugin
-    id 'bio.terra.test-runner-plugin' version '0.0.5-SNAPSHOT'
+    id 'bio.terra.test-runner-plugin' version '0.0.6-SNAPSHOT'
 }
 
 dependencies {
@@ -34,7 +34,7 @@ dependencies {
         googleNotebook = "v1-rev20201110-1.30.10"
 
         datarepoClient = "1.0.155-SNAPSHOT"
-        testRunnerVersion = "0.0.5-SNAPSHOT"
+        testRunnerVersion = "0.0.6-SNAPSHOT"
     }
     implementation group: 'org.apache.commons', name: 'commons-math3', version: "${apacheMath}"
     implementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: "${jUnit}"

--- a/integration/gradle.lockfile
+++ b/integration/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 bio.terra:datarepo-client:1.0.155-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra:terra-test-runner:0.0.5-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:terra-test-runner:0.0.6-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.2.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.2.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/integration/src/main/resources/configs/resiliency/DeleteInitialPods.json
+++ b/integration/src/main/resources/configs/resiliency/DeleteInitialPods.json
@@ -13,10 +13,10 @@
   "testScripts": [
     {
       "name": "ServiceStatus",
-      "parameters": [120],
+      "parameters": [150],
       "numberOfUserJourneyThreadsToRun": 2,
       "userJourneyThreadPoolSize": 2,
-      "expectedTimeForEach": 120,
+      "expectedTimeForEach": 150,
       "expectedTimeForEachUnit": "SECONDS"
     }
   ],


### PR DESCRIPTION
Bump TestRunner version to 0.0.6-SNAPSHOT to fix intermittent NPE issue in resiliency tests.

For more information, please refer to this PR as well: [https://github.com/DataBiosphere/terra-test-runner/pull/17](https://github.com/DataBiosphere/terra-test-runner/pull/17)