### PR TITLE
[PF-811] Clone Referenced Resources

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -9,6 +9,7 @@ import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiClient;
+import bio.terra.workspace.model.CloneReferencedGcpGcsBucketResourceResult;
 import bio.terra.workspace.model.CloneReferencedResourceRequestBody;
 import bio.terra.workspace.model.CloneReferencedResourceResult;
 import bio.terra.workspace.model.CloningInstructionsEnum;
@@ -95,7 +96,7 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
         sourceBucketReference.getMetadata().getWorkspaceId(),
         sourceBucketReference.getMetadata().getResourceId(),
         destinationWorkspaceId);
-    final CloneReferencedResourceResult cloneBucketReferenceResult = referencedGcpResourceApi.cloneReferencedResource(cloneBucketReferenceRequestBody,
+    final CloneReferencedGcpGcsBucketResourceResult cloneBucketReferenceResult = referencedGcpResourceApi.cloneGcpGcsBucketReference(cloneBucketReferenceRequestBody,
         getWorkspaceId(),
         sourceBucketReference.getMetadata().getResourceId());
     assertEquals(getWorkspaceId(), cloneBucketReferenceResult.getSourceWorkspaceId());
@@ -105,7 +106,7 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
     assertEquals(sourceBucketReference.getMetadata().getDescription(), cloneBucketReferenceResult.getResource().getMetadata().getDescription());
     assertEquals(CLONED_BUCKET_RESOURCE_NAME, cloneBucketReferenceResult.getResource().getMetadata().getName());
     assertEquals(TEST_BUCKET_NAME,
-        cloneBucketReferenceResult.getResource().getResourceAttributes().getGcpGcsBucket().getBucketName());
+        cloneBucketReferenceResult.getResource().getAttributes().getBucketName());
 
     final var cloneBigQueryDatasetRequestBody = new CloneReferencedResourceRequestBody()
         .cloningInstructions(CloningInstructionsEnum.REFERENCE)

--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -9,9 +9,9 @@ import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiClient;
+import bio.terra.workspace.model.CloneReferencedGcpDataRepoSnapshotResourceResult;
 import bio.terra.workspace.model.CloneReferencedGcpGcsBucketResourceResult;
 import bio.terra.workspace.model.CloneReferencedResourceRequestBody;
-import bio.terra.workspace.model.CloneReferencedResourceResult;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.CreateWorkspaceRequestBody;
 import bio.terra.workspace.model.CreatedWorkspace;
@@ -141,8 +141,8 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
         sourceDataRepoSnapshotReference.getMetadata().getResourceId(),
         destinationWorkspaceId);
 
-    final CloneReferencedResourceResult cloneDataRepoSnapshotResult =
-        referencedGcpResourceApi.cloneReferencedResource(cloneDataRepoSnapshotReferenceRequestBody,
+    final CloneReferencedGcpDataRepoSnapshotResourceResult cloneDataRepoSnapshotResult =
+        referencedGcpResourceApi.cloneGcpDataRepoSnapshotReference(cloneDataRepoSnapshotReferenceRequestBody,
             sourceDataRepoSnapshotReference.getMetadata().getWorkspaceId(),
             sourceDataRepoSnapshotReference.getMetadata().getResourceId());
     assertEquals(getWorkspaceId(), cloneDataRepoSnapshotResult.getSourceWorkspaceId());
@@ -153,8 +153,8 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
     assertEquals(sourceDataRepoSnapshotReference.getMetadata().getName(), clonedDataRepoSnapshotResourceMetadata.getName());
     assertEquals(sourceDataRepoSnapshotReference.getMetadata().getDescription(), clonedDataRepoSnapshotResourceMetadata.getDescription());
     assertEquals(sourceDataRepoSnapshotReference.getAttributes().getSnapshot(),
-        cloneDataRepoSnapshotResult.getResource().getResourceAttributes().getGcpDataRepoSnapshot().getSnapshot());
+        cloneDataRepoSnapshotResult.getResource().getAttributes().getSnapshot());
     assertEquals(sourceDataRepoSnapshotReference.getAttributes().getInstanceName(),
-        cloneDataRepoSnapshotResult.getResource().getResourceAttributes().getGcpDataRepoSnapshot().getInstanceName());
+        cloneDataRepoSnapshotResult.getResource().getAttributes().getInstanceName());
   }
 }

--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -119,8 +119,8 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
         sourceBigQueryDatasetReference.getMetadata().getResourceId(),
         destinationWorkspaceId);
 
