### PR TITLE
[PF-749] fix tag publish

### DIFF
--- a/.github/actions/bump-skip/action.yml
+++ b/.github/actions/bump-skip/action.yml
@@ -1,0 +1,28 @@
+# This action must be done after the checkout action
+name: 'bump-skip'
+description: 'Set skip-out when we are doing a version bump'
+author: 'dd'
+inputs:
+  event-name:
+    description: 'github.event_name from the calling workflow'
+    required: true
+outputs:
+  is-bump:
+    description: 'yes if this is a push made by bumper; no if it is a regular push'
+    value: ${{ steps.bumptest.outputs.is-bump }}
+runs:
+  using: "composite"
+  steps:
+    - name: Bump test
+      id: bumptest
+      run: |
+        log=$(git log --pretty='%B')
+        echo "log=$log"
+        pattern="^bump .*"
+        IS_BUMP=no
+        if [[ "${{ inputs.event-name }}" == "push" && "$log" =~ $pattern ]]; then
+          IS_BUMP=yes
+        fi
+        echo "IS_BUMP=$IS_BUMP"
+        echo ::set-output name=is-bump::$IS_BUMP
+      shell: bash

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -131,8 +131,10 @@ jobs:
         DOCKER_TAG=${{ steps.tag.outputs.tag }}
         echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${DOCKER_TAG}
     - name: Build image locally with jib
+      if: steps.skiptest.outputs.skip-out == 'no'
       run: "./gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain"
     - name: Run Trivy vulnerability scanner
+      if: steps.skiptest.outputs.skip-out == 'no'
       # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
       uses: broadinstitute/dsp-appsec-trivy-action@v1
       with:

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -67,6 +67,7 @@ jobs:
       id: skiptest
       run: |
         log=$(git log --pretty='%B')
+        echo "log=$log"
         pattern="^bump .*"
         #event=${{ github.event_name }}
         event=push
@@ -74,75 +75,76 @@ jobs:
         if [[ "$event" == "push" && "$log" =~ $pattern ]]; then
           SKIP_OUT=yes
         fi
+        echo "SKIP_OUT=$SKIP_OUT"
         echo ::set-output name=skip-out::$SKIP_OUT
