### PR TITLE
[PF-937] Fix email check when removing users

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -415,9 +416,12 @@ public class WorkspaceService {
     // Before launching the flight, validate that the user being removed is a direct member of the
     // specified role. Users may also be added to a workspace via managed groups, but WSM does not
     // control membership of those groups, and so cannot remove them here.
+    // All emails are compared as lowercase strings.
     List<String> roleMembers =
-        samService.listUsersWithWorkspaceRole(workspaceId, role, executingUserRequest);
-    if (!roleMembers.contains(targetUserEmail)) {
+        samService.listUsersWithWorkspaceRole(workspaceId, role, executingUserRequest).stream()
+            .map(String::toLowerCase)
+            .collect(Collectors.toList());
+    if (!roleMembers.contains(targetUserEmail.toLowerCase())) {
       return;
     }
     jobService


### PR DESCRIPTION
#431 added additional functionality as part of removing a user from a workspace. However, it also introduced a bug when checking whether a user is a direct member of a workspace. Sam will always return user emails as lowercase strings, but WSM is comparing those to user-provided strings without lowercasing. This meant calls to remove a user would always do nothing if the provided `userEmail` was not all lowercase already.