### PR TITLE
[PF-878] Move WSM to custom project-level roles

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GcpPolicyBuilder.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GcpPolicyBuilder.java
@@ -89,7 +89,8 @@ public class GcpPolicyBuilder {
    */
   private Binding buildBinding(ControlledResourceIamRole resourceRole, String memberIdentifier) {
     CustomGcpIamRole customRole =
-        CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES.get(resource.getResourceType(), resourceRole);
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES.get(
+            resource.getResourceType(), resourceRole);
     return Binding.newBuilder()
         .setRole(customRole.getFullyQualifiedRoleName(projectId))
         .setMembers(Collections.singletonList(memberIdentifier))

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRole.java
@@ -25,16 +25,30 @@ public class CustomGcpIamRole {
 
   /**
    * Create a custom GCP role named by a combination of a resource type and resource-level IAM role.
+   * Custom roles applied at the resource level should use this to generate the correct role name.
    *
    * @param resourceType The type of resource this role is intended for. Used for name generation
    * @param iamRole The IAM role this GCP role is intended for. Used for name generation.
    * @param includedPermissions The list of GCP permissions this role should grant.
    */
-  CustomGcpIamRole(
+  public CustomGcpIamRole(
       WsmResourceType resourceType,
       ControlledResourceIamRole iamRole,
       List<String> includedPermissions) {
     this.roleName = resourceType.name().toUpperCase() + "_" + iamRole.name().toUpperCase();
+    this.includedPermissions = includedPermissions;
+  }
+
+  /**
+   * Create a custom GCP role from name and permissions list. Roles applied at the resource level
+   * should use {@link CustomGcpIamRole#CustomGcpIamRole(WsmResourceType, ControlledResourceIamRole,
+   * List)} instead.
+   *
+   * @param roleName
+   * @param includedPermissions
+   */
+  public CustomGcpIamRole(String roleName, List<String> includedPermissions) {
+    this.roleName = roleName;
     this.includedPermissions = includedPermissions;
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRole.java
@@ -23,6 +23,11 @@ public class CustomGcpIamRole {
   private final String roleName;
   private final List<String> includedPermissions;
 
+  private CustomGcpIamRole(String roleName, List<String> includedPermissions) {
+    this.roleName = roleName;
+    this.includedPermissions = includedPermissions;
+  }
+
   /**
    * Create a custom GCP role named by a combination of a resource type and resource-level IAM role.
    * Custom roles applied at the resource level should use this to generate the correct role name.
@@ -31,25 +36,24 @@ public class CustomGcpIamRole {
    * @param iamRole The IAM role this GCP role is intended for. Used for name generation.
    * @param includedPermissions The list of GCP permissions this role should grant.
    */
-  public CustomGcpIamRole(
+  public static CustomGcpIamRole ofResource(
       WsmResourceType resourceType,
       ControlledResourceIamRole iamRole,
       List<String> includedPermissions) {
-    this.roleName = resourceType.name().toUpperCase() + "_" + iamRole.name().toUpperCase();
-    this.includedPermissions = includedPermissions;
+    String roleName = resourceType.name().toUpperCase() + "_" + iamRole.name().toUpperCase();
+    return new CustomGcpIamRole(roleName, includedPermissions);
   }
 
   /**
    * Create a custom GCP role from name and permissions list. Roles applied at the resource level
-   * should use {@link CustomGcpIamRole#CustomGcpIamRole(WsmResourceType, ControlledResourceIamRole,
+   * should use {@link CustomGcpIamRole#ofResource(WsmResourceType, ControlledResourceIamRole,
    * List)} instead.
    *
    * @param roleName
    * @param includedPermissions
    */
-  public CustomGcpIamRole(String roleName, List<String> includedPermissions) {
-    this.roleName = roleName;
-    this.includedPermissions = includedPermissions;
+  public static CustomGcpIamRole of(String roleName, List<String> includedPermissions) {
+    return new CustomGcpIamRole(roleName, includedPermissions);
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
@@ -111,7 +111,7 @@ public class CustomGcpIamRoleMapping {
   // The ASSIGNER role does not grant GCP permissions, only Sam permissions. It's included in
   // this map for completeness.
   public static final Table<WsmResourceType, ControlledResourceIamRole, CustomGcpIamRole>
-      CUSTOM_GCP_IAM_ROLES =
+      CUSTOM_GCP_RESOURCE_IAM_ROLES =
           new ImmutableTable.Builder<WsmResourceType, ControlledResourceIamRole, CustomGcpIamRole>()
               // GCS bucket
               .put(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
@@ -117,28 +117,28 @@ public class CustomGcpIamRoleMapping {
               .put(
                   WsmResourceType.GCS_BUCKET,
                   ControlledResourceIamRole.READER,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.GCS_BUCKET,
                       ControlledResourceIamRole.READER,
                       GCS_BUCKET_READER_PERMISSIONS))
               .put(
                   WsmResourceType.GCS_BUCKET,
                   ControlledResourceIamRole.WRITER,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.GCS_BUCKET,
                       ControlledResourceIamRole.WRITER,
                       GCS_BUCKET_WRITER_PERMISSIONS))
               .put(
                   WsmResourceType.GCS_BUCKET,
                   ControlledResourceIamRole.EDITOR,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.GCS_BUCKET,
                       ControlledResourceIamRole.EDITOR,
                       GCS_BUCKET_EDITOR_PERMISSIONS))
               .put(
                   WsmResourceType.GCS_BUCKET,
                   ControlledResourceIamRole.ASSIGNER,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.GCS_BUCKET,
                       ControlledResourceIamRole.ASSIGNER,
                       Collections.emptyList()))
@@ -146,28 +146,28 @@ public class CustomGcpIamRoleMapping {
               .put(
                   WsmResourceType.BIG_QUERY_DATASET,
                   ControlledResourceIamRole.READER,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.READER,
                       BIG_QUERY_DATASET_READER_PERMISSIONS))
               .put(
                   WsmResourceType.BIG_QUERY_DATASET,
                   ControlledResourceIamRole.WRITER,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.WRITER,
                       BIG_QUERY_DATASET_WRITER_PERMISSIONS))
               .put(
                   WsmResourceType.BIG_QUERY_DATASET,
                   ControlledResourceIamRole.EDITOR,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.EDITOR,
                       BIG_QUERY_DATASET_EDITOR_PERMISSIONS))
               .put(
                   WsmResourceType.BIG_QUERY_DATASET,
                   ControlledResourceIamRole.ASSIGNER,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.ASSIGNER,
                       Collections.emptyList()))
@@ -175,28 +175,28 @@ public class CustomGcpIamRoleMapping {
               .put(
                   WsmResourceType.AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.READER,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.READER,
                       AI_NOTEBOOK_INSTANCE_READER_PERMISSIONS))
               .put(
                   WsmResourceType.AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.WRITER,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.WRITER,
                       AI_NOTEBOOK_INSTANCE_WRITER_PERMISSIONS))
               .put(
                   WsmResourceType.AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.EDITOR,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.EDITOR,
                       AI_NOTEBOOK_INSTANCE_EDITOR_PERMISSIONS))
               .put(
                   WsmResourceType.AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.ASSIGNER,
-                  new CustomGcpIamRole(
+                  CustomGcpIamRole.ofResource(
                       WsmResourceType.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.ASSIGNER,
                       Collections.emptyList()))

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -20,7 +20,7 @@ public class CloudSyncRoleMapping {
   // Note that custom roles defined at the project level cannot contain the
   // "resourcemanager.projects.list" permission, even though it was previously included here.
   // See https://cloud.google.com/iam/docs/understanding-custom-roles#known_limitations
-  private static final List<String> READER_PERMISSIONS =
+  private static final List<String> PROJECT_READER_PERMISSIONS =
       ImmutableList.of(
           "bigquery.jobs.create",
           "lifesciences.operations.get",
@@ -32,9 +32,9 @@ public class CloudSyncRoleMapping {
           "serviceusage.quotas.get",
           "serviceusage.services.get",
           "serviceusage.services.list");
-  private static final List<String> WRITER_PERMISSIONS =
+  private static final List<String> PROJECT_WRITER_PERMISSIONS =
       new ImmutableList.Builder<String>()
-          .addAll(READER_PERMISSIONS)
+          .addAll(PROJECT_READER_PERMISSIONS)
           .add(
               // TODO(wchambers): Revise service account permissions when there are controlled
               // resources for service accounts. (Also used by NextFlow)
@@ -47,9 +47,9 @@ public class CloudSyncRoleMapping {
           .build();
 
   private static final CustomGcpIamRole PROJECT_READER =
-      new CustomGcpIamRole("PROJECT_READER", READER_PERMISSIONS);
+      CustomGcpIamRole.of("PROJECT_READER", PROJECT_READER_PERMISSIONS);
   private static final CustomGcpIamRole PROJECT_WRITER =
-      new CustomGcpIamRole("PROJECT_WRITER", WRITER_PERMISSIONS);
+      CustomGcpIamRole.of("PROJECT_WRITER", PROJECT_WRITER_PERMISSIONS);
   // Currently, workspace editors, applications and owners have the same cloud permissions as
   // writers. If that changes, create a new CustomGcpIamRole and modify the map below.
   public static final ImmutableMap<WsmIamRole, CustomGcpIamRole> CUSTOM_GCP_PROJECT_IAM_ROLES =

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
 import bio.terra.workspace.service.iam.model.WsmIamRole;
+import bio.terra.workspace.service.resource.controlled.mappings.CustomGcpIamRole;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
@@ -11,34 +12,52 @@ import java.util.List;
  * <p>Granting these roles at the project level was implemented as a temporary workaround to support
  * objects in a cloud context before controlled resources were built. As controlled resources become
  * available, roles should be granted directly on controlled resources instead (see {@code
- * CustomGcpIamRoleMapping}), and should be removed from this list.
+ * CustomGcpIamRoleMapping}), and should be removed from this list. Some permissions must be granted
+ * at the project level, and will continue to live here.
  */
 public class CloudSyncRoleMapping {
-  // Note that bigquery.jobUser is required at the project level, unlike other permissions which can
-  // be per-dataset.
+
+  // Note that custom roles defined at the project level cannot contain the
+  // "resourcemanager.projects.list" permission, even though it was previously included here.
+  // See https://cloud.google.com/iam/docs/understanding-custom-roles#known_limitations
   private static final List<String> READER_PERMISSIONS =
       ImmutableList.of(
-          "roles/bigquery.jobUser",
-          "roles/lifesciences.viewer",
-          "roles/serviceusage.serviceUsageViewer");
+          "bigquery.jobs.create",
+          "lifesciences.operations.get",
+          "lifesciences.operations.list",
+          "resourcemanager.projects.get",
+          "monitoring.timeSeries.list",
+          "serviceusage.operations.get",
+          "serviceusage.operations.list",
+          "serviceusage.quotas.get",
+          "serviceusage.services.get",
+          "serviceusage.services.list");
   private static final List<String> WRITER_PERMISSIONS =
       new ImmutableList.Builder<String>()
           .addAll(READER_PERMISSIONS)
           .add(
               // TODO(wchambers): Revise service account permissions when there are controlled
               // resources for service accounts. (Also used by NextFlow)
-              "roles/iam.serviceAccountUser",
-              "roles/lifesciences.editor",
-              "roles/serviceusage.serviceUsageConsumer")
+              "iam.serviceAccounts.actAs",
+              "iam.serviceAccounts.get",
+              "iam.serviceAccounts.list",
+              "lifesciences.workflows.run",
+              "lifesciences.operations.cancel",
+              "serviceusage.services.use")
           .build();
-  // Currently, workspace editors, applications and owners have the sam cloud permissions as
-  // writers. If that changes, create a new list and modify the map below.
-  public static final ImmutableMap<WsmIamRole, List<String>> CLOUD_SYNC_ROLE_MAP =
+
+  private static final CustomGcpIamRole PROJECT_READER =
+      new CustomGcpIamRole("PROJECT_READER", READER_PERMISSIONS);
+  private static final CustomGcpIamRole PROJECT_WRITER =
+      new CustomGcpIamRole("PROJECT_WRITER", WRITER_PERMISSIONS);
+  // Currently, workspace editors, applications and owners have the same cloud permissions as
+  // writers. If that changes, create a new CustomGcpIamRole and modify the map below.
+  public static final ImmutableMap<WsmIamRole, CustomGcpIamRole> CUSTOM_GCP_PROJECT_IAM_ROLES =
       ImmutableMap.of(
-          // TODO: this should map to OWNER_PERMISSIONS if that's created.
-          WsmIamRole.OWNER, WRITER_PERMISSIONS,
-          // TODO: this should map to APPLICATION_PERMISSIONS if that's created.
-          WsmIamRole.APPLICATION, WRITER_PERMISSIONS,
-          WsmIamRole.WRITER, WRITER_PERMISSIONS,
-          WsmIamRole.READER, READER_PERMISSIONS);
+          // TODO: this should map to PROJECT_OWNER if that's created.
+          WsmIamRole.OWNER, PROJECT_WRITER,
+          // TODO: this should map to PROJECT_APPLICATION if that's created.
+          WsmIamRole.APPLICATION, PROJECT_WRITER,
+          WsmIamRole.WRITER, PROJECT_WRITER,
+          WsmIamRole.READER, PROJECT_READER);
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateCustomGcpRolesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateCustomGcpRolesStep.java
@@ -55,7 +55,8 @@ public class CreateCustomGcpRolesStep implements Step {
   }
 
   /**
-   * Utility for creating custom roles in GCP from  WSM's CustomGcpIamRole objects.
+   * Utility for creating custom roles in GCP from WSM's CustomGcpIamRole objects. These roles will
+   * be defined at the project level in the specified by projectId.
    */
   private void createCustomRole(CustomGcpIamRole customRole, String projectId)
       throws RetryException {
@@ -66,7 +67,7 @@ public class CreateCustomGcpRolesStep implements Step {
               .setTitle(customRole.getRoleName());
       CreateRoleRequest request =
           new CreateRoleRequest().setRole(gcpRole).setRoleId(customRole.getRoleName());
-      logger.info(
+      logger.debug(
           "Creating role {} with permissions {} in project {}",
           customRole.getRoleName(),
           customRole.getIncludedPermissions(),

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateCustomGcpRolesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateCustomGcpRolesStep.java
@@ -21,7 +21,7 @@ import org.springframework.http.HttpStatus;
 
 /**
  * This step creates custom role definitions in our GCP context. It does not grant these roles to
- * any users, though other steps will do that in the future.
+ * any users, though other steps do.
  */
 public class CreateCustomGcpRolesStep implements Step {
 
@@ -39,7 +39,7 @@ public class CreateCustomGcpRolesStep implements Step {
     String projectId = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
     // First, create the project-level custom roles.
     // Multiple WSM roles may share the same GCP role. De-duping here prevents duplicate requests,
-    // which would lead to unnecessary CONFLICT responses from the cloud.
+    // which would lead to unnecessary CONFLICT responses from GCP.
     ImmutableSet<CustomGcpIamRole> customProjectRoles =
         CloudSyncRoleMapping.CUSTOM_GCP_PROJECT_IAM_ROLES.values().stream()
             .collect(ImmutableSet.toImmutableSet());
@@ -55,8 +55,7 @@ public class CreateCustomGcpRolesStep implements Step {
   }
 
   /**
-   * Utility for translating WSM's CustomGcpIamRole object to GCP's equivalent and making a request
-   * to the cloud.
+   * Utility for creating custom roles in GCP from  WSM's CustomGcpIamRole objects.
    */
   private void createCustomRole(CustomGcpIamRole customRole, String projectId)
       throws RetryException {

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateCustomGcpRolesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateCustomGcpRolesStep.java
@@ -9,14 +9,20 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.resource.controlled.mappings.CustomGcpIamRole;
 import bio.terra.workspace.service.resource.controlled.mappings.CustomGcpIamRoleMapping;
+import bio.terra.workspace.service.workspace.CloudSyncRoleMapping;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.iam.v1.model.CreateRoleRequest;
 import com.google.api.services.iam.v1.model.Role;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
+/**
+ * This step creates custom role definitions in our GCP context. It does not grant these roles to
+ * any users, though other steps will do that in the future.
+ */
 public class CreateCustomGcpRolesStep implements Step {
 
   private final IamCow iamCow;
@@ -31,35 +37,53 @@ public class CreateCustomGcpRolesStep implements Step {
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
     String projectId = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
-    for (CustomGcpIamRole customRole : CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES.values()) {
-      try {
-        Role gcpRole =
-            new Role()
-                .setIncludedPermissions(customRole.getIncludedPermissions())
-                .setTitle(customRole.getRoleName());
-        CreateRoleRequest request =
-            new CreateRoleRequest().setRole(gcpRole).setRoleId(customRole.getRoleName());
-        logger.info(
-            "Creating role {} with permissions {} in project {}",
-            customRole.getRoleName(),
-            customRole.getIncludedPermissions(),
-            projectId);
-        iamCow.projects().roles().create("projects/" + projectId, request).execute();
-      } catch (GoogleJsonResponseException googleEx) {
-        // Because this step may run multiple times, we need to handle duplicate role creation.
-        // The project was retrieved from RBS earlier in this flight, so we assume that any conflict
-        // of role names must be due to duplicate step execution.
-        if (googleEx.getStatusCode() == HttpStatus.CONFLICT.value()) {
-          continue;
-        } else {
-          throw new RetryException(googleEx);
-        }
-      } catch (IOException e) {
-        // Retry on IO exceptions thrown by CRL.
-        throw new RetryException(e);
-      }
+    // First, create the project-level custom roles.
+    // Multiple WSM roles may share the same GCP role. De-duping here prevents duplicate requests,
+    // which would lead to unnecessary CONFLICT responses from the cloud.
+    ImmutableSet<CustomGcpIamRole> customProjectRoles =
+        CloudSyncRoleMapping.CUSTOM_GCP_PROJECT_IAM_ROLES.values().stream()
+            .collect(ImmutableSet.toImmutableSet());
+    for (CustomGcpIamRole customProjectRole : customProjectRoles) {
+      createCustomRole(customProjectRole, projectId);
+    }
+    // Second, create the resource-level custom roles.
+    for (CustomGcpIamRole customResourceRole :
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES.values()) {
+      createCustomRole(customResourceRole, projectId);
     }
     return StepResult.getStepResultSuccess();
+  }
+
+  /**
+   * Utility for translating WSM's CustomGcpIamRole object to GCP's equivalent and making a request
+   * to the cloud.
+   */
+  private void createCustomRole(CustomGcpIamRole customRole, String projectId)
+      throws RetryException {
+    try {
+      Role gcpRole =
+          new Role()
+              .setIncludedPermissions(customRole.getIncludedPermissions())
+              .setTitle(customRole.getRoleName());
+      CreateRoleRequest request =
+          new CreateRoleRequest().setRole(gcpRole).setRoleId(customRole.getRoleName());
+      logger.info(
+          "Creating role {} with permissions {} in project {}",
+          customRole.getRoleName(),
+          customRole.getIncludedPermissions(),
+          projectId);
+      iamCow.projects().roles().create("projects/" + projectId, request).execute();
+    } catch (GoogleJsonResponseException googleEx) {
+      // Because this step may run multiple times, we need to handle duplicate role creation.
+      // The project was retrieved from RBS earlier in this flight, so we assume that any conflict
+      // of role names must be due to duplicate step execution.
+      if (googleEx.getStatusCode() != HttpStatus.CONFLICT.value()) {
+        throw new RetryException(googleEx);
+      }
+    } catch (IOException e) {
+      // Retry on IO exceptions thrown by CRL.
+      throw new RetryException(e);
+    }
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/GcpCloudSyncStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/GcpCloudSyncStep.java
@@ -9,6 +9,7 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
+import bio.terra.workspace.service.resource.controlled.mappings.CustomGcpIamRole;
 import bio.terra.workspace.service.workspace.CloudSyncRoleMapping;
 import bio.terra.workspace.service.workspace.exceptions.RetryableCrlException;
 import com.google.api.services.cloudresourcemanager.v3.model.Binding;
@@ -20,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +52,7 @@ public class GcpCloudSyncStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    String gcpProjectName = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
+    String gcpProjectId = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
     FlightMap workingMap = flightContext.getWorkingMap();
     // Read Sam groups for each workspace role. Stairway does not
     // have a cleaner way of deserializing parameterized types, so we suppress warnings here.
@@ -63,14 +63,15 @@ public class GcpCloudSyncStep implements Step {
       Policy currentPolicy =
           resourceManagerCow
               .projects()
-              .getIamPolicy(gcpProjectName, new GetIamPolicyRequest())
+              .getIamPolicy(gcpProjectId, new GetIamPolicyRequest())
               .execute();
 
       List<Binding> newBindings = new ArrayList<>();
       // Add all existing bindings to ensure we don't accidentally clobber existing permissions.
       newBindings.addAll(currentPolicy.getBindings());
+      // Add appropriate project-level roles for each WSM IAM role.
       for (Map.Entry<WsmIamRole, String> entry : workspaceRoleGroupsMap.entrySet()) {
-        newBindings.addAll(bindingsForRole(entry.getKey(), entry.getValue()));
+        newBindings.add(bindingForRole(entry.getKey(), entry.getValue(), gcpProjectId));
       }
 
       Policy newPolicy =
@@ -80,7 +81,7 @@ public class GcpCloudSyncStep implements Step {
               .setEtag(currentPolicy.getEtag());
       SetIamPolicyRequest iamPolicyRequest = new SetIamPolicyRequest().setPolicy(newPolicy);
       logger.info("Setting new Cloud Context IAM policy: " + iamPolicyRequest.toPrettyString());
-      resourceManagerCow.projects().setIamPolicy(gcpProjectName, iamPolicyRequest).execute();
+      resourceManagerCow.projects().setIamPolicy(gcpProjectId, iamPolicyRequest).execute();
     } catch (IOException e) {
       throw new RetryableCrlException("Error setting IAM permissions", e);
     }
@@ -95,19 +96,17 @@ public class GcpCloudSyncStep implements Step {
   }
 
   /**
-   * Build a list of role bindings for a given group, using CloudSyncRoleMapping.
+   * Build the project-level role binding for a given group, using CloudSyncRoleMapping.
    *
    * @param role The role granted to this user. Translated to GCP roles using CloudSyncRoleMapping.
    * @param email The email of the Google group being granted a role.
+   * @param gcpProjectId The ID of the project the custom role is defined in.
    */
-  private List<Binding> bindingsForRole(WsmIamRole role, String email) {
-    return CloudSyncRoleMapping.CLOUD_SYNC_ROLE_MAP.get(role).stream()
-        .map(
-            gcpRole ->
-                new Binding()
-                    .setRole(gcpRole)
-                    .setMembers(Collections.singletonList(toMemberIdentifier(email))))
-        .collect(Collectors.toList());
+  private Binding bindingForRole(WsmIamRole role, String email, String gcpProjectId) {
+    CustomGcpIamRole customRole = CloudSyncRoleMapping.CUSTOM_GCP_PROJECT_IAM_ROLES.get(role);
+    return new Binding()
+        .setRole(customRole.getFullyQualifiedRoleName(gcpProjectId))
+        .setMembers(Collections.singletonList(toMemberIdentifier(email)));
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/GcpCloudSyncStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/GcpCloudSyncStep.java
@@ -70,9 +70,8 @@ public class GcpCloudSyncStep implements Step {
       // Add all existing bindings to ensure we don't accidentally clobber existing permissions.
       newBindings.addAll(currentPolicy.getBindings());
       // Add appropriate project-level roles for each WSM IAM role.
-      for (Map.Entry<WsmIamRole, String> entry : workspaceRoleGroupsMap.entrySet()) {
-        newBindings.add(bindingForRole(entry.getKey(), entry.getValue(), gcpProjectId));
-      }
+      workspaceRoleGroupsMap.forEach(
+          (role, email) -> newBindings.add(bindingForRole(role, email, gcpProjectId)));
 
       Policy newPolicy =
           new Policy()

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleTest.java
@@ -18,43 +18,43 @@ public class CustomGcpIamRoleTest extends BaseUnitTest {
   public void validateCustomIamRoleNames() {
     assertEquals(
         "GCS_BUCKET_READER",
-        CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
             .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.READER)
             .getRoleName());
     assertEquals(
         "GCS_BUCKET_WRITER",
-        CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
             .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.WRITER)
             .getRoleName());
     assertEquals(
         "GCS_BUCKET_EDITOR",
-        CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
             .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.EDITOR)
             .getRoleName());
     assertEquals(
         "GCS_BUCKET_ASSIGNER",
-        CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
             .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.ASSIGNER)
             .getRoleName());
 
     assertEquals(
         "BIG_QUERY_DATASET_READER",
-        CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
             .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.READER)
             .getRoleName());
     assertEquals(
         "BIG_QUERY_DATASET_WRITER",
-        CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
             .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.WRITER)
             .getRoleName());
     assertEquals(
         "BIG_QUERY_DATASET_EDITOR",
-        CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
             .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.EDITOR)
             .getRoleName());
     assertEquals(
         "BIG_QUERY_DATASET_ASSIGNER",
-        CustomGcpIamRoleMapping.CUSTOM_GCP_IAM_ROLES
+        CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
             .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.ASSIGNER)
             .getRoleName());
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/CloudSyncRoleMappingTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/CloudSyncRoleMappingTest.java
@@ -16,21 +16,39 @@ public class CloudSyncRoleMappingTest extends BaseUnitTest {
   @Test
   void writerPermissionsContainReaderPermissions() {
     assertThat(
-        CloudSyncRoleMapping.CLOUD_SYNC_ROLE_MAP.get(WsmIamRole.READER),
-        everyItem(in((CloudSyncRoleMapping.CLOUD_SYNC_ROLE_MAP.get(WsmIamRole.WRITER)))));
+        CloudSyncRoleMapping.CUSTOM_GCP_PROJECT_IAM_ROLES
+            .get(WsmIamRole.READER)
+            .getIncludedPermissions(),
+        everyItem(
+            in(
+                (CloudSyncRoleMapping.CUSTOM_GCP_PROJECT_IAM_ROLES
+                    .get(WsmIamRole.WRITER)
+                    .getIncludedPermissions()))));
   }
 
   @Test
   void applicationPermissionsContainWriterPermissions() {
     assertThat(
-        CloudSyncRoleMapping.CLOUD_SYNC_ROLE_MAP.get(WsmIamRole.WRITER),
-        everyItem(in((CloudSyncRoleMapping.CLOUD_SYNC_ROLE_MAP.get(WsmIamRole.APPLICATION)))));
+        CloudSyncRoleMapping.CUSTOM_GCP_PROJECT_IAM_ROLES
+            .get(WsmIamRole.WRITER)
+            .getIncludedPermissions(),
+        everyItem(
+            in(
+                (CloudSyncRoleMapping.CUSTOM_GCP_PROJECT_IAM_ROLES
+                    .get(WsmIamRole.APPLICATION)
+                    .getIncludedPermissions()))));
   }
 
   @Test
   void ownerPermissionsContainWriterPermissions() {
     assertThat(
-        CloudSyncRoleMapping.CLOUD_SYNC_ROLE_MAP.get(WsmIamRole.WRITER),
-        everyItem(in((CloudSyncRoleMapping.CLOUD_SYNC_ROLE_MAP.get(WsmIamRole.OWNER)))));
+        CloudSyncRoleMapping.CUSTOM_GCP_PROJECT_IAM_ROLES
+            .get(WsmIamRole.WRITER)
+            .getIncludedPermissions(),
+        everyItem(
+            in(
+                (CloudSyncRoleMapping.CUSTOM_GCP_PROJECT_IAM_ROLES
+                    .get(WsmIamRole.OWNER)
+                    .getIncludedPermissions()))));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -190,11 +190,12 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
   }
 
   /**
-   * Validate that a GCP policy contains expected role bindings for the given role.
+   * Validate that a GCP policy contains the expected role binding for the given role.
    *
-   * @param role An IAM role. Maps to expected GCP roles in CloudSyncRoleMapping.
-   * @param groupEmail The group we expect roles to be bound to.
-   * @param gcpPolicy The GCP policy we're checking for role bindings.
+   * @param role An IAM role. Maps to an expected GCP role in CloudSyncRoleMapping.
+   * @param groupEmail The group we expect the role to be bound to.
+   * @param gcpPolicy The GCP policy we're checking for the role binding.
+   * @param projectId The GCP project our custom roles are defined in.
    */
   private void assertRoleBindingInPolicy(
       WsmIamRole role, String groupEmail, Policy gcpPolicy, String projectId) {

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -150,8 +150,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
   private void assertRolesExist(Project project) throws IOException {
     for (CustomGcpIamRole customRole :
         CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES.values()) {
-      String fullRoleName =
-          "projects/" + project.getProjectId() + "/roles/" + customRole.getRoleName();
+      String fullRoleName = customRole.getFullyQualifiedRoleName(project.getProjectId());
       Role gcpRole = crl.getIamCow().projects().roles().get(fullRoleName).execute();
       assertEquals(customRole.getRoleName(), gcpRole.getTitle());
 


### PR DESCRIPTION
This changes the way WSM handles project-level permissions. Previously, it granted a collection of predefined roles for each workspace role (READER, WRITER, OWNER). Now, it grants a single custom role for each workspace role. The actual permissions are unchanged for this PR - I'll modify the list for PF-869 separately to keep changes separated.

As a reminder, we do not currently have any backfill support for old workspaces/projects using the predefined roles. This change will only affect newly created GCP contexts, though older workspaces can delete and recreate context to pick up this change. This will not affect RAWLS_WORSPACEs, which do not have cloud contexts.