### PR TITLE
[no ticket] remove .git dirs and ignore repo dirs

### DIFF
--- a/service/local-dev/.gitignore
+++ b/service/local-dev/.gitignore
@@ -4,6 +4,9 @@
 # file.
 # Ignore everything in this directory...
 *
+./terra-helm/**
+./terra-helmfile/**
+
 # Except...
 !.gitignore
 !local-postgres-init.sql

--- a/service/local-dev/setup_local_env.sh
+++ b/service/local-dev/setup_local_env.sh
@@ -25,8 +25,13 @@ fi
 # Clone Helm chart and helmfile repos
 rm -rf terra-helm
 rm -rf terra-helmfile
-git clone -b "$TERRA_HELM_BRANCH" --single-branch ${helmgit}
-git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch ${helmfilegit}
+
+# Clone minimal state from repos and remove .git dir (nested .git directories confuse humans, IDE, and git)
+git clone -b "$TERRA_HELM_BRANCH" --single-branch --depth=1 ${helmgit}
+rm -rf terra-helm/.git
+
+git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch --depth=1 ${helmfilegit}
+rm -rf terra-helmfile/.git
 
 # Template in environment
 sed "s|ENV|${ENV}|g" skaffold.yaml.template > skaffold.yaml


### PR DESCRIPTION
Currently, the `setup_local_env` script performs a full branch clone on two repos under the root of the terra-workspace-manager repo. This causes some confusion in the IDE, as the directories can't be .gitignore'd, so their files look like they live in the top repo in search results.

It's also confusing on the command line if you navigate into one of the directories, as your git context switches. Since it's not a good workflow anyway to be checking out branches or looking at the log from within these nested repos, I'm deleting the `.git` directories. This also makes them `.gitignore`-able, which cleans up the UI and project structure.
<img width="287" alt="Screen Shot 2021-07-12 at 4 04 28 PM" src="https://user-images.githubusercontent.com/53479492/125356117-660a9300-e32b-11eb-858e-5bac37d5c266.png">
