### PR TITLE
[PF-945] integration test wait for grant to propagate

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
+++ b/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
@@ -30,7 +30,6 @@ import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.JobControl;
-import bio.terra.workspace.model.JobReport.StatusEnum;
 import bio.terra.workspace.model.ResourceMetadata;
 import bio.terra.workspace.model.ResourceType;
 import bio.terra.workspace.model.StewardshipType;
@@ -161,8 +160,7 @@ public class CloneGcsBucket extends WorkspaceAllocateTestScriptBase {
         CloneControlledGcpGcsBucketResult::getJobReport,
         Duration.ofSeconds(5));
 
-    assertEquals(StatusEnum.SUCCEEDED, cloneResult.getJobReport().getStatus());
-    logger.info("Successfully cloned bucket with result {}", cloneResult);
+    ClientTestUtils.assertJobSuccess("cloned bucket", cloneResult.getJobReport(), cloneResult.getErrorReport());
 
     final ClonedControlledGcpGcsBucket clonedBucket = cloneResult.getBucket();
     assertEquals(getWorkspaceId(), clonedBucket.getSourceWorkspaceId());

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -3,7 +3,6 @@ package scripts.testscripts;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
@@ -24,7 +23,6 @@ import bio.terra.workspace.model.GcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.JobControl;
-import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.ManagedBy;
 import bio.terra.workspace.model.PrivateResourceIamRoles;
 import bio.terra.workspace.model.PrivateResourceUser;
@@ -95,8 +93,8 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
         () -> resourceUserApi.getCreateAiNotebookInstanceResult(getWorkspaceId(), creationJobId),
         CreatedControlledGcpAiNotebookInstanceResult::getJobReport,
         Duration.ofSeconds(10));
-    assertNull(creationResult.getErrorReport());
-    assertEquals(JobReport.StatusEnum.SUCCEEDED, creationResult.getJobReport().getStatus());
+    ClientTestUtils.assertJobSuccess("create ai notebook",
+        creationResult.getJobReport(), creationResult.getErrorReport());
     logger.info(
         "Creation succeeded for instanceId {}",
         creationResult.getAiNotebookInstance().getAttributes().getInstanceId());
@@ -142,8 +140,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
         DeleteControlledGcpAiNotebookInstanceResult::getJobReport,
         Duration.ofSeconds(10));
 
-    assertNull(deleteResult.getErrorReport());
-    assertEquals(JobReport.StatusEnum.SUCCEEDED, deleteResult.getJobReport().getStatus());
+    ClientTestUtils.assertJobSuccess("delete ai notebook", deleteResult.getJobReport(), deleteResult.getErrorReport());
 
     // Verify the notebook was deleted from WSM metadata.
     ApiException notebookIsMissing =

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -24,7 +24,6 @@ import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.JobControl;
-import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.ManagedBy;
 import bio.terra.workspace.model.PrivateResourceIamRoles;
 import bio.terra.workspace.model.PrivateResourceUser;
@@ -35,7 +34,6 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -179,10 +177,8 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
 
     // Workspace owner can delete the bucket through WSM
     var ownerDeleteResult = deleteBucket(workspaceOwnerResourceApi, resourceId);
-    logger.info(
-        "For owner, delete bucket status is {}",
-        ownerDeleteResult.getJobReport().getStatus().toString());
-    assertEquals(JobReport.StatusEnum.SUCCEEDED, ownerDeleteResult.getJobReport().getStatus());
+    ClientTestUtils.assertJobSuccess("owner delete bucket",
+        ownerDeleteResult.getJobReport(), ownerDeleteResult.getErrorReport());
 
     // verify the bucket was deleted from WSM metadata
     ApiException bucketIsMissing =

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -544,8 +544,9 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     }
     return Optional.ofNullable(commonFields.getPrivateResourceUser().getUserName())
         .orElseGet(
-            () -> SamService.rethrowIfSamInterrupted(
-                () -> samService.getRequestUserEmail(userRequest), "getRequestUserEmail"));
+            () ->
+                SamService.rethrowIfSamInterrupted(
+                    () -> samService.getRequestUserEmail(userRequest), "getRequestUserEmail"));
   }
 
   /**


### PR DESCRIPTION
Two changes:
1. Added a wait for the cloning user to be able to read the dataset before proceeding with the user journey
2. Made a general `assertJobSuccess` that will info-log success and error-log the ErrorReport on failure. In the current state, if we assert the job status is SUCCEEDED, then on failure we get no information about why. I applied that change to all places where we were asserting on SUCCEEDED.
