### PR TITLE
[AS-787] Add a snapshot list end point that matches the existing snapshot get end point

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -1,13 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import bio.terra.workspace.generated.controller.ReferencedGcpResourceApi;
-import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDatasetReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiCreateGcpGcsBucketReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
-import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
-import bio.terra.workspace.generated.model.ApiUpdateDataReferenceRequestBody;
+import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -198,14 +192,19 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<ApiDataRepoSnapshotResource> getDataRepoSnapshotReference(
+  public ResponseEntity<ApiResourceDescription> getDataRepoSnapshotReference(
       UUID id, UUID referenceId) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResource(id, referenceId, userReq);
-    ApiDataRepoSnapshotResource response =
-        referenceResource.castToDataRepoSnapshotResource().toApiResource();
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    ApiResourceMetadata apiResourceMetadata = referenceResource.toApiMetadata();
+    ReferencedDataRepoSnapshotResource referencedDataRepoSnapshotResource =
+        referenceResource.castToDataRepoSnapshotResource();
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.gcpDataRepoSnapshot(referencedDataRepoSnapshotResource.toApiAttributes());
+    return new ResponseEntity<>(
+        new ApiResourceDescription().metadata(apiResourceMetadata).resourceAttributes(union),
+        HttpStatus.OK);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -139,6 +139,16 @@ public class ResourceDao {
     return DbRetryUtils.retry(() -> enumerateReferencesInner(workspaceId, offset, limit));
   }
 
+  public List<ReferencedResource> enumerateSnapshots(UUID workspaceId, int offset, int limit)
+      throws InterruptedException {
+    List<WsmResource> wsmResources =
+        DbRetryUtils.retry(
+            () ->
+                enumerateResourcesInner(
+                    workspaceId, null, WsmResourceType.DATA_REPO_SNAPSHOT, null, offset, limit));
+    return wsmResources.stream().map(ReferencedResource.class::cast).collect(Collectors.toList());
+  }
+
   @Transactional(
       propagation = Propagation.REQUIRED,
       isolation = Isolation.SERIALIZABLE,

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
@@ -132,6 +132,14 @@ public class ReferencedResourceService {
         () -> resourceDao.enumerateReferences(workspaceId, offset, limit));
   }
 
+  public List<ReferencedResource> enumerateSnapshots(
+      UUID workspaceId, int offset, int limit, AuthenticatedUserRequest userReq) {
+    workspaceService.validateWorkspaceAndAction(
+        userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    return DbRetryUtils.throwIfInterrupted(
+        () -> resourceDao.enumerateSnapshots(workspaceId, offset, limit));
+  }
+
   public boolean checkAccess(UUID workspaceId, UUID resourceId, AuthenticatedUserRequest userReq) {
     workspaceService.validateWorkspaceAndAction(
         userReq, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -351,6 +351,23 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+    get:
+      summary: Gets a list of snapshots for a workspace.
+      operationId: getSnapshotsForWorkspace
+      tags: [ ReferencedGcpResource ]
+      parameters:
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          $ref: '#/components/responses/EnumerateSnapshotsResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/datarepo/snapshots/{resourceId}:
     parameters:
@@ -362,7 +379,7 @@ paths:
       tags: [ReferencedGcpResource]
       responses:
         '200':
-          $ref: '#/components/responses/SingleSnapshotReferenceResponse'
+          $ref: '#/components/responses/DataRepoSnapshotReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -2296,6 +2313,16 @@ components:
           items:
             $ref: '#/components/schemas/ResourceDescription'
 
+    SnapshotList:
+      type: object
+      required: [ snapshots ]
+      properties:
+        snapshots:
+          description: List of snapshots
+          type: array
+          items:
+            $ref: '#/components/schemas/DataRepoSnapshotResource'
+
     ResourceMetadata:
       type: object
       properties:
@@ -2389,13 +2416,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/DataRepoSnapshotResource'
-
-    SingleSnapshotReferenceResponse:
-      description: Response containing a reference to a Data Repo snapshot.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ResourceDescription'
 
     GcpGcsBucketReferenceResponse:
       description: Response containing a reference to a Gcp bucket.
@@ -2513,6 +2533,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ResourceList'
+
+    EnumerateSnapshotsResponse:
+      description: Listing of snapshots
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SnapshotList'
 
     CheckReferenceAccessResponse:
       description: Whether the specified reference is accessible or not

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -362,7 +362,7 @@ paths:
       tags: [ReferencedGcpResource]
       responses:
         '200':
-          $ref: '#/components/responses/DataRepoSnapshotReferenceResponse'
+          $ref: '#/components/responses/SingleSnapshotReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -2389,6 +2389,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/DataRepoSnapshotResource'
+
+    SingleSnapshotReferenceResponse:
+      description: Response containing a reference to a Data Repo snapshot.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ResourceDescription'
 
     GcpGcsBucketReferenceResponse:
       description: Response containing a reference to a Gcp bucket.


### PR DESCRIPTION
App Services received feedback from the Hornet team that they would like Rawls responses to be consistent between get and list for snapshots.  https://broadworkbench.atlassian.net/browse/AS-787 We can accomplish this by making the get and list responses consistent in WSM (this PR outlines one way to do that) or we can reformat the responses in Rawls.  Initially, folks on app services leaned in favor of making changes in WSM.  More details below..

Currently the Rawls end points to get snapshots delegate to WSM:

-  List `/api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2` -> `/api/workspaces/v1/{workspaceId}/resources` 
- Get `/api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/{snapshotId}` -> `/api/workspaces/v1/{workspaceId}/resources/referenced/datarepo/snapshots/{resourceId}`

The List mapping uses a more general end point on the WSM side to return resource (Snapshots, Buckets, BQ datasets, etc) and produces a response like this:

```
{
  "resources": [
    {
      "metadata": {
        "workspaceId": "54c76162-2337-4e65-b856-92e8202778cd",
        "resourceId": "46550c98-74f1-43c0-bf2b-a27e20d67a10",
        "name": "string",
        "description": "string",
        "resourceType": "DATA_REPO_SNAPSHOT",
        "stewardshipType": "REFERENCED",
        "cloudPlatform": "GCP",
        "cloningInstructions": "COPY_NOTHING"
      },
      "resourceAttributes": {
        "gcpDataRepoSnapshot": {
          "instanceName": "terra",
          "snapshot": "6b073ea9-caea-4a64-9cbf-745d17d5a0c8"
        }
      }
    }
  ]
} 
```

This newly proposed end point to return a list of snapshots returns a response that looks like this:
```
{
  "snapshots": [
    {
      "metadata": {
        "workspaceId": "54c76162-2337-4e65-b856-92e8202778cd",
        "resourceId": "46550c98-74f1-43c0-bf2b-a27e20d67a10",
        "name": "string",
        "description": "string",
        "resourceType": "DATA_REPO_SNAPSHOT",
        "stewardshipType": "REFERENCED",
        "cloudPlatform": "GCP",
        "cloningInstructions": "COPY_NOTHING"
      },
      "attributes": {
        "instanceName": "terra",
        "snapshot": "6b073ea9-caea-4a64-9cbf-745d17d5a0c8"
      }
    }
  ]
}
```
And is the "plural" form of the existing get a snapshot response:
```
{
  "metadata": {
    "workspaceId": "54c76162-2337-4e65-b856-92e8202778cd",
    "resourceId": "46550c98-74f1-43c0-bf2b-a27e20d67a10",
    "name": "string",
    "description": "string",
    "resourceType": "DATA_REPO_SNAPSHOT",
    "stewardshipType": "REFERENCED",
    "cloudPlatform": "GCP",
    "cloningInstructions": "COPY_NOTHING"
  },
  "attributes": {
    "instanceName": "terra",
    "snapshot": "6b073ea9-caea-4a64-9cbf-745d17d5a0c8"
  }
}
```