-    final CloneReferencedResourceResult cloneDatasetReferenceResult =
-        referencedGcpResourceApi.cloneReferencedResource(cloneBigQueryDatasetRequestBody,
+    final var cloneDatasetReferenceResult =
+        referencedGcpResourceApi.cloneGcpBigQueryDatasetReference(cloneBigQueryDatasetRequestBody,
         getWorkspaceId(),
         sourceBigQueryDatasetReference.getMetadata().getResourceId());
     assertEquals(getWorkspaceId(), cloneDatasetReferenceResult.getSourceWorkspaceId());
@@ -131,7 +131,7 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
     assertEquals(CLONED_DATASET_RESOURCE_NAME, clonedDatasetResourceMetadata.getName());
     assertEquals(CLONED_DATASET_DESCRIPTION, clonedDatasetResourceMetadata.getDescription());
     assertEquals(sourceBigQueryDatasetReference.getAttributes().getProjectId(),
-        cloneDatasetReferenceResult.getResource().getResourceAttributes().getGcpBqDataset().getProjectId());
+        cloneDatasetReferenceResult.getResource().getAttributes().getProjectId());
 
     final var cloneDataRepoSnapshotReferenceRequestBody = new CloneReferencedResourceRequestBody()
         .cloningInstructions(CloningInstructionsEnum.REFERENCE)

--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -76,12 +76,6 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
             .stage(getStageModel());
     final CreatedWorkspace createdDestinationWorkspace = workspaceApi.createWorkspace(requestBody);
     assertThat(createdDestinationWorkspace.getId(), equalTo(destinationWorkspaceId));
-
-    // create destination cloud context
-    String destinationProjectId = CloudContextMaker
-        .createGcpCloudContext(destinationWorkspaceId, workspaceApi);
-    logger.info("Created destination project {} in workspace {}", destinationProjectId, destinationWorkspaceId);
-
   }
 
   @Override

