### PR TITLE
[PF-749] Restore the version number

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ include 'integration'
 // -- Global Variables --
 // For defining shared state and common dependencies
 
-gradle.ext.wsmVersion = "-SNAPSHOT"
+gradle.ext.wsmVersion = "0.254.53-SNAPSHOT"
 gradle.ext.openapiSourceFile = "${rootDir}/service/src/main/resources/api/service_openapi.yaml"
 
 // Single place to define the versions of dependencies shared between components.


### PR DESCRIPTION
Use the fixed bumper. This _should_ properly publish a new client with a new version number.