### PR TITLE
[PF-985] Azure PoC authn

### DIFF
--- a/AZURE_POC.md
+++ b/AZURE_POC.md
@@ -55,3 +55,15 @@ public class Foo {
   }
 }
 ```
+
+## Testing
+
+### Running Tests
+You can run the azure-specific tests like this:
+```shell script
+./gradlew :service:azureTest
+```
+
+### Developing Tests
+To add a test that will run as part of the `azureTest` gradle task, simply derive your
+test from `BaseAzureTest`.

--- a/AZURE_POC.md
+++ b/AZURE_POC.md
@@ -24,12 +24,6 @@ or by setting the envvar:
 export SPRING_PROFILES_ACTIVE='azure'
 ```
 
-An alternative is to use `SPRING_PROFILES_INCLUDE` to include the profile without overriding
-other profiles that have been set. For example, my personal setup is:
-```shell script
-export SPRING_PROFILES_INCLUDE=dd,azure,human-readable-logging
-```
-
 ## Feature Control
 You can conditionally include Azure features by autowiring the `AzureState` component
 and then testing its `isEnabled()` method. The boolean response is determined based on

--- a/AZURE_POC.md
+++ b/AZURE_POC.md
@@ -1,0 +1,57 @@
+# Azure PoC
+
+This file describes the Azure PoC branch. The purpose of the PoC is to prototype how workspace
+manager might work on Azure. The goals and approach are described in
+[WSM for Azure PoC](https://docs.google.com/document/d/1N3FlbnLw8LotLQ4bKRB8vEkJlbAF3evuz8bK9ZV-PUg/edit#heading=h.tg5lhyvrdvny).
+
+## azure-poc branch
+The azure-poc branch holds the integrated code that for running the PoC. The expectation is that
+developers will branch off of the azure-poc branch and will make PRs to merge onto the branch. As
+this is a PoC, we will not require code reviews. Merged code should compile and pass the WSM unit
+and connected tests. It should also pass whatever azure-poc tests we have deployed at the time.
+
+Ideally, we will be able to pull from the`main` branch into the `azure-poc` branch to keep it
+current with ongoing WSM feature development.
+
+## Enabling the PoC Features
+We use the `azure` profile to enable the PoC features. That can be enabled on the gradle
+command line like this:
+```text
+./gradlew :service:bootRun --args='--spring.profiles.active=azure'
+``` 
+or by setting the envvar:
+```shell script
+export SPRING_PROFILES_ACTIVE='azure'
+```
+
+An alternative is to use `SPRING_PROFILES_INCLUDE` to include the profile without overriding
+other profiles that have been set. For example, my personal setup is:
+```shell script
+export SPRING_PROFILES_INCLUDE=dd,azure,human-readable-logging
+```
+
+## Feature Control
+You can conditionally include Azure features by autowiring the `AzureState` component
+and then testing its `isEnabled()` method. The boolean response is determined based on
+setting the `azure` profile. For example,
+```java
+public class Foo {
+  private final AzureState azureState;
+
+
+  // This is the preferred constructor form of autowiring
+  @Autowired
+  public Foo(AzureState azureState) {
+    this.azureState = azureState;
+  }
+
+  public void doSomething() {
+    // Common idiom for checking if we are running the Azure Poc
+    if (azureState.isEnabled()) {
+      // do azure stuff
+    } else {
+      // do existing stuff
+    }
+  }
+}
+```

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -210,6 +210,13 @@ task connectedTest(type: Test) {
     outputs.upToDateWhen { false }
 }
 
+task azureTest(type: Test) {
+    useJUnitPlatform {
+        includeTags "azure"
+    }
+    outputs.upToDateWhen { false }
+}
+
 spotless {
     java {
         googleJavaFormat()

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
@@ -1,0 +1,56 @@
+package bio.terra.workspace.app.configuration.external;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/** Azure POC code */
+@EnableConfigurationProperties
+@EnableTransactionManagement
+@ConfigurationProperties(prefix = "workspace.azure")
+public class AzureConfiguration {
+
+  /** tenant where WSM managed app is deployed */
+  private String tenantId;
+
+  /** MRG id */
+  private String managedResourceGroupId;
+
+  /** clientId for access to the MRG */
+  private String clientId;
+
+  /** clientSecret for access to the MRG */
+  private String clientSecret;
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public String getManagedResourceGroupId() {
+    return managedResourceGroupId;
+  }
+
+  public void setManagedResourceGroupId(String managedResourceGroupId) {
+    this.managedResourceGroupId = managedResourceGroupId;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public void setClientId(String clientId) {
+    this.clientId = clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public void setClientSecret(String clientSecret) {
+    this.clientSecret = clientSecret;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureState.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureState.java
@@ -1,0 +1,5 @@
+package bio.terra.workspace.app.configuration.external;
+
+public interface AzureState {
+  boolean isEnabled();
+}

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureStateDisabled.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureStateDisabled.java
@@ -1,0 +1,13 @@
+package bio.terra.workspace.app.configuration.external;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!azure")
+public class AzureStateDisabled implements AzureState {
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureStateEnabled.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureStateEnabled.java
@@ -1,0 +1,13 @@
+package bio.terra.workspace.app.configuration.external;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("azure")
+public class AzureStateEnabled implements AzureState {
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -98,7 +98,11 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<ApiCreatedWorkspace> createWorkspace(
       @RequestBody ApiCreateWorkspaceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    logger.info("Creating workspace {} for {}", body.getId(), userRequest.getEmail());
+    logger.info(
+        "Creating workspace {} for {} subject {}",
+        body.getId(),
+        userRequest.getEmail(),
+        userRequest.getSubjectId());
 
     // Existing client libraries should not need to know about the stage, as they won't use any of
     // the features it gates. If stage isn't specified in a create request, we default to

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
 import bio.terra.cloudres.google.iam.ServiceAccountName;
+import bio.terra.workspace.app.configuration.external.AzureState;
 import bio.terra.workspace.app.configuration.external.BufferServiceConfiguration;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.crl.CrlService;
@@ -63,6 +64,7 @@ public class WorkspaceService {
   private final BufferServiceConfiguration bufferServiceConfiguration;
   private final StageService stageService;
   private final CrlService crlService;
+  private final AzureState azureState;
 
   @Autowired
   public WorkspaceService(
@@ -72,7 +74,8 @@ public class WorkspaceService {
       SpendProfileService spendProfileService,
       BufferServiceConfiguration bufferServiceConfiguration,
       StageService stageService,
-      CrlService crlService) {
+      CrlService crlService,
+      AzureState azureState) {
     this.jobService = jobService;
     this.workspaceDao = workspaceDao;
     this.samService = samService;
@@ -80,6 +83,7 @@ public class WorkspaceService {
     this.bufferServiceConfiguration = bufferServiceConfiguration;
     this.stageService = stageService;
     this.crlService = crlService;
+    this.azureState = azureState;
   }
 
   /** Create a workspace with the specified parameters. Returns workspaceID of the new workspace. */
@@ -88,6 +92,12 @@ public class WorkspaceService {
       WorkspaceRequest workspaceRequest, AuthenticatedUserRequest userRequest) {
 
     String description = "Create workspace " + workspaceRequest.workspaceId().toString();
+
+    // TODO: finish this. Just using it to test basic auth
+    if (azureState.isEnabled()) {
+      return UUID.randomUUID();
+    }
+
     JobBuilder createJob =
         jobService
             .newJob(

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -3033,7 +3033,12 @@ components:
             openid: open id authorization
             email: email authorization
             profile: profile authorization
+    ## for AzurePoC - we do not do authn. Just accept the user email and objectId as user/pwd
+    basicAuth:
+      type: http
+      scheme: basic
 
 security:
   - bearerAuth: []
   - authorization: [openid, email, profile]
+  - basicAuth: []

--- a/service/src/main/resources/application-azure.yml
+++ b/service/src/main/resources/application-azure.yml
@@ -1,0 +1,8 @@
+# Azure setup - we may not want a common setup here, but rather use envvars to supply these
+# in different environments
+workspace:
+  azure:
+    tenantId: TBD
+    managedResourceGroupId: TBD
+    clientId: TBD
+    clientSecret: TBD

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/AzureStateDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/AzureStateDisabledTest.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.app.configuration.external;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import bio.terra.workspace.common.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class AzureStateDisabledTest extends BaseUnitTest {
+
+  @Autowired private AzureState azureState;
+
+  @Test
+  void azureIsEnableTest() {
+    assertFalse(azureState.isEnabled(), "azure is not enabled");
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/AzureStateEnabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/AzureStateEnabledTest.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.app.configuration.external;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.workspace.common.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("azure")
+public class AzureStateEnabledTest extends BaseUnitTest {
+
+  @Autowired private AzureState azureState;
+
+  @Test
+  void azureIsEnableTest() {
+    assertTrue(azureState.isEnabled(), "azure is enabled");
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureTest.java
@@ -1,0 +1,11 @@
+package bio.terra.workspace.common;
+
+import org.junit.jupiter.api.Tag;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Base class for azure tests. Treat these as connected tests: connected to Azure
+ */
+@Tag("azure")
+@ActiveProfiles("azure-test")
+public class BaseAzureTest extends BaseTest {}

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureTest.java
@@ -3,9 +3,7 @@ package bio.terra.workspace.common;
 import org.junit.jupiter.api.Tag;
 import org.springframework.test.context.ActiveProfiles;
 
-/**
- * Base class for azure tests. Treat these as connected tests: connected to Azure
- */
+/** Base class for azure tests. Treat these as connected tests: connected to Azure */
 @Tag("azure")
 @ActiveProfiles("azure-test")
 public class BaseAzureTest extends BaseTest {}


### PR DESCRIPTION
- Enabled basic auth in the OpenAPI, so it gets passed through.
- Restructured `ProxiedAuthenticatedUserRequest` to handle the additional choice
- Added logging and fast return for create workspace so I could hand-test the auth change.