### PR TITLE
[PF-992] Fix email extraction to call Sam when needed

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -549,7 +549,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
         .orElseGet(
             () ->
                 SamRethrow.onInterrupted(
-                    () -> samService.getEmailFromRequestOrSam(userRequest), "getRequestUserEmail"));
+                    () -> samService.getEmailFromRequestOrSam(userRequest),
+                    "getEmailFromRequestOrSam"));
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -549,7 +549,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
         .orElseGet(
             () ->
                 SamRethrow.onInterrupted(
-                    () -> samService.getRequestUserEmail(userRequest), "getRequestUserEmail"));
+                    () -> samService.getEmailFromRequestOrSam(userRequest), "getRequestUserEmail"));
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -106,13 +106,29 @@ public class SamService {
    * @param userRequest - request object for this user
    * @return - email address of user
    */
-  public String getRequestUserEmail(AuthenticatedUserRequest userRequest)
+  public String getEmailFromRequestOrSam(AuthenticatedUserRequest userRequest)
       throws InterruptedException {
     Optional<String> emailMaybe = Optional.ofNullable(userRequest.getEmail());
     if (emailMaybe.isPresent()) {
       return emailMaybe.get();
     } else {
-      return getEmailFromToken(userRequest.getRequiredToken());
+      return getEmailFromSam(userRequest);
+    }
+  }
+
+  /**
+   * Fetch the email associated with user credentials directly from Sam. Unlike
+   * {@code getRequestUserEmail}, this will always call Sam to fetch an email and will never read
+   * it from the AuthenticatedUserRequest. This is important for calls made by pet service accounts,
+   * which will have a pet email in the AuthenticatedUserRequest, but Sam will return the owner's
+   * email.
+   * */
+  public String getEmailFromSam(AuthenticatedUserRequest userRequest) throws InterruptedException {
+    UsersApi usersApi = samUsersApi(userRequest.getRequiredToken());
+    try {
+      return SamRetry.retry(() -> usersApi.getUserStatusInfo().getUserEmail());
+    } catch (ApiException apiException) {
+      throw SamExceptionFactory.create("Error getting user email from Sam", apiException);
     }
   }
 
@@ -185,9 +201,7 @@ public class SamService {
     // Sam will throw an error if no owner is specified, so the caller's email is required. It can
     // be looked up using the auth token if that's all the caller provides.
     String callerEmail =
-        userRequest.getEmail() == null
-            ? getEmailFromToken(userRequest.getRequiredToken())
-            : userRequest.getEmail();
+        userRequest.getEmail() == null ? getEmailFromSam(userRequest) : userRequest.getEmail();
     CreateResourceRequestV2 workspaceRequest =
         new CreateResourceRequestV2()
             .resourceId(id.toString())
@@ -317,7 +331,7 @@ public class SamService {
       AuthenticatedUserRequest userRequest, String resourceType, String resourceId, String action)
       throws InterruptedException {
     boolean isAuthorized = isAuthorized(userRequest, resourceType, resourceId, action);
-    final String userEmail = getEmailFromToken(userRequest.getRequiredToken());
+    final String userEmail = getEmailFromSam(userRequest);
     if (!isAuthorized)
       throw new UnauthorizedException(
           String.format(
@@ -682,7 +696,7 @@ public class SamService {
     if (resource.getAccessScope() == AccessScopeType.ACCESS_SCOPE_PRIVATE) {
       // The assigned user is always the current user for private resources.
       addPrivateResourcePolicies(
-          resourceRequest, privateIamRoles, getRequestUserEmail(userRequest));
+          resourceRequest, privateIamRoles, getEmailFromRequestOrSam(userRequest));
     }
 
     try {
@@ -828,7 +842,9 @@ public class SamService {
   private void addWsmResourceOwnerPolicy(CreateResourceRequestV2 request)
       throws InterruptedException {
     try {
-      String wsmSaEmail = getEmailFromToken(getWsmServiceAccountToken());
+      AuthenticatedUserRequest wsmRequest =
+          new AuthenticatedUserRequest().token(Optional.of(getWsmServiceAccountToken()));
+      String wsmSaEmail = getEmailFromSam(wsmRequest);
       AccessPolicyMembershipV2 ownerPolicy =
           new AccessPolicyMembershipV2()
               .addRolesItem(ControlledResourceIamRole.OWNER.toSamRole())
@@ -876,16 +892,6 @@ public class SamService {
     request.putPoliciesItem(ControlledResourceIamRole.READER.toSamRole(), readerPolicy);
     request.putPoliciesItem(ControlledResourceIamRole.WRITER.toSamRole(), writerPolicy);
     request.putPoliciesItem(ControlledResourceIamRole.EDITOR.toSamRole(), editorPolicy);
-  }
-
-  /** Fetch the email associated with an authToken from Sam. */
-  private String getEmailFromToken(String authToken) throws InterruptedException {
-    UsersApi usersApi = samUsersApi(authToken);
-    try {
-      return SamRetry.retry(() -> usersApi.getUserStatusInfo().getUserEmail());
-    } catch (ApiException apiException) {
-      throw SamExceptionFactory.create("Error getting user email from Sam", apiException);
-    }
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -409,7 +409,7 @@ public class ControlledResourceService {
     }
     final String requestUserEmail =
         SamRethrow.onInterrupted(
-            () -> samService.getRequestUserEmail(userRequest), "validateOnlySelfAssignment");
+            () -> samService.getEmailFromRequestOrSam(userRequest), "validateOnlySelfAssignment");
     // If there is no assigned user, this condition is satisfied.
     //noinspection deprecation
     final boolean isAllowed =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -409,7 +409,7 @@ public class ControlledResourceService {
     }
     final String requestUserEmail =
         SamRethrow.onInterrupted(
-            () -> samService.getEmailFromRequestOrSam(userRequest), "validateOnlySelfAssignment");
+            () -> samService.getEmailFromRequestOrSam(userRequest), "getEmailFromRequestOrSam");
     // If there is no assigned user, this condition is satisfied.
     //noinspection deprecation
     final boolean isAllowed =

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -357,7 +357,7 @@ public class WorkspaceService {
             userRequest, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     stageService.assertMcWorkspace(workspace, "enablePet");
 
-    // getEmailFromToken will always call Sam, which will return a user email even if the requesting
+    // getEmailFromSam will always call Sam, which will return a user email even if the requesting
     // access token belongs to a pet SA.
     String userEmail =
         SamRethrow.onInterrupted(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -361,7 +361,7 @@ public class WorkspaceService {
     // access token belongs to a pet SA.
     String userEmail =
         SamRethrow.onInterrupted(
-            () -> samService.getEmailFromSam(userRequest), "getEmailFromSam");
+            () -> samService.getUserEmailFromSam(userRequest), "getEmailFromSam");
     String projectId = getRequiredGcpProject(workspaceId);
     String petSaEmail = samService.getOrCreatePetSaEmail(projectId, userRequest);
     ServiceAccountName petSaName =

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -361,7 +361,7 @@ public class WorkspaceService {
     // access token belongs to a pet SA.
     String userEmail =
         SamRethrow.onInterrupted(
-            () -> samService.getRequestUserEmail(userRequest), "getRequestUserEmail");
+            () -> samService.getEmailFromSam(userRequest), "getEmailFromSam");
     String projectId = getRequiredGcpProject(workspaceId);
     String petSaEmail = samService.getOrCreatePetSaEmail(projectId, userRequest);
     ServiceAccountName petSaName =


### PR DESCRIPTION
A previous change replaced a call to `getEmailFromToken` with `getRequestUserEmail`, which have subtly different (and poorly documented) differences in behavior around reading an email from a `AuthenticatedUserRequest` object directly vs. calling Sam. This is an important difference when making requests as a pet service account, as the userRequest will contain the pet's email but Sam will return the owner's email.
I've renamed the methods here to be clearer and added additional documentation. In order not to break the Azure POC changes from #440, I've also changed the interface of `getEmailFromSam` to take an `AuthenticatedUserRequest` instead of a token directly.