### PR TITLE
[PF-879] Fix error reporting on start-local-server

### DIFF
--- a/.github/actions/start-local-server/action.yml
+++ b/.github/actions/start-local-server/action.yml
@@ -22,8 +22,7 @@ runs:
     - name: Wait for boot run to be ready
       id: wait-for-ready
       run: |
-        timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
-        resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
+        resultStatus=$(timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done' && echo $?)
         if [[ $resultStatus == 0 ]]
         then
           echo "Server started successfully"

--- a/.github/actions/start-local-server/action.yml
+++ b/.github/actions/start-local-server/action.yml
@@ -22,6 +22,10 @@ runs:
     - name: Wait for boot run to be ready
       id: wait-for-ready
       run: |
+        # If the timeout command times out, it SIGTERMs, which if done at the top-level of the
+        # GHA script exits the script. So, we wrap the timeout and return status in a subprocess.
+        # If timeout terminates its subprocess, then resultStatus is empty.
+        # If echo succeeds, timeout exits normally, and resultStatus is 0.
         resultStatus=$(timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done' && echo $?)
         if [[ $resultStatus == 0 ]]
         then


### PR DESCRIPTION
The action code has a scripting bug so it is not dumping the log file when the local WSM fails to come up.
Trying a fix for that and hoping it reveals whether anything is actually wrong with the integration tests post-rename.

I think this is still a good fix, even though it looks like the previous failures were Sam-related.

The problem was that the `timeout` statement would cause the action to terminate. By wrapping it in a subprocess and catching the output, it stops doing that.

I hope that the next time startup-local-server timesout, we will get a log of what went wrong.