### PR TITLE
[PF-765] Remove project-level SA permissions

### DIFF
--- a/integration/src/main/java/scripts/testscripts/EnablePet.java
+++ b/integration/src/main/java/scripts/testscripts/EnablePet.java
@@ -35,9 +35,7 @@ public class EnablePet extends WorkspaceAllocateTestScriptBase {
     GoogleApi samGoogleApi = SamClientUtils.samGoogleApi(testUser, server);
     String petSaEmail = samGoogleApi.getPetServiceAccount(projectId);
     Iam userIamClient = ClientTestUtils.getGcpIamClient(testUser);
-    // TODO(PF-765): This will fail until project level SA permissions are removed, as the user
-    //   gets this permission at the project level.
-    // assertFalse(canImpersonateSa(userIamClient, petSaEmail));
+    assertFalse(canImpersonateSa(userIamClient, petSaEmail));
 
     String returnedPetSaEmail = userWorkspaceApi.enablePet(getWorkspaceId());
     assertEquals(petSaEmail, returnedPetSaEmail);
@@ -51,8 +49,7 @@ public class EnablePet extends WorkspaceAllocateTestScriptBase {
     String petEnableResult = petSaWorkspaceApi.enablePet(getWorkspaceId());
     assertEquals(petSaEmail, petEnableResult);
     Iam petIamClient = ClientTestUtils.getGcpIamClientFromToken(petSaToken);
-    // TODO(PF-765): This will fail until project level SA permissions are removed, as the pet SA
-    //   gets this permission at the project level.
+    // TODO(PF-991): This will fail until pet SA self-impersonation is fixed.
     // assertFalse(canImpersonateSa(petIamClient, petSaEmail));
   }
 

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -123,9 +124,8 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
     Instance instance = userNotebooks.projects().locations().instances().get(instanceName)
         .execute();
 
-    // TODO(PF-765): Assert that the other user does not have proxy access once we don't have
-    // project level service account permissions.
     assertUserHasProxyAccess(resourceUser, instance, resource.getAttributes().getProjectId());
+    // assertFalse(ResourceModifier.userHasProxyAccess());
     // The user should be able to stop their notebook.
     userNotebooks.projects().locations().instances().stop(instanceName, new StopInstanceRequest());
 

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -46,9 +46,6 @@ public class CloudSyncRoleMapping {
       new ImmutableList.Builder<String>()
           .addAll(PROJECT_READER_PERMISSIONS)
           .add(
-              // TODO(wchambers): Revise service account permissions when there are controlled
-              // resources for service accounts. (Also used by NextFlow)
-              "iam.serviceAccounts.actAs",
               "iam.serviceAccounts.get",
               "iam.serviceAccounts.list",
               "lifesciences.operations.cancel",

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -31,10 +31,10 @@ import bio.terra.workspace.service.workspace.model.WorkspaceRequest;
 import com.google.api.services.iam.v1.model.Binding;
 import com.google.api.services.iam.v1.model.Policy;
 import com.google.api.services.iam.v1.model.SetIamPolicyRequest;
+import com.google.common.collect.ImmutableList;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -367,10 +367,12 @@ public class WorkspaceService {
     try {
       Policy saPolicy =
           crlService.getIamCow().projects().serviceAccounts().getIamPolicy(petSaName).execute();
+      // TODO(PF-991): In the future, the pet SA should not be included in this binding. This is a
+      //  workaround to support Nextflow and other applications which call Pipelines API.
       Binding saUserBinding =
           new Binding()
               .setRole(serviceAccountUserRole)
-              .setMembers(Collections.singletonList("user:" + userEmail));
+              .setMembers(ImmutableList.of("user:" + userEmail, "serviceAccount:" + petSaEmail));
       // If no bindings exist, getBindings() returns null instead of an empty list.
       List<Binding> bindingList =
           Optional.ofNullable(saPolicy.getBindings()).orElse(new ArrayList<>());

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -369,7 +369,8 @@ public class WorkspaceService {
       Policy saPolicy =
           crlService.getIamCow().projects().serviceAccounts().getIamPolicy(petSaName).execute();
       // TODO(PF-991): In the future, the pet SA should not be included in this binding. This is a
-      //  workaround to support Nextflow and other applications which call Pipelines API.
+      //  workaround to support the CLI and other applications which call the GCP Pipelines API with
+      //  the pet SA's credentials.
       Binding saUserBinding =
           new Binding()
               .setRole(serviceAccountUserRole)

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -349,11 +349,10 @@ public class WorkspaceService {
   public String enablePetServiceAccountImpersonation(
       UUID workspaceId, AuthenticatedUserRequest userRequest) {
     final String serviceAccountUserRole = "roles/iam.serviceAccountUser";
-    // Validate that the user is at least a writer in this workspace, as only writers can run
-    // workflows.
+    // Validate that the user is a member of the workspace.
     Workspace workspace =
         validateWorkspaceAndAction(
-            userRequest, workspaceId, SamConstants.SAM_WORKSPACE_WRITE_ACTION);
+            userRequest, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     stageService.assertMcWorkspace(workspace, "enablePet");
 
     // getEmailFromToken will always call Sam, which will return a user email even if the requesting


### PR DESCRIPTION
Followup to #427 and https://github.com/DataBiosphere/terra-cli/pull/134 which removes the project-level SA permissions WSM previously granted in workspaces. As a temporary workaround for the CLI, this continues to allow pet SA self-impersonation (tracking in PF-991).

Additionally, this lowers the role required to call the `enablePet` endpoint from WRITER to READER to align with the CLI approach of calling this endpoint as soon as users create or load a workspace. This does not change the role required to run Pipelines API jobs, which is still WRITER.

This should not merge before https://github.com/DataBiosphere/terra-cli/pull/134.