### PR TITLE
DDO-1293 Update Skaffold workflow for compatibility with upcoming Helm changes

### DIFF
--- a/service/local-dev/README.md
+++ b/service/local-dev/README.md
@@ -1,14 +1,8 @@
-This directory contains scripts for running continuous development builds. This 
+This directory contains scripts for running continuous development builds. This
 is not necessary for deployment, but it can be helpful for developing faster.
-The provided setup script clones the terra-helm and terra-helmfile git repos,
-and templates in the desired Terra environment/k8s namespace to target.
-If you need to pull changes to either terra-helm or terra-helmfile, rerun this script.
-
-To use this, first ensure [Helm](https://helm.sh/docs/intro/install/#from-homebrew-macos) and [Skaffold](https://skaffold.dev/) are installed on your local machine. 
-
-> Older versions of Skaffold (v1.4.0 and earlier) do not have support for Helm 3 and will fail to deploy your 
-changes. If you're seeing errors like `UPGRADE FAILED: "(Release name)" has no 
-deployed releases`, try updating Skaffold.
+The provided setup script clones the terra-helmfile git repo and renders
+Kubernetes manifests for the target Terra environment/k8s namespace.
+If you need to pull changes to terra-helmfile, rerun this script.
 
 You may need to use gcloud to provide GCR
  credentials with `gcloud auth configure-docker`. Finally, run local-run.sh with
@@ -18,9 +12,9 @@ You may need to use gcloud to provide GCR
 ./setup_local_env.sh <environment>
 ```
 
-Optionally, you can provide a branch of [terra-helm](https://github.com/broadinstitute/terra-helm) and/or [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) to use if you are testing PRs to either. They default to master.
+Optionally, you can provide a branch of [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) to use if you are testing a PR. (The script defaults to master).
 ```
-./setup_local_env.sh <environment> <terra-helm ref> <terra-helmfile ref>
+./setup_local_env.sh <environment> <terra-helmfile ref>
 ```
 
 You can now push to the specified environment by running
@@ -29,5 +23,5 @@ You can now push to the specified environment by running
 skaffold run
 ```
 
-or by using IntelliJ's Cloud Code integration, which will auto-detect the 
+or by using IntelliJ's Cloud Code integration, which will auto-detect the
 generated skaffold.yaml file.

--- a/service/local-dev/setup_local_env.sh
+++ b/service/local-dev/setup_local_env.sh
@@ -9,24 +9,25 @@ set -e
 # Required input
 ENV=$1
 # Optional input
-TERRA_HELM_BRANCH=${2:-master}
-TERRA_HELMFILE_BRANCH=${3:-master}
-GIT_PROTOCOL=${4:-http}
+TERRA_HELMFILE_BRANCH=${2:-master}
+GIT_PROTOCOL=${3:-http}
 
 if [ "$GIT_PROTOCOL" = "http" ]; then
-    helmgit=https://github.com/broadinstitute/terra-helm
     helmfilegit=https://github.com/broadinstitute/terra-helmfile
 else
-    # use ssh
-    helmgit=git@github.com:broadinstitute/terra-helm.git
     helmfilegit=git@github.com:broadinstitute/terra-helmfile.git
 fi
 
 # Clone Helm chart and helmfile repos
-rm -rf terra-helm
 rm -rf terra-helmfile
-git clone -b "$TERRA_HELM_BRANCH" --single-branch ${helmgit}
 git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch ${helmfilegit}
+
+# Render manifests to manifests.yaml
+./terra-helmfile/bin/render \
+  -e "${ENV}" \
+  -a workspacemanager \
+  --stdout > \
+  manifests.yaml
 
 # Template in environment
 sed "s|ENV|${ENV}|g" skaffold.yaml.template > skaffold.yaml

--- a/service/local-dev/setup_local_env.sh
+++ b/service/local-dev/setup_local_env.sh
@@ -31,7 +31,6 @@ git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch ${helmfilegit}
 
 # Template in environment
 sed "s|ENV|${ENV}|g" skaffold.yaml.template > skaffold.yaml
-sed "s|ENV|${ENV}|g" values.yaml.template > values.yaml
 
 # That's it! You can now deploy to the k8s cluster by running
 # $ skaffold run

--- a/service/local-dev/skaffold.yaml.template
+++ b/service/local-dev/skaffold.yaml.template
@@ -1,5 +1,5 @@
 #This is a Skaffold configuration, which lets developers continuously push new images to their development namespaces.
-apiVersion: skaffold/v2alpha4
+apiVersion: skaffold/v2beta17
 kind: Config
 build:
   artifacts:
@@ -8,15 +8,7 @@ build:
     jib:
       project: service
 deploy:
-  helm:
-    releases:
-      - name: workspacemanager-ENV
-        namespace: terra-ENV
-        chartPath: terra-helm/charts/workspacemanager
-        values:
-          image: gcr.io/terra-kernel-k8s/terra-workspace-manager
-        valuesFiles:
-          - terra-helmfile/terra/values/workspacemanager.yaml
-          - terra-helmfile/terra/values/workspacemanager/personal.yaml
-          - terra-helmfile/terra/values/workspacemanager/personal/ENV.yaml
-          - values.yaml
+  kubectl:
+    manifests:
+    - manifests.yaml
+    defaultNamespace: terra-ENV

--- a/service/local-dev/values.yaml.template
+++ b/service/local-dev/values.yaml.template
@@ -1,5 +1,0 @@
-imageConfig:
-  imagePullPolicy: IfNotPresent
-global:
-  terraEnv: ENV
-initDB: true


### PR DESCRIPTION
This PR updates WSM's Skaffold configuration for compatibility with [upcoming Helm changes](https://docs.google.com/document/d/1B1BU_C2AXEYBbMfLAZlQzYst-4ctVOlt1EoJcaEJszI/edit?usp=sharing).

I've tested this PR by deploying to the `gmalkov` personal environment using `skaffold  run`.

Changes:
* Remove references to terra-helm.
* Convert Skaffold deployer from `helm` to [`kubectl`](https://skaffold.dev/docs/pipeline-stages/deployers/kubectl/), using terra-helmfile's `render` tool to generate manifests. (`render` is the public API for terra-helmfile, so this will continue to work even as we make changes to terra-helmfile's structure)
* Move the values specified in the local values.yaml to terra-helmfile values ([PR](https://github.com/broadinstitute/terra-helmfile/pull/1384)). If folks feel strongly about keeping these here, I can instead adapt the `render` script to accept a local values file.