### PR TITLE
[PF-937] Handle removing users from private resources

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneBigQueryDataset.java
+++ b/integration/src/main/java/scripts/testscripts/CloneBigQueryDataset.java
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
-import scripts.utils.ResourceMaker;
+import scripts.utils.ResourceModifier;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class CloneBigQueryDataset extends WorkspaceAllocateTestScriptBase {
@@ -76,7 +76,7 @@ public class CloneBigQueryDataset extends WorkspaceAllocateTestScriptBase {
     sourceDataset = makeControlledBigQueryDatasetUserShared(sourceOwnerResourceApi, getWorkspaceId(),
         sourceResourceName);
 
-    ResourceMaker.populateBigQueryDataset(sourceDataset, sourceOwnerUser, sourceProjectId);
+    ResourceModifier.populateBigQueryDataset(sourceDataset, sourceOwnerUser, sourceProjectId);
 
     // Make the cloning user a reader on the existing workspace
     sourceOwnerWorkspaceApi.grantRole(

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -6,45 +6,32 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiException;
-import bio.terra.workspace.model.AccessScope;
-import bio.terra.workspace.model.CloningInstructionsEnum;
-import bio.terra.workspace.model.ControlledResourceCommonFields;
-import bio.terra.workspace.model.ControlledResourceIamRole;
-import bio.terra.workspace.model.CreateControlledGcpAiNotebookInstanceRequestBody;
 import bio.terra.workspace.model.CreatedControlledGcpAiNotebookInstanceResult;
 import bio.terra.workspace.model.DeleteControlledGcpAiNotebookInstanceRequest;
 import bio.terra.workspace.model.DeleteControlledGcpAiNotebookInstanceResult;
-import bio.terra.workspace.model.GcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.model.GcpAiNotebookInstanceResource;
-import bio.terra.workspace.model.GcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.JobControl;
-import bio.terra.workspace.model.ManagedBy;
-import bio.terra.workspace.model.PrivateResourceIamRoles;
-import bio.terra.workspace.model.PrivateResourceUser;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.services.iam.v1.model.TestIamPermissionsRequest;
 import com.google.api.services.notebooks.v1.AIPlatformNotebooks;
-import com.google.api.services.notebooks.v1.model.Instance;
 import com.google.api.services.notebooks.v1.model.StopInstanceRequest;
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
-import org.hamcrest.Matchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
+import scripts.utils.ResourceMaker;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAllocateTestScriptBase {
@@ -89,18 +76,8 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
     ControlledGcpResourceApi resourceUserApi =
         ClientTestUtils.getControlledGcpResourceClient(resourceUser, server);
     CreatedControlledGcpAiNotebookInstanceResult creationResult =
-        createPrivateNotebook(resourceUser, resourceUserApi);
-    String creationJobId = creationResult.getJobReport().getId();
-    creationResult = ClientTestUtils.pollWhileRunning(
-        creationResult,
-        () -> resourceUserApi.getCreateAiNotebookInstanceResult(getWorkspaceId(), creationJobId),
-        CreatedControlledGcpAiNotebookInstanceResult::getJobReport,
-        Duration.ofSeconds(10));
-    ClientTestUtils.assertJobSuccess("create ai notebook",
-        creationResult.getJobReport(), creationResult.getErrorReport());
-    logger.info(
-        "Creation succeeded for instanceId {}",
-        creationResult.getAiNotebookInstance().getAttributes().getInstanceId());
+        ResourceMaker.makeControlledNotebookUserPrivate(
+            getWorkspaceId(), instanceId, resourceUser, resourceUserApi);
 
     UUID resourceId = creationResult.getAiNotebookInstance().getMetadata().getResourceId();
 
@@ -120,12 +97,11 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
             resource.getAttributes().getLocation(), resource.getAttributes().getInstanceId());
     AIPlatformNotebooks userNotebooks = ClientTestUtils.getAIPlatformNotebooksClient(resourceUser);
 
-    Instance instance = userNotebooks.projects().locations().instances().get(instanceName)
-        .execute();
-
     // TODO(PF-765): Assert that the other user does not have proxy access once we don't have
     // project level service account permissions.
-    assertUserHasProxyAccess(resourceUser, instance, resource.getAttributes().getProjectId());
+    assertTrue(ResourceMaker.userHasProxyAccess(
+        creationResult, resourceUser, resource.getAttributes().getProjectId()),
+        "Private resource user has access to their notebook");
     // The user should be able to stop their notebook.
     userNotebooks.projects().locations().instances().stop(instanceName, new StopInstanceRequest());
 
@@ -166,70 +142,5 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
     assertThat("Error from GCP is 403 or 404",
         notebookNotFound.getStatusCode(),
         anyOf(equalTo(HttpStatus.SC_NOT_FOUND), equalTo(HttpStatus.SC_FORBIDDEN)));
-  }
-
-  private CreatedControlledGcpAiNotebookInstanceResult createPrivateNotebook(
-      TestUserSpecification user, ControlledGcpResourceApi resourceApi)
-      throws ApiException, InterruptedException {
-    // Fill out the minimum required fields to arbitrary values.
-    var creationParameters =
-        new GcpAiNotebookInstanceCreationParameters()
-            .instanceId(instanceId)
-            .location("us-east1-b")
-            .machineType("e2-standard-2")
-            .vmImage(
-                new GcpAiNotebookInstanceVmImage()
-                    .projectId("deeplearning-platform-release")
-                    .imageFamily("r-latest-cpu-experimental"));
-
-    PrivateResourceIamRoles privateIamRoles = new PrivateResourceIamRoles();
-    privateIamRoles.add(ControlledResourceIamRole.EDITOR);
-    privateIamRoles.add(ControlledResourceIamRole.WRITER);
-    var commonParameters =
-        new ControlledResourceCommonFields()
-            .name(RandomStringUtils.randomAlphabetic(6))
-            .cloningInstructions(CloningInstructionsEnum.NOTHING)
-            .accessScope(AccessScope.PRIVATE_ACCESS)
-            .managedBy(ManagedBy.USER)
-            .privateResourceUser(
-                new PrivateResourceUser()
-                    .userName(user.userEmail)
-                    .privateResourceIamRoles(privateIamRoles));
-
-    var body =
-        new CreateControlledGcpAiNotebookInstanceRequestBody()
-            .aiNotebookInstance(creationParameters)
-            .common(commonParameters)
-            .jobControl(new JobControl().id(UUID.randomUUID().toString()));
-
-    return resourceApi.createAiNotebookInstance(body, getWorkspaceId());
-  }
-
-  /**
-   * Assert that the user has access to the Notebook through the proxy with a service account.
-   * <p>We can't directly test that we can go through the proxy to the Jupyter notebook without a
-   * real Google user auth flow, so we check the necessary ingredients instead.
-   */
-  private static void assertUserHasProxyAccess(TestUserSpecification user, Instance instance,
-      String projectId) throws GeneralSecurityException, IOException {
-    // Test that the user has access to the notebook with a service account through proxy mode.
-    // git secrets gets a false positive if 'service_account' is double quoted.
-    assertThat("Notebook has correct proxy mode access", instance.getMetadata(),
-        Matchers.hasEntry("proxy-mode", "service_" + "account"));
-
-    // The user needs to have the actAs permission on the service account.
-    String actAsPermission = "iam.serviceAccounts.actAs";
-    String serviceAccountName = String
-        .format("projects/%s/serviceAccounts/%s", projectId, instance.getServiceAccount());
-    assertThat("User may actAs notebook SA",
-        ClientTestUtils.getGcpIamClient(user)
-            .projects()
-            .serviceAccounts()
-            .testIamPermissions(
-                serviceAccountName,
-                new TestIamPermissionsRequest().setPermissions(List.of(actAsPermission)))
-            .execute()
-            .getPermissions(),
-        Matchers.contains(actAsPermission));
   }
 }

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
 import scripts.utils.ResourceMaker;
+import scripts.utils.ResourceModifier;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAllocateTestScriptBase {
@@ -99,7 +100,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
 
     // TODO(PF-765): Assert that the other user does not have proxy access once we don't have
     // project level service account permissions.
-    assertTrue(ResourceMaker.userHasProxyAccess(
+    assertTrue(ResourceModifier.userHasProxyAccess(
         creationResult, resourceUser, resource.getAttributes().getProjectId()),
         "Private resource user has access to their notebook");
     // The user should be able to stop their notebook.

--- a/integration/src/main/java/scripts/testscripts/RemoveUser.java
+++ b/integration/src/main/java/scripts/testscripts/RemoveUser.java
@@ -1,0 +1,212 @@
+package scripts.testscripts;
+
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static scripts.utils.GcsBucketTestFixtures.BUCKET_PREFIX;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.ControlledGcpResourceApi;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import bio.terra.workspace.model.ControlledResourceIamRole;
+import bio.terra.workspace.model.CreatedControlledGcpAiNotebookInstanceResult;
+import bio.terra.workspace.model.CreatedControlledGcpGcsBucket;
+import bio.terra.workspace.model.GcpBigQueryDatasetResource;
+import bio.terra.workspace.model.GrantRoleRequestBody;
+import bio.terra.workspace.model.IamRole;
+import bio.terra.workspace.model.PrivateResourceIamRoles;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.storage.StorageException;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
+import scripts.utils.ClientTestUtils;
+import scripts.utils.CloudContextMaker;
+import scripts.utils.ResourceMaker;
+import scripts.utils.WorkspaceAllocateTestScriptBase;
+
+public class RemoveUser extends WorkspaceAllocateTestScriptBase {
+
+  private TestUserSpecification privateResourceUser;
+  private TestUserSpecification sharedResourceUser;
+  private String projectId;
+  private CreatedControlledGcpGcsBucket sharedBucket;
+  private CreatedControlledGcpGcsBucket privateBucket;
+  private GcpBigQueryDatasetResource privateDataset;
+  private CreatedControlledGcpAiNotebookInstanceResult privateNotebook;
+  // Roles to grant user on private resource
+  private static final ImmutableList<ControlledResourceIamRole> PRIVATE_ROLES =
+      ImmutableList.of(ControlledResourceIamRole.WRITER, ControlledResourceIamRole.EDITOR);
+
+  @Override
+  protected void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi ownerWorkspaceApi)
+      throws Exception {
+    super.doSetup(testUsers, ownerWorkspaceApi);
+    assertThat(
+        "There must be at least three test users defined for this test.",
+        testUsers != null && testUsers.size() > 2);
+    TestUserSpecification workspaceOwner = testUsers.get(0);
+    this.privateResourceUser = testUsers.get(1);
+    this.sharedResourceUser = testUsers.get(2);
+    assertNotEquals(privateResourceUser.userEmail, sharedResourceUser.userEmail,
+        "The two test users are distinct");
+
+    // Add one user as a reader, and one as both a reader and writer.
+    ownerWorkspaceApi.grantRole(
+        new GrantRoleRequestBody().memberEmail(privateResourceUser.userEmail),
+        getWorkspaceId(),
+        IamRole.READER);
+    ownerWorkspaceApi.grantRole(
+        new GrantRoleRequestBody().memberEmail(privateResourceUser.userEmail),
+        getWorkspaceId(),
+        IamRole.WRITER);
+    ownerWorkspaceApi.grantRole(
+        new GrantRoleRequestBody().memberEmail(sharedResourceUser.userEmail),
+        getWorkspaceId(),
+        IamRole.WRITER);
+
+    // Create a GCP cloud context.
+    projectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), ownerWorkspaceApi);
+
+    // Create a shared GCS bucket with one object inside.
+    ControlledGcpResourceApi ownerResourceApi = ClientTestUtils
+        .getControlledGcpResourceClient(workspaceOwner, server);
+    String sharedBucketName = BUCKET_PREFIX + UUID.randomUUID();
+    sharedBucket = ResourceMaker.makeControlledGcsBucketUserShared(
+        ownerResourceApi, getWorkspaceId(), sharedBucketName, CloningInstructionsEnum.NOTHING);
+    ResourceMaker.addFileToBucket(sharedBucket, workspaceOwner, projectId);
+
+    // Create a private GCS bucket for privateResourceUser with one object inside.
+    String privateBucketName = BUCKET_PREFIX + UUID.randomUUID();
+    PrivateResourceIamRoles privateRoles = new PrivateResourceIamRoles();
+    privateRoles.addAll(PRIVATE_ROLES);
+    ControlledGcpResourceApi privateUserResourceApi =
+        ClientTestUtils.getControlledGcpResourceClient(privateResourceUser, server);
+    privateBucket = ResourceMaker.makeControlledGcsBucketUserPrivate(
+        privateUserResourceApi, getWorkspaceId(), privateBucketName, privateResourceUser.userEmail,
+        privateRoles);
+    ResourceMaker.addFileToBucket(privateBucket, privateResourceUser, projectId);
+
+    // Create a private BQ dataset for privateResourceUser and populate it.
+    String datasetId = RandomStringUtils.randomAlphabetic(8).toLowerCase();
+    privateDataset = ResourceMaker.makeControlledBigQueryDatasetUserPrivate(
+        privateUserResourceApi, getWorkspaceId(), datasetId, privateResourceUser.userEmail,
+        privateRoles, CloningInstructionsEnum.NOTHING);
+    ResourceMaker.populateBigQueryDataset(privateDataset, privateResourceUser, projectId);
+    // Create a private notebook for privateResourceUser.
+    String notebookInstanceId = RandomStringUtils.randomAlphabetic(8).toLowerCase();
+    privateNotebook = ResourceMaker.makeControlledNotebookUserPrivate(
+        getWorkspaceId(), notebookInstanceId, privateResourceUser, privateUserResourceApi);
+  }
+
+  @Override
+  protected void doUserJourney(TestUserSpecification workspaceOwner, WorkspaceApi ownerWorkspaceApi)
+      throws Exception {
+    String sharedBucketName = sharedBucket.getGcpBucket().getAttributes().getBucketName();
+    String privateBucketName = privateBucket.getGcpBucket().getAttributes().getBucketName();
+    // Validate that setup ran correctly and users have appropriate resource access.
+    ResourceMaker.retrieveBucketFile(sharedBucketName, projectId, sharedResourceUser);
+    ResourceMaker.retrieveBucketFile(privateBucketName, projectId, privateResourceUser);
+
+    // Remove WRITER role from sharedResourceUser. This is their only role, so they are no longer
+    // a member of this workspace.
+    ownerWorkspaceApi.removeRole(getWorkspaceId(), IamRole.WRITER, sharedResourceUser.userEmail);
+
+    // Validate that sharedResourceUser can no longer read resources in the workspace.
+    // This requires syncing google groups, so there is often a delay that we need to wait for.
+    ClientTestUtils.runWithRetryOnException(
+        () -> assertUserCannotReadBucket(sharedBucketName, sharedResourceUser));
+
+    // privateResource user can still read the shared bucket.
+    ResourceMaker.retrieveBucketFile(sharedBucketName, projectId, privateResourceUser);
+
+    // Remove READER role from privateResourceUser. They are also a writer, so they should not lose
+    // access to workspace resources because of this.
+    ownerWorkspaceApi.removeRole(getWorkspaceId(), IamRole.READER, privateResourceUser.userEmail);
+
+    // Validate privateResourceWriter still has access to all resources.
+    ResourceMaker.retrieveBucketFile(sharedBucketName, projectId, privateResourceUser);
+    ResourceMaker.retrieveBucketFile(privateBucketName, projectId, privateResourceUser);
+    ResourceMaker.readPopulatedBigQueryTable(privateDataset, privateResourceUser, projectId);
+    assertTrue(ResourceMaker.userHasProxyAccess(privateNotebook, privateResourceUser, projectId));
+
+    // Remove WRITER role from privateResourceUser. This is their last role, so they are no longer
+    // a member of this workspace.
+    ownerWorkspaceApi.removeRole(getWorkspaceId(), IamRole.WRITER, privateResourceUser.userEmail);
+
+    // Validate privateResourceWriter no longer has access to any private resources.
+    ClientTestUtils.runWithRetryOnException(
+        () -> assertUserCannotReadBucket(sharedBucketName, privateResourceUser));
+    ClientTestUtils.runWithRetryOnException(
+        () -> assertUserCannotReadBucket(privateBucketName, privateResourceUser));
+    ClientTestUtils.runWithRetryOnException(
+        () -> assertUserCannotReadDataset(privateDataset, privateResourceUser));
+    ClientTestUtils.runWithRetryOnException(
+        () -> assertUserCannotAccessNotebook(privateNotebook, privateResourceUser));
+  }
+
+  /**
+   * An assertion that the given user cannot read from the given bucket. This is pulled into a
+   * separate function to make retrying simpler.
+   */
+  private void assertUserCannotReadBucket(String bucketName, TestUserSpecification testUser) {
+    try {
+      ResourceMaker.retrieveBucketFile(bucketName, projectId, testUser);
+      // If nothing is thrown, that's bad! The user actually can read the bucket.
+      throw new RuntimeException(String
+          .format("User %s is still able to access bucket %s", testUser.userEmail, bucketName));
+    } catch (StorageException googleError) {
+      // If this is a 403 error, the user was successfully removed from the bucket.
+      assertEquals(SC_FORBIDDEN, googleError.getCode());
+    } catch (IOException e) {
+      // Unexpected error, rethrow
+      throw new RuntimeException("Error checking user is removed from bucket", e);
+    }
+  }
+
+  /**
+   * An assertion that the given user cannot read from the given dataset. This is pulled into a
+   * separate function to make retrying simpler.
+   */
+  private void assertUserCannotReadDataset(GcpBigQueryDatasetResource dataset,
+      TestUserSpecification testUser) {
+    try {
+      ResourceMaker.readPopulatedBigQueryTable(dataset, testUser, projectId);
+      // If nothing is thrown, that's bad! The user actually can read the dataset.
+      throw new RuntimeException(String
+          .format("User %s is still able to access dataset %s",
+              testUser.userEmail, dataset.getMetadata().getResourceId()));
+    } catch (BigQueryException googleError) {
+      // If this is a 403 error, the user was successfully removed from the dataset.
+      assertEquals(SC_FORBIDDEN, googleError.getCode());
+    } catch (IOException | InterruptedException e) {
+      // Unexpected error, rethrow
+      throw new RuntimeException("Error checking user is removed from dataset", e);
+    }
+  }
+
+  /**
+   * An assertion that the given user cannot access the given notebook. This is pulled into a
+   * separate function to make retrying simpler.
+   */
+  private void assertUserCannotAccessNotebook(
+      CreatedControlledGcpAiNotebookInstanceResult createdNotebook,
+      TestUserSpecification testUser) {
+    try {
+      if (ResourceMaker.userHasProxyAccess(createdNotebook, testUser, projectId)) {
+        throw new RuntimeException(
+            String.format("User %s is still able to access notebook %s",
+                testUser.userEmail,
+                createdNotebook.getAiNotebookInstance().getMetadata().getResourceId()));
+      }
+    } catch (GeneralSecurityException | IOException e) {
+      throw new RuntimeException("Error checking notebook access", e);
+    }
+  }
+}

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -263,7 +263,6 @@ public class ClientTestUtils {
     Duration sleepDuration = Duration.ofSeconds(15);
     while (numTries > 0) {
       try {
-        // read blob as second user
         result = supplier.get();
         break;
       } catch (Exception e) {
@@ -277,6 +276,13 @@ public class ClientTestUtils {
       }
     }
     return result;
+  }
+
+  public static void runWithRetryOnException(Runnable fn) throws InterruptedException {
+    getWithRetryOnException(() -> {
+      fn.run();
+      return null;
+    });
   }
 
   /**

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -1,15 +1,8 @@
 package scripts.utils;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static scripts.utils.ClientTestUtils.TEST_BQ_DATASET_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BQ_DATASET_PROJECT;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME;
-import static scripts.utils.GcsBucketTestFixtures.GCS_BLOB_CONTENT;
-import static scripts.utils.GcsBucketTestFixtures.GCS_BLOB_NAME;
 import static scripts.utils.GcsBucketTestFixtures.LIFECYCLE_RULES;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
@@ -48,45 +41,19 @@ import bio.terra.workspace.model.ManagedBy;
 import bio.terra.workspace.model.PrivateResourceIamRoles;
 import bio.terra.workspace.model.PrivateResourceUser;
 import bio.terra.workspace.model.ReferenceResourceCommonFields;
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.services.iam.v1.model.TestIamPermissionsRequest;
-import com.google.api.services.notebooks.v1.AIPlatformNotebooks;
-import com.google.api.services.notebooks.v1.model.Instance;
-import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.Field;
-import com.google.cloud.bigquery.InsertAllRequest;
-import com.google.cloud.bigquery.LegacySQLTypeName;
-import com.google.cloud.bigquery.QueryJobConfiguration;
-import com.google.cloud.bigquery.Schema;
-import com.google.cloud.bigquery.StandardTableDefinition;
-import com.google.cloud.bigquery.Table;
-import com.google.cloud.bigquery.TableId;
-import com.google.cloud.bigquery.TableInfo;
-import com.google.cloud.bigquery.TableResult;
-import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.BlobId;
-import com.google.cloud.storage.BlobInfo;
-import com.google.cloud.storage.Storage;
-import com.google.common.collect.ImmutableMap;
-import java.io.IOException;
-import java.security.GeneralSecurityException;
+
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.http.HttpStatus;
-import org.hamcrest.Matchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // Static methods to create resources
 public class ResourceMaker {
   private static final Logger logger = LoggerFactory.getLogger(ResourceMaker.class);
-  private static final long CREATE_BUCKET_POLL_SECONDS = 5;
   private static final long DELETE_BUCKET_POLL_SECONDS = 15;
 
   public static GcpBigQueryDatasetResource makeBigQueryReference(
@@ -229,25 +196,6 @@ public class ResourceMaker {
     }
   }
 
-  public static Blob addFileToBucket(CreatedControlledGcpGcsBucket bucket,
-      TestUserSpecification bucketWriter, String gcpProjectId) throws IOException {
-    final Storage sourceOwnerStorageClient = ClientTestUtils.getGcpStorageClient(bucketWriter, gcpProjectId);
-    final BlobId blobId = BlobId.of(bucket.getGcpBucket().getAttributes().getBucketName(), GCS_BLOB_NAME);
-    final BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
-    return sourceOwnerStorageClient.create(blobInfo, GCS_BLOB_CONTENT.getBytes());
-  }
-
-  public static Blob retrieveBucketFile(String bucketName, String gcpProjectId,
-      TestUserSpecification bucketReader) throws IOException {
-    Storage cloningUserStorageClient = ClientTestUtils.getGcpStorageClient(bucketReader, gcpProjectId);
-    BlobId blobId = BlobId.of(bucketName, GCS_BLOB_NAME);
-
-    final Blob retrievedFile = cloningUserStorageClient.get(blobId);
-    assertNotNull(retrievedFile);
-    assertEquals(blobId.getName(), retrievedFile.getBlobId().getName());
-    return retrievedFile;
-  }
-
   /**
    * Create and return a BigQuery dataset controlled resource with constant values. This uses the
    * given datasetID as both the WSM resource name and the actual BigQuery dataset ID.
@@ -304,102 +252,6 @@ public class ResourceMaker {
     logger.info("Creating dataset {} workspace {}", datasetId, workspaceId);
     return resourceApi.createBigQueryDataset(body, workspaceId).getBigQueryDataset();
   }
-  /**
-   * Create two tables with multiple rows in them into the provided dataset.
-   * Uses a mixture of streaming and DDL insertion to demonstrate the difference
-   * in copy job behavior.
-   * @param dataset - empty BigQuery dataset
-   * @param ownerUser - User who owns the dataset
-   * @param projectId - project that owns the dataset
-   * @throws IOException
-   * @throws InterruptedException
-   */
-  public static void populateBigQueryDataset(
-      GcpBigQueryDatasetResource dataset,
-      TestUserSpecification ownerUser,
-      String projectId)
-      throws IOException, InterruptedException {
-    // Add tables to the source dataset
-    final BigQuery bigQueryClient = ClientTestUtils.getGcpBigQueryClient(ownerUser, projectId);
-
-    final Schema employeeSchema = Schema.of(
-        Field.of("employee_id", LegacySQLTypeName.INTEGER),
-        Field.of("name", LegacySQLTypeName.STRING));
-    final TableId employeeTableId = TableId.of(projectId, dataset.getAttributes().getDatasetId(), "employee");
-
-    final TableInfo employeeTableInfo = TableInfo
-        .newBuilder(employeeTableId, StandardTableDefinition.of(employeeSchema))
-        .setFriendlyName("Employee")
-        .build();
-    final Table createdEmployeeTable = bigQueryClient.create(
-        employeeTableInfo);
-    logger.debug("Employee Table: {}", createdEmployeeTable);
-
-    final Table createdDepartmentTable = bigQueryClient.create(
-        TableInfo.newBuilder(TableId.of(projectId, dataset.getAttributes().getDatasetId(), "department"),
-        StandardTableDefinition.of(
-            Schema.of(
-                Field.of("department_id", LegacySQLTypeName.INTEGER),
-                Field.of("manager_id", LegacySQLTypeName.INTEGER),
-                Field.of("name", LegacySQLTypeName.STRING))))
-        .setFriendlyName("Department")
-        .build());
-    logger.debug("Department Table: {}", createdDepartmentTable);
-
-    // Add rows to the tables
-
-    // Stream insert one row to check the error handling/warning. This row may not be copied. (If
-    // the stream happens after the DDL insert, sometimes it gets copied).
-    bigQueryClient.insertAll(InsertAllRequest.newBuilder(employeeTableInfo)
-        .addRow(ImmutableMap.of("employee_id", 103, "name", "Batman"))
-        .build());
-
-    // Use DDL to insert rows instead of InsertAllRequest so that data won't
-    // be in the streaming buffer where it's un-copyable for up to 90 minutes.
-    bigQueryClient.query(QueryJobConfiguration.newBuilder(
-        "INSERT INTO `" + projectId + "." + dataset.getAttributes().getDatasetId()
-            + ".employee` (employee_id, name) VALUES("
-            + "101, 'Aquaman'), (102, 'Superman');")
-        .build());
-
-    bigQueryClient.query(QueryJobConfiguration.newBuilder(
-        "INSERT INTO `" + projectId + "." + dataset.getAttributes().getDatasetId()
-            + ".department` (department_id, manager_id, name) "
-            + "VALUES(201, 101, 'ocean'), (202, 102, 'sky');")
-        .build());
-
-    // double-check the rows are there
-    final TableResult employeeTableResult = bigQueryClient.query(QueryJobConfiguration.newBuilder(
-        "SELECT * FROM `" +
-            projectId + "." +
-            dataset.getAttributes().getDatasetId() + ".employee`;")
-        .build());
-    final long numRows = StreamSupport.stream(employeeTableResult.getValues().spliterator(), false)
-        .count();
-    assertThat(numRows, is(greaterThanOrEqualTo(2L)));
-  }
-
-  /**
-   * Read and validate data populated by {@code populateBigQueryDataset} from a BigQuery dataset.
-   * This is intended for validating that the provided user has read access to the given dataset.
-   */
-  public static TableResult readPopulatedBigQueryTable(
-      GcpBigQueryDatasetResource dataset,
-      TestUserSpecification user,
-      String projectId)
-      throws IOException, InterruptedException {
-
-    final BigQuery bigQueryClient = ClientTestUtils.getGcpBigQueryClient(user, projectId);
-    final TableResult employeeTableResult = bigQueryClient.query(QueryJobConfiguration.newBuilder(
-        "SELECT * FROM `" +
-            projectId + "." +
-            dataset.getAttributes().getDatasetId() + ".employee`;")
-        .build());
-    final long numRows = StreamSupport.stream(employeeTableResult.getValues().spliterator(), false)
-        .count();
-    assertThat(numRows, is(greaterThanOrEqualTo(2L)));
-    return employeeTableResult;
-  }
 
   /**
    * Create and return a private AI Platform Notebook controlled resource with constant values. This
@@ -449,55 +301,5 @@ public class ResourceMaker {
     ClientTestUtils.assertJobSuccess("create ai notebook",
         creationResult.getJobReport(), creationResult.getErrorReport());
     return creationResult;
-  }
-
-
-  /**
-   * Check whether the user has access to the Notebook through the proxy with a service account.
-   * <p>We can't directly test that we can go through the proxy to the Jupyter notebook without a
-   * real Google user auth flow, so we check the necessary ingredients instead.
-   */
-  public static boolean userHasProxyAccess(
-      CreatedControlledGcpAiNotebookInstanceResult createdNotebook,
-      TestUserSpecification user,
-      String projectId)
-      throws GeneralSecurityException, IOException {
-
-    String instanceName = String
-        .format("projects/%s/locations/%s/instances/%s",
-            createdNotebook.getAiNotebookInstance().getAttributes().getProjectId(),
-            createdNotebook.getAiNotebookInstance().getAttributes().getLocation(),
-            createdNotebook.getAiNotebookInstance().getAttributes().getInstanceId());
-    AIPlatformNotebooks userNotebooks = ClientTestUtils.getAIPlatformNotebooksClient(user);
-    Instance instance;
-    try {
-      instance = userNotebooks.projects().locations().instances().get(instanceName).execute();
-    } catch (GoogleJsonResponseException googleException) {
-      // If we get a 403 or 404 when fetching the instance, the user does not have access.
-      if (googleException.getStatusCode()  == HttpStatus.SC_FORBIDDEN
-          || googleException.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-        return false;
-      } else {
-        // If a different status code is thrown instead, rethrow here as that's an unexpected error.
-        throw googleException;
-      }
-    }
-    // Test that the user has access to the notebook with a service account through proxy mode.
-    // git secrets gets a false positive if 'service_account' is double quoted.
-    assertThat("Notebook has correct proxy mode access", instance.getMetadata(),
-        Matchers.hasEntry("proxy-mode", "service_" + "account"));
-
-    // The user needs to have the actAs permission on the service account.
-    String actAsPermission = "iam.serviceAccounts.actAs";
-    String serviceAccountName = String
-        .format("projects/%s/serviceAccounts/%s", projectId, instance.getServiceAccount());
-    return ClientTestUtils.getGcpIamClient(user)
-            .projects()
-            .serviceAccounts()
-            .testIamPermissions(
-                serviceAccountName,
-                new TestIamPermissionsRequest().setPermissions(List.of(actAsPermission)))
-            .execute()
-            .getPermissions().contains(actAsPermission);
   }
 }

--- a/integration/src/main/java/scripts/utils/ResourceModifier.java
+++ b/integration/src/main/java/scripts/utils/ResourceModifier.java
@@ -1,0 +1,216 @@
+package scripts.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static scripts.utils.GcsBucketTestFixtures.GCS_BLOB_CONTENT;
+import static scripts.utils.GcsBucketTestFixtures.GCS_BLOB_NAME;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.model.CreatedControlledGcpAiNotebookInstanceResult;
+import bio.terra.workspace.model.CreatedControlledGcpGcsBucket;
+import bio.terra.workspace.model.GcpBigQueryDatasetResource;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.iam.v1.model.TestIamPermissionsRequest;
+import com.google.api.services.notebooks.v1.AIPlatformNotebooks;
+import com.google.api.services.notebooks.v1.model.Instance;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Static test utilities for modifying existing resources including reading, writing, and checking
+ * access.
+ */
+public class ResourceModifier {
+
+  private static final Logger logger = LoggerFactory.getLogger(ResourceModifier.class);
+
+  public static Blob addFileToBucket(CreatedControlledGcpGcsBucket bucket,
+      TestUserSpecification bucketWriter, String gcpProjectId) throws IOException {
+    final Storage sourceOwnerStorageClient = ClientTestUtils.getGcpStorageClient(bucketWriter, gcpProjectId);
+    final BlobId blobId = BlobId.of(bucket.getGcpBucket().getAttributes().getBucketName(), GCS_BLOB_NAME);
+    final BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
+    return sourceOwnerStorageClient.create(blobInfo, GCS_BLOB_CONTENT.getBytes());
+  }
+
+  public static Blob retrieveBucketFile(String bucketName, String gcpProjectId,
+      TestUserSpecification bucketReader) throws IOException {
+    Storage cloningUserStorageClient = ClientTestUtils.getGcpStorageClient(bucketReader, gcpProjectId);
+    BlobId blobId = BlobId.of(bucketName, GCS_BLOB_NAME);
+
+    final Blob retrievedFile = cloningUserStorageClient.get(blobId);
+    assertNotNull(retrievedFile);
+    assertEquals(blobId.getName(), retrievedFile.getBlobId().getName());
+    return retrievedFile;
+  }
+
+  /**
+   * Create two tables with multiple rows in them into the provided dataset.
+   * Uses a mixture of streaming and DDL insertion to demonstrate the difference
+   * in copy job behavior.
+   * @param dataset - empty BigQuery dataset
+   * @param ownerUser - User who owns the dataset
+   * @param projectId - project that owns the dataset
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public static void populateBigQueryDataset(
+      GcpBigQueryDatasetResource dataset,
+      TestUserSpecification ownerUser,
+      String projectId)
+      throws IOException, InterruptedException {
+    // Add tables to the source dataset
+    final BigQuery bigQueryClient = ClientTestUtils.getGcpBigQueryClient(ownerUser, projectId);
+
+    final Schema employeeSchema = Schema.of(
+        Field.of("employee_id", LegacySQLTypeName.INTEGER),
+        Field.of("name", LegacySQLTypeName.STRING));
+    final TableId employeeTableId = TableId.of(projectId, dataset.getAttributes().getDatasetId(), "employee");
+
+    final TableInfo employeeTableInfo = TableInfo
+        .newBuilder(employeeTableId, StandardTableDefinition.of(employeeSchema))
+        .setFriendlyName("Employee")
+        .build();
+    final Table createdEmployeeTable = bigQueryClient.create(
+        employeeTableInfo);
+    logger.debug("Employee Table: {}", createdEmployeeTable);
+
+    final Table createdDepartmentTable = bigQueryClient.create(
+        TableInfo.newBuilder(TableId.of(projectId, dataset.getAttributes().getDatasetId(), "department"),
+            StandardTableDefinition.of(
+                Schema.of(
+                    Field.of("department_id", LegacySQLTypeName.INTEGER),
+                    Field.of("manager_id", LegacySQLTypeName.INTEGER),
+                    Field.of("name", LegacySQLTypeName.STRING))))
+            .setFriendlyName("Department")
+            .build());
+    logger.debug("Department Table: {}", createdDepartmentTable);
+
+    // Add rows to the tables
+
+    // Stream insert one row to check the error handling/warning. This row may not be copied. (If
+    // the stream happens after the DDL insert, sometimes it gets copied).
+    bigQueryClient.insertAll(InsertAllRequest.newBuilder(employeeTableInfo)
+        .addRow(ImmutableMap.of("employee_id", 103, "name", "Batman"))
+        .build());
+
+    // Use DDL to insert rows instead of InsertAllRequest so that data won't
+    // be in the streaming buffer where it's un-copyable for up to 90 minutes.
+    bigQueryClient.query(QueryJobConfiguration.newBuilder(
+        "INSERT INTO `" + projectId + "." + dataset.getAttributes().getDatasetId()
+            + ".employee` (employee_id, name) VALUES("
+            + "101, 'Aquaman'), (102, 'Superman');")
+        .build());
+
+    bigQueryClient.query(QueryJobConfiguration.newBuilder(
+        "INSERT INTO `" + projectId + "." + dataset.getAttributes().getDatasetId()
+            + ".department` (department_id, manager_id, name) "
+            + "VALUES(201, 101, 'ocean'), (202, 102, 'sky');")
+        .build());
+
+    // double-check the rows are there
+    final TableResult employeeTableResult = bigQueryClient.query(QueryJobConfiguration.newBuilder(
+        "SELECT * FROM `" +
+            projectId + "." +
+            dataset.getAttributes().getDatasetId() + ".employee`;")
+        .build());
+    final long numRows = StreamSupport.stream(employeeTableResult.getValues().spliterator(), false)
+        .count();
+    assertThat(numRows, is(greaterThanOrEqualTo(2L)));
+  }
+
+  /**
+   * Read and validate data populated by {@code populateBigQueryDataset} from a BigQuery dataset.
+   * This is intended for validating that the provided user has read access to the given dataset.
+   */
+  public static TableResult readPopulatedBigQueryTable(
+      GcpBigQueryDatasetResource dataset,
+      TestUserSpecification user,
+      String projectId)
+      throws IOException, InterruptedException {
+
+    final BigQuery bigQueryClient = ClientTestUtils.getGcpBigQueryClient(user, projectId);
+    final TableResult employeeTableResult = bigQueryClient.query(QueryJobConfiguration.newBuilder(
+        "SELECT * FROM `" +
+            projectId + "." +
+            dataset.getAttributes().getDatasetId() + ".employee`;")
+        .build());
+    final long numRows = StreamSupport.stream(employeeTableResult.getValues().spliterator(), false)
+        .count();
+    assertThat(numRows, is(greaterThanOrEqualTo(2L)));
+    return employeeTableResult;
+  }
+
+  /**
+   * Check whether the user has access to the Notebook through the proxy with a service account.
+   * <p>We can't directly test that we can go through the proxy to the Jupyter notebook without a
+   * real Google user auth flow, so we check the necessary ingredients instead.
+   */
+  public static boolean userHasProxyAccess(
+      CreatedControlledGcpAiNotebookInstanceResult createdNotebook,
+      TestUserSpecification user,
+      String projectId)
+      throws GeneralSecurityException, IOException {
+
+    String instanceName = String
+        .format("projects/%s/locations/%s/instances/%s",
+            createdNotebook.getAiNotebookInstance().getAttributes().getProjectId(),
+            createdNotebook.getAiNotebookInstance().getAttributes().getLocation(),
+            createdNotebook.getAiNotebookInstance().getAttributes().getInstanceId());
+    AIPlatformNotebooks userNotebooks = ClientTestUtils.getAIPlatformNotebooksClient(user);
+    Instance instance;
+    try {
+      instance = userNotebooks.projects().locations().instances().get(instanceName).execute();
+    } catch (GoogleJsonResponseException googleException) {
+      // If we get a 403 or 404 when fetching the instance, the user does not have access.
+      if (googleException.getStatusCode()  == HttpStatus.SC_FORBIDDEN
+          || googleException.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+        return false;
+      } else {
+        // If a different status code is thrown instead, rethrow here as that's an unexpected error.
+        throw googleException;
+      }
+    }
+    // Test that the user has access to the notebook with a service account through proxy mode.
+    // git secrets gets a false positive if 'service_account' is double quoted.
+    assertThat("Notebook has correct proxy mode access", instance.getMetadata(),
+        Matchers.hasEntry("proxy-mode", "service_" + "account"));
+
+    // The user needs to have the actAs permission on the service account.
+    String actAsPermission = "iam.serviceAccounts.actAs";
+    String serviceAccountName = String
+        .format("projects/%s/serviceAccounts/%s", projectId, instance.getServiceAccount());
+    return ClientTestUtils.getGcpIamClient(user)
+        .projects()
+        .serviceAccounts()
+        .testIamPermissions(
+            serviceAccountName,
+            new TestIamPermissionsRequest().setPermissions(List.of(actAsPermission)))
+        .execute()
+        .getPermissions().contains(actAsPermission);
+  }
+}

--- a/integration/src/main/resources/configs/integration/RemoveUser.json
+++ b/integration/src/main/resources/configs/integration/RemoveUser.json
@@ -1,0 +1,18 @@
+{
+  "name": "RemoveUser",
+  "description": "Test revoking permissions when users are removed.",
+  "serverSpecificationFile": "workspace-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "RemoveUser",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 1,
+      "expectedTimeForEach": 10,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parameters": ["wm-default-spend-profile"]
+    }
+  ],
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"]
+}

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -19,6 +19,7 @@
     "integration/GetRoles.json",
     "integration/PrivateControlledAiNotebookInstanceLifecycle.json",
     "integration/PrivateControlledGcsBucketLifecycle.json",