--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -1,0 +1,159 @@
+package scripts.testscripts;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.ReferencedGcpResourceApi;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiClient;
+import bio.terra.workspace.model.CloneReferencedResourceRequestBody;
+import bio.terra.workspace.model.CloneReferencedResourceResult;
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import bio.terra.workspace.model.CreateWorkspaceRequestBody;
+import bio.terra.workspace.model.CreatedWorkspace;
+import bio.terra.workspace.model.DataRepoSnapshotResource;
+import bio.terra.workspace.model.GcpBigQueryDatasetResource;
+import bio.terra.workspace.model.GcpGcsBucketResource;
+import bio.terra.workspace.model.ResourceMetadata;
+import bio.terra.workspace.model.ResourceType;
+import bio.terra.workspace.model.StewardshipType;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scripts.utils.ClientTestUtils;
+import scripts.utils.CloudContextMaker;
+import scripts.utils.DataRepoTestScriptBase;
+import scripts.utils.ResourceMaker;
+import scripts.utils.WorkspaceAllocateTestScriptBase;
+
+public class CloneReferencedResources extends DataRepoTestScriptBase {
+
+  private static final String DATASET_RESOURCE_NAME = "dataset_resource_name";
+  private static final Logger logger = LoggerFactory.getLogger(CloneReferencedResources.class);
+  private static final String CLONED_BUCKET_RESOURCE_NAME = "a_new_name";
+  private static final String CLONED_DATASET_RESOURCE_NAME = "a_cloned_reference";
+  private static final String CLONED_DATASET_DESCRIPTION = "Second star to the right.";
+
+  private DataRepoSnapshotResource sourceDataRepoSnapshotReference;
+  private GcpGcsBucketResource sourceBucketReference;
+  private GcpBigQueryDatasetResource sourceBigQueryDatasetReference;
+  private UUID destinationWorkspaceId;
+  private ReferencedGcpResourceApi referencedGcpResourceApi;
+
+  @Override
+  protected void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doSetup(testUsers, workspaceApi);
+    ApiClient apiClient = ClientTestUtils.getClientForTestUser(testUsers.get(0), server);
+    referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
+    String bucketReferenceName = RandomStringUtils.random(16, true, false);
+    // create reference to existing test bucket
+    sourceBucketReference =
+        ResourceMaker
+            .makeGcsBucketReference(referencedGcpResourceApi, getWorkspaceId(), bucketReferenceName);
+
+    sourceBigQueryDatasetReference = ResourceMaker.makeBigQueryReference(referencedGcpResourceApi, getWorkspaceId(),
+        DATASET_RESOURCE_NAME);
+
+    final String snapshotReferenceName = RandomStringUtils.random(6, true, false);
+
+    // Create a data repo snapshot reference
+    sourceDataRepoSnapshotReference = ResourceMaker.makeDataRepoSnapshotReference(referencedGcpResourceApi,
+        getWorkspaceId(), snapshotReferenceName, getDataRepoSnapshotId(), getDataRepoInstanceName());
+
+    // create a new workspace with cloud context
+    destinationWorkspaceId = UUID.randomUUID();
+    final var requestBody =
+        new CreateWorkspaceRequestBody()
+            .id(destinationWorkspaceId)
+            .spendProfile(getSpendProfileId())
+            .stage(getStageModel());
+    final CreatedWorkspace createdDestinationWorkspace = workspaceApi.createWorkspace(requestBody);
+    assertThat(createdDestinationWorkspace.getId(), equalTo(destinationWorkspaceId));
+
+    // create destination cloud context
+    String destinationProjectId = CloudContextMaker
+        .createGcpCloudContext(destinationWorkspaceId, workspaceApi);
+    logger.info("Created destination project {} in workspace {}", destinationProjectId, destinationWorkspaceId);
+
+  }
+
+  @Override
+  protected void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
+      throws Exception {
+    // clone source reference to destination
+    final var cloneBucketReferenceRequestBody = new CloneReferencedResourceRequestBody()
+        .cloningInstructions(CloningInstructionsEnum.REFERENCE)
+        .name(CLONED_BUCKET_RESOURCE_NAME)
+        .destinationWorkspaceId(destinationWorkspaceId);
+    logger.info("Cloning GCS Bucket Reference\n\tworkspaceId: {}\n\tresourceId: {}\ninto\n\tworkspaceId: {}",
+        sourceBucketReference.getMetadata().getWorkspaceId(),
+        sourceBucketReference.getMetadata().getResourceId(),
+        destinationWorkspaceId);
+    final CloneReferencedResourceResult cloneBucketReferenceResult = referencedGcpResourceApi.cloneReferencedResource(cloneBucketReferenceRequestBody,
+        getWorkspaceId(),
+        sourceBucketReference.getMetadata().getResourceId());
+    assertEquals(getWorkspaceId(), cloneBucketReferenceResult.getSourceWorkspaceId());
+    assertEquals(StewardshipType.REFERENCED, cloneBucketReferenceResult.getResource().getMetadata().getStewardshipType());
+    assertEquals(ResourceType.GCS_BUCKET, cloneBucketReferenceResult.getResource().getMetadata().getResourceType());
+    assertEquals(sourceBucketReference.getMetadata().getResourceId(), cloneBucketReferenceResult.getSourceResourceId());
+    assertEquals(sourceBucketReference.getMetadata().getDescription(), cloneBucketReferenceResult.getResource().getMetadata().getDescription());
+    assertEquals(CLONED_BUCKET_RESOURCE_NAME, cloneBucketReferenceResult.getResource().getMetadata().getName());
+    assertEquals(TEST_BUCKET_NAME,
+        cloneBucketReferenceResult.getResource().getResourceAttributes().getGcpGcsBucket().getBucketName());
+
+    final var cloneBigQueryDatasetRequestBody = new CloneReferencedResourceRequestBody()
+        .cloningInstructions(CloningInstructionsEnum.REFERENCE)
+        .name(CLONED_DATASET_RESOURCE_NAME)
+        .description(CLONED_DATASET_DESCRIPTION)
+        .destinationWorkspaceId(destinationWorkspaceId);
+
+    logger.info("Cloning BigQuery Dataset Reference\n\tworkspaceId: {}\n\tresourceId: {}\ninto\n\tworkspaceId: {}",
+        sourceBigQueryDatasetReference.getMetadata().getWorkspaceId(),
+        sourceBigQueryDatasetReference.getMetadata().getResourceId(),
+        destinationWorkspaceId);
+
+    final CloneReferencedResourceResult cloneDatasetReferenceResult =
+        referencedGcpResourceApi.cloneReferencedResource(cloneBigQueryDatasetRequestBody,
+        getWorkspaceId(),
+        sourceBigQueryDatasetReference.getMetadata().getResourceId());
+    assertEquals(getWorkspaceId(), cloneDatasetReferenceResult.getSourceWorkspaceId());
+    final ResourceMetadata clonedDatasetResourceMetadata = cloneDatasetReferenceResult.getResource().getMetadata();
+    assertEquals(StewardshipType.REFERENCED, clonedDatasetResourceMetadata.getStewardshipType());
+    assertEquals(ResourceType.BIG_QUERY_DATASET, clonedDatasetResourceMetadata.getResourceType());
+    assertEquals(sourceBigQueryDatasetReference.getMetadata().getResourceId(), cloneDatasetReferenceResult.getSourceResourceId());
+    assertEquals(CLONED_DATASET_RESOURCE_NAME, clonedDatasetResourceMetadata.getName());
+    assertEquals(CLONED_DATASET_DESCRIPTION, clonedDatasetResourceMetadata.getDescription());
+    assertEquals(sourceBigQueryDatasetReference.getAttributes().getProjectId(),
+        cloneDatasetReferenceResult.getResource().getResourceAttributes().getGcpBqDataset().getProjectId());
+
+    final var cloneDataRepoSnapshotReferenceRequestBody = new CloneReferencedResourceRequestBody()
+        .cloningInstructions(CloningInstructionsEnum.REFERENCE)
+        .destinationWorkspaceId(destinationWorkspaceId);
+    logger.info("Cloning Data Repo Snapshot Reference\n\tworkspaceId: {}\n\tresourceId: {}\ninto\n\tworkspaceId: {}",
+        sourceDataRepoSnapshotReference.getMetadata().getWorkspaceId(),
+        sourceDataRepoSnapshotReference.getMetadata().getResourceId(),
+        destinationWorkspaceId);
+
+    final CloneReferencedResourceResult cloneDataRepoSnapshotResult =
+        referencedGcpResourceApi.cloneReferencedResource(cloneDataRepoSnapshotReferenceRequestBody,
+            sourceDataRepoSnapshotReference.getMetadata().getWorkspaceId(),
+            sourceDataRepoSnapshotReference.getMetadata().getResourceId());
+    assertEquals(getWorkspaceId(), cloneDataRepoSnapshotResult.getSourceWorkspaceId());
+    final ResourceMetadata clonedDataRepoSnapshotResourceMetadata = cloneDataRepoSnapshotResult.getResource().getMetadata();
+    assertEquals(StewardshipType.REFERENCED, clonedDataRepoSnapshotResourceMetadata.getStewardshipType());
+    assertEquals(ResourceType.DATA_REPO_SNAPSHOT, clonedDataRepoSnapshotResourceMetadata.getResourceType());
+    assertEquals(sourceDataRepoSnapshotReference.getMetadata().getResourceId(), cloneDataRepoSnapshotResult.getSourceResourceId());
+    assertEquals(sourceDataRepoSnapshotReference.getMetadata().getName(), clonedDataRepoSnapshotResourceMetadata.getName());
+    assertEquals(sourceDataRepoSnapshotReference.getMetadata().getDescription(), clonedDataRepoSnapshotResourceMetadata.getDescription());
+    assertEquals(sourceDataRepoSnapshotReference.getAttributes().getSnapshot(),
+        cloneDataRepoSnapshotResult.getResource().getResourceAttributes().getGcpDataRepoSnapshot().getSnapshot());
+    assertEquals(sourceDataRepoSnapshotReference.getAttributes().getInstanceName(),
+        cloneDataRepoSnapshotResult.getResource().getResourceAttributes().getGcpDataRepoSnapshot().getInstanceName());
+  }
+}

