### PR TITLE
DDO-1319 Update local dev workflow to use `render` tool

### DIFF
--- a/service/local-dev/README.md
+++ b/service/local-dev/README.md
@@ -1,14 +1,9 @@
-This directory contains scripts for running continuous development builds. This 
+This directory contains scripts for running continuous development builds. This
 is not necessary for deployment, but it can be helpful for developing faster.
+
 The provided setup script clones the terra-helm and terra-helmfile git repos,
 and templates in the desired Terra environment/k8s namespace to target.
 If you need to pull changes to either terra-helm or terra-helmfile, rerun this script.
-
-To use this, first ensure [Helm](https://helm.sh/docs/intro/install/#from-homebrew-macos) and [Skaffold](https://skaffold.dev/) are installed on your local machine. 
-
-> Older versions of Skaffold (v1.4.0 and earlier) do not have support for Helm 3 and will fail to deploy your 
-changes. If you're seeing errors like `UPGRADE FAILED: "(Release name)" has no 
-deployed releases`, try updating Skaffold.
 
 You may need to use gcloud to provide GCR
  credentials with `gcloud auth configure-docker`. Finally, run local-run.sh with
@@ -18,9 +13,9 @@ You may need to use gcloud to provide GCR
 ./setup_local_env.sh <environment>
 ```
 
-Optionally, you can provide a branch of [terra-helm](https://github.com/broadinstitute/terra-helm) and/or [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) to use if you are testing PRs to either. They default to master.
+Optionally, you can provide a branch of [terra-helm](https://github.com/broadinstitute/terra-helm) and/or [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) to use if you are testing PRs to either. They default to master. A git protocol (`ssh` or `http`) can optionally be specified as a fourth argument to the script.
 ```
-./setup_local_env.sh <environment> <terra-helm ref> <terra-helmfile ref>
+./setup_local_env.sh <environment> [<terra-helm ref>] [<terra-helmfile ref>] [ssh|http]
 ```
 
 You can now push to the specified environment by running
@@ -29,5 +24,5 @@ You can now push to the specified environment by running
 skaffold run
 ```
 
-or by using IntelliJ's Cloud Code integration, which will auto-detect the 
+or by using IntelliJ's Cloud Code integration, which will auto-detect the
 generated skaffold.yaml file.

--- a/service/local-dev/setup_local_env.sh
+++ b/service/local-dev/setup_local_env.sh
@@ -33,6 +33,17 @@ rm -rf terra-helm/.git
 git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch --depth=1 ${helmfilegit}
 rm -rf terra-helmfile/.git
 
+# Render manifests to terra-helmfile/output/ directory.
+#
+# Unfortunately we need to render them all into a single mega-file
+# because Skaffold's `kubectl` deployment does not support
+# recursive globbing like "output/manifests/**/*.yaml"
+mkdir -p ./terra-helmfile/output
+./terra-helmfile/bin/render \
+  -e "${ENV}" \
+  -a workspacemanager \
+  --stdout > terra-helmfile/output/manifests.yaml
+
 # Template in environment
 sed "s|ENV|${ENV}|g" skaffold.yaml.template > skaffold.yaml
 sed "s|ENV|${ENV}|g" values.yaml.template > values.yaml

--- a/service/local-dev/skaffold.yaml.template
+++ b/service/local-dev/skaffold.yaml.template
@@ -1,5 +1,5 @@
 #This is a Skaffold configuration, which lets developers continuously push new images to their development namespaces.
-apiVersion: skaffold/v2alpha4
+apiVersion: skaffold/v2beta17
 kind: Config
 build:
   artifacts:
@@ -8,15 +8,7 @@ build:
     jib:
       project: service
 deploy:
-  helm:
-    releases:
-      - name: workspacemanager-ENV
-        namespace: terra-ENV
-        chartPath: terra-helm/charts/workspacemanager
-        values:
-          image: gcr.io/terra-kernel-k8s/terra-workspace-manager
-        valuesFiles:
-          - terra-helmfile/terra/values/workspacemanager.yaml
-          - terra-helmfile/terra/values/workspacemanager/personal.yaml
-          - terra-helmfile/terra/values/workspacemanager/personal/ENV.yaml
-          - values.yaml
+  kubectl:
+    manifests:
+    - terra-helmfile/output/manifests.yaml
+    defaultNamespace: terra-ENV


### PR DESCRIPTION
Update local dev workflow to use terra-helmfile's `render` tool to render manifests instead of configuring Skaffold to use hard-coded paths to files in the terra-helmfile repo. DevOps is preparing to make some changes to the directory structure of terra-helmfile; the `render` tool is a public API for the terra-helmfile repo and will not break when those changes are made.

References to terra-helm will be removed in a future PR, when the workspacemanager chart is moved out of terra-helm.

Note that this is a reimplementation of https://github.com/DataBiosphere/terra-workspace-manager/pull/384, based on feedback on that PR.

I have tested this locally, against the `gmalkov` personal environment.