+    "integration/RemoveUser.json",
     "integration/ValidateReferencedResources.json",
     "integration/WorkspaceLifecycle.json"
   ]

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -376,11 +376,8 @@ public class WorkspaceApiController implements WorkspaceApi {
       throw new InvalidRoleException(
           "Users cannot remove role APPLICATION. Use application registration instead.");
     }
-    SamService.rethrowIfSamInterrupted(
-        () ->
-            samService.removeWorkspaceRole(
-                id, getAuthenticatedInfo(), WsmIamRole.fromApiModel(role), memberEmail),
-        "removeWorkspaceRole");
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    workspaceService.removeRole(id, WsmIamRole.fromApiModel(role), memberEmail, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -377,7 +377,8 @@ public class WorkspaceApiController implements WorkspaceApi {
           "Users cannot remove role APPLICATION. Use application registration instead.");
     }
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.removeRole(id, WsmIamRole.fromApiModel(role), memberEmail, userRequest);
+    workspaceService.removeWorkspaceRoleFromUser(
+        id, WsmIamRole.fromApiModel(role), memberEmail, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -241,6 +241,26 @@ public class ResourceDao {
         .collect(Collectors.toList());
   }
 
+  /** Returns a list of all private resources assigned to a user in a given workspace. */
+  @ReadTransaction
+  public List<ControlledResource> listPrivateResourcesByUser(UUID workspaceId, String userEmail) {
+    String sql =
+        RESOURCE_SELECT_SQL
+            + " AND access_scope = :access_scope"
+            + " AND assigned_user = :user_email";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("workspace_id", workspaceId.toString())
+            .addValue("access_scope", AccessScopeType.ACCESS_SCOPE_PRIVATE.toSql())
+            .addValue("user_email", userEmail);
+
+    List<DbResource> dbResources = jdbcTemplate.query(sql, params, DB_RESOURCE_ROW_MAPPER);
+    return dbResources.stream()
+        .map(this::constructResource)
+        .map(WsmResource::castToControlledResource)
+        .collect(Collectors.toList());
+  }
+
   /**
    * Deletes all controlled resources on a specified cloud platform in a workspace.
    *

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -241,16 +241,18 @@ public class ResourceDao {
         .collect(Collectors.toList());
   }
 
-  /** Returns a list of all private resources assigned to a user in a given workspace. */
+  /** Returns a list of all private controlled resources assigned to a user in a given workspace. */
   @ReadTransaction
   public List<ControlledResource> listPrivateResourcesByUser(UUID workspaceId, String userEmail) {
     String sql =
         RESOURCE_SELECT_SQL
+            + " AND stewardship_type = :controlled_resource"
             + " AND access_scope = :access_scope"
             + " AND assigned_user = :user_email";
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("workspace_id", workspaceId.toString())
+            .addValue("controlled_resource", CONTROLLED.toSql())
             .addValue("access_scope", AccessScopeType.ACCESS_SCOPE_PRIVATE.toSql())
             .addValue("user_email", userEmail);
 

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/ControlledResourceIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/ControlledResourceIamRole.java
@@ -43,6 +43,17 @@ public enum ControlledResourceIamRole {
                     + apiModel.toString()));
   }
 