--- a/integration/src/main/resources/configs/integration/CloneReferencedResources.json
+++ b/integration/src/main/resources/configs/integration/CloneReferencedResources.json
@@ -1,0 +1,18 @@
+{
+  "name": "CloneReferencedResources",
+  "description": "Exercise reference access validation over all resource types",
+  "serverSpecificationFile": "workspace-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "CloneReferencedResources",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 5,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
+    }
+  ],
+  "testUserFiles": ["bella.json"]
+}

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -5,19 +5,20 @@
   "testConfigurationFiles": [
     "integration/BasicAuthenticated.json",
     "integration/BasicUnauthenticated.json",
-    "integration/GetRoles.json",
-    "integration/WorkspaceLifecycle.json",
-    "integration/DataReferenceLifecycle.json",
-    "integration/EnumerateDataReferences.json",
-    "integration/ControlledGcsBucketLifecycle.json",
+    "integration/CloneGcsBucket.json",
+    "integration/CloneReferencedResources.json",
     "integration/ControlledBigQueryDatasetLifecycle.json",
-    "integration/PrivateControlledGcsBucketLifecycle.json",
-    "integration/PrivateControlledAiNotebookInstanceLifecycle.json",
-    "integration/EnumerateResources.json",
+    "integration/ControlledGcsBucketLifecycle.json",
+    "integration/DataReferenceLifecycle.json",
     "integration/DeleteGcpContextWithControlledResource.json",
     "integration/DeleteWorkspaceWithControlledResource.json",
+    "integration/EnumerateDataReferences.json",
+    "integration/EnumerateResources.json",
+    "integration/GetRoles.json",
+    "integration/PrivateControlledAiNotebookInstanceLifecycle.json",
+    "integration/PrivateControlledGcsBucketLifecycle.json",
     "integration/ValidateReferencedResources.json",
-    "integration/CloneGcsBucket.json"
+    "integration/WorkspaceLifecycle.json"
   ]
 }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedBigQueryDatasetResource.java
