### PR TITLE
PF-228: Bump RBS pool id from v8 -> v9.

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -79,7 +79,7 @@ workspace:
     enabled: true
     client-credential-file-path: ../config/buffer-client-sa.json
     instanceUrl: https://buffer.tools.integ.envs.broadinstitute.org
-    poolId: workspace_manager_v8
+    poolId: workspace_manager_v9
 
   spend:
     spend-profiles:


### PR DESCRIPTION
Change the RBS pool id from `workspace_manager_v8` -> `workspace_manager_v9`. This new pool uses GCP-style project names with two words and a number. It also changes the project id prefix from `terra-wsm-test` -> `terra-wsm-t`, in order to leave more room for the generated words. e.g. `terra-wsm-t-shining-okra-5362`