-    - name: Bump the tag to a new version
-      if: steps.skiptest.outputs.skip-out == 'no'
-      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
-      id: tag
-      env:
-        DEFAULT_BUMP: patch
-        GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-        HOTFIX_BRANCHES: hotfix.*
-        OVERRIDE_BUMP: ${{ steps.controls.outputs.semver-part }}
-        RELEASE_BRANCHES: dev
-        VERSION_FILE_PATH: settings.gradle
-        VERSION_LINE_MATCH: "^gradle.ext.wsmVersion\\s*=\\s*\".*\""
-        VERSION_SUFFIX: SNAPSHOT
-    - name: Set up AdoptOpenJDK
-      if: steps.skiptest.outputs.skip-out == 'no'
-      uses: joschi/setup-jdk@v2
-      with:
-        java-version: 11
-    - name: Cache Gradle packages
-      if: steps.skiptest.outputs.skip-out == 'no'
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-        restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
-    - name: Grant execute permission for gradlew
-      if: steps.skiptest.outputs.skip-out == 'no'
-      run: chmod +x gradlew
-    - name: "Publish to Artifactory"
-      if: steps.skiptest.outputs.skip-out == 'no'
-      run: ./gradlew :client:artifactoryPublish
-      env:
-        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-        ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
-    - name: Auth to GCR
-      if: steps.skiptest.outputs.skip-out == 'no'
-      uses: google-github-actions/setup-gcloud@master
-      with:
-        version: '270.0.0'
-        service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
-        service_account_key: ${{ secrets.GCR_PUBLISH_KEY }}
-    - name: Explicitly auth Docker for GCR
-      if: steps.skiptest.outputs.skip-out == 'no'
-      run: gcloud auth configure-docker --quiet
-    - name: Construct docker image name and tag
-      if: steps.skiptest.outputs.skip-out == 'no'
-      id: image-name
-      run: |
-        DOCKER_TAG=${{ steps.tag.outputs.tag }}
-        echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${DOCKER_TAG}
-    - name: Build image locally with jib
-      run: "./gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain"
-    - name: Run Trivy vulnerability scanner
-      # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
-      uses: broadinstitute/dsp-appsec-trivy-action@v1
-      with:
-        image: ${{ steps.image-name.outputs.name }}
-    - name: Push GCR image
-      if: steps.skiptest.outputs.skip-out == 'no'
-      run: "docker push ${{ steps.image-name.outputs.name }}"
-    - name: Deploy to Terra Dev environment
-      if: github.event_name == 'push' && steps.skiptest.outputs.skip-out == 'no'
-      uses: broadinstitute/repository-dispatch@master
-      with:
-        token: ${{ secrets.BROADBOT_TOKEN }}
-        repository: broadinstitute/terra-helmfile
-        event-type: update-service
-        client-payload: '{"service": "workspacemanager", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
+#    - name: Bump the tag to a new version
+#      if: steps.skiptest.outputs.skip-out == 'no'
+#      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
+#      id: tag
+#      env:
+#        DEFAULT_BUMP: patch
+#        GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+#        HOTFIX_BRANCHES: hotfix.*
+#        OVERRIDE_BUMP: ${{ steps.controls.outputs.semver-part }}
+#        RELEASE_BRANCHES: dev
+#        VERSION_FILE_PATH: settings.gradle
+#        VERSION_LINE_MATCH: "^gradle.ext.wsmVersion\\s*=\\s*\".*\""
+#        VERSION_SUFFIX: SNAPSHOT
+#    - name: Set up AdoptOpenJDK
+#      if: steps.skiptest.outputs.skip-out == 'no'
+#      uses: joschi/setup-jdk@v2
+#      with:
+#        java-version: 11
+#    - name: Cache Gradle packages
+#      if: steps.skiptest.outputs.skip-out == 'no'
+#      uses: actions/cache@v2
+#      with:
+#        path: |
+#          ~/.gradle/caches
+#          ~/.gradle/wrapper
+#        key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+#        restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+#    - name: Grant execute permission for gradlew
+#      if: steps.skiptest.outputs.skip-out == 'no'
+#      run: chmod +x gradlew
+#    - name: "Publish to Artifactory"
+#      if: steps.skiptest.outputs.skip-out == 'no'
+#      run: ./gradlew :client:artifactoryPublish
+#      env:
+#        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+#        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+#        ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
+#    - name: Auth to GCR
+#      if: steps.skiptest.outputs.skip-out == 'no'
+#      uses: google-github-actions/setup-gcloud@master
+#      with:
+#        version: '270.0.0'
+#        service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
+#        service_account_key: ${{ secrets.GCR_PUBLISH_KEY }}
+#    - name: Explicitly auth Docker for GCR
+#      if: steps.skiptest.outputs.skip-out == 'no'
+#      run: gcloud auth configure-docker --quiet
+#    - name: Construct docker image name and tag
+#      if: steps.skiptest.outputs.skip-out == 'no'
+#      id: image-name
+#      run: |
+#        DOCKER_TAG=${{ steps.tag.outputs.tag }}
+#        echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${DOCKER_TAG}
+#    - name: Build image locally with jib
+#      run: "./gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain"
+#    - name: Run Trivy vulnerability scanner
+#      # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
+#      uses: broadinstitute/dsp-appsec-trivy-action@v1
+#      with:
+#        image: ${{ steps.image-name.outputs.name }}
+#    - name: Push GCR image
+#      if: steps.skiptest.outputs.skip-out == 'no'
+#      run: "docker push ${{ steps.image-name.outputs.name }}"
+#    - name: Deploy to Terra Dev environment
+#      if: github.event_name == 'push' && steps.skiptest.outputs.skip-out == 'no'
+#      uses: broadinstitute/repository-dispatch@master
+#      with:
+#        token: ${{ secrets.BROADBOT_TOKEN }}
+#        repository: broadinstitute/terra-helmfile
+#        event-type: update-service
+#        client-payload: '{"service": "workspacemanager", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -63,7 +63,20 @@ jobs:
       with:
         ref: ${{ steps.controls.outputs.checkout-branch }}
         token: ${{ secrets.BROADBOT_TOKEN }}
