### PR TITLE
* DDO-1476 Add Trivy scan for GCP CloudSQL proxy image

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -131,6 +131,11 @@ jobs:
       uses: broadinstitute/dsp-appsec-trivy-action@v1
       with:
         image: ${{ steps.image-name.outputs.name }}
+    - name: Run trivy vulnerability scanner on GCE cloudsql proxy image
+        # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
+      uses: broadinstitute/dsp-appsec-trivy-action@v1
+      with:
+        image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-buster
     - name: Push GCR image
       if: steps.skiptest.outputs.is-bump == 'no'
       run: "docker push ${{ steps.image-name.outputs.name }}"


### PR DESCRIPTION
To address some startup issues due to the CloudSQL container ([DDO-1352](https://broadworkbench.atlassian.net/browse/DDO-1352?atlOrigin=eyJpIjoiZDcxNjY4NGJiNjc4NDI5N2JiYTBkZDYxNTU3ZWJhZjgiLCJwIjoiaiJ9)), a new, unblessed image, gcr.io/cloudsql-docker/gce-proxy:1.24.0-buster, [has been introduced](https://github.com/broadinstitute/terra-helm/blob/9a43419a5b0e0e555e77cd655a88cce300e6dc69/charts/workspacemanager/templates/deployment.yaml#L81). This pr adds a Trivy scan for the image. 