### PR TITLE
PF-904: Add bigquery.readsessions.* permissions to project reader.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/mappings/CustomGcpIamRoleMapping.java
@@ -36,7 +36,6 @@ public class CustomGcpIamRoleMapping {
   static final ImmutableList<String> BIG_QUERY_DATASET_READER_PERMISSIONS =
       ImmutableList.of(
           "bigquery.datasets.get",
-          "bigquery.jobs.create",
           "bigquery.models.export",
           "bigquery.models.getData",
           "bigquery.models.getMetadata",

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -23,6 +23,9 @@ public class CloudSyncRoleMapping {
   private static final List<String> PROJECT_READER_PERMISSIONS =
       ImmutableList.of(
           "bigquery.jobs.create",
+          "bigquery.readsessions.create",
+          "bigquery.readsessions.getData",
+          "bigquery.readsessions.update",
           "lifesciences.operations.get",
           "lifesciences.operations.list",
           "resourcemanager.projects.get",


### PR DESCRIPTION
Added `bigquery.readsessions.*` permissions to the project reader role. ~1/2 page summary [here](https://docs.google.com/document/d/12z7e2VHbe8Q0UpDRHqbDJd2IrMGZj4H3RK5hw1hHflk/edit?resourcekey=0-98P0n7HBnhkL_NVEzJiw2A#).

Also removed `bigquery.jobs.create` permission from the resource-level role (`BIG_QUERY_DATASET_READER_PERMISSIONS `), since it's already included in the project-level role (`PROJECT_READER_PERMISSIONS`).