### PR TITLE
[no ticket] Swap underscore for dash in notebook instance id validation.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
@@ -54,9 +54,9 @@ public class ValidationUtils {
 
   public static void validateAiNotebookInstanceId(String name) {
     if (!AI_NOTEBOOK_INSTANCE_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
-      logger.warn("Invalid AI Notebook instance name {}", name);
+      logger.warn("Invalid AI Notebook instance ID {}", name);
       throw new InvalidReferenceException(
-          "Invalid AI Notebook instance name specified. Name must be 1 to 63 alphanumeric lower case characters or underscores, where the first letter is a lower case letter.");
+          "Invalid AI Notebook instance ID specified. ID must be 1 to 63 alphanumeric lower case characters or dashes, where the first character is a lower case letter.");
     }
   }
 


### PR DESCRIPTION
A notebook instance id can contain lowercase letters, digits, and dashes. Fixed error message that swapped underscore with dash.