### PR TITLE
[no ticket] use SA cow

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/RetrieveBigQueryDatasetCloudAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/RetrieveBigQueryDatasetCloudAttributesStep.java
@@ -48,7 +48,7 @@ public class RetrieveBigQueryDatasetCloudAttributesStep implements Step {
     // from the source dataset.
     final String projectId =
         workspaceService.getRequiredGcpProject(datasetResource.getWorkspaceId());
-    final BigQueryCow bigQueryCow = crlService.createBigQueryCow(userRequest);
+    final BigQueryCow bigQueryCow = crlService.createWsmSaBigQueryCow();
     try {
       final Dataset dataset =
           bigQueryCow.datasets().get(projectId, datasetResource.getDatasetName()).execute();


### PR DESCRIPTION
Hit an error when running in the CLI test framework that the call to get the BigQuery datasets had insufficient scopes. We should be using the WSM SA for this anyway from what I can tell.