### PR TITLE
PF-996: cleanup workspaces

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
+++ b/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
@@ -18,6 +18,7 @@ import static scripts.utils.ResourceMaker.makeControlledGcsBucketUserShared;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
 import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.CloneControlledGcpGcsBucketRequest;
 import bio.terra.workspace.model.CloneControlledGcpGcsBucketResult;
 import bio.terra.workspace.model.ClonedControlledGcpGcsBucket;
@@ -43,6 +44,7 @@ import com.google.cloud.storage.BucketInfo.LifecycleRule.DeleteLifecycleAction;
 import com.google.cloud.storage.BucketInfo.LifecycleRule.SetStorageClassLifecycleAction;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageClass;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -232,5 +234,17 @@ public class CloneGcsBucket extends WorkspaceAllocateTestScriptBase {
     final Blob retrievedFile = cloningUserStorageClient.get(blobId);
     assertNotNull(retrievedFile);
     assertEquals(blobId.getName(), retrievedFile.getBlobId().getName());
+  }
+
+  @Override
+  protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) {
+    if (destinationWorkspaceId != null) {
+      try {
+        final WorkspaceApi cloningUserWorkspaceApi = ClientTestUtils.getWorkspaceClient(cloningUser, server);
+        cloningUserWorkspaceApi.deleteWorkspace(destinationWorkspaceId);
+      } catch (ApiException | IOException e) {
+        logger.error("Failed to clean up destination workspace: {}", e.getMessage());
+      }
+    }
   }
 }

--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -9,6 +9,7 @@ import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiClient;
+import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.CloneReferencedGcpDataRepoSnapshotResourceResult;
 import bio.terra.workspace.model.CloneReferencedGcpGcsBucketResourceResult;
 import bio.terra.workspace.model.CloneReferencedResourceRequestBody;
@@ -21,6 +22,7 @@ import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.ResourceMetadata;
 import bio.terra.workspace.model.ResourceType;
 import bio.terra.workspace.model.StewardshipType;
+import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -150,5 +152,16 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
         cloneDataRepoSnapshotResult.getResource().getAttributes().getSnapshot());
     assertEquals(sourceDataRepoSnapshotReference.getAttributes().getInstanceName(),
         cloneDataRepoSnapshotResult.getResource().getAttributes().getInstanceName());
+  }
+
+  @Override
+  protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) {
+    if (destinationWorkspaceId != null) {
+      try {
+        workspaceApi.deleteWorkspace(destinationWorkspaceId);
+      } catch (ApiException e) {
+        logger.error("Failed to clean up destination workspace: {}", e.getMessage());
+      }
+    }
   }
 }


### PR DESCRIPTION
Destination workspace leaked in these two tests, contributing to Elijah's woes.