### PR TITLE
[PF-949] use self hosted runners for nightly tests

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -16,11 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # On the self-hosted runner we need to install postgres ourselves. The process is:
-      # Create the file repository configuration.
-      # Import the repository signing key.
-      # Update the package lists.
-      # Install the latest version of PostgreSQL. If you want a specific version, use 'postgresql-12' or similar instead of 'postgresql':
+      # On the self-hosted runner we need to install additional software ourselves
+      - name: Install wget
+        run: apt-get install wget
+
+      # Install postgres:
+      # - Create the file repository configuration.
+      # - Import the repository signing key.
+      # - Update the package lists.
+      # - Install the latest version of PostgreSQL. If you want a specific version, use 'postgresql-12' or similar instead of 'postgresql':
       - name: Install the latest postgres
         run: |
             sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -16,10 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # On the self-hosted runner we need to install additional software ourselves
-      - name: Install wget
-        run: apt-get install wget
-
       # Install postgres:
       # - Create the file repository configuration.
       # - Import the repository signing key.
@@ -27,10 +23,10 @@ jobs:
       # - Install the latest version of PostgreSQL. If you want a specific version, use 'postgresql-12' or similar instead of 'postgresql':
       - name: Install the latest postgres
         run: |
-            sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-            sudo apt-get update
-            sudo apt-get -y install postgresql
+            sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+            curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+            apt-get update
+            apt-get -y install postgresql
 
       - name: Set up AdoptOpenJDK 11
         uses: joschi/setup-jdk@v2

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -66,12 +66,23 @@ jobs:
           vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
           target: wsmtest
 
+      # The ArgoCD sync triggers the synchronization of the wsmtest cluster. Typically,
+      # the cluster is reset within a few seconds. However, it is possible for it to take
+      # minutes or hours. We have no way to check that the sync is complete. We sleep
+      # for a bit and just accept that in some crazy long cases, these tests will fail.
+      # The sync is bracketed by /version probes so we have the pre and post sync versions
+      # in the log.
       - name: ArgoCD sync
         run: |
+          version=$(curl https://workspace.wsmtest.integ.envs.broadinstitute.org/version)
+          echo "pre-sync wsmtest version: $version"
           curl --fail --silent --show-error --location --request POST \
           'https://ap-argocd.dsp-devops.broadinstitute.org/api/v1/applications/workspacemanager-wsmtest/sync' \
           --header "Authorization: Bearer ${{ secrets.WSMTEST_SYNC_ARGOCD_TOKEN }}" \
           | jq .operation
+          sleep 30
+          version=$(curl https://workspace.wsmtest.integ.envs.broadinstitute.org/version)
+          echo "post-sync wsmtest version: $version"
 
       - name: clean databases before integration suite
         if: always()

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -75,14 +75,14 @@ jobs:
       - name: ArgoCD sync
         run: |
           version=$(curl https://workspace.wsmtest.integ.envs.broadinstitute.org/version)
-          echo "pre-sync wsmtest version: $version"
+          echo "$(date "+%Y-%m-%dT%H:%M:%S") pre-sync wsmtest version: $version"
           curl --fail --silent --show-error --location --request POST \
           'https://ap-argocd.dsp-devops.broadinstitute.org/api/v1/applications/workspacemanager-wsmtest/sync' \
           --header "Authorization: Bearer ${{ secrets.WSMTEST_SYNC_ARGOCD_TOKEN }}" \
           | jq .operation
-          sleep 30
+          sleep 120
           version=$(curl https://workspace.wsmtest.integ.envs.broadinstitute.org/version)
-          echo "post-sync wsmtest version: $version"
+          echo "$(date "+%Y-%m-%dT%H:%M:%S") post-sync wsmtest version: $version"
 
       - name: clean databases before integration suite
         if: always()

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,5 +1,5 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+# This workflow runs the WSM full regression tests, including perf, integration, and
+# resilience suites.
 
 name: Nightly Tests
 
@@ -11,7 +11,7 @@ on:
 jobs:
   nightly-tests:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v2
@@ -53,6 +53,13 @@ jobs:
         with:
           vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
           target: wsmtest
+
+      - name: ArgoCD sync
+        run: |
+          curl --fail --silent --show-error --location --request POST \
+          'https://ap-argocd.dsp-devops.broadinstitute.org/api/v1/applications/workspacemanager-wsmtest/sync' \
+          --header "Authorization: Bearer ${{ secrets.WSMTEST_SYNC_ARGOCD_TOKEN }}" \
+          | jq .operation
 
       - name: clean databases before integration suite
         if: always()

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - uses: actions/checkout@v2
+
       # On the self-hosted runner we need to install postgres ourselves. The process is:
       # Create the file repository configuration.
       # Import the repository signing key.
@@ -25,8 +27,6 @@ jobs:
             wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
             sudo apt-get update
             sudo apt-get -y install postgresql
-
-      - uses: actions/checkout@v2
 
       - name: Set up AdoptOpenJDK 11
         uses: joschi/setup-jdk@v2

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -14,6 +14,18 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      # On the self-hosted runner we need to install postgres ourselves. The process is:
+      # Create the file repository configuration.
+      # Import the repository signing key.
+      # Update the package lists.
+      # Install the latest version of PostgreSQL. If you want a specific version, use 'postgresql-12' or similar instead of 'postgresql':
+      - name: Install the latest postgres
+        run: |
+            sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+            sudo apt-get update
+            sudo apt-get -y install postgresql
+
       - uses: actions/checkout@v2
 
       - name: Set up AdoptOpenJDK 11


### PR DESCRIPTION
DevOps set up hosted runners for github actions. There are VMs within the Broad perimeter and therefore can access the ArgoCD server. That allows the nightly test to poke ArgoCD to update the software on the `wsmtest` cluster ahead of running the tests.

Since these are running with our own container, they do not have all of the software that comes with the github runners. So the big change in this flow is installing postgres ahead of running the tests.
