### PR TITLE
[PF-909] Make listResources show private resources, support GCP cloud console

### DIFF
--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.ControlledResourceCommonFields;
+import bio.terra.workspace.model.ControlledResourceIamRole;
 import bio.terra.workspace.model.CreateControlledGcpBigQueryDatasetRequestBody;
 import bio.terra.workspace.model.CreateControlledGcpGcsBucketRequestBody;
 import bio.terra.workspace.model.CreateDataRepoSnapshotReferenceRequestBody;
@@ -36,6 +37,8 @@ import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.ManagedBy;
+import bio.terra.workspace.model.PrivateResourceIamRoles;
+import bio.terra.workspace.model.PrivateResourceUser;
 import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import java.util.ArrayList;
 import java.util.List;
@@ -115,6 +118,33 @@ public class ResourceMaker {
             .common(
                 new ControlledResourceCommonFields()
                     .accessScope(AccessScope.SHARED_ACCESS)
+                    .managedBy(ManagedBy.USER)
+                    .cloningInstructions(CloningInstructionsEnum.NOTHING)
+                    .description("Description of " + name)
+                    .name(name))
+            .gcsBucket(
+                new GcpGcsBucketCreationParameters()
+                    .name(bucketName)
+                    .defaultStorageClass(GcpGcsBucketDefaultStorageClass.STANDARD)
+                    .lifecycle(new GcpGcsBucketLifecycle().rules(LIFECYCLE_RULES))
+                    .location("US-CENTRAL1"));
+
+    logger.info("Creating bucket {} workspace {}", bucketName, workspaceId);
+    return resourceApi.createBucket(body, workspaceId);
+  }
+
+  public static CreatedControlledGcpGcsBucket makeControlledGcsBucketUserPrivate(
+      ControlledGcpResourceApi resourceApi, UUID workspaceId, String name,
+      String privateResourceUserEmail, PrivateResourceIamRoles privateResourceRoles) throws Exception {
+    String bucketName = ClientTestUtils.generateCloudResourceName();
+    var body =
+        new CreateControlledGcpGcsBucketRequestBody()
+            .common(
+                new ControlledResourceCommonFields()
+                    .accessScope(AccessScope.PRIVATE_ACCESS)
+                    .privateResourceUser(new PrivateResourceUser()
+                      .userName(privateResourceUserEmail)
+                      .privateResourceIamRoles(privateResourceRoles))
                     .managedBy(ManagedBy.USER)
                     .cloningInstructions(CloningInstructionsEnum.NOTHING)
                     .description("Description of " + name)

--- a/integration/src/main/resources/configs/integration/EnumerateResources.json
+++ b/integration/src/main/resources/configs/integration/EnumerateResources.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
-  "testUserFiles": ["bella.json"]
+  "testUserFiles": ["bella.json", "liam.json"]
 }

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -220,12 +220,10 @@ public class ResourceDao {
     }
 
     // There are three cases for the stewardship type filter
-    // 1. If it is REFERENCED, then we ignore id list and just filter
-    //    for referenced resources.
-    // 2. If it is CONTROLLED, then we filter for
-    //    CONTROLLED resources.
-    // 3. If no filter is specified (it is null), then we want both REFERENCED
-    //    and CONTROLLED resources; that is, we want the OR of 1 and 2
+    // 1. If it is REFERENCED, then we ignore id list and just filter for referenced resources.
+    // 2. If it is CONTROLLED, then we filter for CONTROLLED resources.
+    // 3. If no filter is specified (it is null), then we want both REFERENCED and CONTROLLED
+    //    resources; that is, we want the OR of 1 and 2
     boolean includeReferenced = (stewardshipType == null || stewardshipType == REFERENCED);
     boolean includeControlled = (stewardshipType == null || stewardshipType == CONTROLLED);
 

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -166,19 +166,14 @@ public class ResourceDao {
    * Resource enumeration
    *
    * <p>The default behavior of resource enumeration is to find all resources that are visible to
-   * the caller. If the caller has gotten this far, then they are allowed to see all referenced
-   * resources. We know which controlled resources they are allowed to see from the list provided as
-   * input.
+   * the caller. If the caller has gotten this far, then they are allowed to see all referenced and
+   * controlled resources.
    *
    * <p>The enumeration can be filtered by a resource type. If a resource type is specified, then
-   * only that type of resource is returned.
-   *
-   * <p>The enumeration can also be filtered by a stewardship type. The implementation of the
-   * stewardship type filter is more complex than simply filtering by type. That is because the
-   * placeholder substitution for the IN list yields invalid SQL if the list is empty.
+   * only that type of resource is returned. The enumeration can also be filtered by a stewardship
+   * type.
    *
    * @param workspaceId identifier for work space to enumerate
-   * @param controlledResourceIds identifiers of controlled resources visible to the caller
    * @param resourceType filter by this resource type - optional
    * @param stewardshipType filtered by this stewardship type - optional
    * @param offset starting row for result
@@ -187,16 +182,13 @@ public class ResourceDao {
    */
   public List<WsmResource> enumerateResources(
       UUID workspaceId,
-      @Nullable List<String> controlledResourceIds,
       @Nullable WsmResourceType resourceType,
       @Nullable StewardshipType stewardshipType,
       int offset,
       int limit)
       throws InterruptedException {
     return DbRetryUtils.retry(
-        () ->
-            enumerateResourcesInner(
-                workspaceId, controlledResourceIds, resourceType, stewardshipType, offset, limit));
+        () -> enumerateResourcesInner(workspaceId, resourceType, stewardshipType, offset, limit));
   }
 
   @Transactional(
@@ -205,7 +197,6 @@ public class ResourceDao {
       readOnly = true)
   private List<WsmResource> enumerateResourcesInner(
       UUID workspaceId,
-      @Nullable List<String> controlledResourceIds,
       @Nullable WsmResourceType resourceType,
       @Nullable StewardshipType stewardshipType,
       int offset,
@@ -231,28 +222,23 @@ public class ResourceDao {
     // There are three cases for the stewardship type filter
     // 1. If it is REFERENCED, then we ignore id list and just filter
     //    for referenced resources.
-    // 2. If it is CONTROLLED, and the id list is not empty, then we filter for
-    //    CONTROLLED and require that the resources be in the id list.
+    // 2. If it is CONTROLLED, then we filter for
+    //    CONTROLLED resources.
     // 3. If no filter is specified (it is null), then we want both REFERENCED
     //    and CONTROLLED resources; that is, we want the OR of 1 and 2
     boolean includeReferenced = (stewardshipType == null || stewardshipType == REFERENCED);
-    boolean includeControlled =
-        ((controlledResourceIds != null && !controlledResourceIds.isEmpty())
-            && (stewardshipType == null || (stewardshipType == CONTROLLED)));
+    boolean includeControlled = (stewardshipType == null || stewardshipType == CONTROLLED);
 
     final String referencedPhrase = "stewardship_type = :referenced_resource";
-    final String controlledPhrase =
-        "(stewardship_type = :controlled_resource AND resource_id IN (:id_list))";
+    final String controlledPhrase = "stewardship_type = :controlled_resource";
 
     sb.append(" AND ");
     if (includeReferenced && includeControlled) {
       sb.append("(").append(referencedPhrase).append(" OR ").append(controlledPhrase).append(")");
-      params.addValue("id_list", controlledResourceIds);
     } else if (includeReferenced) {
       sb.append(referencedPhrase);
     } else if (includeControlled) {
       sb.append(controlledPhrase);
-      params.addValue("id_list", controlledResourceIds);
     } else {
       // Nothing is included, so we return an empty result
       return Collections.emptyList();

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -26,15 +26,22 @@ public class CloudSyncRoleMapping {
           "bigquery.readsessions.create",
           "bigquery.readsessions.getData",
           "bigquery.readsessions.update",
+          "compute.acceleratorTypes.list",
+          "compute.diskTypes.list",
+          "compute.instances.list",
+          "compute.machineTypes.list",
+          "compute.subnetworks.list",
           "lifesciences.operations.get",
           "lifesciences.operations.list",
           "monitoring.timeSeries.list",
+          "notebooks.instances.list",
           "resourcemanager.projects.get",
           "serviceusage.operations.get",
           "serviceusage.operations.list",
           "serviceusage.quotas.get",
           "serviceusage.services.get",
-          "serviceusage.services.list");
+          "serviceusage.services.list",
+          "storage.buckets.list");
   private static final List<String> PROJECT_WRITER_PERMISSIONS =
       new ImmutableList.Builder<String>()
           .addAll(PROJECT_READER_PERMISSIONS)


### PR DESCRIPTION
This change modifies the behavior of WSM's resource enumeration endpoint. Previously, we only showed the controlled resources that users had permissions on, meaning that workspace readers would generally not see private resources. After this change, all members of a workspace will see all resources in that workspace, including private resources which they cannot read/write to. Filter behavior on the endpoint is unchanged, and callers will not see these controlled resources if they only request referenced resources.

Additionally, this adds a number of GCP permissions so that all workspace users can navigate GCS buckets and AI Platform Notebooks directly in the cloud console. This allows workspace users to view metadata on these resources, though they still cannot read/write to private resource if they are not the assigned user, and the cloud console generally gives informative error messages if they do. BigQuery dataset IAM is handled differently by GCP, and as a result users can still only see private datasets in the BigQuery viewer if they are the assigned user. However, they can now see metadata of those resources via the WSM resource enumeration endpoint.