+    - name: Skip version bump merges
+      id: skiptest
+      run: |
+        log=$(git log --pretty='%B')
+        pattern="^bump .*"
+        #event=${{ github.event_name }}
+        event=push
+        SKIP_OUT=no
+        if [[ "$event" == "push" && "$log" =~ $pattern ]]; then
+          SKIP_OUT=yes
+        fi
+        echo ::set-output name=skip-out::$SKIP_OUT
     - name: Bump the tag to a new version
+      if: steps.skiptest.outputs.skip-out == 'no'
       uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
       id: tag
       env:
@@ -76,10 +89,12 @@ jobs:
         VERSION_LINE_MATCH: "^gradle.ext.wsmVersion\\s*=\\s*\".*\""
         VERSION_SUFFIX: SNAPSHOT
     - name: Set up AdoptOpenJDK
+      if: steps.skiptest.outputs.skip-out == 'no'
       uses: joschi/setup-jdk@v2
       with:
         java-version: 11
     - name: Cache Gradle packages
+      if: steps.skiptest.outputs.skip-out == 'no'
       uses: actions/cache@v2
       with:
         path: |
@@ -88,22 +103,27 @@ jobs:
         key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
         restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
     - name: Grant execute permission for gradlew
+      if: steps.skiptest.outputs.skip-out == 'no'
       run: chmod +x gradlew
     - name: "Publish to Artifactory"
+      if: steps.skiptest.outputs.skip-out == 'no'
       run: ./gradlew :client:artifactoryPublish
       env:
         ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
         ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
     - name: Auth to GCR
+      if: steps.skiptest.outputs.skip-out == 'no'
       uses: google-github-actions/setup-gcloud@master
       with:
         version: '270.0.0'
         service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
         service_account_key: ${{ secrets.GCR_PUBLISH_KEY }}
     - name: Explicitly auth Docker for GCR
+      if: steps.skiptest.outputs.skip-out == 'no'
       run: gcloud auth configure-docker --quiet
     - name: Construct docker image name and tag
+      if: steps.skiptest.outputs.skip-out == 'no'
       id: image-name
       run: |
         DOCKER_TAG=${{ steps.tag.outputs.tag }}
@@ -116,9 +136,10 @@ jobs:
       with:
         image: ${{ steps.image-name.outputs.name }}
     - name: Push GCR image
+      if: steps.skiptest.outputs.skip-out == 'no'
       run: "docker push ${{ steps.image-name.outputs.name }}"
     - name: Deploy to Terra Dev environment
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && steps.skiptest.outputs.skip-out == 'no'
       uses: broadinstitute/repository-dispatch@master
       with:
         token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -67,8 +67,7 @@ jobs:
       id: skiptest
       uses: ./.github/actions/bump-skip
       with:
-        #event-name: ${{ github.event_name }}
-        event-name: push
+        event-name: ${{ github.event_name }}
     - name: Bump the tag to a new version
       if: steps.skiptest.outputs.is-bump == 'no'
       uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -77,74 +77,74 @@ jobs:
         fi
         echo "SKIP_OUT=$SKIP_OUT"
         echo ::set-output name=skip-out::$SKIP_OUT
