### PR TITLE
PF-871: Ignore case in private resource user email.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -238,7 +238,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     // TODO: validate correct workspace ID. PF-859
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ApiCloneControlledGcpGcsBucketResult result = fetchCloneGcsBucketResult(jobId, userRequest);
-    return new ResponseEntity<>(result, ControllerUtils.getAsyncResponseCode(result.getJobReport()));
+    return new ResponseEntity<>(
+        result, ControllerUtils.getAsyncResponseCode(result.getJobReport()));
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -316,10 +316,14 @@ public class ControlledResourceService {
     // If there is no assigned user, this condition is satisfied.
     //noinspection deprecation
     final boolean isAllowed =
-        controlledResource.getAssignedUser().map(requestUserEmail::equals).orElse(true);
+        controlledResource.getAssignedUser().map(requestUserEmail::equalsIgnoreCase).orElse(true);
     if (!isAllowed) {
       throw new BadRequestException(
-          "User may only assign a private controlled resource to themselves.");
+          "User ("
+              + requestUserEmail
+              + ") may only assign a private controlled resource to themselves ("
+              + controlledResource.getAssignedUser().orElse("")
+              + ").");
     }
   }
 }


### PR DESCRIPTION
Ignore case when validating a private resource user email. Came across this when writing CLI tests for private resources.