### PR TITLE
[PF-903] Replace 15s timeouts in tests with longer polling

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -118,7 +118,7 @@ public class ControlledBigQueryDatasetLifecycle extends WorkspaceAllocateTestScr
     // This is the reader's first use of cloud APIs after being added to the workspace, so we
     // retry this operation until cloud IAM has properly synced.
     var readTable = ClientTestUtils.getWithRetryOnException(() ->
-        readerBqClient.getTable(table.getTableId()), 20, Duration.ofSeconds(30));
+        readerBqClient.getTable(table.getTableId()));
     assertEquals(table, readTable);
     logger.info("Read table {} as workspace reader", tableName);
 

--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -147,10 +147,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
     logger.info("Added {} as a reader to workspace {}", reader.userEmail, getWorkspaceId());
 
     Blob readerRetrievedFile = ClientTestUtils
-        .getWithRetryOnException(() ->
-            readerStorageClient.get(blobId),
-            20,
-            Duration.ofSeconds(30));
+        .getWithRetryOnException(() -> readerStorageClient.get(blobId));
     assertNotNull(readerRetrievedFile);
     assertEquals(createdFile.getBlobId(), readerRetrievedFile.getBlobId());
     logger.info("Read existing blob {} from bucket as reader", retrievedFile.getBlobId());

--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -146,7 +146,6 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
         new GrantRoleRequestBody().memberEmail(reader.userEmail), getWorkspaceId(), IamRole.READER);
     logger.info("Added {} as a reader to workspace {}", reader.userEmail, getWorkspaceId());
 
-    // TODO(PF-643): this should happen inside WSM.
     Blob readerRetrievedFile = ClientTestUtils
         .getWithRetryOnException(() ->
             readerStorageClient.get(blobId),

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -106,7 +106,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     // Cloud IAM permissions may take several minutes to sync, so we retry this operation until
     // it succeeds.
     CreatedControlledGcpGcsBucket bucket = ClientTestUtils.getWithRetryOnException(() ->
-        createPrivateBucket(privateUserResourceApi), 20, Duration.ofSeconds(30));
+        createPrivateBucket(privateUserResourceApi));
     UUID resourceId = bucket.getResourceId();
 
     // Retrieve the bucket resource from WSM

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -35,6 +35,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -101,12 +102,11 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     logger.info(
         "Added {} as a writer to workspace {}", privateResourceUser.userEmail, getWorkspaceId());
 
-    // TODO(PF-643): this should happen inside WSM.
-    logger.info("Waiting 15s for permissions to propagate");
-    TimeUnit.SECONDS.sleep(15);
-
     // Create a private bucket, which privateResourceUser assigns to themself.
-    CreatedControlledGcpGcsBucket bucket = createPrivateBucket(privateUserResourceApi);
+    // Cloud IAM permissions may take several minutes to sync, so we retry this operation until
+    // it succeeds.
+    CreatedControlledGcpGcsBucket bucket = ClientTestUtils.getWithRetryOnException(() ->
+        createPrivateBucket(privateUserResourceApi), 20, Duration.ofSeconds(30));
     UUID resourceId = bucket.getResourceId();
 
     // Retrieve the bucket resource from WSM

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -233,21 +233,19 @@ public class ClientTestUtils {
 
   /**
    * Get a result from a call that might throw an exception. Treat the exception as retryable,
-   * sleep for a specific duration, and retry up to a fixed number of times. This structure
-   * is useful for situations where we are waiting on a cloud IAM permission change to take effect.
+   * sleep for 15 seconds, and retry up to 40 times. This structure is useful for situations where
+   * we are waiting on a cloud IAM permission change to take effect.
    * @param supplier - code returning the result or throwing an exception
-   * @param numTries - number of times to retry the operation
-   * @param sleepDuration - sleep time between attempts
    * @param <T> - type of result
    * @return - result from supplier, the first time it doesn't throw, or null if all tries have been
    *     exhausted
    * @throws InterruptedException
    */
   public static @Nullable <T> T getWithRetryOnException(
-      SupplierWithException<T> supplier,
-      int numTries,
-      Duration sleepDuration) throws InterruptedException {
+      SupplierWithException<T> supplier) throws InterruptedException {
     T result = null;
+    int numTries = 40;
+    Duration sleepDuration = Duration.ofSeconds(15);
     while (numTries > 0) {
       try {
         // read blob as second user

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -226,6 +226,11 @@ public class ClientTestUtils {
     return jobReport.getStatus().equals(JobReport.StatusEnum.RUNNING);
   }
 
+  @FunctionalInterface
+  public interface SupplierWithException<T> {
+    T get() throws Exception;
+  }
+
   /**
    * Get a result from a call that might throw an exception. Treat the exception as retryable,
    * sleep for a specific duration, and retry up to a fixed number of times. This structure
@@ -239,7 +244,7 @@ public class ClientTestUtils {
    * @throws InterruptedException
    */
   public static @Nullable <T> T getWithRetryOnException(
-      Supplier<T> supplier,
+      SupplierWithException<T> supplier,
       int numTries,
       Duration sleepDuration) throws InterruptedException {
     T result = null;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -54,7 +54,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.Matchers;
@@ -157,10 +156,6 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
         resource,
         controlledResourceService.getControlledResource(
             workspace.getWorkspaceId(), resource.getResourceId(), user.getAuthenticatedRequest()));
-
-    // TODO(PF-643): this should happen inside WSM.
-    // Waiting 15s for permissions to propagate
-    TimeUnit.SECONDS.sleep(15);
 
     InstanceName instanceName =
         resource.toInstanceName(workspace.getGcpCloudContext().get().getGcpProjectId());


### PR DESCRIPTION
There are a few spots in our tests where we wait a static 15s for cloud IAM permissions to propagate. According to GCP these changes may take several minutes, and as a result we sometimes get flaky failures for not waiting long enough. This change replaces the static 15s waits with polling every 30s up to a 10 minute timeout, which should reduce flaky test failures.