### PR TITLE
PF-861: Bump test runner to 0.0.7

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -10,7 +10,7 @@ plugins {
     //  fine in the service project.
     // id "com.diffplug.spotless" version "5.12.4"
     // Terra Test Runner Plugin
-    id 'bio.terra.test-runner-plugin' version '0.0.7a-SNAPSHOT'
+    id 'bio.terra.test-runner-plugin' version '0.0.7-SNAPSHOT'
 }
 
 dependencies {

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         googleNotebook = "v1-rev20201110-1.30.10"
 
         datarepoClient = "1.0.155-SNAPSHOT"
-        testRunnerVersion = "0.0.7a-SNAPSHOT"
+        testRunnerVersion = "0.0.7-SNAPSHOT"
     }
     implementation group: 'org.apache.commons', name: 'commons-math3', version: "${apacheMath}"
     implementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: "${jUnit}"

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -10,7 +10,7 @@ plugins {
     //  fine in the service project.
     // id "com.diffplug.spotless" version "5.12.4"
     // Terra Test Runner Plugin
-    id 'bio.terra.test-runner-plugin' version '0.0.6-SNAPSHOT'
+    id 'bio.terra.test-runner-plugin' version '0.0.7a-SNAPSHOT'
 }
 
 dependencies {
@@ -34,7 +34,7 @@ dependencies {
         googleNotebook = "v1-rev20201110-1.30.10"
 
         datarepoClient = "1.0.155-SNAPSHOT"
-        testRunnerVersion = "0.0.6-SNAPSHOT"
+        testRunnerVersion = "0.0.7a-SNAPSHOT"
     }
     implementation group: 'org.apache.commons', name: 'commons-math3', version: "${apacheMath}"
     implementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: "${jUnit}"

--- a/integration/gradle.lockfile
+++ b/integration/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 bio.terra:datarepo-client:1.0.155-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra:terra-test-runner:0.0.6-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:terra-test-runner:0.0.7a-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.2.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.2.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/integration/gradle.lockfile
+++ b/integration/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 bio.terra:datarepo-client:1.0.155-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra:terra-test-runner:0.0.7a-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:terra-test-runner:0.0.7-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.2.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.2.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath


### PR DESCRIPTION
Bump the Test Runner library version. Details of the fixes that went into this version bump are in the [Test Runner PR](https://github.com/DataBiosphere/terra-test-runner/pull/18).