### PR TITLE
[PF-992] Make SamService more consistent

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -33,6 +33,7 @@ import bio.terra.workspace.generated.model.ApiUpdateControlledGcpBigQueryDataset
 import bio.terra.workspace.generated.model.ApiUpdateControlledGcpGcsBucketRequestBody;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
+import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.job.JobService;
@@ -547,7 +548,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
         .map(ApiPrivateResourceUser::getUserName)
         .orElseGet(
             () ->
-                SamService.rethrowIfSamInterrupted(
+                SamRethrow.onInterrupted(
                     () -> samService.getRequestUserEmail(userRequest), "getRequestUserEmail"));
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -29,6 +29,7 @@ import bio.terra.workspace.generated.model.ApiWorkspaceDescriptionList;
 import bio.terra.workspace.generated.model.ApiWorkspaceStageModel;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
+import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.exception.InvalidRoleException;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
@@ -358,7 +359,7 @@ public class WorkspaceApiController implements WorkspaceApi {
       throw new InvalidRoleException(
           "Users cannot grant role APPLICATION. Use application registration instead.");
     }
-    SamService.rethrowIfSamInterrupted(
+    SamRethrow.onInterrupted(
         () ->
             samService.grantWorkspaceRole(
                 id, getAuthenticatedInfo(), WsmIamRole.fromApiModel(role), body.getMemberEmail()),
@@ -385,7 +386,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   @Override
   public ResponseEntity<ApiRoleBindingList> getRoles(@PathVariable("workspaceId") UUID id) {
     List<bio.terra.workspace.service.iam.model.RoleBinding> bindingList =
-        SamService.rethrowIfSamInterrupted(
+        SamRethrow.onInterrupted(
             () -> samService.listRoleBindings(id, getAuthenticatedInfo()), "listRoleBindings");
     ApiRoleBindingList responseList = new ApiRoleBindingList();
     for (bio.terra.workspace.service.iam.model.RoleBinding roleBinding : bindingList) {

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamRethrow.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamRethrow.java
@@ -1,0 +1,60 @@
+package bio.terra.workspace.service.iam;
+
+import bio.terra.common.sam.exception.SamExceptionFactory;
+
+/**
+ * When we use Sam in flights, we want to let InterruptedException fly and be caught by Stairway.
+ * However, when we use Sam outside of flights, we want to propagate the Interrupted exception.
+ * These static methods perform that propagation.
+ */
+public class SamRethrow {
+
+  /**
+   * For use with onInterrupted methods.
+   *
+   * @param <R>
+   */
+  @FunctionalInterface
+  public interface InterruptedSupplier<R> {
+    R apply() throws InterruptedException;
+  }
+
+  /** For use with onInterrupted. */
+  public interface VoidInterruptedSupplier {
+    void apply() throws InterruptedException;
+  }
+
+  /**
+   * Use this function outside of Flights. In that case, we do not expect SamRetry to be interrupted
+   * so the interruption is unexpected and should be surfaced all the way up as an unchecked
+   * exception, which this function does.
+   *
+   * <p>Usage: SamRethrow.onInterrupted(() -> samService.isAuthorized(...), "isAuthorized")) {
+   *
+   * @param function The SamService function to call.
+   * @param operation The name of the function to use in the error message.
+   * @param <T> The return type of the function to call.
+   * @return The return value of the function to call.
+   */
+  public static <T> T onInterrupted(InterruptedSupplier<T> function, String operation) {
+    try {
+      return function.apply();
+    } catch (InterruptedException e) {
+      throw SamExceptionFactory.create("Interrupted during Sam operation " + operation, e);
+    }
+  }
+
+  /**
+   * Like above, but for functions that return void.
+   *
+   * @param function The SamService function to call.
+   * @param operation The name of the function to use in the error message.
+   */
+  public static void onInterrupted(VoidInterruptedSupplier function, String operation) {
+    try {
+      function.apply();
+    } catch (InterruptedException e) {
+      throw SamExceptionFactory.create("Interrupted during Sam operation " + operation, e);
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamRethrow.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamRethrow.java
@@ -12,7 +12,7 @@ public class SamRethrow {
   /**
    * For use with onInterrupted methods.
    *
-   * @param <R>
+   * @param <R> return parameter from the implementation
    */
   @FunctionalInterface
   public interface InterruptedSupplier<R> {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.resource.controlled;
 
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceActions;
 import bio.terra.workspace.service.resource.ValidationUtils;
@@ -79,7 +80,7 @@ public class ControlledResourceMetadataManager {
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId, String action) {
     WsmResource resource = resourceDao.getResource(workspaceId, resourceId);
     ControlledResource controlledResource = resource.castToControlledResource();
-    SamService.rethrowIfSamInterrupted(
+    SamRethrow.onInterrupted(
         () ->
             samService.checkAuthz(
                 userRequest,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -10,6 +10,7 @@ import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketUpdateParameters;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceActions;
@@ -407,7 +408,7 @@ public class ControlledResourceService {
       return;
     }
     final String requestUserEmail =
-        SamService.rethrowIfSamInterrupted(
+        SamRethrow.onInterrupted(
             () -> samService.getRequestUserEmail(userRequest), "validateOnlySelfAssignment");
     // If there is no assigned user, this condition is satisfied.
     //noinspection deprecation

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.spendprofile;
 
 import bio.terra.workspace.app.configuration.external.SpendProfileConfiguration;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.spendprofile.exceptions.SpendUnauthorizedException;
@@ -44,10 +45,10 @@ public class SpendProfileService {
    */
   public SpendProfile authorizeLinking(
       SpendProfileId spendProfileId, AuthenticatedUserRequest userRequest) {
-    if (!SamService.rethrowIfSamInterrupted(
+    if (!SamRethrow.onInterrupted(
         () ->
             samService.isAuthorized(
-                userRequest.getRequiredToken(),
+                userRequest,
                 SamConstants.SPEND_PROFILE_RESOURCE,
                 spendProfileId.id(),
                 SamConstants.SPEND_PROFILE_LINK_ACTION),

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -5,6 +5,7 @@ import bio.terra.workspace.app.configuration.external.BufferServiceConfiguration
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
@@ -135,7 +136,7 @@ public class WorkspaceService {
   public Workspace validateWorkspaceAndAction(
       AuthenticatedUserRequest userRequest, UUID workspaceId, String action) {
     Workspace workspace = workspaceDao.getWorkspace(workspaceId);
-    SamService.rethrowIfSamInterrupted(
+    SamRethrow.onInterrupted(
         () ->
             samService.checkAuthz(
                 userRequest, SamConstants.SAM_WORKSPACE_RESOURCE, workspaceId.toString(), action),
@@ -154,7 +155,7 @@ public class WorkspaceService {
   public List<Workspace> listWorkspaces(
       AuthenticatedUserRequest userRequest, int offset, int limit) {
     List<UUID> samWorkspaceIds =
-        SamService.rethrowIfSamInterrupted(
+        SamRethrow.onInterrupted(
             () -> samService.listWorkspaceIds(userRequest), "listWorkspaceIds");
     return workspaceDao.getWorkspacesMatchingList(samWorkspaceIds, offset, limit);
   }
@@ -360,9 +361,8 @@ public class WorkspaceService {
     // getEmailFromToken will always call Sam, which will return a user email even if the requesting
     // access token belongs to a pet SA.
     String userEmail =
-        SamService.rethrowIfSamInterrupted(
-            () -> samService.getEmailFromToken(userRequest.getRequiredToken()),
-            "getEmailFromToken");
+        SamRethrow.onInterrupted(
+            () -> samService.getRequestUserEmail(userRequest), "getEmailFromToken");
     String projectId = getRequiredGcpProject(workspaceId);
     String petSaEmail = samService.getOrCreatePetSaEmail(projectId, userRequest);
     ServiceAccountName petSaName =

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -362,7 +362,7 @@ public class WorkspaceService {
     // access token belongs to a pet SA.
     String userEmail =
         SamRethrow.onInterrupted(
-            () -> samService.getRequestUserEmail(userRequest), "getEmailFromToken");
+            () -> samService.getRequestUserEmail(userRequest), "getRequestUserEmail");
     String projectId = getRequiredGcpProject(workspaceId);
     String petSaEmail = samService.getOrCreatePetSaEmail(projectId, userRequest);
     ServiceAccountName petSaName =

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CheckSamWorkspaceAuthzStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CheckSamWorkspaceAuthzStep.java
@@ -50,7 +50,7 @@ public class CheckSamWorkspaceAuthzStep implements Step {
 
   private boolean canReadExistingWorkspace(UUID workspaceID) throws InterruptedException {
     return samService.isAuthorized(
-        userRequest.getRequiredToken(),
+        userRequest,
         SamConstants.SAM_WORKSPACE_RESOURCE,
         workspaceID.toString(),
         SamConstants.SAM_WORKSPACE_READ_ACTION);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
@@ -48,13 +48,13 @@ public class CreateWorkspaceAuthzStep implements Step {
     FlightMap inputMap = flightContext.getInputParameters();
     UUID workspaceID =
         UUID.fromString(inputMap.get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
-    samService.deleteWorkspace(userRequest.getRequiredToken(), workspaceID);
+    samService.deleteWorkspace(userRequest, workspaceID);
     return StepResult.getStepResultSuccess();
   }
 
   private boolean canReadExistingWorkspace(UUID workspaceID) throws InterruptedException {
     return samService.isAuthorized(
-        userRequest.getRequiredToken(),
+        userRequest,
         SamConstants.SAM_WORKSPACE_RESOURCE,
         workspaceID.toString(),
         SamConstants.SAM_WORKSPACE_READ_ACTION);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteWorkspaceAuthzStep.java
@@ -26,7 +26,7 @@ public class DeleteWorkspaceAuthzStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws RetryException, InterruptedException {
-    samService.deleteWorkspace(userRequest.getRequiredToken(), workspaceId);
+    samService.deleteWorkspace(userRequest, workspaceId);
     return StepResult.getStepResultSuccess();
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -162,7 +162,7 @@ class SamServiceTest extends BaseConnectedTest {
                 WsmIamRole.READER,
                 userAccessUtils.getSecondUserEmail()));
 
-    samService.deleteWorkspace(defaultUserRequest().getRequiredToken(), workspaceId);
+    samService.deleteWorkspace(defaultUserRequest(), workspaceId);
   }
 
   @Test
@@ -260,7 +260,7 @@ class SamServiceTest extends BaseConnectedTest {
     // Workspace reader should have read access on a user-shared resource via inheritance
     assertTrue(
         samService.isAuthorized(
-            secondaryUserRequest().getRequiredToken(),
+            secondaryUserRequest(),
             ControlledResourceCategory.USER_SHARED.getSamResourceName(),
             bucketResource.getResourceId().toString(),
             SamConstants.SAM_WORKSPACE_READ_ACTION));
@@ -289,14 +289,14 @@ class SamServiceTest extends BaseConnectedTest {
     // Workspace reader should not have read access on a private resource.
     assertFalse(
         samService.isAuthorized(
-            secondaryUserRequest().getRequiredToken(),
+            secondaryUserRequest(),
             ControlledResourceCategory.USER_PRIVATE.getSamResourceName(),
             bucketResource.getResourceId().toString(),
             SamConstants.SAM_WORKSPACE_READ_ACTION));
     // However, the assigned user should have read access.
     assertTrue(
         samService.isAuthorized(
-            defaultUserRequest().getRequiredToken(),
+            defaultUserRequest(),
             ControlledResourceCategory.USER_PRIVATE.getSamResourceName(),
             bucketResource.getResourceId().toString(),
             SamConstants.SAM_WORKSPACE_READ_ACTION));

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -490,7 +490,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
     Mockito.when(
             mockSamService.isAuthorized(
-                Mockito.eq(USER_REQUEST.getRequiredToken()),
+                Mockito.eq(USER_REQUEST),
                 Mockito.eq(SamConstants.SPEND_PROFILE_RESOURCE),
                 Mockito.any(),
                 Mockito.eq(SamConstants.SPEND_PROFILE_LINK_ACTION)))

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -14,6 +14,7 @@ import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobMapKeys;
@@ -170,7 +171,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
                     Function.identity(),
                     role ->
                         "group:"
-                            + SamService.rethrowIfSamInterrupted(
+                            + SamRethrow.onInterrupted(
                                 () ->
                                     samService.syncWorkspacePolicy(
                                         workspaceId,

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -91,7 +91,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
     // Validate with Sam that secondary user can read their private resource
     assertTrue(
         samService.isAuthorized(
-            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            userAccessUtils.secondUserAuthRequest(),
             privateDataset.getCategory().getSamResourceName(),
             privateDataset.getResourceId().toString(),
             SamControlledResourceActions.WRITE_ACTION));
@@ -120,13 +120,13 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
     // resource.
     assertTrue(
         samService.isAuthorized(
-            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            userAccessUtils.secondUserAuthRequest(),
             SamConstants.SAM_WORKSPACE_RESOURCE,
             workspaceId.toString(),
             SamConstants.SAM_WORKSPACE_WRITE_ACTION));
     assertTrue(
         samService.isAuthorized(
-            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            userAccessUtils.secondUserAuthRequest(),
             privateDataset.getCategory().getSamResourceName(),
             privateDataset.getResourceId().toString(),
             SamControlledResourceActions.WRITE_ACTION));
@@ -145,13 +145,13 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
     // Verify the secondary user can no longer access the workspace or their private resource
     assertFalse(
         samService.isAuthorized(
-            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            userAccessUtils.secondUserAuthRequest(),
             SamConstants.SAM_WORKSPACE_RESOURCE,
             workspaceId.toString(),
             SamConstants.SAM_WORKSPACE_WRITE_ACTION));
     assertFalse(
         samService.isAuthorized(
-            userAccessUtils.secondUserAccessToken().getTokenValue(),
+            userAccessUtils.secondUserAuthRequest(),
             privateDataset.getCategory().getSamResourceName(),
             privateDataset.getResourceId().toString(),
             SamControlledResourceActions.WRITE_ACTION));


### PR DESCRIPTION
In working on the Azure PoC, I noticed that some Sam methods were taking the auth token directly. Most were taking `AuthenticatedUserRequest`. It is a minor inconsistency, but in order to plumb in the mock Sam for Azure PoC, I need access to the `AuthenticatedUserRequest` in all cases.

This PR changes SamService so that all public methods use `AuthenticatedUserRequest`.  I think this is worth doing in the main branch.

In addition, I factored out the static `rethrowIfSamInterrupted` code into a separate module. SamService is pushing 1KLOC. There are probably other chunks that could be refactored to make it more manageable. In any case, now instead of saying
```
SamService.rethrowIfSamInterrupted(...)
```
you say
```
SamRethrow.onInterrupted(...)
```
