### PR TITLE
[PF-957] Fix ValidateReferencedResources test

### DIFF
--- a/integration/src/main/resources/configs/integration/ValidateReferencedResources.json
+++ b/integration/src/main/resources/configs/integration/ValidateReferencedResources.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "liam.json"]
 }


### PR DESCRIPTION
Moving this test to use `liam` as the test user without access to our test reference bucket, as we recently granted `elijah` access for other tests. Documentation on what the resources that each user can/can't access to follow.