@@ -115,6 +115,23 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
     return crlService.canReadBigQueryDataset(projectId, datasetName, userReq);
   }
 
+  /**
+   * Build a builder with values from this object. This is useful when creating related objects that
+   * share several values.
+   *
+   * @return - a Builder for a new ReferencedBigQueryDatasetResource
+   */
+  public Builder toBuilder() {
+    return builder()
+        .cloningInstructions(getCloningInstructions())
+        .datasetName(getDatasetName())
+        .description(getDescription())
+        .name(getName())
+        .projectId(getProjectId())
+        .resourceId(getResourceId())
+        .workspaceId(getWorkspaceId());
+  }
+
   public static class Builder {
     private UUID workspaceId;
     private UUID resourceId;

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedDataRepoSnapshotResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedDataRepoSnapshotResource.java
@@ -112,14 +112,25 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
     return dataRepoService.snapshotReadable(instanceName, snapshotId, userReq);
   }
 
+  public Builder toBuilder() {
+    return builder()
+        .cloningInstructions(getCloningInstructions())
+        .description(getDescription())
+        .instanceName(getInstanceName())
+        .name(getName())
+        .snapshotId(getSnapshotId())
+        .resourceId(getResourceId())
+        .workspaceId(getWorkspaceId());
+  }
+
   public static class Builder {
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
     private CloningInstructions cloningInstructions;
+    private String description;
     private String instanceName;
+    private String name;
     private String snapshotId;
+    private UUID resourceId;
+    private UUID workspaceId;
 
     public ReferencedDataRepoSnapshotResource.Builder workspaceId(UUID workspaceId) {
       this.workspaceId = workspaceId;

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedGcsBucketResource.java
@@ -99,17 +99,33 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
     return crlService.canReadGcsBucket(bucketName, userReq);
   }
 
+  /**
+   * Make a copy of this object via a new builder. This is convenient for reusing objects with one
+   * or two fields changed.
+   *
+   * @return builder object ready for new values to replace existing ones
+   */
+  public Builder toBuilder() {
+    return builder()
+        .bucketName(getBucketName())
+        .cloningInstructions(getCloningInstructions())
+        .description(getDescription())
+        .name(getName())
+        .resourceId(getResourceId())
+        .workspaceId(getWorkspaceId());
+  }
+
   public static Builder builder() {
     return new Builder();
   }
 
   public static class Builder {
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
     private CloningInstructions cloningInstructions;
     private String bucketName;
+    private String description;
+    private String name;
+    private UUID resourceId;
+    private UUID workspaceId;
 
     public Builder workspaceId(UUID workspaceId) {
       this.workspaceId = workspaceId;

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource.referenced;
 
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.db.DbRetryUtils;
 import bio.terra.workspace.db.ResourceDao;
@@ -13,6 +14,7 @@ import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -139,5 +141,104 @@ public class ReferencedResourceService {
         DbRetryUtils.throwIfInterrupted(
             () -> resourceDao.getResource(workspaceId, resourceId).castToReferencedResource());
     return referencedResource.checkAccess(beanBag, userReq);
+  }
+
+  public ReferencedResource cloneReferencedResource(
+      ReferencedResource sourceReferencedResource,
+      UUID destinationWorkspaceId,
+      @Nullable String name,
+      @Nullable String description,
+      AuthenticatedUserRequest userReq) {
+    final ReferencedResource destinationResource;
+    switch (sourceReferencedResource.getResourceType()) {
+      case GCS_BUCKET:
+        destinationResource =
+            buildDestinationGcsBucketReference(
+                sourceReferencedResource.castToGcsBucketResource(),
+                destinationWorkspaceId,
+                name,
+                description);
+        break;
+      case DATA_REPO_SNAPSHOT:
+        destinationResource =
+            buildDestinationDataRepoSnapshotReference(
+                sourceReferencedResource.castToDataRepoSnapshotResource(),
+                destinationWorkspaceId,
+                name,
+                description);
+        break;
+      case BIG_QUERY_DATASET:
+        destinationResource =
+            buildDestinationBigQueryDatasetReference(
+                sourceReferencedResource.castToBigQueryDatasetResource(),
+                destinationWorkspaceId,
+                name,
+                description);
+        break;
+      case AI_NOTEBOOK_INSTANCE:
+      default:
+        throw new BadRequestException(
+            String.format(
+                "Resource type %s not supported",
+                sourceReferencedResource.getResourceType().toString()));
+    }
+    return createReferenceResource(destinationResource, userReq);
+  }
+
+  /**
+   * Create a clone of a reference, which is identical in all fields except workspace ID, resource
+   * ID, and (possibly) name and description. This method reuses the createReferenceResource()
+   * method on the ReferenceResourceService.
+   *
+   * @param userReq - authenticated user request object
+   * @param sourceBucketResource - original resource to be cloned
+   * @param destinationWorkspaceId - workspace ID for new reference
+   * @param name - resource name for cloned reference. Will use original name if this is null.
+   * @param description - resource description for cloned reference. Uses original if left null.
+   * @return
+   */
+  private ReferencedResource buildDestinationGcsBucketReference(
+      ReferencedGcsBucketResource sourceBucketResource,
+      UUID destinationWorkspaceId,
+      @Nullable String name,
+      @Nullable String description) {
+
+    final ReferencedGcsBucketResource.Builder resultBuilder =
+        sourceBucketResource.toBuilder()
+            .workspaceId(destinationWorkspaceId)
+            .resourceId(UUID.randomUUID());
+    // apply optional override variables
+    Optional.ofNullable(name).ifPresent(resultBuilder::name);
+    Optional.ofNullable(description).ifPresent(resultBuilder::description);
+    return resultBuilder.build();
+  }
+
+  private ReferencedResource buildDestinationBigQueryDatasetReference(
+      ReferencedBigQueryDatasetResource sourceBigQueryResource,
+      UUID destinationWorkspaceId,
+      @Nullable String name,
+      @Nullable String description) {
+    // keep projectId and dataset name the same since they are for the referent
+    final ReferencedBigQueryDatasetResource.Builder resultBuilder =
+        sourceBigQueryResource.toBuilder()
+            .workspaceId(destinationWorkspaceId)
+            .resourceId(UUID.randomUUID());
+    Optional.ofNullable(name).ifPresent(resultBuilder::name);
+    Optional.ofNullable(description).ifPresent(resultBuilder::description);
+    return resultBuilder.build();
+  }
+
+  private ReferencedResource buildDestinationDataRepoSnapshotReference(
+      ReferencedDataRepoSnapshotResource sourceReferencedDataRepoSnapshotResource,
+      UUID destinationWorkspaceId,
+      @Nullable String name,
+      @Nullable String description) {
+    final ReferencedDataRepoSnapshotResource.Builder resultBuilder =
+        sourceReferencedDataRepoSnapshotResource.toBuilder()
+            .workspaceId(destinationWorkspaceId)
+            .resourceId(UUID.randomUUID());
+    Optional.ofNullable(name).ifPresent(resultBuilder::name);
+    Optional.ofNullable(description).ifPresent(resultBuilder::description);
+    return resultBuilder.build();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
@@ -190,7 +190,6 @@ public class ReferencedResourceService {
    * ID, and (possibly) name and description. This method reuses the createReferenceResource()
    * method on the ReferenceResourceService.
    *
-   * @param userReq - authenticated user request object
    * @param sourceBucketResource - original resource to be cloned
    * @param destinationWorkspaceId - workspace ID for new reference
    * @param name - resource name for cloned reference. Will use original name if this is null.

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -327,6 +327,32 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/workspaces/v1/{workspaceId}/resources/referenced/{resourceId}/clone:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
+    post:
+      summary: Clone a referenced resource
+      operationId: cloneReferencedResource
+      tags: [ReferencedGcpResource]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CloneReferencedResourceRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/CloneReferencedResourceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/workspaces/v1/{workspaceId}/resources/referenced/datarepo/snapshots:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'
@@ -1202,6 +1228,25 @@ components:
         $ref: '#/components/schemas/CloudPlatform'
 
   schemas:
+    CloneReferencedResourceRequestBody:
+      description: >-
+        Cloning options for referenced resources. If optional parameters are omitted,
+        the source values will be used.
+      type: object
+      required: [destinationWorkspaceId]
+      properties:
+        cloningInstructions:
+          $ref: '#/components/schemas/CloningInstructionsEnum'
+        destinationWorkspaceId:
+          type: string
+          format: uuid
+        # Null for original name
+        name:
+          $ref: "#/components/schemas/Name"
+        description:
+          description: Description for the referenced resource clone, or null to use original.
+          type: string
+
     ### DEPRECATED SCHEMAS ###
     # TODO(PF-404): remove this in favor of reference-type specific objects.
     CreateDataReferenceRequestBody:
@@ -1965,7 +2010,26 @@ components:
           $ref: '#/components/schemas/JobReport'
         errorReport:
           $ref: '#/components/schemas/ErrorReport'
-
+    CloneReferencedResourceResult:
+      description: >-
+        API result class for cloning a referenced resource. Includes source workspace
+        and resource IDs for provenance, and uses the union-typed ResourceDescription object
+        for the cloned referenced resource details. If the effective cloning instructions are not
+        COPY_REFERENCE, then no clone is created and the resource is null.
+      type: object
+      properties:
+        effectiveCloningInstructions:
+          $ref: '#/components/schemas/CloningInstructionsEnum'
+        sourceWorkspaceId:
+          description: ID of the workspace of the source resource for this clone
+          type: string
+          format: uuid
+        sourceResourceId:
+          description: ID of the source resource
+          type: string
+          format: uuid
+        resource:
+          $ref: '#/components/schemas/ResourceDescription'
     GcpBigQueryDatasetCreationParameters:
       description: >-
         Dataset-specific properties to be set on creation. These are a subset of the
@@ -2424,6 +2488,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CloneControlledGcpGcsBucketResult'
+
+    CloneReferencedResourceResponse:
+      description: Response to referenced resource clone operation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CloneReferencedResourceResult'
 
     DeleteControlledGcpGcsBucketResponse:
       description: Response Payload for deleting a Gcs bucket

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -327,32 +327,6 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{workspaceId}/resources/referenced/{resourceId}/clone:
-    parameters:
-      - $ref: '#/components/parameters/WorkspaceId'
-      - $ref: '#/components/parameters/ResourceId'
-    post:
-      summary: Clone a referenced resource
-      operationId: cloneReferencedResource
-      tags: [ReferencedGcpResource]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CloneReferencedResourceRequestBody'
-      responses:
-        '200':
-          $ref: '#/components/responses/CloneReferencedResourceResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/PermissionDenied'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
-
   /api/workspaces/v1/{workspaceId}/resources/referenced/datarepo/snapshots:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'
@@ -421,6 +395,31 @@ paths:
       responses:
         '204':
           description: OK
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/workspaces/v1/{workspaceId}/resources/referenced/datarepo/snapshots/{resourceId}/clone:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
+    post:
+      summary: Clone a referenced Data Repo Snapshot resource
+      operationId: cloneGcpDataRepoSnapshotReference
+      tags: [ ReferencedGcpResource ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CloneReferencedResourceRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/CloneReferencedGcpDataRepoSnapshotResourceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -2097,11 +2096,10 @@ components:
           format: uuid
         resource:
           $ref: '#/components/schemas/GcpBigQueryDatasetResource'
-    CloneReferencedResourceResult:
+    CloneReferencedGcpDataRepoSnapshotResourceResult:
       description: >-
-        API result class for cloning a referenced resource. Includes source workspace
-        and resource IDs for provenance, and uses the union-typed ResourceDescription object
-        for the cloned referenced resource details. If the effective cloning instructions are not
+        API result class for cloning a referenced Data Repo snapshot resource. Includes source workspace
+        and resource IDs for provenance. If the effective cloning instructions are not
         COPY_REFERENCE, then no clone is created and the resource is null.
       type: object
       properties:
@@ -2116,7 +2114,7 @@ components:
           type: string
           format: uuid
         resource:
-          $ref: '#/components/schemas/ResourceDescription'
+          $ref: '#/components/schemas/DataRepoSnapshotResource'
     GcpBigQueryDatasetCreationParameters:
       description: >-
         Dataset-specific properties to be set on creation. These are a subset of the
@@ -2576,13 +2574,6 @@ components:
           schema:
             $ref: '#/components/schemas/CloneControlledGcpGcsBucketResult'
 
-    CloneReferencedResourceResponse:
-      description: Response to referenced resource clone operation.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/CloneReferencedResourceResult'
-
     DeleteControlledGcpGcsBucketResponse:
       description: Response Payload for deleting a Gcs bucket
       content:
@@ -2655,6 +2646,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CloneReferencedGcpBigQueryDatasetResourceResult'
+    CloneReferencedGcpDataRepoSnapshotResourceResponse:
+      description: Response for successful Data Repo Snapshot reference clone
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CloneReferencedGcpDataRepoSnapshotResourceResult'
     JobReportResponse:
       description: A response containing a JobReport object. Returned for running jobs.
       headers:

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -637,6 +637,31 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bigquerydatasets/{resourceId}/clone:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
+    post:
+      summary: Clone a BigQuery Dataset
+      operationId: cloneGcpBigQueryDatasetReference
+      tags: [ReferencedGcpResource]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CloneReferencedResourceRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/CloneReferencedGcpBigQueryDatasetResourceResponse'
+        '202':
+          $ref: '#/components/responses/CloneReferencedGcpBigQueryDatasetResourceResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bigquerydatasets/name/{name}:
     parameters:
@@ -2053,6 +2078,25 @@ components:
           format: uuid
         resource:
           $ref: '#/components/schemas/GcpGcsBucketResource'
+    CloneReferencedGcpBigQueryDatasetResourceResult:
+      description: >-
+        API result class for cloning a referenced BigQuery dataset resource. Includes source workspace
+        and resource IDs for provenance. If the effective cloning instructions are not
+        COPY_REFERENCE, then no clone is created and the resource is null.
+      type: object
+      properties:
+        effectiveCloningInstructions:
+          $ref: '#/components/schemas/CloningInstructionsEnum'
+        sourceWorkspaceId:
+          description: ID of the workspace of the source resource for this clone
+          type: string
+          format: uuid
+        sourceResourceId:
+          description: ID of the source resource
+          type: string
+          format: uuid
+        resource:
+          $ref: '#/components/schemas/GcpBigQueryDatasetResource'
     CloneReferencedResourceResult:
       description: >-
         API result class for cloning a referenced resource. Includes source workspace
@@ -2605,6 +2649,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CloneReferencedGcpGcsBucketResourceResult'
+    CloneReferencedGcpBigQueryDatasetResourceResponse:
+      description: Response for successful BigQuery dataset reference clone
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CloneReferencedGcpBigQueryDatasetResourceResult'
     JobReportResponse:
       description: A response containing a JobReport object. Returned for running jobs.
       headers:

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -520,7 +520,31 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-
+  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/buckets/{resourceId}/clone:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
+    post:
+      summary: Clone a referenced GCS Bucket resource
+      operationId: cloneGcpGcsBucketReference
+      tags: [ReferencedGcpResource]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CloneReferencedResourceRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/CloneReferencedGcpGcsBucketResourceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/buckets/name/{name}:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'
@@ -2010,6 +2034,25 @@ components:
           $ref: '#/components/schemas/JobReport'
         errorReport:
           $ref: '#/components/schemas/ErrorReport'
+    CloneReferencedGcpGcsBucketResourceResult:
+      description: >-
+        API result class for cloning a referenced GCS Bucket resource. Includes source workspace
+        and resource IDs for provenance. If the effective cloning instructions are not
+        COPY_REFERENCE, then no clone is created and the resource is null.
+      type: object
+      properties:
+        effectiveCloningInstructions:
+          $ref: '#/components/schemas/CloningInstructionsEnum'
+        sourceWorkspaceId:
+          description: ID of the workspace of the source resource for this clone
+          type: string
+          format: uuid
+        sourceResourceId:
+          description: ID of the source resource
+          type: string
+          format: uuid
+        resource:
+          $ref: '#/components/schemas/GcpGcsBucketResource'
     CloneReferencedResourceResult:
       description: >-
         API result class for cloning a referenced resource. Includes source workspace
@@ -2556,7 +2599,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CreateCloudContextResult'
-
+    CloneReferencedGcpGcsBucketResourceResponse:
+      description: Response for successful GCS Bucket reference clone
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CloneReferencedGcpGcsBucketResourceResult'
     JobReportResponse:
       description: A response containing a JobReport object. Returned for running jobs.
       headers:


### PR DESCRIPTION
Create clones of all reference types that point to the original referent. This didn't involve any new flights, but reused the create reference flight.