-#    - name: Bump the tag to a new version
-#      if: steps.skiptest.outputs.skip-out == 'no'
-#      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
-#      id: tag
-#      env:
-#        DEFAULT_BUMP: patch
-#        GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-#        HOTFIX_BRANCHES: hotfix.*
-#        OVERRIDE_BUMP: ${{ steps.controls.outputs.semver-part }}
-#        RELEASE_BRANCHES: dev
-#        VERSION_FILE_PATH: settings.gradle
-#        VERSION_LINE_MATCH: "^gradle.ext.wsmVersion\\s*=\\s*\".*\""
-#        VERSION_SUFFIX: SNAPSHOT
-#    - name: Set up AdoptOpenJDK
-#      if: steps.skiptest.outputs.skip-out == 'no'
-#      uses: joschi/setup-jdk@v2
-#      with:
-#        java-version: 11
-#    - name: Cache Gradle packages
-#      if: steps.skiptest.outputs.skip-out == 'no'
-#      uses: actions/cache@v2
-#      with:
-#        path: |
-#          ~/.gradle/caches
-#          ~/.gradle/wrapper
-#        key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-#        restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
-#    - name: Grant execute permission for gradlew
-#      if: steps.skiptest.outputs.skip-out == 'no'
-#      run: chmod +x gradlew
-#    - name: "Publish to Artifactory"
-#      if: steps.skiptest.outputs.skip-out == 'no'
-#      run: ./gradlew :client:artifactoryPublish
-#      env:
-#        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-#        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-#        ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
-#    - name: Auth to GCR
-#      if: steps.skiptest.outputs.skip-out == 'no'
-#      uses: google-github-actions/setup-gcloud@master
-#      with:
-#        version: '270.0.0'
-#        service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
-#        service_account_key: ${{ secrets.GCR_PUBLISH_KEY }}
-#    - name: Explicitly auth Docker for GCR
-#      if: steps.skiptest.outputs.skip-out == 'no'
-#      run: gcloud auth configure-docker --quiet
-#    - name: Construct docker image name and tag
-#      if: steps.skiptest.outputs.skip-out == 'no'
-#      id: image-name
-#      run: |
-#        DOCKER_TAG=${{ steps.tag.outputs.tag }}
-#        echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${DOCKER_TAG}
-#    - name: Build image locally with jib
-#      run: "./gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain"
-#    - name: Run Trivy vulnerability scanner
-#      # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
-#      uses: broadinstitute/dsp-appsec-trivy-action@v1
-#      with:
-#        image: ${{ steps.image-name.outputs.name }}
-#    - name: Push GCR image
-#      if: steps.skiptest.outputs.skip-out == 'no'
-#      run: "docker push ${{ steps.image-name.outputs.name }}"
-#    - name: Deploy to Terra Dev environment
-#      if: github.event_name == 'push' && steps.skiptest.outputs.skip-out == 'no'
-#      uses: broadinstitute/repository-dispatch@master
-#      with:
-#        token: ${{ secrets.BROADBOT_TOKEN }}
-#        repository: broadinstitute/terra-helmfile
-#        event-type: update-service
-#        client-payload: '{"service": "workspacemanager", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
+    - name: Bump the tag to a new version
+      if: steps.skiptest.outputs.skip-out == 'no'
+      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
+      id: tag
+      env:
+        DEFAULT_BUMP: patch
+        GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+        HOTFIX_BRANCHES: hotfix.*
+        OVERRIDE_BUMP: ${{ steps.controls.outputs.semver-part }}
+        RELEASE_BRANCHES: dev
+        VERSION_FILE_PATH: settings.gradle
+        VERSION_LINE_MATCH: "^gradle.ext.wsmVersion\\s*=\\s*\".*\""
+        VERSION_SUFFIX: SNAPSHOT
+    - name: Set up AdoptOpenJDK
+      if: steps.skiptest.outputs.skip-out == 'no'
+      uses: joschi/setup-jdk@v2
+      with:
+        java-version: 11
+    - name: Cache Gradle packages
+      if: steps.skiptest.outputs.skip-out == 'no'
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+    - name: Grant execute permission for gradlew
+      if: steps.skiptest.outputs.skip-out == 'no'
+      run: chmod +x gradlew
+    - name: "Publish to Artifactory"
+      if: steps.skiptest.outputs.skip-out == 'no'
+      run: ./gradlew :client:artifactoryPublish
+      env:
+        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
+    - name: Auth to GCR
+      if: steps.skiptest.outputs.skip-out == 'no'
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        version: '270.0.0'
+        service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
+        service_account_key: ${{ secrets.GCR_PUBLISH_KEY }}
+    - name: Explicitly auth Docker for GCR
+      if: steps.skiptest.outputs.skip-out == 'no'
+      run: gcloud auth configure-docker --quiet
+    - name: Construct docker image name and tag
+      if: steps.skiptest.outputs.skip-out == 'no'
+      id: image-name
+      run: |
+        DOCKER_TAG=${{ steps.tag.outputs.tag }}
+        echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${DOCKER_TAG}
+    - name: Build image locally with jib
+      run: "./gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain"
+    - name: Run Trivy vulnerability scanner
+      # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
+      uses: broadinstitute/dsp-appsec-trivy-action@v1
+      with:
+        image: ${{ steps.image-name.outputs.name }}
+    - name: Push GCR image
+      if: steps.skiptest.outputs.skip-out == 'no'
+      run: "docker push ${{ steps.image-name.outputs.name }}"
+    - name: Deploy to Terra Dev environment
+      if: github.event_name == 'push' && steps.skiptest.outputs.skip-out == 'no'
+      uses: broadinstitute/repository-dispatch@master
+      with:
+        token: ${{ secrets.BROADBOT_TOKEN }}
+        repository: broadinstitute/terra-helmfile
+        event-type: update-service
+        client-payload: '{"service": "workspacemanager", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set part of semantic version to bump
-      id: semver
+      id: controls
       run: |
         SEMVER_PART=""
         CHECKOUT_BRANCH="$GITHUB_REF"

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -65,20 +65,12 @@ jobs:
         token: ${{ secrets.BROADBOT_TOKEN }}
     - name: Skip version bump merges
       id: skiptest