+  public static ControlledResourceIamRole fromSamRole(String samRole) {
+    Optional<ControlledResourceIamRole> result =
+        Arrays.stream(ControlledResourceIamRole.values())
+            .filter(x -> x.samRole.equals(samRole))
+            .findFirst();
+    return result.orElseThrow(
+        () ->
+            new RuntimeException(
+                "No ControlledResourceIamRole enum found corresponding to Sam role " + samRole));
+  }
+
   public String toSamRole() {
     return samRole;
   }

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
@@ -16,6 +16,7 @@ public class SamConstants {
 
   public static class SamControlledResourceActions {
     public static final String READ_ACTION = "read";
+    public static final String WRITE_ACTION = "write";
     public static final String EDIT_ACTION = "edit";
     public static final String DELETE_ACTION = "delete";
 

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
@@ -5,6 +5,7 @@ public class SamConstants {
   public static final String SAM_WORKSPACE_RESOURCE = "workspace";
   public static final String SAM_WORKSPACE_READ_ACTION = "read";
   public static final String SAM_WORKSPACE_WRITE_ACTION = "write";
+  public static final String SAM_WORKSPACE_OWN_ACTION = "own";
   public static final String SAM_WORKSPACE_DELETE_ACTION = "delete";
   public static final String SAM_WORKSPACE_READ_IAM_ACTION = "read_policies";
   public static final String SAM_CREATE_REFERENCED_RESOURCE = "create_referenced_resource";

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -56,6 +56,10 @@ public class CreateGcsBucketStep implements Step {
             .map(GcsApiConversions::toGcsApiRulesList)
             .orElse(Collections.emptyList()));
 
+    BucketInfo.IamConfiguration iamConfiguration =
+        BucketInfo.IamConfiguration.newBuilder().setIsUniformBucketLevelAccessEnabled(true).build();
+    bucketInfoBuilder.setIamConfiguration(iamConfiguration);
+
     StorageCow storageCow = crlService.createStorageCow(projectId);
 
     // Don't try to create it if it already exists. At this point the assumption is

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/ServiceAccountPolicyStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/ServiceAccountPolicyStep.java
@@ -23,9 +23,9 @@ import com.google.api.services.iam.v1.model.Binding;
 import com.google.api.services.iam.v1.model.Policy;
 import com.google.api.services.iam.v1.model.SetIamPolicyRequest;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -113,7 +113,7 @@ public class ServiceAccountPolicyStep implements Step {
     String writerGroupEmail = resourceRoleGroupsMap.get(ControlledResourceIamRole.WRITER);
     return new Binding()
         .setRole(SERVICE_ACCOUNT_USER_ROLE)
-        .setMembers(ImmutableList.of("group:" + writerGroupEmail));
+        .setMembers(Collections.singletonList("group:" + writerGroupEmail));
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/ServiceAccountPolicyStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/ServiceAccountPolicyStep.java
@@ -17,7 +17,7 @@ import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.resource.controlled.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.workspace.WorkspaceService;
-import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.api.services.iam.v1.model.Binding;
 import com.google.api.services.iam.v1.model.Policy;
@@ -108,8 +108,7 @@ public class ServiceAccountPolicyStep implements Step {
     // Grant permission via private resource's Sam group so that access can be revoked via Sam.
     Map<ControlledResourceIamRole, String> resourceRoleGroupsMap =
         workingMap.get(
-            WorkspaceFlightMapKeys.ControlledResourceKeys.IAM_RESOURCE_GROUP_EMAIL_MAP,
-            new TypeReference<>() {});
+            ControlledResourceKeys.IAM_RESOURCE_GROUP_EMAIL_MAP, new TypeReference<>() {});
     String writerGroupEmail = resourceRoleGroupsMap.get(ControlledResourceIamRole.WRITER);
     return new Binding()
         .setRole(SERVICE_ACCOUNT_USER_ROLE)

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -7,6 +7,7 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
+import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobBuilder;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.job.JobService;
@@ -21,6 +22,7 @@ import bio.terra.workspace.service.workspace.exceptions.MissingSpendProfileExcep
 import bio.terra.workspace.service.workspace.exceptions.NoBillingAccountException;
 import bio.terra.workspace.service.workspace.flight.CreateGcpContextFlight;
 import bio.terra.workspace.service.workspace.flight.DeleteGcpContextFlight;
+import bio.terra.workspace.service.workspace.flight.RemoveUserFromWorkspaceFlight;
 import bio.terra.workspace.service.workspace.flight.WorkspaceCreateFlight;
 import bio.terra.workspace.service.workspace.flight.WorkspaceDeleteFlight;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
@@ -389,5 +391,31 @@ public class WorkspaceService {
     } catch (IOException e) {
       throw new RuntimeException("Error enabling user's pet SA", e);
     }
+  }
+
+  public void removeRole(
+      UUID workspaceId, WsmIamRole role, String userEmail, AuthenticatedUserRequest userRequest) {
+    Workspace workspace =
+        validateWorkspaceAndAction(userRequest, workspaceId, SamConstants.SAM_WORKSPACE_OWN_ACTION);
+    stageService.assertMcWorkspace(workspace, "deleteGcpCloudContext");
+    // Before launching the flight, validate that the user being removed is a direct member of the
+    // specified role. Users may also be added to a workspace via managed groups, but WSM does not
+    // control membership of those groups, and so cannot remove them here.
+    List<String> roleMembers =
+        samService.listWorkspacePolicyMembers(workspaceId, role, userRequest);
+    if (!roleMembers.contains(userEmail)) {
+      return;
+    }
+    jobService
+        .newJob(
+            "Remove user from workspace " + workspaceId,
+            UUID.randomUUID().toString(),
+            RemoveUserFromWorkspaceFlight.class,
+            /* request= */ null,
+            userRequest)
+        .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString())
+        .addParameter(WorkspaceFlightMapKeys.USER_TO_REMOVE, userEmail)
+        .addParameter(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, role.name())
+        .submitAndWait(null);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -431,7 +431,7 @@ public class WorkspaceService {
             executingUserRequest)
         .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString())
         .addParameter(WorkspaceFlightMapKeys.USER_TO_REMOVE, targetUserEmail)
-        .addParameter(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, role.name())
+        .addParameter(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, role)
         .submitAndWait(null);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CheckUserStillInWorkspaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CheckUserStillInWorkspaceStep.java
@@ -1,0 +1,51 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.SamConstants;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import java.util.UUID;
+
+public class CheckUserStillInWorkspaceStep implements Step {
+
+  private final UUID workspaceId;
+  private final SamService samService;
+  private final AuthenticatedUserRequest userRequest;
+  private final String removedUserEmail;
+
+  public CheckUserStillInWorkspaceStep(
+      UUID workspaceId,
+      String removedUserEmail,
+      SamService samService,
+      AuthenticatedUserRequest userRequest) {
+    this.workspaceId = workspaceId;
+    this.samService = samService;
+    this.userRequest = userRequest;
+    this.removedUserEmail = removedUserEmail;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    boolean userCanReadWorkspace =
+        samService.userIsAuthorized(
+            SamConstants.SAM_WORKSPACE_RESOURCE,
+            workspaceId.toString(),
+            SamConstants.SAM_WORKSPACE_READ_ACTION,
+            removedUserEmail,
+            userRequest);
+    FlightMap workingMap = context.getWorkingMap();
+    workingMap.put(ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, userCanReadWorkspace);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // This step is only writes to the flight map, so nothing to undo.
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/ReadUserPrivateResourcesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/ReadUserPrivateResourcesStep.java
@@ -13,7 +13,6 @@ import bio.terra.workspace.service.resource.controlled.ControlledResource;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public class ReadUserPrivateResourcesStep implements Step {
@@ -41,10 +40,7 @@ public class ReadUserPrivateResourcesStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     FlightMap workingMap = context.getWorkingMap();
     boolean userStillInWorkspace =
-        Optional.ofNullable(
-                workingMap.get(
-                    ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, Boolean.class))
-            .orElse(false);
+        workingMap.get(ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, Boolean.class);
     // This flight is triggered whenever a user loses any role on a workspace. If they are still
     // a member of the workspace via a group or another role, we do not need to remove their access
     // to private resources.

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/ReadUserPrivateResourcesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/ReadUserPrivateResourcesStep.java
@@ -1,0 +1,52 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.service.resource.controlled.ControlledResource;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class ReadUserPrivateResourcesStep implements Step {
+
+  private final ResourceDao resourceDao;
+  private final UUID workspaceId;
+  private final String userEmail;
+
+  public ReadUserPrivateResourcesStep(UUID workspaceId, String userEmail, ResourceDao resourceDao) {
+    this.resourceDao = resourceDao;
+    this.workspaceId = workspaceId;
+    this.userEmail = userEmail;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    boolean userStillInWorkspace =
+        Optional.ofNullable(
+                workingMap.get(
+                    ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, Boolean.class))
+            .orElse(false);
+    // This flight is triggered whenever a user loses any role on a workspace. If they are still
+    // a member of the workspace via a group or another role, we do not need to remove their access
+    // to private resources.
+    if (userStillInWorkspace) {
+      return StepResult.getStepResultSuccess();
+    }
+    List<ControlledResource> userResources =
+        resourceDao.listPrivateResourcesByUser(workspaceId, userEmail);
+    workingMap.put(ControlledResourceKeys.REVOCABLE_PRIVATE_RESOURCES, userResources);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Do nothing, this step only populates the working map.
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemovePrivateResourceAccessStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemovePrivateResourceAccessStep.java
@@ -1,0 +1,73 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
+import bio.terra.workspace.service.resource.controlled.ControlledResource;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RemovePrivateResourceAccessStep implements Step {
+
+  private final SamService samService;
+  private final AuthenticatedUserRequest userRequest;
+  private final String userToRemove;
+
+  private final Logger logger = LoggerFactory.getLogger(RemovePrivateResourceAccessStep.class);
+
+  public RemovePrivateResourceAccessStep(
+      String userToRemove, SamService samService, AuthenticatedUserRequest userRequest) {
+    this.samService = samService;
+    this.userRequest = userRequest;
+    this.userToRemove = userToRemove;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    boolean userStillInWorkspace =
+        Optional.ofNullable(
+                workingMap.get(
+                    ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, Boolean.class))
+            .orElse(false);
+    // This flight is triggered whenever a user loses any role on a workspace. If they are still
+    // a member of the workspace via a group or another role, we do not need to remove their access
+    // to private resources.
+    if (userStillInWorkspace) {
+      return StepResult.getStepResultSuccess();
+    }
+
+    List<ControlledResource> userResources =
+        workingMap.get(
+            ControlledResourceKeys.REVOCABLE_PRIVATE_RESOURCES, new TypeReference<>() {});
+    for (ControlledResource resource : userResources) {
+      // WSM does not store which roles user have on their private resources, so here we attempt
+      // to remove them from all possible roles.
+      samService.removeResourceRole(
+          resource, userRequest, ControlledResourceIamRole.READER, userToRemove);
+      samService.removeResourceRole(
+          resource, userRequest, ControlledResourceIamRole.WRITER, userToRemove);
+      samService.removeResourceRole(
+          resource, userRequest, ControlledResourceIamRole.EDITOR, userToRemove);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // WSM does not store which roles users have on their private resources, so there is no way
+    // to undo any removal that happened in the DO step. The best we can do here is log an error and
+    // surface whatever failure led to this undo.
+    logger.error("Unable to undo resource access removal for user {}", userToRemove);
+    return context.getResult();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemovePrivateResourceAccessStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemovePrivateResourceAccessStep.java
@@ -7,22 +7,16 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
-import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
-import bio.terra.workspace.service.resource.controlled.ControlledResource;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RemovePrivateResourceAccessStep implements Step {
 
   private final SamService samService;
   private final AuthenticatedUserRequest userRequest;
   private final String userToRemove;
-
-  private final Logger logger = LoggerFactory.getLogger(RemovePrivateResourceAccessStep.class);
 
   public RemovePrivateResourceAccessStep(
       String userToRemove, SamService samService, AuthenticatedUserRequest userRequest) {
@@ -46,28 +40,39 @@ public class RemovePrivateResourceAccessStep implements Step {
       return StepResult.getStepResultSuccess();
     }
 
-    List<ControlledResource> userResources =
-        workingMap.get(
-            ControlledResourceKeys.REVOCABLE_PRIVATE_RESOURCES, new TypeReference<>() {});
-    for (ControlledResource resource : userResources) {
-      // WSM does not store which roles user have on their private resources, so here we attempt
-      // to remove them from all possible roles.
+    List<ResourceRolePair> resourceRolesToRemove =
+        workingMap.get(ControlledResourceKeys.RESOURCE_ROLES_TO_REMOVE, new TypeReference<>() {});
+    for (ResourceRolePair resourceRolePair : resourceRolesToRemove) {
       samService.removeResourceRole(
-          resource, userRequest, ControlledResourceIamRole.READER, userToRemove);
-      samService.removeResourceRole(
-          resource, userRequest, ControlledResourceIamRole.WRITER, userToRemove);
-      samService.removeResourceRole(
-          resource, userRequest, ControlledResourceIamRole.EDITOR, userToRemove);
+          resourceRolePair.getResource(), userRequest, resourceRolePair.getRole(), userToRemove);
     }
     return StepResult.getStepResultSuccess();
   }
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
-    // WSM does not store which roles users have on their private resources, so there is no way
-    // to undo any removal that happened in the DO step. The best we can do here is log an error and
-    // surface whatever failure led to this undo.
-    logger.error("Unable to undo resource access removal for user {}", userToRemove);
-    return context.getResult();
+    FlightMap workingMap = context.getWorkingMap();
+    boolean userStillInWorkspace =
+        Optional.ofNullable(
+                workingMap.get(
+                    ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, Boolean.class))
+            .orElse(false);
+    // This flight is triggered whenever a user loses any role on a workspace. If they are still
+    // a member of the workspace via a group or another role, we do not need to restore their access
+    // to private resources here.
+    if (userStillInWorkspace) {
+      return StepResult.getStepResultSuccess();
+    }
+
+    // Restore all roles removed in the DO step.
+    List<ResourceRolePair> resourceRolesToRestore =
+        workingMap.get(ControlledResourceKeys.RESOURCE_ROLES_TO_REMOVE, new TypeReference<>() {});
+    for (ResourceRolePair resourceRolePair : resourceRolesToRestore) {
+      // Sam de-duplicates policy membership, so it's safe to restore roles that may not have been
+      // removed in the DO step.
+      samService.restoreResourceRole(
+          resourceRolePair.getResource(), userRequest, resourceRolePair.getRole(), userToRemove);
+    }
+    return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemovePrivateResourceAccessStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemovePrivateResourceAccessStep.java
@@ -10,7 +10,6 @@ import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
-import java.util.Optional;
 
 public class RemovePrivateResourceAccessStep implements Step {
 
@@ -29,10 +28,7 @@ public class RemovePrivateResourceAccessStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     FlightMap workingMap = context.getWorkingMap();
     boolean userStillInWorkspace =
-        Optional.ofNullable(
-                workingMap.get(
-                    ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, Boolean.class))
-            .orElse(false);
+        workingMap.get(ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, Boolean.class);
     // This flight is triggered whenever a user loses any role on a workspace. If they are still
     // a member of the workspace via a group or another role, we do not need to remove their access
     // to private resources.
@@ -53,10 +49,7 @@ public class RemovePrivateResourceAccessStep implements Step {
   public StepResult undoStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
     boolean userStillInWorkspace =
-        Optional.ofNullable(
-                workingMap.get(
-                    ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, Boolean.class))
-            .orElse(false);
+        workingMap.get(ControlledResourceKeys.REMOVED_USER_IS_WORKSPACE_MEMBER, Boolean.class);
     // This flight is triggered whenever a user loses any role on a workspace. If they are still
     // a member of the workspace via a group or another role, we do not need to restore their access
     // to private resources here.

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromSamStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromSamStep.java
@@ -1,0 +1,44 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.WsmIamRole;
+import java.util.UUID;
+
+public class RemoveUserFromSamStep implements Step {
+
+  private final SamService samService;
+  private final UUID workspaceId;
+  private final WsmIamRole roleToRemove;
+  private final String userToRemoveEmail;
+  private final AuthenticatedUserRequest userRequest;
+
+  public RemoveUserFromSamStep(
+      UUID workspaceId,
+      WsmIamRole roleToRemove,
+      String userToRemoveEmail,
+      SamService samService,
+      AuthenticatedUserRequest userRequest) {
+    this.samService = samService;
+    this.workspaceId = workspaceId;
+    this.roleToRemove = roleToRemove;
+    this.userToRemoveEmail = userToRemoveEmail;
+    this.userRequest = userRequest;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    samService.removeWorkspaceRole(workspaceId, userRequest, roleToRemove, userToRemoveEmail);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    samService.grantWorkspaceRole(workspaceId, userRequest, roleToRemove, userToRemoveEmail);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromSamStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromSamStep.java
@@ -32,12 +32,16 @@ public class RemoveUserFromSamStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    // Sam returns a 204 regardless of whether the user was actually removed or not, so this step is
+    // always idempotent.
     samService.removeWorkspaceRole(workspaceId, userRequest, roleToRemove, userToRemoveEmail);
     return StepResult.getStepResultSuccess();
   }
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Sam de-duplicates policy membership, so it's safe to restore roles that may not have been
+    // removed in the DO step.
     samService.grantWorkspaceRole(workspaceId, userRequest, roleToRemove, userToRemoveEmail);
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
@@ -21,8 +21,7 @@ public class RemoveUserFromWorkspaceFlight extends Flight {
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
     String userToRemove = inputParameters.get(WorkspaceFlightMapKeys.USER_TO_REMOVE, String.class);
     WsmIamRole roleToRemove =
-        WsmIamRole.valueOf(
-            inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class));
+        inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, WsmIamRole.class);
 
     // Flight plan:
     // 0. (Pre-flight): Validate that the user is directly granted the specified workspace role.

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
@@ -43,7 +43,12 @@ public class RemoveUserFromWorkspaceFlight extends Flight {
         new CheckUserStillInWorkspaceStep(
             workspaceId, userToRemove, appContext.getSamService(), userRequest));
     addStep(
-        new ReadUserPrivateResourcesStep(workspaceId, userToRemove, appContext.getResourceDao()));
+        new ReadUserPrivateResourcesStep(
+            workspaceId,
+            userToRemove,
+            appContext.getResourceDao(),
+            appContext.getSamService(),
+            userRequest));
     addStep(
         new RemovePrivateResourceAccessStep(userToRemove, appContext.getSamService(), userRequest));
   }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
@@ -1,0 +1,50 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.common.utils.FlightBeanBag;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.model.WsmIamRole;
+import bio.terra.workspace.service.job.JobMapKeys;
+import java.util.UUID;
+
+public class RemoveUserFromWorkspaceFlight extends Flight {
+
+  public RemoveUserFromWorkspaceFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+    FlightBeanBag appContext = FlightBeanBag.getFromObject(applicationContext);
+
+    UUID workspaceId =
+        UUID.fromString(inputParameters.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
+    AuthenticatedUserRequest userRequest =
+        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+    String userToRemove = inputParameters.get(WorkspaceFlightMapKeys.USER_TO_REMOVE, String.class);
+    WsmIamRole roleToRemove =
+        WsmIamRole.valueOf(
+            inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class));
+
+    // Flight plan:
+    // 0. (Pre-flight): Validate that the user is directly granted the specified workspace role.
+    //  WSM does not manage groups, so users with indirect group-based access cannot be removed
+    //  via this flight.
+    // 1. Remove user from the specified role.
+    // 2. Check with Sam whether the user is still in the workspace (i.e. can still read in the
+    //  workspace) via other roles or groups. If so, we do not need to clean up their private
+    //  resources, and can skip the rest of the flight.
+    // 3. If the user is fully removed from the workspace, build a list of their private resources
+    //  by reading WSM's DB.
+    // 4. Remove the user from all roles on those private resources. Because WSM does not track
+    //  which roles users have on private resources, this cannot be undone.
+    addStep(
+        new RemoveUserFromSamStep(
+            workspaceId, roleToRemove, userToRemove, appContext.getSamService(), userRequest));
+    addStep(
+        new CheckUserStillInWorkspaceStep(
+            workspaceId, userToRemove, appContext.getSamService(), userRequest));
+    addStep(
+        new ReadUserPrivateResourcesStep(workspaceId, userToRemove, appContext.getResourceDao()));
+    addStep(
+        new RemovePrivateResourceAccessStep(userToRemove, appContext.getSamService(), userRequest));
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/ResourceRolePair.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/ResourceRolePair.java
@@ -1,0 +1,27 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
+import bio.terra.workspace.service.resource.controlled.ControlledResource;
+
+/**
+ * A pair of ControlledResource and ControlledResourceIamRole objects. This represents a single role
+ * on a particular controlled resource.
+ */
+public class ResourceRolePair {
+
+  private final ControlledResource resource;
+  private final ControlledResourceIamRole role;
+
+  public ResourceRolePair(ControlledResource resource, ControlledResourceIamRole role) {
+    this.resource = resource;
+    this.role = role;
+  }
+
+  public ControlledResource getResource() {
+    return resource;
+  }
+
+  public ControlledResourceIamRole getRole() {
+    return role;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -10,6 +10,8 @@ public final class WorkspaceFlightMapKeys {
   public static final String RBS_RESOURCE_ID = "rbsResourceId";
   public static final String DISPLAY_NAME = "displayNameId";
   public static final String DESCRIPTION = "descriptionId";
+  public static final String USER_TO_REMOVE = "userToRemove";
+  public static final String ROLE_TO_REMOVE = "roleToRemove";
 
   private WorkspaceFlightMapKeys() {}
 
@@ -29,6 +31,9 @@ public final class WorkspaceFlightMapKeys {
     public static final String PREVIOUS_RESOURCE_NAME = "previousResourceName";
     public static final String RESOURCE_DESCRIPTION = "resourceDescription";
     public static final String PREVIOUS_RESOURCE_DESCRIPTION = "previousResourceDescription";
+
+    public static final String REVOCABLE_PRIVATE_RESOURCES = "revocablePrivateResources";
+    public static final String REMOVED_USER_IS_WORKSPACE_MEMBER = "removedUserIsWorkspaceMember";
 
     // Notebooks keys
     public static final String CREATE_NOTEBOOK_NETWORK_NAME = "createNotebookNetworkName";

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -32,7 +32,7 @@ public final class WorkspaceFlightMapKeys {
     public static final String RESOURCE_DESCRIPTION = "resourceDescription";
     public static final String PREVIOUS_RESOURCE_DESCRIPTION = "previousResourceDescription";
 
-    public static final String REVOCABLE_PRIVATE_RESOURCES = "revocablePrivateResources";
+    public static final String RESOURCE_ROLES_TO_REMOVE = "resourceRolesToRemove";
     public static final String REMOVED_USER_IS_WORKSPACE_MEMBER = "removedUserIsWorkspaceMember";
 
     // Notebooks keys

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -1,0 +1,188 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.stairway.FlightDebugInfo;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.FlightState;
+import bio.terra.stairway.FlightStatus;
+import bio.terra.workspace.common.BaseConnectedTest;
+import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
+import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
+import bio.terra.workspace.service.iam.model.SamConstants;
+import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceActions;
+import bio.terra.workspace.service.iam.model.WsmIamRole;
+import bio.terra.workspace.service.job.JobMapKeys;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.job.JobService.AsyncJobResult;
+import bio.terra.workspace.service.resource.controlled.AccessScopeType;
+import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import bio.terra.workspace.service.resource.controlled.ManagedByType;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
+import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import bio.terra.workspace.service.workspace.model.WorkspaceRequest;
+import bio.terra.workspace.service.workspace.model.WorkspaceStage;
+import com.google.common.collect.ImmutableList;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
+
+  @Autowired private WorkspaceService workspaceService;
+  @Autowired private ControlledResourceService controlledResourceService;
+  @Autowired private JobService jobService;
+  @Autowired private SamService samService;
+  @Autowired private SpendConnectedTestUtils spendUtils;
+  @Autowired private UserAccessUtils userAccessUtils;
+
+  private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(3);
+
+  @Test
+  @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
+  void removeUserFromWorkspaceFlightDoUndo() throws Exception {
+    // Create a workspace as the default test user
+    WorkspaceRequest request =
+        WorkspaceRequest.builder()
+            .workspaceId(UUID.randomUUID())
+            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+            .spendProfileId(Optional.of(spendUtils.defaultSpendId()))
+            .build();
+    UUID workspaceId =
+        workspaceService.createWorkspace(request, userAccessUtils.defaultUserAuthRequest());
+    // Add the secondary test user as a writer
+    samService.grantWorkspaceRole(
+        workspaceId,
+        userAccessUtils.defaultUserAuthRequest(),
+        WsmIamRole.WRITER,
+        userAccessUtils.getSecondUserEmail());
+
+    // Create a GCP context as default user
+    String makeContextJobId = RandomStringUtils.randomAlphabetic(8);
+    workspaceService.createGcpCloudContext(
+        workspaceId, makeContextJobId, userAccessUtils.defaultUserAuthRequest());
+    jobService.waitForJob(makeContextJobId);
+    AsyncJobResult<GcpCloudContext> createContextJobResult =
+        jobService.retrieveAsyncJobResult(
+            makeContextJobId, GcpCloudContext.class, userAccessUtils.defaultUserAuthRequest());
+    assertEquals(StatusEnum.SUCCEEDED, createContextJobResult.getJobReport().getStatus());
+    GcpCloudContext gcpContext = createContextJobResult.getResult();
+
+    // Create a private dataset for secondary user
+    String datasetId = RandomStringUtils.randomAlphabetic(8);
+    ControlledBigQueryDatasetResource privateDataset = buildPrivateDataset(workspaceId, datasetId);
+    assertNotNull(privateDataset);
+
+    // Validate with Sam that secondary user can read their private resource
+    assertTrue(
+        samService.isAuthorized(
+            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            privateDataset.getCategory().getSamResourceName(),
+            privateDataset.getResourceId().toString(),
+            SamControlledResourceActions.WRITE_ACTION));
+
+    // Run the "removeUser" flight to the very end, then undo it
+    FlightDebugInfo failingDebugInfo = FlightDebugInfo.newBuilder().lastStepFailure(true).build();
+    FlightMap inputParameters = new FlightMap();
+    inputParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString());
+    inputParameters.put(
+        WorkspaceFlightMapKeys.USER_TO_REMOVE, userAccessUtils.getSecondUserEmail());
+    inputParameters.put(
+        WorkspaceFlightMapKeys.ROLE_TO_REMOVE, ControlledResourceIamRole.WRITER.name());
+    // Auth info comes from default user, as they are the ones "making this request"
+    inputParameters.put(
+        JobMapKeys.AUTH_USER_INFO.getKeyName(), userAccessUtils.defaultUserAuthRequest());
+    FlightState flightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            RemoveUserFromWorkspaceFlight.class,
+            inputParameters,
+            STAIRWAY_FLIGHT_TIMEOUT,
+            failingDebugInfo);
+    assertEquals(FlightStatus.ERROR, flightState.getFlightStatus());
+
+    // Validate that secondary user is still a workspace writer and can still read their private
+    // resource.
+    assertTrue(
+        samService.isAuthorized(
+            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            SamConstants.SAM_WORKSPACE_RESOURCE,
+            workspaceId.toString(),
+            SamConstants.SAM_WORKSPACE_WRITE_ACTION));
+    assertTrue(
+        samService.isAuthorized(
+            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            privateDataset.getCategory().getSamResourceName(),
+            privateDataset.getResourceId().toString(),
+            SamControlledResourceActions.WRITE_ACTION));
+
+    // Run the flight again, this time to success.
+    FlightDebugInfo passingDebugInfo = FlightDebugInfo.newBuilder().build();
+    FlightState passingFlightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            RemoveUserFromWorkspaceFlight.class,
+            inputParameters,
+            STAIRWAY_FLIGHT_TIMEOUT,
+            passingDebugInfo);
+    assertEquals(FlightStatus.SUCCESS, passingFlightState.getFlightStatus());
+
+    // Verify the secondary user can no longer access the workspace or their private resource
+    assertFalse(
+        samService.isAuthorized(
+            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            SamConstants.SAM_WORKSPACE_RESOURCE,
+            workspaceId.toString(),
+            SamConstants.SAM_WORKSPACE_WRITE_ACTION));
+    assertFalse(
+        samService.isAuthorized(
+            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            privateDataset.getCategory().getSamResourceName(),
+            privateDataset.getResourceId().toString(),
+            SamControlledResourceActions.WRITE_ACTION));
+
+    // Cleanup
+    workspaceService.deleteWorkspace(workspaceId, userAccessUtils.defaultUserAuthRequest());
+  }
+
+  private ControlledBigQueryDatasetResource buildPrivateDataset(
+      UUID workspaceId, String datasetName) {
+    ControlledBigQueryDatasetResource datasetToCreate =
+        ControlledBigQueryDatasetResource.builder()
+            .workspaceId(workspaceId)
+            .resourceId(UUID.randomUUID())
+            .name(datasetName)
+            .cloningInstructions(CloningInstructions.COPY_NOTHING)
+            .assignedUser(userAccessUtils.getSecondUserEmail())
+            .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
+            .managedBy(ManagedByType.MANAGED_BY_USER)
+            .datasetName(datasetName)
+            .build();
+    ApiGcpBigQueryDatasetCreationParameters datasetCreationParameters =
+        new ApiGcpBigQueryDatasetCreationParameters()
+            .datasetId(datasetName)
+            .location("us-central1");
+    List<ControlledResourceIamRole> privateRoles =
+        ImmutableList.of(ControlledResourceIamRole.WRITER, ControlledResourceIamRole.EDITOR);
+    return controlledResourceService.createBigQueryDataset(
+        datasetToCreate,
+        datasetCreationParameters,
+        privateRoles,
+        userAccessUtils.secondUserAuthRequest());
+  }
+}


### PR DESCRIPTION
This change revokes users' access to private resources when they are removed from a workspace (i.e. when their last role in a workspace is revoked). Previously, users would maintain private resource access even when they were no longer in the workspace.

This can only handle cases where users are direct members of a workspace. WSM does not manage groups, and so cannot remove users from a workspace if they have access via a group. However, WSM can check that users have access, and will not revoke private resource access if a user still has workspace access via a group.

As part of this change, I also made two unrelated fixes:
- Controlled GCS buckets now have uniform project level access enabled. This is in line with the Terra IAM model of resources as the most granular permissions.
- Access to private Notebook service accounts now happens via Sam group instead of directly granting users cloud permissions. This is in line with how other controlled resources manage GCP permissions.