### PR TITLE
[PF-616] Ensure assignedUser field is always stored, even if not specified

### DIFF
--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -108,6 +108,8 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
     assertEquals(instanceId, resource.getAttributes().getInstanceId());
     assertEquals(instanceId,
         creationResult.getAiNotebookInstance().getAttributes().getInstanceId());
+    assertEquals(resourceUser.userEmail,
+        resource.getMetadata().getControlledResourceMetadata().getPrivateResourceUser().getUserName());
 
     String instanceName = String
         .format("projects/%s/locations/%s/instances/%s", resource.getAttributes().getProjectId(),

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -114,6 +114,10 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     GcpGcsBucketResource gotBucket = privateUserResourceApi.getBucket(getWorkspaceId(), resourceId);
     assertEquals(bucket.getGcpBucket().getAttributes().getBucketName(), gotBucket.getAttributes().getBucketName());
     assertEquals(bucketName, gotBucket.getAttributes().getBucketName());
+    // Assert the bucket is assigned to privateResourceUser, even though resource user was
+    // not specified
+    assertEquals(privateResourceUser.userEmail,
+        gotBucket.getMetadata().getControlledResourceMetadata().getPrivateResourceUser().getUserName());
 
     Storage ownerStorageClient = ClientTestUtils.getGcpStorageClient(testUser, projectId);
     Storage privateUserStorageClient =
@@ -211,7 +215,6 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             .accessScope(AccessScope.PRIVATE_ACCESS)
             .privateResourceUser(
                 new PrivateResourceUser()
-                    .userName(privateResourceUser.userEmail)
                     .privateResourceIamRoles(privateUser))
             .managedBy(ManagedBy.USER);
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -543,8 +543,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
       return null;
     }
     return Optional.ofNullable(commonFields.getPrivateResourceUser().getUserName())
-        .orElse(
-            SamService.rethrowIfSamInterrupted(
+        .orElseGet(
+            () -> SamService.rethrowIfSamInterrupted(
                 () -> samService.getRequestUserEmail(userRequest), "getRequestUserEmail"));
   }
 


### PR DESCRIPTION
This change ensures WSM stores the assigned user of a private resource in its database in all cases, even when `assignedUser` is not specified and we default to assigning the resource to the caller.

This ticket originally covered storing and returning the actual roles that private users held (READER, WRITER, EDITOR), but I decided against this approach after further discussion.