### PR TITLE
PF-538: Bump default RBS project pool id from `_v6` to `_v8`.

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -79,7 +79,7 @@ workspace:
     enabled: true
     client-credential-file-path: ../config/buffer-client-sa.json
     instanceUrl: https://buffer.tools.integ.envs.broadinstitute.org
-    poolId: workspace_manager_v6
+    poolId: workspace_manager_v8
 
   spend:
     spend-profiles:


### PR DESCRIPTION
Update the default RBS project pool id to `workspace_manager_v8` instead of the previous `workspace_manager_v6`.

The new pool does not delete the default compute engine service account or the default VPC network. This was to support Nextflow, which required both of these things. Now there is a Nextflow edge release that allows overriding both defaults.

I've tested this against my personal environment WSM and updated CLI code. There is a [terra-helmfile PR](https://github.com/broadinstitute/terra-helmfile/pull/1439) out to update WSM dev and all personal environments. Once this PR and the terra-helmfile one are merged, I will update the RBS pool schema for dev and tools to remove the `_v6` pools.