### PR TITLE
[PF-506] Add omitted GCS lifecycle conditions to WSM

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/GcsApiConversions.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/GcsApiConversions.java
@@ -212,10 +212,6 @@ public class GcsApiConversions {
     resultBuilder.setCreatedBefore(toGoogleDateTime(condition.getCreatedBefore()));
     resultBuilder.setNumberOfNewerVersions(condition.getNumNewerVersions());
     resultBuilder.setIsLive(condition.isLive());
-    resultBuilder.setMatchesStorageClass(
-        Optional.ofNullable(condition.getMatchesStorageClass())
-            .map(c -> c.stream().map(GcsApiConversions::toGcsApi).collect(Collectors.toList()))
-            .orElse(null));
     resultBuilder.setDaysSinceNoncurrentTime(condition.getDaysSinceNoncurrentTime());
     resultBuilder.setNoncurrentTimeBefore(toGoogleDateTime(condition.getNoncurrentTimeBefore()));
     resultBuilder.setCustomTimeBefore(toGoogleDateTime(condition.getCustomTimeBefore()));

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/GcsApiConversions.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/GcsApiConversions.java
@@ -208,12 +208,18 @@ public class GcsApiConversions {
   public static LifecycleCondition toGcsApi(ApiGcpGcsBucketLifecycleRuleCondition condition) {
     final var resultBuilder = LifecycleCondition.newBuilder();
 
-    /* TODO(PF-506): some conditions aren't in the version of the Google Storage API in the
-     *    latest version of the CRL. */
     resultBuilder.setAge(condition.getAge());
     resultBuilder.setCreatedBefore(toGoogleDateTime(condition.getCreatedBefore()));
     resultBuilder.setNumberOfNewerVersions(condition.getNumNewerVersions());
     resultBuilder.setIsLive(condition.isLive());
+    resultBuilder.setMatchesStorageClass(
+        Optional.ofNullable(condition.getMatchesStorageClass())
+            .map(c -> c.stream().map(GcsApiConversions::toGcsApi).collect(Collectors.toList()))
+            .orElse(null));
+    resultBuilder.setDaysSinceNoncurrentTime(condition.getDaysSinceNoncurrentTime());
+    resultBuilder.setNoncurrentTimeBefore(toGoogleDateTime(condition.getNoncurrentTimeBefore()));
+    resultBuilder.setCustomTimeBefore(toGoogleDateTime(condition.getCustomTimeBefore()));
+    resultBuilder.setDaysSinceCustomTime(condition.getDaysSinceCustomTime());
 
     resultBuilder.setMatchesStorageClass(
         Optional.ofNullable(condition.getMatchesStorageClass())
@@ -231,7 +237,11 @@ public class GcsApiConversions {
         .matchesStorageClass(
             Optional.ofNullable(condition.getMatchesStorageClass())
                 .map(c -> c.stream().map(GcsApiConversions::toWsmApi).collect(Collectors.toList()))
-                .orElse(null));
+                .orElse(null))
+        .daysSinceNoncurrentTime(condition.getDaysSinceNoncurrentTime())
+        .noncurrentTimeBefore(toOffsetDateTime(condition.getNoncurrentTimeBefore()))
+        .customTimeBefore(toOffsetDateTime(condition.getCustomTimeBefore()))
+        .daysSinceCustomTime(condition.getDaysSinceCustomTime());
   }
 
   @Nullable

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -229,6 +229,10 @@ public class ControlledResourceFixtures {
           .setAge(42)
           .setIsLive(false)
           .setNumberOfNewerVersions(2)
+          .setDaysSinceNoncurrentTime(5)
+          .setNoncurrentTimeBefore(DATE_TIME_1)
+          .setCustomTimeBefore(DATE_TIME_2)
+          .setDaysSinceCustomTime(100)
           .build();
   public static final LifecycleCondition GCS_LIFECYCLE_CONDITION_2 =
       LifecycleCondition.newBuilder()

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/GcsApiConversionsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/GcsApiConversionsTest.java
@@ -122,6 +122,18 @@ public class GcsApiConversionsTest extends BaseUnitTest {
         gcsRule1.getCondition().getNumberOfNewerVersions());
     assertEquals(
         GCS_LIFECYCLE_RULE_1.getCondition().getIsLive(), gcsRule1.getCondition().getIsLive());
+    assertEquals(
+        GCS_LIFECYCLE_RULE_1.getCondition().getDaysSinceNoncurrentTime(),
+        gcsRule1.getCondition().getDaysSinceNoncurrentTime());
+    assertEquals(
+        GCS_LIFECYCLE_RULE_1.getCondition().getNoncurrentTimeBefore(),
+        gcsRule1.getCondition().getNoncurrentTimeBefore());
+    assertEquals(
+        GCS_LIFECYCLE_RULE_1.getCondition().getCustomTimeBefore(),
+        gcsRule1.getCondition().getCustomTimeBefore());
+    assertEquals(
+        GCS_LIFECYCLE_RULE_1.getCondition().getDaysSinceCustomTime(),
+        gcsRule1.getCondition().getDaysSinceCustomTime());
   }
 
   @Test


### PR DESCRIPTION
This adds support for a few GCS lifecycle rules that were previously included in WSM's API but not propagated to GCP due to versioning issues with the GCS library. The newly supported lifecycle conditions are:

- noncurrentTimeBefore
- daysSinceCustomTime
- daysSinceNoncurrentTime
- customTimeBefore

This did not require updating the version of CRL that WSM was using - I think that update happened sometime between when the bug was filed and now, though we didn't add support inside WSM.