-      run: |
-        log=$(git log --pretty='%B')
-        echo "log=$log"
-        pattern="^bump .*"
-        #event=${{ github.event_name }}
-        event=push
-        SKIP_OUT=no
-        if [[ "$event" == "push" && "$log" =~ $pattern ]]; then
-          SKIP_OUT=yes
-        fi
-        echo "SKIP_OUT=$SKIP_OUT"
-        echo ::set-output name=skip-out::$SKIP_OUT
+      uses: ./.github/actions/bump-skip
+      with:
+        #event-name: ${{ github.event_name }}
+        event-name: push
     - name: Bump the tag to a new version
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
       id: tag
       env:
@@ -91,12 +83,12 @@ jobs:
         VERSION_LINE_MATCH: "^gradle.ext.wsmVersion\\s*=\\s*\".*\""
         VERSION_SUFFIX: SNAPSHOT
     - name: Set up AdoptOpenJDK
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       uses: joschi/setup-jdk@v2
       with:
         java-version: 11
     - name: Cache Gradle packages
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       uses: actions/cache@v2
       with:
         path: |
@@ -105,45 +97,45 @@ jobs:
         key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
         restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
     - name: Grant execute permission for gradlew
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       run: chmod +x gradlew
     - name: "Publish to Artifactory"
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       run: ./gradlew :client:artifactoryPublish
       env:
         ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
         ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
     - name: Auth to GCR
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       uses: google-github-actions/setup-gcloud@master
       with:
         version: '270.0.0'
         service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
         service_account_key: ${{ secrets.GCR_PUBLISH_KEY }}
     - name: Explicitly auth Docker for GCR
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       run: gcloud auth configure-docker --quiet
     - name: Construct docker image name and tag
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       id: image-name
       run: |
         DOCKER_TAG=${{ steps.tag.outputs.tag }}
         echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${DOCKER_TAG}
     - name: Build image locally with jib
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       run: "./gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain"
     - name: Run Trivy vulnerability scanner
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
       uses: broadinstitute/dsp-appsec-trivy-action@v1
       with:
         image: ${{ steps.image-name.outputs.name }}
     - name: Push GCR image
-      if: steps.skiptest.outputs.skip-out == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       run: "docker push ${{ steps.image-name.outputs.name }}"
     - name: Deploy to Terra Dev environment
