### PR TITLE
[PF-869] Support polling notebook start/stop operations

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
@@ -86,11 +86,7 @@ public class CustomGcpIamRoleMapping {
               "notebooks.instances.setMachineType",
               "notebooks.instances.start",
               "notebooks.instances.stop",
-              "notebooks.instances.use",
-              "notebooks.operations.cancel",
-              "notebooks.operations.delete",
-              "notebooks.operations.get",
-              "notebooks.operations.list")
+              "notebooks.instances.use")
           .build();
   static final ImmutableList<String> AI_NOTEBOOK_INSTANCE_EDITOR_PERMISSIONS =
       ImmutableList.of(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -25,8 +25,8 @@ public class CloudSyncRoleMapping {
           "bigquery.jobs.create",
           "lifesciences.operations.get",
           "lifesciences.operations.list",
-          "resourcemanager.projects.get",
           "monitoring.timeSeries.list",
+          "resourcemanager.projects.get",
           "serviceusage.operations.get",
           "serviceusage.operations.list",
           "serviceusage.quotas.get",
@@ -41,13 +41,13 @@ public class CloudSyncRoleMapping {
               "iam.serviceAccounts.actAs",
               "iam.serviceAccounts.get",
               "iam.serviceAccounts.list",
-              "lifesciences.workflows.run",
               "lifesciences.operations.cancel",
-              "serviceusage.services.use",
+              "lifesciences.workflows.run",
               "notebooks.operations.cancel",
               "notebooks.operations.delete",
               "notebooks.operations.get",
-              "notebooks.operations.list")
+              "notebooks.operations.list",
+              "serviceusage.services.use")
           .build();
 
   private static final CustomGcpIamRole PROJECT_READER =

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -43,7 +43,11 @@ public class CloudSyncRoleMapping {
               "iam.serviceAccounts.list",
               "lifesciences.workflows.run",
               "lifesciences.operations.cancel",
-              "serviceusage.services.use")
+              "serviceusage.services.use",
+              "notebooks.operations.cancel",
+              "notebooks.operations.delete",
+              "notebooks.operations.get",
+              "notebooks.operations.list")
           .build();
 
   private static final CustomGcpIamRole PROJECT_READER =


### PR DESCRIPTION
This change (re)adds support for polling notebook start/stop operations. These permissions must be granted at the project level - we previously granted them on individual notebook instances, which had no effect. This functionality was removed when we moved permissions from broad project-level roles to narrower resource-level roles (#361), though it can be supported again now that we have custom project-level roles (#399).

This change does not address the second part of PF-869 which is focused on notebook usability in the cloud console. That will be handled as part of a design change as we revisit visibility of private resources.