### PR TITLE
[PF-985] Azure PoC authn

### DIFF
--- a/AZURE_POC.md
+++ b/AZURE_POC.md
@@ -17,17 +17,11 @@ current with ongoing WSM feature development.
 We use the `azure` profile to enable the PoC features. That can be enabled on the gradle
 command line like this:
 ```text
-./gradlew :service:bootRun --args='--spring.profiles.active=azure'
+./gradlew :service:bootRun --args='--spring.profiles.active=azure,human-readable-logging'
 ``` 
 or by setting the envvar:
 ```shell script
 export SPRING_PROFILES_ACTIVE='azure'
-```
-
-An alternative is to use `SPRING_PROFILES_INCLUDE` to include the profile without overriding
-other profiles that have been set. For example, my personal setup is:
-```shell script
-export SPRING_PROFILES_INCLUDE=dd,azure,human-readable-logging
 ```
 
 ## Feature Control

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -98,7 +98,11 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<ApiCreatedWorkspace> createWorkspace(
       @RequestBody ApiCreateWorkspaceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    logger.info("Creating workspace {} for {}", body.getId(), userRequest.getEmail());
+    logger.info(
+        "Creating workspace {} for {} subject {}",
+        body.getId(),
+        userRequest.getEmail(),
+        userRequest.getSubjectId());
 
     // Existing client libraries should not need to know about the stage, as they won't use any of
     // the features it gates. If stage isn't specified in a create request, we default to

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
 import bio.terra.cloudres.google.iam.ServiceAccountName;
+import bio.terra.workspace.app.configuration.external.AzureState;
 import bio.terra.workspace.app.configuration.external.BufferServiceConfiguration;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.crl.CrlService;
@@ -63,6 +64,7 @@ public class WorkspaceService {
   private final BufferServiceConfiguration bufferServiceConfiguration;
   private final StageService stageService;
   private final CrlService crlService;
+  private final AzureState azureState;
 
   @Autowired
   public WorkspaceService(
@@ -72,7 +74,8 @@ public class WorkspaceService {
       SpendProfileService spendProfileService,
       BufferServiceConfiguration bufferServiceConfiguration,
       StageService stageService,
-      CrlService crlService) {
+      CrlService crlService,
+      AzureState azureState) {
     this.jobService = jobService;
     this.workspaceDao = workspaceDao;
     this.samService = samService;
@@ -80,6 +83,7 @@ public class WorkspaceService {
     this.bufferServiceConfiguration = bufferServiceConfiguration;
     this.stageService = stageService;
     this.crlService = crlService;
+    this.azureState = azureState;
   }
 
   /** Create a workspace with the specified parameters. Returns workspaceID of the new workspace. */
@@ -88,6 +92,12 @@ public class WorkspaceService {
       WorkspaceRequest workspaceRequest, AuthenticatedUserRequest userRequest) {
 
     String description = "Create workspace " + workspaceRequest.workspaceId().toString();
+
+    // TODO: finish this. Just using it to test basic auth
+    if (azureState.isEnabled()) {
+      return UUID.randomUUID();
+    }
+
     JobBuilder createJob =
         jobService
             .newJob(

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -3033,7 +3033,12 @@ components:
             openid: open id authorization
             email: email authorization
             profile: profile authorization
+    ## for AzurePoC - we do not do authn. Just accept the user email and objectId as user/pwd
+    basicAuth:
+      type: http
+      scheme: basic
 
 security:
   - bearerAuth: []
   - authorization: [openid, email, profile]
+  - basicAuth: []

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureTest.java
@@ -3,7 +3,9 @@ package bio.terra.workspace.common;
 import org.junit.jupiter.api.Tag;
 import org.springframework.test.context.ActiveProfiles;
 
-/** Base class for azure tests. Treat these as connected tests: connected to Azure */
+/**
+ * Base class for azure tests. Treat these as connected tests: connected to Azure
+ */
 @Tag("azure")
 @ActiveProfiles("azure-test")
 public class BaseAzureTest extends BaseTest {}

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureTest.java
@@ -3,9 +3,7 @@ package bio.terra.workspace.common;
 import org.junit.jupiter.api.Tag;
 import org.springframework.test.context.ActiveProfiles;
 
-/**
- * Base class for azure tests. Treat these as connected tests: connected to Azure
- */
+/** Base class for azure tests. Treat these as connected tests: connected to Azure */
 @Tag("azure")
 @ActiveProfiles("azure-test")
 public class BaseAzureTest extends BaseTest {}


### PR DESCRIPTION
- Enable basic auth in OpenApi spec for REST API
- Restructure `ProxiedAuthenticatedUserRequestFactory` to handle the additional option; only available when azure profile is enabled.
- When azure is enabled, stub out createWorkspace so it just logs the basic auth info; temporary for hand-testing.