-      if: github.event_name == 'push' && steps.skiptest.outputs.skip-out == 'no'
+      if: github.event_name == 'push' && steps.skiptest.outputs.is-bump == 'no'
       uses: broadinstitute/repository-dispatch@master
       with:
         token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,17 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout current code
+      uses: actions/checkout@v2
+
+    - name: Skip version bump merges
+      id: skiptest
+      uses: ./.github/actions/bump-skip
+      with:
+        event-name: ${{ github.event_name }}
 
     - name: Set env
+      if: steps.skiptest.outputs.is-bump == 'no'
       id: set-env-step
       run: |
         if ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}; then
@@ -69,16 +77,19 @@ jobs:
         echo ::set-output name=test-env::$ENV
 
     - name: Initialize Postgres DB
+      if: steps.skiptest.outputs.is-bump == 'no'
       env:
         PGPASSWORD: postgres
       run: psql -h 127.0.0.1 -U postgres -f ./service/local-dev/local-postgres-init.sql
 
     - name: Set up AdoptOpenJDK 11
+      if: steps.skiptest.outputs.is-bump == 'no'
       uses: joschi/setup-jdk@v2
       with:
         java-version: 11
 
     - name: Cache Gradle packages
+      if: steps.skiptest.outputs.is-bump == 'no'
       uses: actions/cache@v2
       with:
         path: |
@@ -88,11 +99,12 @@ jobs:
         restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
 
     - name: Grant execute permission for gradlew
+      if: steps.skiptest.outputs.is-bump == 'no'
       run: chmod +x gradlew
 
     # These steps aren't needed for unit tests
     - name: Get Vault token
-      if: matrix.gradleTask != 'unitTest'
+      if: matrix.gradleTask != 'unitTest' && steps.skiptest.outputs.is-bump == 'no'
       id: vault-token-step
       env:
         VAULT_ADDR: https://clotho.broadinstitute.org:8200
@@ -107,7 +119,7 @@ jobs:
         echo ::add-mask::$VAULT_TOKEN
 
     - name: Write config
-      if: matrix.gradleTask != 'unitTest'
+      if: matrix.gradleTask != 'unitTest' && steps.skiptest.outputs.is-bump == 'no'
       id: config
       uses: ./.github/actions/write-config
       with:
@@ -118,6 +130,7 @@ jobs:
 
       # Run tests
     - name: Run tests
+      if: steps.skiptest.outputs.is-bump == 'no'
       env:
         # PRINT_STANDARD_STREAMS is temporary to let us inspect logs for a particular
         # issue with Stairway serdes.
@@ -126,7 +139,7 @@ jobs:
       run: ./gradlew :service:${{ matrix.gradleTask }} --scan
 
     - name: Codacy Coverage Reporter
-      if: matrix.gradleTask == 'unitTest'
+      if: matrix.gradleTask == 'unitTest' && steps.skiptest.outputs.is-bump == 'no'
       uses: codacy/codacy-coverage-reporter-action@0.2.0
       continue-on-error: true
       env:
@@ -136,7 +149,7 @@ jobs:
         coverage-reports: service/build/reports/jacoco/test/jacoco.xml
 
     - name: Upload Test Reports
-      if: always()
+      if: always() && steps.skiptest.outputs.is-bump == 'no'
       uses: actions/upload-artifact@v1
       with:
         name: Test Reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ dev ]
     paths-ignore:
-      - 'README.md'
+      - '*.md'
       - '.github/**'
       - 'service/local-dev/**'
   pull_request:


### PR DESCRIPTION
Skip the test workflow and the tag-publish workflow if the push to dev commit message is `"^bump .*"`. This will save a complete, redundant test pass and tag computation when merging code.

I added a composite action, `bump-skip`, that performs the check and sets an output. Then each following step includes an `if:` that checks against that output.

There is no "exit at this point" logic in github actions, so the `if:` approach is the recommended solution. An alternative is to use sequential jobs and put the `if:` at the job level. However, that would mean two separate checkouts, so the step level seemed like the more straightforward approach.