### PR TITLE
[PF-1002] Refactor cloud context

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -249,7 +249,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
   public ResponseEntity<ApiGcpBigQueryDatasetResource> getBigQueryDataset(
       UUID workspaceId, UUID resourceId) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    String projectId = workspaceService.getRequiredGcpProject(workspaceId);
+    String projectId = workspaceService.getRequiredGcpProject(workspaceId, userRequest);
     return getControlledResourceAsResponseEntity(
         workspaceId,
         resourceId,
@@ -278,7 +278,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
         body.getDescription());
 
     // Retrieve and cast response to UpdateControlledGcpBigQueryDatasetResponse
-    String projectId = workspaceService.getRequiredGcpProject(workspaceId);
+    String projectId = workspaceService.getRequiredGcpProject(workspaceId, userRequest);
     return getControlledResourceAsResponseEntity(
         workspaceId,
         resourceId,
@@ -320,7 +320,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
       UUID workspaceId, ApiCreateControlledGcpBigQueryDatasetRequestBody body) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
 
-    String projectId = workspaceService.getRequiredGcpProject(workspaceId);
+    String projectId = workspaceService.getRequiredGcpProject(workspaceId, userRequest);
 
     ControlledBigQueryDatasetResource resource =
         ControlledBigQueryDatasetResource.builder()
@@ -419,7 +419,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     ApiGcpAiNotebookInstanceResource apiResource = null;
     if (jobResult.getJobReport().getStatus().equals(ApiJobReport.StatusEnum.SUCCEEDED)) {
       ControlledAiNotebookInstanceResource resource = jobResult.getResult();
-      String workspaceProjectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+      String workspaceProjectId =
+          workspaceService.getRequiredGcpProject(resource.getWorkspaceId(), userRequest);
       apiResource = resource.toApiResource(workspaceProjectId);
     }
     return new ApiCreatedControlledGcpAiNotebookInstanceResult()
@@ -481,7 +482,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
       ApiGcpAiNotebookInstanceResource response =
           controlledResource
               .castToAiNotebookInstanceResource()
-              .toApiResource(workspaceService.getRequiredGcpProject(workspaceId));
+              .toApiResource(workspaceService.getRequiredGcpProject(workspaceId, userRequest));
       return new ResponseEntity<>(response, HttpStatus.OK);
     } catch (InvalidMetadataException ex) {
       throw new BadRequestException(

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -249,7 +249,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
   public ResponseEntity<ApiGcpBigQueryDatasetResource> getBigQueryDataset(
       UUID workspaceId, UUID resourceId) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    String projectId = workspaceService.getRequiredGcpProject(workspaceId, userRequest);
+    String projectId = workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
     return getControlledResourceAsResponseEntity(
         workspaceId,
         resourceId,
@@ -278,7 +278,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
         body.getDescription());
 
     // Retrieve and cast response to UpdateControlledGcpBigQueryDatasetResponse
-    String projectId = workspaceService.getRequiredGcpProject(workspaceId, userRequest);
+    String projectId = workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
     return getControlledResourceAsResponseEntity(
         workspaceId,
         resourceId,
@@ -320,7 +320,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
       UUID workspaceId, ApiCreateControlledGcpBigQueryDatasetRequestBody body) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
 
-    String projectId = workspaceService.getRequiredGcpProject(workspaceId, userRequest);
+    String projectId = workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
 
     ControlledBigQueryDatasetResource resource =
         ControlledBigQueryDatasetResource.builder()
@@ -420,7 +420,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     if (jobResult.getJobReport().getStatus().equals(ApiJobReport.StatusEnum.SUCCEEDED)) {
       ControlledAiNotebookInstanceResource resource = jobResult.getResult();
       String workspaceProjectId =
-          workspaceService.getRequiredGcpProject(resource.getWorkspaceId(), userRequest);
+          workspaceService.getAuthorizedRequiredGcpProject(resource.getWorkspaceId(), userRequest);
       apiResource = resource.toApiResource(workspaceProjectId);
     }
     return new ApiCreatedControlledGcpAiNotebookInstanceResult()
@@ -482,7 +482,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
       ApiGcpAiNotebookInstanceResource response =
           controlledResource
               .castToAiNotebookInstanceResource()
-              .toApiResource(workspaceService.getRequiredGcpProject(workspaceId, userRequest));
+              .toApiResource(
+                  workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest));
       return new ResponseEntity<>(response, HttpStatus.OK);
     } catch (InvalidMetadataException ex) {
       throw new BadRequestException(

--- a/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
@@ -87,8 +87,9 @@ public class ResourceController implements ResourceApi {
             offset,
             limit,
             userRequest);
+
     // projectId
-    String gcpProjectId = workspaceService.getGcpProject(workspaceId).orElse(null);
+    String gcpProjectId = workspaceService.getGcpProject(workspaceId, userRequest).orElse(null);
 
     List<ApiResourceDescription> apiResourceDescriptionList =
         wsmResources.stream()

--- a/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
@@ -89,7 +89,8 @@ public class ResourceController implements ResourceApi {
             userRequest);
 
     // projectId
-    String gcpProjectId = workspaceService.getGcpProject(workspaceId, userRequest).orElse(null);
+    String gcpProjectId =
+        workspaceService.getAuthorizedGcpProject(workspaceId, userRequest).orElse(null);
 
     List<ApiResourceDescription> apiResourceDescriptionList =
         wsmResources.stream()

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -72,6 +72,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final HttpServletRequest request;
   private final ReferencedResourceService referenceResourceService;
+  private final Logger logger = LoggerFactory.getLogger(WorkspaceApiController.class);
 
   @Autowired
   public WorkspaceApiController(
@@ -88,8 +89,6 @@ public class WorkspaceApiController implements WorkspaceApi {
     this.request = request;
     this.referenceResourceService = referenceResourceService;
   }
-
-  private final Logger logger = LoggerFactory.getLogger(WorkspaceApiController.class);
 
   private AuthenticatedUserRequest getAuthenticatedInfo() {
     return authenticatedUserRequestFactory.from(request);
@@ -142,9 +141,12 @@ public class WorkspaceApiController implements WorkspaceApi {
 
   private ApiWorkspaceDescription buildWorkspaceDescription(Workspace workspace) {
     ApiGcpContext gcpContext =
-        workspace.getGcpCloudContext().map(GcpCloudContext::toApi).orElse(null);
-    // Note projectId will be null here if no GCP cloud context exists.
+        workspaceService
+            .getGcpCloudContext(workspace.getWorkspaceId())
+            .map(GcpCloudContext::toApi)
+            .orElse(null);
     // When we have another cloud context, we will need to do a similar retrieval for it.
+
     return new ApiWorkspaceDescription()
         .id(workspace.getWorkspaceId())
         .spendProfile(workspace.getSpendProfileId().map(SpendProfileId::id).orElse(null))

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -72,7 +72,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final HttpServletRequest request;
   private final ReferencedResourceService referenceResourceService;
-  private final Logger logger = LoggerFactory.getLogger(WorkspaceApiController.class);
+  private static final Logger logger = LoggerFactory.getLogger(WorkspaceApiController.class);
 
   @Autowired
   public WorkspaceApiController(

--- a/service/src/main/java/bio/terra/workspace/common/utils/FlightBeanBag.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/FlightBeanBag.java
@@ -10,6 +10,7 @@ import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadat
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.BucketCloneRolesComponent;
 import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -31,6 +32,7 @@ public class FlightBeanBag {
   private final ControlledResourceService controlledResourceService;
   private final CrlService crlService;
   private final DataRepoService dataRepoService;
+  private final GcpCloudContextService gcpCloudContextService;
   private final ReferencedResourceService referencedResourceService;
   private final ResourceDao resourceDao;
   private final SamService samService;
@@ -46,6 +48,7 @@ public class FlightBeanBag {
       ControlledResourceService controlledResourceService,
       CrlService crlService,
       DataRepoService dataRepoService,
+      GcpCloudContextService gcpCloudContextService,
       ReferencedResourceService referencedResourceService,
       ResourceDao resourceDao,
       SamService samService,
@@ -57,6 +60,7 @@ public class FlightBeanBag {
     this.controlledResourceService = controlledResourceService;
     this.crlService = crlService;
     this.dataRepoService = dataRepoService;
+    this.gcpCloudContextService = gcpCloudContextService;
     this.referencedResourceService = referencedResourceService;
     this.resourceDao = resourceDao;
     this.samService = samService;
@@ -90,6 +94,10 @@ public class FlightBeanBag {
 
   public DataRepoService getDataRepoService() {
     return dataRepoService;
+  }
+
+  public GcpCloudContextService getGcpCloudContextService() {
+    return gcpCloudContextService;
   }
 
   public ReferencedResourceService getReferencedResourceService() {

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -7,7 +7,6 @@ import static java.util.stream.Collectors.toList;
 
 import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
-import bio.terra.workspace.db.exception.CloudContextRequiredException;
 import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.WsmResource;
@@ -26,6 +25,7 @@ import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDataset
 import bio.terra.workspace.service.resource.referenced.ReferencedDataRepoSnapshotResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedResource;
+import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import java.util.Collections;
 import java.util.List;

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -10,6 +10,7 @@ import bio.terra.workspace.service.workspace.exceptions.DuplicateWorkspaceExcept
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -208,6 +209,11 @@ public class WorkspaceDao {
    */
   @ReadTransaction
   public List<Workspace> getWorkspacesMatchingList(List<UUID> idList, int offset, int limit) {
+    // If the incoming list is empty, the caller does not have permission to see any
+    // workspaces, so we return an empty list.
+    if (idList.isEmpty()) {
+      return Collections.emptyList();
+    }
     String sql =
         WORKSPACE_SELECT_SQL
             + " WHERE workspace_id IN (:workspace_ids) ORDER BY workspace_id OFFSET :offset LIMIT :limit";

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -7,17 +7,15 @@ import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateCloudContextException;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateWorkspaceException;
-import bio.terra.workspace.service.workspace.exceptions.InvalidSerializedVersionException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,18 +36,30 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class WorkspaceDao {
-  /** Serializing format of the GCP cloud context */
-  @VisibleForTesting static final long GCP_CLOUD_CONTEXT_DB_VERSION = 1;
+  private final Logger logger = LoggerFactory.getLogger(WorkspaceDao.class);
+  private final NamedParameterJdbcTemplate jdbcTemplate;
 
   /** SQL query for reading a workspace, including its cloud context. */
   private static final String WORKSPACE_SELECT_SQL =
-      "SELECT W.workspace_id, W.display_name, W.description, W.spend_profile,"
-          + " W.properties, W.workspace_stage, C.context"
-          + " FROM workspace W LEFT JOIN cloud_context C"
-          + " ON W.workspace_id = C.workspace_id ";
+      "SELECT workspace_id, display_name, description, spend_profile, properties, workspace_stage"
+          + " FROM workspace W ";
 
-  private final NamedParameterJdbcTemplate jdbcTemplate;
-  private final Logger logger = LoggerFactory.getLogger(WorkspaceDao.class);
+  private static final RowMapper<Workspace> WORKSPACE_ROW_MAPPER =
+      (rs, rowNum) ->
+          Workspace.builder()
+              .workspaceId(UUID.fromString(rs.getString("workspace_id")))
+              .displayName(rs.getString("display_name"))
+              .description(rs.getString("description"))
+              .spendProfileId(
+                  Optional.ofNullable(rs.getString("spend_profile"))
+                      .map(SpendProfileId::create)
+                      .orElse(null))
+              .properties(
+                  Optional.ofNullable(rs.getString("properties"))
+                      .map(DbSerDes::jsonToProperties)
+                      .orElse(null))
+              .workspaceStage(WorkspaceStage.valueOf(rs.getString("workspace_stage")))
+              .build();
 
   @Autowired
   public WorkspaceDao(NamedParameterJdbcTemplate jdbcTemplate) {
@@ -128,9 +138,7 @@ public class WorkspaceDao {
     if (id == null) {
       throw new MissingRequiredFieldException("Valid workspace id is required");
     }
-    String sql =
-        WORKSPACE_SELECT_SQL
-            + " WHERE W.workspace_id = :id AND (C.cloud_platform = 'GCP' OR C.cloud_platform IS NULL)";
+    String sql = WORKSPACE_SELECT_SQL + " WHERE W.workspace_id = :id";
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("id", id.toString());
     try {
       Workspace result =
@@ -222,49 +230,19 @@ public class WorkspaceDao {
    */
   @ReadTransaction
   public Optional<GcpCloudContext> getGcpCloudContext(UUID workspaceId) {
-    String sql =
-        "SELECT context FROM cloud_context "
-            + "WHERE workspace_id = :workspace_id AND cloud_platform = :cloud_platform";
-    MapSqlParameterSource params =
-        new MapSqlParameterSource()
-            .addValue("workspace_id", workspaceId.toString())
-            .addValue("cloud_platform", CloudPlatform.GCP.toString());
-    try {
-      return Optional.ofNullable(
-          DataAccessUtils.singleResult(
-              jdbcTemplate.query(
-                  sql,
-                  params,
-                  (rs, rowNum) -> deserializeGcpCloudContext(rs.getString("context")))));
-    } catch (EmptyResultDataAccessException e) {
-      return Optional.empty();
-    }
+    return getCloudContextWorker(workspaceId, CloudPlatform.GCP).map(GcpCloudContext::deserialize);
   }
 
   /**
-   * Create the cloud context of the workspace
+   * Create the GCP cloud context of the workspace
    *
    * @param workspaceId unique id of the workspace
    * @param cloudContext the GCP cloud context to create
    */
   @WriteTransaction
-  public void createGcpCloudContext(UUID workspaceId, GcpCloudContext cloudContext) {
-    final String sql =
-        "INSERT INTO cloud_context (workspace_id, cloud_platform, context)"
-            + " VALUES (:workspace_id, :cloud_platform, :context::json)";
-    MapSqlParameterSource params =
-        new MapSqlParameterSource()
-            .addValue("workspace_id", workspaceId.toString())
-            .addValue("cloud_platform", CloudPlatform.GCP.toString())
-            .addValue("context", serializeGcpCloudContext(cloudContext));
-    try {
-      jdbcTemplate.update(sql, params);
-      logger.info("Inserted record for GCP cloud context for workspace {}", workspaceId);
-    } catch (DuplicateKeyException e) {
-      throw new DuplicateCloudContextException(
-          String.format("Workspace with id %s already has context for GCP cloud type", workspaceId),
-          e);
-    }
+  public void createGcpCloudContext(
+      UUID workspaceId, GcpCloudContext cloudContext, String flightId) {
+    createCloudContextWorker(workspaceId, CloudPlatform.GCP, cloudContext.serialize(), flightId);
   }
 
   /**
@@ -274,93 +252,109 @@ public class WorkspaceDao {
    */
   @WriteTransaction
   public void deleteGcpCloudContext(UUID workspaceId) {
-    deleteGcpCloudContextWorker(workspaceId);
+    deleteCloudContextWorker(workspaceId, CloudPlatform.GCP, null);
   }
 
   /**
-   * Delete a cloud context for the workspace validating the projectId
+   * Delete a cloud context for the workspace validating the flight id
    *
    * @param workspaceId workspace of the cloud context
-   * @param projectId the GCP project id to validate
+   * @param flightId flight id making the delete request
    */
   @WriteTransaction
-  public void deleteGcpCloudContextWithIdCheck(UUID workspaceId, String projectId) {
-    // Only perform the delete, if the project id matches the input project id
-    Optional<GcpCloudContext> gcpCloudContext = getGcpCloudContext(workspaceId);
-    if (gcpCloudContext.isPresent()) {
-      if (StringUtils.equals(projectId, gcpCloudContext.get().getGcpProjectId())) {
-        deleteGcpCloudContextWorker(workspaceId);
-      }
+  public void deleteGcpCloudContextWithCheck(UUID workspaceId, String flightId) {
+    deleteCloudContextWorker(workspaceId, CloudPlatform.GCP, flightId);
+  }
+
+  /**
+   * Common method for cloud context creates
+   *
+   * @param workspaceId unique id of the workspace
+   * @param cloudPlatform cloud platform enum
+   * @param context serialized cloud context attributes
+   * @param flightId calling flight id. Used to ensure that we do not delete a good context while
+   *     undoing from trying to create a conflicting context.
+   */
+  private void createCloudContextWorker(
+      UUID workspaceId, CloudPlatform cloudPlatform, String context, String flightId) {
+    final String platform = cloudPlatform.toSql();
+    final String sql =
+        "INSERT INTO cloud_context (workspace_id, cloud_platform, context, creating_flight)"
+            + " VALUES (:workspace_id, :cloud_platform, :context::json, :creating_flight)";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("workspace_id", workspaceId.toString())
+            .addValue("cloud_platform", platform)
+            .addValue("context", context)
+            .addValue("creating_flight", flightId);
+    try {
+      jdbcTemplate.update(sql, params);
+      logger.info("Inserted record for {} cloud context for workspace {}", platform, workspaceId);
+    } catch (DuplicateKeyException e) {
+      throw new DuplicateCloudContextException(
+          String.format(
+              "Workspace with id %s already has context for %s cloud type", workspaceId, platform),
+          e);
     }
   }
 
-  private void deleteGcpCloudContextWorker(UUID workspaceId) {
-    final String sql =
+  /**
+   * Common worker for retrieving cloud context
+   *
+   * @param workspaceId workspace of the context
+   * @param cloudPlatform platform context to retrieve
+   * @return empty or the serialized cloud context info
+   */
+  private Optional<String> getCloudContextWorker(UUID workspaceId, CloudPlatform cloudPlatform) {
+    String sql =
+        "SELECT context FROM cloud_context "
+            + "WHERE workspace_id = :workspace_id AND cloud_platform = :cloud_platform";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("workspace_id", workspaceId.toString())
+            .addValue("cloud_platform", cloudPlatform.toSql());
+    try {
+      return Optional.ofNullable(
+          DataAccessUtils.singleResult(
+              jdbcTemplate.query(sql, params, (rs, rowNum) -> rs.getString("context"))));
+    } catch (EmptyResultDataAccessException e) {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Common worker for deleting cloud context
+   *
+   * @param workspaceId workspace holding the context
+   * @param cloudPlatform platform of the context
+   * @param flightId if non-null, then it is compared to the creating_flight to make sure a
+   *     conflicting create does not delete a valid cloud context
+   */
+  private void deleteCloudContextWorker(
+      UUID workspaceId, CloudPlatform cloudPlatform, @Nullable String flightId) {
+    final String platform = cloudPlatform.toSql();
+    String sql =
         "DELETE FROM cloud_context "
             + "WHERE workspace_id = :workspace_id AND cloud_platform = :cloud_platform";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("workspace_id", workspaceId.toString())
-            .addValue("cloud_platform", CloudPlatform.GCP.toString());
+            .addValue("cloud_platform", platform);
+
+    if (StringUtils.isNotEmpty(flightId)) {
+      sql = sql + " AND creating_flight = :flightid";
+      params.addValue("flightid", flightId);
+    }
 
     int rowsAffected = jdbcTemplate.update(sql, params);
     boolean deleted = rowsAffected > 0;
 
     if (deleted) {
-      logger.info("Deleted GCP cloud context for workspace {}", workspaceId);
+      logger.info("Deleted {} cloud context for workspace {}", platform, workspaceId);
     } else {
-      logger.info("No record to delete for GCP cloud context for workspace {}", workspaceId);
-    }
-  }
-
-  private static final RowMapper<Workspace> WORKSPACE_ROW_MAPPER =
-      (rs, rowNum) ->
-          Workspace.builder()
-              .workspaceId(UUID.fromString(rs.getString("workspace_id")))
-              .displayName(rs.getString("display_name"))
-              .description(rs.getString("description"))
-              .spendProfileId(
-                  Optional.ofNullable(rs.getString("spend_profile"))
-                      .map(SpendProfileId::create)
-                      .orElse(null))
-              .properties(
-                  Optional.ofNullable(rs.getString("properties"))
-                      .map(DbSerDes::jsonToProperties)
-                      .orElse(null))
-              .workspaceStage(WorkspaceStage.valueOf(rs.getString("workspace_stage")))
-              .gcpCloudContext(
-                  Optional.ofNullable(rs.getString("context"))
-                      .map(WorkspaceDao::deserializeGcpCloudContext)
-                      .orElse(null))
-              .build();
-  // -- serdes for GcpCloudContext --
-
-  @VisibleForTesting
-  String serializeGcpCloudContext(GcpCloudContext gcpCloudContext) {
-    GcpCloudContextV1 dbContext = GcpCloudContextV1.from(gcpCloudContext.getGcpProjectId());
-    return DbSerDes.toJson(dbContext);
-  }
-
-  @VisibleForTesting
-  static GcpCloudContext deserializeGcpCloudContext(String json) {
-    GcpCloudContextV1 result = DbSerDes.fromJson(json, GcpCloudContextV1.class);
-    if (result.version != GCP_CLOUD_CONTEXT_DB_VERSION) {
-      throw new InvalidSerializedVersionException("Invalid serialized version");
-    }
-    return new GcpCloudContext(result.gcpProjectId);
-  }
-
-  static class GcpCloudContextV1 {
-    /** Version marker to store in the db so that we can update the format later if we need to. */
-    @JsonProperty final long version = GCP_CLOUD_CONTEXT_DB_VERSION;
-
-    @JsonProperty String gcpProjectId;
-
-    public static GcpCloudContextV1 from(String googleProjectId) {
-      GcpCloudContextV1 result = new GcpCloudContextV1();
-      result.gcpProjectId = googleProjectId;
-      return result;
+      logger.info(
+          "No record to delete for {} cloud context for workspace {}", platform, workspaceId);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/db/exception/CloudContextRequiredException.java
+++ b/service/src/main/java/bio/terra/workspace/db/exception/CloudContextRequiredException.java
@@ -1,9 +1,0 @@
-package bio.terra.workspace.db.exception;
-
-import bio.terra.common.exception.BadRequestException;
-
-public class CloudContextRequiredException extends BadRequestException {
-  public CloudContextRequiredException(String message) {
-    super(message);
-  }
-}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
@@ -42,7 +42,7 @@ public class CloneControlledGcsBucketResourceFlight extends Flight {
         new RetrieveGcsBucketCloudAttributesStep(
             sourceBucket,
             flightBeanBag.getCrlService(),
-            flightBeanBag.getWorkspaceService(),
+            flightBeanBag.getGcpCloudContextService(),
             RetrievalMode.CREATION_PARAMETERS));
     addStep(
         new CopyGcsBucketDefinitionStep(
@@ -50,7 +50,7 @@ public class CloneControlledGcsBucketResourceFlight extends Flight {
     addStep(
         new SetBucketRolesStep(
             sourceBucket,
-            flightBeanBag.getWorkspaceService(),
+            flightBeanBag.getGcpCloudContextService(),
             flightBeanBag.getBucketCloneRolesComponent()));
     addStep(new CreateStorageTransferServiceJobStep());
     addStep(new CompleteTransferOperationStep());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetBucketRolesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetBucketRolesStep.java
@@ -9,7 +9,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.GcpUtils;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.google.api.services.storagetransfer.v1.Storagetransfer;
 import java.io.IOException;
@@ -30,15 +30,15 @@ public class SetBucketRolesStep implements Step {
           .collect(Collectors.toList());
 
   private final ControlledGcsBucketResource sourceBucket;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
   private final BucketCloneRolesComponent bucketCloneRolesService;
 
   public SetBucketRolesStep(
       ControlledGcsBucketResource sourceBucket,
-      WorkspaceService workspaceService,
+      GcpCloudContextService gcpCloudContextService,
       BucketCloneRolesComponent bucketCloneRolesService) {
     this.sourceBucket = sourceBucket;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
     this.bucketCloneRolesService = bucketCloneRolesService;
   }
 
@@ -101,7 +101,7 @@ public class SetBucketRolesStep implements Step {
 
   private BucketCloneInputs getSourceInputs() {
     final String sourceProjectId =
-        workspaceService.getRequiredGcpProject(sourceBucket.getWorkspaceId());
+        gcpCloudContextService.getRequiredGcpProject(sourceBucket.getWorkspaceId());
     final String sourceBucketName = sourceBucket.getBucketName();
     return new BucketCloneInputs(
         sourceBucket.getWorkspaceId(), sourceProjectId, sourceBucketName, SOURCE_BUCKET_ROLE_NAMES);
@@ -117,7 +117,7 @@ public class SetBucketRolesStep implements Step {
         flightContext
             .getInputParameters()
             .get(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, UUID.class);
-    final String projectId = workspaceService.getRequiredGcpProject(workspaceId);
+    final String projectId = gcpCloudContextService.getRequiredGcpProject(workspaceId);
     final String bucketName =
         flightContext
             .getWorkingMap()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
@@ -37,7 +37,7 @@ public class CloneControlledGcpBigQueryDatasetResourceFlight extends Flight {
         new RetrieveBigQueryDatasetCloudAttributesStep(
             sourceDataset,
             flightBeanBag.getCrlService(),
-            flightBeanBag.getWorkspaceService(),
+            flightBeanBag.getGcpCloudContextService(),
             userRequest));
 
     addStep(
@@ -45,10 +45,12 @@ public class CloneControlledGcpBigQueryDatasetResourceFlight extends Flight {
             sourceDataset,
             flightBeanBag.getControlledResourceService(),
             userRequest,
-            flightBeanBag.getWorkspaceService()));
+            flightBeanBag.getGcpCloudContextService()));
     addStep(
         new CreateTableCopyJobsStep(
-            flightBeanBag.getCrlService(), flightBeanBag.getWorkspaceService(), sourceDataset),
+            flightBeanBag.getCrlService(),
+            flightBeanBag.getGcpCloudContextService(),
+            sourceDataset),
         RetryRules.cloud());
     addStep(
         new CompleteTableCopyJobsStep(flightBeanBag.getCrlService()),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CompleteTableCopyJobsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CompleteTableCopyJobsStep.java
@@ -7,8 +7,6 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -43,10 +41,7 @@ public class CompleteTableCopyJobsStep implements Step {
     }
     final Map<String, String> tableToJobId =
         workingMap.get(ControlledResourceKeys.TABLE_TO_JOB_ID_MAP, new TypeReference<>() {});
-    final AuthenticatedUserRequest userRequest =
-        flightContext
-            .getInputParameters()
-            .get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+
     // TODO(jaycarlton): PF-942 implement needed endpoints in CRL and use them here
     final Bigquery bigQueryClient = crlService.createWsmSaNakedBigQueryClient();
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import java.util.List;
 import java.util.Optional;
@@ -26,17 +26,17 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
   private final ControlledBigQueryDatasetResource sourceDataset;
   private final ControlledResourceService controlledResourceService;
   private final AuthenticatedUserRequest userRequest;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public CopyBigQueryDatasetDefinitionStep(
       ControlledBigQueryDatasetResource sourceDataset,
       ControlledResourceService controlledResourceService,
       AuthenticatedUserRequest userRequest,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.sourceDataset = sourceDataset;
     this.controlledResourceService = controlledResourceService;
     this.userRequest = userRequest;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
@@ -109,7 +109,7 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
 
     workingMap.put(ControlledResourceKeys.CLONED_RESOURCE_DEFINITION, clonedResource);
     final String destinationProjectId =
-        workspaceService.getRequiredGcpProject(destinationWorkspaceId);
+        gcpCloudContextService.getRequiredGcpProject(destinationWorkspaceId);
     final ApiClonedControlledGcpBigQueryDataset apiResult =
         new ApiClonedControlledGcpBigQueryDataset()
             .dataset(clonedResource.toApiResource(destinationProjectId))

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CreateTableCopyJobsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CreateTableCopyJobsStep.java
@@ -8,11 +8,9 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.api.services.bigquery.Bigquery;
@@ -39,15 +37,15 @@ public class CreateTableCopyJobsStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(CreateTableCopyJobsStep.class);
   public static final Duration COPY_JOB_TIMEOUT = Duration.ofHours(12);
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
   private final ControlledBigQueryDatasetResource sourceDataset;
 
   public CreateTableCopyJobsStep(
       CrlService crlService,
-      WorkspaceService workspaceService,
+      GcpCloudContextService gcpCloudContextService,
       ControlledBigQueryDatasetResource sourceDataset) {
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
     this.sourceDataset = sourceDataset;
   }
 
@@ -79,10 +77,6 @@ public class CreateTableCopyJobsStep implements Step {
     final DatasetCloneInputs destinationInputs = getDestinationInputs(flightContext);
     workingMap.put(ControlledResourceKeys.DESTINATION_CLONE_INPUTS, destinationInputs);
 
-    final AuthenticatedUserRequest userRequest =
-        flightContext
-            .getInputParameters()
-            .get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
     final BigQueryCow bigQueryCow = crlService.createWsmSaBigQueryCow();
     // TODO(jaycarlton):  remove usage of this client when it's all in CRL PF-942
     final Bigquery bigQueryClient = crlService.createWsmSaNakedBigQueryClient();
@@ -207,7 +201,7 @@ public class CreateTableCopyJobsStep implements Step {
 
   private DatasetCloneInputs getSourceInputs() {
     final String sourceProjectId =
-        workspaceService.getRequiredGcpProject(sourceDataset.getWorkspaceId());
+        gcpCloudContextService.getRequiredGcpProject(sourceDataset.getWorkspaceId());
     final String sourceDatasetName = sourceDataset.getDatasetName();
     return new DatasetCloneInputs(
         sourceDataset.getWorkspaceId(), sourceProjectId, sourceDatasetName);
@@ -219,7 +213,7 @@ public class CreateTableCopyJobsStep implements Step {
             .getInputParameters()
             .get(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, UUID.class);
     final String destinationProjectId =
-        workspaceService.getRequiredGcpProject(destinationWorkspaceId);
+        gcpCloudContextService.getRequiredGcpProject(destinationWorkspaceId);
     final String destinationDatasetName =
         flightContext
             .getWorkingMap()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/RetrieveBigQueryDatasetCloudAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/RetrieveBigQueryDatasetCloudAttributesStep.java
@@ -9,7 +9,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.google.api.client.util.Strings;
 import com.google.api.services.bigquery.model.Dataset;
@@ -20,17 +20,17 @@ public class RetrieveBigQueryDatasetCloudAttributesStep implements Step {
 
   private final ControlledBigQueryDatasetResource datasetResource;
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
   private final AuthenticatedUserRequest userRequest;
 
   public RetrieveBigQueryDatasetCloudAttributesStep(
       ControlledBigQueryDatasetResource datasetResource,
       CrlService crlService,
-      WorkspaceService workspaceService,
+      GcpCloudContextService gcpCloudContextService,
       AuthenticatedUserRequest userRequest) {
     this.datasetResource = datasetResource;
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
     this.userRequest = userRequest;
   }
 
@@ -47,7 +47,7 @@ public class RetrieveBigQueryDatasetCloudAttributesStep implements Step {
     // Since no location was specified, we need to find the original one
     // from the source dataset.
     final String projectId =
-        workspaceService.getRequiredGcpProject(datasetResource.getWorkspaceId());
+        gcpCloudContextService.getRequiredGcpProject(datasetResource.getWorkspaceId());
     final BigQueryCow bigQueryCow = crlService.createWsmSaBigQueryCow();
     try {
       final Dataset dataset =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateGcpContextFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateGcpContextFlightStep.java
@@ -34,8 +34,6 @@ public class LaunchCreateGcpContextFlightStep implements Step {
         ControlledResourceKeys.DESTINATION_WORKSPACE_ID,
         ControlledResourceKeys.CREATE_CLOUD_CONTEXT_FLIGHT_ID);
 
-    final var sourceWorkspaceId =
-        context.getInputParameters().get(ControlledResourceKeys.SOURCE_WORKSPACE_ID, UUID.class);
     final var userRequest =
         context
             .getInputParameters()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
@@ -16,7 +16,7 @@ import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.resource.controlled.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.BigQueryApiConversions;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -47,17 +47,17 @@ public class CreateBigQueryDatasetStep implements Step {
 
   private final CrlService crlService;
   private final ControlledBigQueryDatasetResource resource;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   private final Logger logger = LoggerFactory.getLogger(CreateBigQueryDatasetStep.class);
 
   public CreateBigQueryDatasetStep(
       CrlService crlService,
       ControlledBigQueryDatasetResource resource,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.crlService = crlService;
     this.resource = resource;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
@@ -67,7 +67,7 @@ public class CreateBigQueryDatasetStep implements Step {
     FlightMap workingMap = flightContext.getWorkingMap();
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
         inputMap.get(CREATION_PARAMETERS, ApiGcpBigQueryDatasetCreationParameters.class);
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
 
     List<Access> accessConfiguration = buildDatasetAccessConfiguration(workingMap, projectId);
     DatasetReference datasetId =
@@ -159,7 +159,7 @@ public class CreateBigQueryDatasetStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     BigQueryCow bqCow = crlService.createWsmSaBigQueryCow();
 
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
@@ -69,12 +69,12 @@ public class CreateControlledResourceFlight extends Flight {
             new CreateGcsBucketStep(
                 flightBeanBag.getCrlService(),
                 resource.castToGcsBucketResource(),
-                flightBeanBag.getWorkspaceService()));
+                flightBeanBag.getGcpCloudContextService()));
         addStep(
             new GcsBucketCloudSyncStep(
                 flightBeanBag.getCrlService(),
                 resource.castToGcsBucketResource(),
-                flightBeanBag.getWorkspaceService()));
+                flightBeanBag.getGcpCloudContextService()));
         break;
       case AI_NOTEBOOK_INSTANCE:
         addNotebookSteps(
@@ -90,7 +90,7 @@ public class CreateControlledResourceFlight extends Flight {
             new CreateBigQueryDatasetStep(
                 flightBeanBag.getCrlService(),
                 resource.castToBigQueryDatasetResource(),
-                flightBeanBag.getWorkspaceService()),
+                flightBeanBag.getGcpCloudContextService()),
             gcpRetryRule);
         break;
       default:
@@ -108,12 +108,12 @@ public class CreateControlledResourceFlight extends Flight {
       List<ControlledResourceIamRole> privateResourceIamRoles) {
     addStep(
         new RetrieveNetworkNameStep(
-            flightBeanBag.getCrlService(), resource, flightBeanBag.getWorkspaceService()),
+            flightBeanBag.getCrlService(), resource, flightBeanBag.getGcpCloudContextService()),
         gcpRetryRule);
     addStep(new GenerateServiceAccountIdStep());
     addStep(
         new CreateServiceAccountStep(
-            flightBeanBag.getCrlService(), flightBeanBag.getWorkspaceService(), resource),
+            flightBeanBag.getCrlService(), flightBeanBag.getGcpCloudContextService(), resource),
         gcpRetryRule);
     addStep(
         new ServiceAccountPolicyStep(
@@ -121,16 +121,16 @@ public class CreateControlledResourceFlight extends Flight {
             flightBeanBag.getCrlService(),
             resource,
             flightBeanBag.getSamService(),
-            flightBeanBag.getWorkspaceService(),
+            flightBeanBag.getGcpCloudContextService(),
             privateResourceIamRoles),
         gcpRetryRule);
     addStep(
         new CreateAiNotebookInstanceStep(
-            flightBeanBag.getCrlService(), resource, flightBeanBag.getWorkspaceService()),
+            flightBeanBag.getCrlService(), resource, flightBeanBag.getGcpCloudContextService()),
         gcpRetryRule);
     addStep(
         new NotebookCloudSyncStep(
-            flightBeanBag.getCrlService(), resource, flightBeanBag.getWorkspaceService()),
+            flightBeanBag.getCrlService(), resource, flightBeanBag.getGcpCloudContextService()),
         gcpRetryRule);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.GcsApiConversions;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.cloud.storage.BucketInfo;
 import java.util.Collections;
 import java.util.Optional;
@@ -24,15 +24,15 @@ public class CreateGcsBucketStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(CreateGcsBucketStep.class);
   private final CrlService crlService;
   private final ControlledGcsBucketResource resource;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public CreateGcsBucketStep(
       CrlService crlService,
       ControlledGcsBucketResource resource,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.crlService = crlService;
     this.resource = resource;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
@@ -41,7 +41,7 @@ public class CreateGcsBucketStep implements Step {
     FlightMap inputMap = flightContext.getInputParameters();
     ApiGcpGcsBucketCreationParameters creationParameters =
         inputMap.get(CREATION_PARAMETERS, ApiGcpGcsBucketCreationParameters.class);
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     BucketInfo.Builder bucketInfoBuilder =
         BucketInfo.newBuilder(resource.getBucketName())
             .setLocation(creationParameters.getLocation());
@@ -76,7 +76,7 @@ public class CreateGcsBucketStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     final StorageCow storageCow = crlService.createStorageCow(projectId);
     storageCow.delete(resource.getBucketName());
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GcsBucketCloudSyncStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GcsBucketCloudSyncStep.java
@@ -11,7 +11,7 @@ import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.resource.controlled.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -25,23 +25,23 @@ public class GcsBucketCloudSyncStep implements Step {
 
   private final CrlService crlService;
   private final ControlledGcsBucketResource resource;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
   private final Logger logger = LoggerFactory.getLogger(GcsBucketCloudSyncStep.class);
 
   public GcsBucketCloudSyncStep(
       CrlService crlService,
       ControlledGcsBucketResource resource,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.crlService = crlService;
     this.resource = resource;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
     final FlightMap workingMap = flightContext.getWorkingMap();
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     // Users do not have read or write access to IAM policies, so requests are executed via
     // WSM's service account.
     StorageCow wsmSaStorageCow = crlService.createStorageCow(projectId);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/CreateAiNotebookInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/CreateAiNotebookInstanceStep.java
@@ -24,7 +24,7 @@ import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParam
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.notebooks.v1.model.AcceleratorConfig;
 import com.google.api.services.notebooks.v1.model.ContainerImage;
@@ -56,21 +56,21 @@ public class CreateAiNotebookInstanceStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(CreateAiNotebookInstanceStep.class);
   private final CrlService crlService;
   private final ControlledAiNotebookInstanceResource resource;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public CreateAiNotebookInstanceStep(
       CrlService crlService,
       ControlledAiNotebookInstanceResource resource,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.crlService = crlService;
     this.resource = resource;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     InstanceName instanceName = resource.toInstanceName(projectId);
     Instance instance = createInstanceModel(flightContext, projectId);
 
@@ -181,7 +181,7 @@ public class CreateAiNotebookInstanceStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     InstanceName instanceName = resource.toInstanceName(projectId);
 
     AIPlatformNotebooksCow notebooks = crlService.getAIPlatformNotebooksCow();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/CreateServiceAccountStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/CreateServiceAccountStep.java
@@ -11,7 +11,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.iam.v1.model.CreateServiceAccountRequest;
 import com.google.api.services.iam.v1.model.ServiceAccount;
@@ -35,22 +35,22 @@ public class CreateServiceAccountStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(CreateServiceAccountStep.class);
 
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
   private final ControlledAiNotebookInstanceResource resource;
 
   public CreateServiceAccountStep(
       CrlService crlService,
-      WorkspaceService workspaceService,
+      GcpCloudContextService gcpCloudContextService,
       ControlledAiNotebookInstanceResource resource) {
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     IamCow iam = crlService.getIamCow();
     String serviceAccountId =
         flightContext.getWorkingMap().get(CREATE_NOTEBOOK_SERVICE_ACCOUNT_ID, String.class);
@@ -84,7 +84,7 @@ public class CreateServiceAccountStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     IamCow iam = crlService.getIamCow();
     String serviceAccountEmail =
         ServiceAccountName.emailFromAccountId(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/NotebookCloudSyncStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/NotebookCloudSyncStep.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.resource.controlled.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.flight.create.GcpPolicyBuilder;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.api.services.notebooks.v1.model.Binding;
@@ -34,21 +34,21 @@ public class NotebookCloudSyncStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(NotebookCloudSyncStep.class);
   private final CrlService crlService;
   private final ControlledAiNotebookInstanceResource resource;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public NotebookCloudSyncStep(
       CrlService crlService,
       ControlledAiNotebookInstanceResource resource,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.crlService = crlService;
     this.resource = resource;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     List<Binding> newBindings = createBindings(projectId, flightContext.getWorkingMap());
 
     AIPlatformNotebooksCow notebooks = crlService.getAIPlatformNotebooksCow();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/RetrieveNetworkNameStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/RetrieveNetworkNameStep.java
@@ -15,7 +15,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.model.Subnetwork;
 import com.google.api.services.compute.model.SubnetworkList;
@@ -31,21 +31,21 @@ public class RetrieveNetworkNameStep implements Step {
 
   private final CrlService crlService;
   private final ControlledAiNotebookInstanceResource resource;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public RetrieveNetworkNameStep(
       CrlService crlService,
       ControlledAiNotebookInstanceResource resource,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.crlService = crlService;
     this.resource = resource;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     CloudComputeCow compute = crlService.getCloudComputeCow();
     SubnetworkList subnetworks;
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/ServiceAccountPolicyStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/notebook/ServiceAccountPolicyStep.java
@@ -16,7 +16,7 @@ import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.resource.controlled.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.api.services.iam.v1.model.Binding;
@@ -49,7 +49,7 @@ public class ServiceAccountPolicyStep implements Step {
   private final CrlService crlService;
   private final ControlledAiNotebookInstanceResource resource;
   private final SamService samService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
   private final List<ControlledResourceIamRole> privateIamRoles;
 
   public ServiceAccountPolicyStep(
@@ -57,13 +57,13 @@ public class ServiceAccountPolicyStep implements Step {
       CrlService crlService,
       ControlledAiNotebookInstanceResource resource,
       SamService samService,
-      WorkspaceService workspaceService,
+      GcpCloudContextService gcpCloudContextService,
       List<ControlledResourceIamRole> privateIamRoles) {
     this.userRequest = userRequest;
     this.crlService = crlService;
     this.resource = resource;
     this.samService = samService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
     this.privateIamRoles = privateIamRoles;
   }
 
@@ -73,7 +73,7 @@ public class ServiceAccountPolicyStep implements Step {
     List<Binding> newBindings = new ArrayList<>();
     newBindings.add(createWriterBinding(flightContext.getWorkingMap()));
 
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     IamCow iam = crlService.getIamCow();
 
     String serviceAccountEmail =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteBigQueryDatasetStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteBigQueryDatasetStep.java
@@ -8,7 +8,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import java.io.IOException;
 import org.apache.http.HttpStatus;
@@ -23,23 +23,23 @@ public class DeleteBigQueryDatasetStep implements Step {
 
   private final ControlledBigQueryDatasetResource resource;
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   private final Logger logger = LoggerFactory.getLogger(DeleteBigQueryDatasetStep.class);
 
   public DeleteBigQueryDatasetStep(
       ControlledBigQueryDatasetResource resource,
       CrlService crlService,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.resource = resource;
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     BigQueryCow bqCow = crlService.createWsmSaBigQueryCow();
     try {
       // With deleteContents set to true, this will delete the dataset even if it still has tables.
@@ -65,7 +65,7 @@ public class DeleteBigQueryDatasetStep implements Step {
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
     // Deletes cannot be undone, so we log a warning and continue the flight.
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
 
     logger.error(
         "Cannot undo delete of BQ dataset {} in project {}.", resource.getDatasetName(), projectId);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceFlight.java
@@ -64,7 +64,7 @@ public class DeleteControlledResourceFlight extends Flight {
             new DeleteGcsBucketStep(
                 flightBeanBag.getCrlService(),
                 flightBeanBag.getResourceDao(),
-                flightBeanBag.getWorkspaceService(),
+                flightBeanBag.getGcpCloudContextService(),
                 workspaceId,
                 resourceId));
         break;
@@ -73,7 +73,7 @@ public class DeleteControlledResourceFlight extends Flight {
             new DeleteBigQueryDatasetStep(
                 resource.castToBigQueryDatasetResource(),
                 flightBeanBag.getCrlService(),
-                flightBeanBag.getWorkspaceService()),
+                flightBeanBag.getGcpCloudContextService()),
             gcpRetryRule);
         break;
       case AI_NOTEBOOK_INSTANCE:
@@ -81,19 +81,19 @@ public class DeleteControlledResourceFlight extends Flight {
             new RetrieveNotebookServiceAccountStep(
                 resource.castToAiNotebookInstanceResource(),
                 flightBeanBag.getCrlService(),
-                flightBeanBag.getWorkspaceService()),
+                flightBeanBag.getGcpCloudContextService()),
             gcpRetryRule);
         addStep(
             new DeleteAiNotebookInstanceStep(
                 resource.castToAiNotebookInstanceResource(),
                 flightBeanBag.getCrlService(),
-                flightBeanBag.getWorkspaceService()),
+                flightBeanBag.getGcpCloudContextService()),
             gcpRetryRule);
         addStep(
             new DeleteServiceAccountStep(
                 resource.castToAiNotebookInstanceResource(),
                 flightBeanBag.getCrlService(),
-                flightBeanBag.getWorkspaceService()),
+                flightBeanBag.getGcpCloudContextService()),
             gcpRetryRule);
         break;
       default:

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteGcsBucketStep.java
@@ -10,7 +10,7 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.WsmResource;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.exception.BucketDeleteTimeoutException;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
@@ -34,7 +34,7 @@ public class DeleteGcsBucketStep implements Step {
   private static final int MAX_DELETE_TRIES = 72; // 3 days
   private final CrlService crlService;
   private final ResourceDao resourceDao;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
   private final UUID workspaceId;
   private final UUID resourceId;
 
@@ -43,12 +43,12 @@ public class DeleteGcsBucketStep implements Step {
   public DeleteGcsBucketStep(
       CrlService crlService,
       ResourceDao resourceDao,
-      WorkspaceService workspaceService,
+      GcpCloudContextService gcpCloudContextService,
       UUID workspaceId,
       UUID resourceId) {
     this.crlService = crlService;
     this.resourceDao = resourceDao;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
     this.workspaceId = workspaceId;
     this.resourceId = resourceId;
   }
@@ -56,7 +56,7 @@ public class DeleteGcsBucketStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     int deleteTries = 0;
-    String projectId = workspaceService.getRequiredGcpProject(workspaceId);
+    String projectId = gcpCloudContextService.getRequiredGcpProject(workspaceId);
     WsmResource wsmResource = resourceDao.getResource(workspaceId, resourceId);
     ControlledGcsBucketResource resource =
         wsmResource.castToControlledResource().castToGcsBucketResource();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/notebook/DeleteAiNotebookInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/notebook/DeleteAiNotebookInstanceStep.java
@@ -10,7 +10,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.GcpUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.notebooks.v1.model.Operation;
 import java.io.IOException;
@@ -26,21 +26,21 @@ public class DeleteAiNotebookInstanceStep implements Step {
 
   private final ControlledAiNotebookInstanceResource resource;
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public DeleteAiNotebookInstanceStep(
       ControlledAiNotebookInstanceResource resource,
       CrlService crlService,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.resource = resource;
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     InstanceName instanceName = resource.toInstanceName(projectId);
     AIPlatformNotebooksCow notebooks = crlService.getAIPlatformNotebooksCow();
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/notebook/DeleteServiceAccountStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/notebook/DeleteServiceAccountStep.java
@@ -11,7 +11,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import java.io.IOException;
 import org.apache.http.HttpStatus;
@@ -27,21 +27,21 @@ public class DeleteServiceAccountStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(DeleteAiNotebookInstanceStep.class);
   private final ControlledAiNotebookInstanceResource resource;
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public DeleteServiceAccountStep(
       ControlledAiNotebookInstanceResource resource,
       CrlService crlService,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.resource = resource;
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     IamCow iam = crlService.getIamCow();
     ServiceAccountName serviceAccountName =
         ServiceAccountName.builder()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/notebook/RetrieveNotebookServiceAccountStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/notebook/RetrieveNotebookServiceAccountStep.java
@@ -11,7 +11,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.services.notebooks.v1.model.Instance;
 import java.io.IOException;
 
@@ -26,21 +26,21 @@ import java.io.IOException;
 public class RetrieveNotebookServiceAccountStep implements Step {
   private final ControlledAiNotebookInstanceResource resource;
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public RetrieveNotebookServiceAccountStep(
       ControlledAiNotebookInstanceResource resource,
       CrlService crlService,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.resource = resource;
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    String projectId = workspaceService.getRequiredGcpProject(resource.getWorkspaceId());
+    String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     InstanceName instanceName =
         InstanceName.builder()
             .projectId(projectId)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/RetrieveBigQueryDatasetCloudAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/RetrieveBigQueryDatasetCloudAttributesStep.java
@@ -11,7 +11,7 @@ import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetUpdateParameters
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.BigQueryApiConversions;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.google.api.services.bigquery.model.Dataset;
 import java.io.IOException;
@@ -23,15 +23,15 @@ public class RetrieveBigQueryDatasetCloudAttributesStep implements Step {
       LoggerFactory.getLogger(RetrieveBigQueryDatasetCloudAttributesStep.class);
   private final ControlledBigQueryDatasetResource datasetResource;
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public RetrieveBigQueryDatasetCloudAttributesStep(
       ControlledBigQueryDatasetResource datasetResource,
       CrlService crlService,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.datasetResource = datasetResource;
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
@@ -39,7 +39,7 @@ public class RetrieveBigQueryDatasetCloudAttributesStep implements Step {
       throws InterruptedException, RetryException {
     final FlightMap workingMap = flightContext.getWorkingMap();
     final String projectId =
-        workspaceService.getRequiredGcpProject(datasetResource.getWorkspaceId());
+        gcpCloudContextService.getRequiredGcpProject(datasetResource.getWorkspaceId());
     final String datasetId = datasetResource.getDatasetName();
     final BigQueryCow bigQueryCow = crlService.createWsmSaBigQueryCow();
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/RetrieveGcsBucketCloudAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/RetrieveGcsBucketCloudAttributesStep.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiGcpGcsBucketUpdateParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.GcsApiConversions;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.google.cloud.storage.BucketInfo;
 import javax.ws.rs.BadRequestException;
@@ -25,7 +25,7 @@ public class RetrieveGcsBucketCloudAttributesStep implements Step {
       LoggerFactory.getLogger(RetrieveGcsBucketCloudAttributesStep.class);
   private final ControlledGcsBucketResource bucketResource;
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
   private final RetrievalMode retrievalMode;
 
   // TODO: PF-850 - just use creation parameters and remove retrieval mode.
@@ -37,11 +37,11 @@ public class RetrieveGcsBucketCloudAttributesStep implements Step {
   public RetrieveGcsBucketCloudAttributesStep(
       ControlledGcsBucketResource bucketResource,
       CrlService crlService,
-      WorkspaceService workspaceService,
+      GcpCloudContextService gcpCloudContextService,
       RetrievalMode retrievalMode) {
     this.bucketResource = bucketResource;
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
     this.retrievalMode = retrievalMode;
   }
 
@@ -50,7 +50,7 @@ public class RetrieveGcsBucketCloudAttributesStep implements Step {
       throws InterruptedException, RetryException {
     final FlightMap workingMap = flightContext.getWorkingMap();
     final String projectId =
-        workspaceService.getRequiredGcpProject(bucketResource.getWorkspaceId());
+        gcpCloudContextService.getRequiredGcpProject(bucketResource.getWorkspaceId());
     // get the storage cow
     final StorageCow storageCow = crlService.createStorageCow(projectId);
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateBigQueryDatasetStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateBigQueryDatasetStep.java
@@ -15,7 +15,7 @@ import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetUpdateParameters
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.BigQueryApiConversions;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.services.bigquery.model.Dataset;
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -26,15 +26,15 @@ public class UpdateBigQueryDatasetStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(UpdateBigQueryDatasetStep.class);
   private final ControlledBigQueryDatasetResource datasetResource;
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public UpdateBigQueryDatasetStep(
       ControlledBigQueryDatasetResource datasetResource,
       CrlService crlService,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.datasetResource = datasetResource;
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
@@ -65,7 +65,7 @@ public class UpdateBigQueryDatasetStep implements Step {
       return StepResult.getStepResultSuccess();
     }
     final String projectId =
-        workspaceService.getRequiredGcpProject(datasetResource.getWorkspaceId());
+        gcpCloudContextService.getRequiredGcpProject(datasetResource.getWorkspaceId());
     final String datasetId = datasetResource.getDatasetName();
     final BigQueryCow bigQueryCow = crlService.createWsmSaBigQueryCow();
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateControlledBigQueryDatasetResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateControlledBigQueryDatasetResourceFlight.java
@@ -37,7 +37,7 @@ public class UpdateControlledBigQueryDatasetResourceFlight extends Flight {
         new RetrieveBigQueryDatasetCloudAttributesStep(
             resource.castToBigQueryDatasetResource(),
             flightBeanBag.getCrlService(),
-            flightBeanBag.getWorkspaceService()),
+            flightBeanBag.getGcpCloudContextService()),
         gcpRetryRule);
 
     // Update the dataset's cloud attributes
@@ -45,7 +45,7 @@ public class UpdateControlledBigQueryDatasetResourceFlight extends Flight {
         new UpdateBigQueryDatasetStep(
             resource.castToBigQueryDatasetResource(),
             flightBeanBag.getCrlService(),
-            flightBeanBag.getWorkspaceService()),
+            flightBeanBag.getGcpCloudContextService()),
         gcpRetryRule);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateControlledGcsBucketResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateControlledGcsBucketResourceFlight.java
@@ -34,7 +34,7 @@ public class UpdateControlledGcsBucketResourceFlight extends Flight {
         new RetrieveGcsBucketCloudAttributesStep(
             resource.castToGcsBucketResource(),
             flightBeanBag.getCrlService(),
-            flightBeanBag.getWorkspaceService(),
+            flightBeanBag.getGcpCloudContextService(),
             RetrievalMode.UPDATE_PARAMETERS));
 
     // Update the bucket's cloud attributes
@@ -42,6 +42,6 @@ public class UpdateControlledGcsBucketResourceFlight extends Flight {
         new UpdateGcsBucketStep(
             resource.castToGcsBucketResource(),
             flightBeanBag.getCrlService(),
-            flightBeanBag.getWorkspaceService()));
+            flightBeanBag.getGcpCloudContextService()));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/update/UpdateGcsBucketStep.java
@@ -16,7 +16,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketUpdateParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.cloud.storage.BucketInfo.LifecycleRule;
 import com.google.cloud.storage.StorageClass;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -32,15 +32,15 @@ public class UpdateGcsBucketStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(UpdateGcsBucketStep.class);
   private final ControlledGcsBucketResource bucketResource;
   private final CrlService crlService;
-  private final WorkspaceService workspaceService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   public UpdateGcsBucketStep(
       ControlledGcsBucketResource bucketResource,
       CrlService crlService,
-      WorkspaceService workspaceService) {
+      GcpCloudContextService gcpCloudContextService) {
     this.bucketResource = bucketResource;
     this.crlService = crlService;
-    this.workspaceService = workspaceService;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
@@ -70,7 +70,7 @@ public class UpdateGcsBucketStep implements Step {
       return StepResult.getStepResultSuccess();
     }
     final String projectId =
-        workspaceService.getRequiredGcpProject(bucketResource.getWorkspaceId());
+        gcpCloudContextService.getRequiredGcpProject(bucketResource.getWorkspaceId());
     final StorageCow storageCow = crlService.createStorageCow(projectId);
 
     final BucketCow existingBucketCow = storageCow.get(bucketResource.getBucketName());

--- a/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudContextService.java
@@ -1,0 +1,104 @@
+package bio.terra.workspace.service.workspace;
+
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This service provides methods for managing GCP cloud context. These methods do not perform any
+ * access control and operate directly against the {@link bio.terra.workspace.db.WorkspaceDao}
+ */
+@Component
+public class GcpCloudContextService {
+
+  private final WorkspaceDao workspaceDao;
+
+  @Autowired
+  public GcpCloudContextService(WorkspaceDao workspaceDao) {
+    this.workspaceDao = workspaceDao;
+  }
+
+  /**
+   * Create the GCP cloud context of the workspace
+   *
+   * @param workspaceId unique id of the workspace
+   * @param cloudContext the GCP cloud context to create
+   */
+  public void createGcpCloudContext(
+      UUID workspaceId, GcpCloudContext cloudContext, String flightId) {
+    workspaceDao.createCloudContext(
+        workspaceId, CloudPlatform.GCP, cloudContext.serialize(), flightId);
+  }
+
+  /**
+   * Delete the GCP cloud context for a workspace For details: {@link
+   * WorkspaceDao#deleteCloudContext(UUID, CloudPlatform)}
+   *
+   * @param workspaceId workspace of the cloud context
+   */
+  public void deleteGcpCloudContext(UUID workspaceId) {
+    workspaceDao.deleteCloudContext(workspaceId, CloudPlatform.GCP);
+  }
+
+  /**
+   * Delete a cloud context for the workspace validating the flight id. For details: {@link
+   * WorkspaceDao#deleteCloudContextWithCheck(UUID, CloudPlatform, String)}
+   *
+   * @param workspaceId workspace of the cloud context
+   * @param flightId flight id making the delete request
+   */
+  public void deleteGcpCloudContextWithCheck(UUID workspaceId, String flightId) {
+    workspaceDao.deleteCloudContextWithCheck(workspaceId, CloudPlatform.GCP, flightId);
+  }
+
+  /**
+   * Retrieve the optional GCP cloud context
+   *
+   * @param workspaceId workspace identifier of the cloud context
+   * @return optional GCP cloud context
+   */
+  public Optional<GcpCloudContext> getGcpCloudContext(UUID workspaceId) {
+    return workspaceDao
+        .getCloudContext(workspaceId, CloudPlatform.GCP)
+        .map(GcpCloudContext::deserialize);
+  }
+
+  /**
+   * Retrieve the optional GCP cloud context, providing a workspace This is a frequent usage, so we
+   * make a method for it to save coding the fetch of workspace id every time
+   */
+  public Optional<GcpCloudContext> getGcpCloudContext(Workspace workspace) {
+    return getGcpCloudContext(workspace.getWorkspaceId());
+  }
+
+  /**
+   * Helper method for looking up the GCP project ID for a given workspace ID, if one exists. Unlike
+   * {@link #getRequiredGcpProject(UUID)}, this returns an empty Optional instead of throwing if the
+   * given workspace does not have a GCP cloud context. NOTE: no user auth validation
+   *
+   * @param workspaceId workspace identifier of the cloud context
+   * @return optional GCP project from the cloud context
+   */
+  public Optional<String> getGcpProject(UUID workspaceId) {
+    return getGcpCloudContext(workspaceId).map(GcpCloudContext::getGcpProjectId);
+  }
+
+  /**
+   * Helper method used by other classes that require the GCP project to exist in the workspace. It
+   * throws if the project (GCP cloud context) is not set up. NOTE: no user auth validation
+   *
+   * @param workspaceId unique workspace id
+   * @return GCP project id
+   */
+  public String getRequiredGcpProject(UUID workspaceId) {
+    return getGcpProject(workspaceId)
+        .orElseThrow(
+            () -> new CloudContextRequiredException("Operation requires GCP cloud context"));
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -313,6 +313,36 @@ public class WorkspaceService {
   }
 
   /**
+   * Retrieve the optional GCP cloud context
+   *
+   * @param workspaceId workspace identifier of the cloud context
+   * @return optional GCP cloud context
+   */
+  public Optional<GcpCloudContext> getGcpCloudContext(UUID workspaceId) {
+    return workspaceDao.getGcpCloudContext(workspaceId);
+  }
+
+  /**
+   * Retrieve the optional GCP cloud context, providing a workspace This is a frequent usage, so we
+   * make a method for it to save coding the fetch of workspace id every time
+   */
+  public Optional<GcpCloudContext> getGcpCloudContext(Workspace workspace) {
+    return workspaceDao.getGcpCloudContext(workspace.getWorkspaceId());
+  }
+
+  /**
+   * Helper method for looking up the GCP project ID for a given workspace ID, if one exists. Unlike
+   * {@link #getRequiredGcpProject(UUID)}, this returns an empty Optional instead of throwing if the
+   * given workspace does not have a GCP cloud context.
+   *
+   * @param workspaceId workspace identifier of the cloud context
+   * @return optional GCP project from the cloud context
+   */
+  public Optional<String> getGcpProject(UUID workspaceId) {
+    return workspaceDao.getGcpCloudContext(workspaceId).map(GcpCloudContext::getGcpProjectId);
+  }
+
+  /**
    * Helper method used by other classes that require the GCP project to exist in the workspace. It
    * throws if the project (GCP cloud context) is not set up.
    *
@@ -320,25 +350,12 @@ public class WorkspaceService {
    * @return GCP project id
    */
   public String getRequiredGcpProject(UUID workspaceId) {
-    Workspace workspace = workspaceDao.getWorkspace(workspaceId);
     GcpCloudContext gcpCloudContext =
-        workspace
-            .getGcpCloudContext()
+        workspaceDao
+            .getGcpCloudContext(workspaceId)
             .orElseThrow(
                 () -> new CloudContextRequiredException("Operation requires GCP cloud context"));
     return gcpCloudContext.getGcpProjectId();
-  }
-
-  /**
-   * Helper method for looking up the GCP project ID for a given workspace ID, if one exists. Unlike
-   * {@link #getRequiredGcpProject(UUID)}, this returns an empty Optional instead of throwing if the
-   * given workspace does not have a GCP cloud context.
-   */
-  public Optional<String> getGcpProject(UUID workspaceId) {
-    return workspaceDao
-        .getWorkspace(workspaceId)
-        .getGcpCloudContext()
-        .map(GcpCloudContext::getGcpProjectId);
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -313,7 +313,7 @@ public class WorkspaceService {
   }
 
   /**
-   * Retrieve the optional GCP cloud context
+   * Retrieve the optional GCP cloud context NOTE: no user auth validation
    *
    * @param workspaceId workspace identifier of the cloud context
    * @return optional GCP cloud context
@@ -324,7 +324,8 @@ public class WorkspaceService {
 
   /**
    * Retrieve the optional GCP cloud context, providing a workspace This is a frequent usage, so we
-   * make a method for it to save coding the fetch of workspace id every time
+   * make a method for it to save coding the fetch of workspace id every time NOTE: no user auth
+   * validation
    */
   public Optional<GcpCloudContext> getGcpCloudContext(Workspace workspace) {
     return workspaceDao.getGcpCloudContext(workspace.getWorkspaceId());
@@ -333,7 +334,7 @@ public class WorkspaceService {
   /**
    * Helper method for looking up the GCP project ID for a given workspace ID, if one exists. Unlike
    * {@link #getRequiredGcpProject(UUID)}, this returns an empty Optional instead of throwing if the
-   * given workspace does not have a GCP cloud context.
+   * given workspace does not have a GCP cloud context. NOTE: no user auth validation
    *
    * @param workspaceId workspace identifier of the cloud context
    * @return optional GCP project from the cloud context
@@ -344,7 +345,7 @@ public class WorkspaceService {
 
   /**
    * Helper method used by other classes that require the GCP project to exist in the workspace. It
-   * throws if the project (GCP cloud context) is not set up.
+   * throws if the project (GCP cloud context) is not set up. NOTE: no user auth validation
    *
    * @param workspaceId unique workspace id
    * @return GCP project id
@@ -356,6 +357,18 @@ public class WorkspaceService {
             .orElseThrow(
                 () -> new CloudContextRequiredException("Operation requires GCP cloud context"));
     return gcpCloudContext.getGcpProjectId();
+  }
+
+  /**
+   * Get the GcpProject with authentication for use in controllers
+   *
+   * @param workspaceId unique workspace id
+   * @param userRequest authenticated user
+   * @return GCP project id
+   */
+  public String getRequiredGcpProject(UUID workspaceId, AuthenticatedUserRequest userRequest) {
+    validateWorkspaceAndAction(userRequest, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
+    return getRequiredGcpProject(workspaceId);
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -351,12 +351,8 @@ public class WorkspaceService {
    * @return GCP project id
    */
   public String getRequiredGcpProject(UUID workspaceId) {
-    GcpCloudContext gcpCloudContext =
-        workspaceDao
-            .getGcpCloudContext(workspaceId)
-            .orElseThrow(
-                () -> new CloudContextRequiredException("Operation requires GCP cloud context"));
-    return gcpCloudContext.getGcpProjectId();
+    return getGcpProject(workspaceId).orElseThrow(
+            () -> new CloudContextRequiredException("Operation requires GCP cloud context"));
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -314,33 +314,44 @@ public class WorkspaceService {
         .submitAndWait(null);
   }
 
-  /** Get an optional cloud context */
-  public Optional<GcpCloudContext> getGcpCloudContext(
+  /**
+   * We ensure that the workspace exists and the user has read access. If so, we lookup the GCP
+   * cloud context, if any.
+   *
+   * @param workspaceId id of the workspace whose cloud context we want to get
+   * @param userRequest auth of user to test for read access
+   * @return optional GCP cloud context
+   */
+  public Optional<GcpCloudContext> getAuthorizedGcpCloudContext(
       UUID workspaceId, AuthenticatedUserRequest userRequest) {
     validateWorkspaceAndAction(userRequest, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     return gcpCloudContextService.getGcpCloudContext(workspaceId);
   }
 
   /**
-   * Get an option project id from an optional GCP cloud context
+   * We ensure that the workspace exists and the user has read access. If so, we lookup the GCP
+   * project id, if any.
    *
-   * @param workspaceId unique workspace id
-   * @param userRequest authenticated user
+   * @param workspaceId id of the workspace whose GCP project id we want to get
+   * @param userRequest auth of user to test for read access
    * @return optional project id
    */
-  public Optional<String> getGcpProject(UUID workspaceId, AuthenticatedUserRequest userRequest) {
+  public Optional<String> getAuthorizedGcpProject(
+      UUID workspaceId, AuthenticatedUserRequest userRequest) {
     validateWorkspaceAndAction(userRequest, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     return gcpCloudContextService.getGcpProject(workspaceId);
   }
 
   /**
-   * Get the GcpProject or throw
+   * We ensure that the workspace exists and the user has read access. If so, we lookup the GCP
+   * project id. If it does not exist, an exception is thrown.
    *
-   * @param workspaceId unique workspace id
-   * @param userRequest authenticated user
-   * @return GCP project id
+   * @param workspaceId id of the workspace whose GCP project id we want to get
+   * @param userRequest auth of user to test for read access
+   * @return project id
    */
-  public String getRequiredGcpProject(UUID workspaceId, AuthenticatedUserRequest userRequest) {
+  public String getAuthorizedRequiredGcpProject(
+      UUID workspaceId, AuthenticatedUserRequest userRequest) {
     validateWorkspaceAndAction(userRequest, workspaceId, SamConstants.SAM_WORKSPACE_READ_ACTION);
     return gcpCloudContextService.getRequiredGcpProject(workspaceId);
   }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -351,7 +351,8 @@ public class WorkspaceService {
    * @return GCP project id
    */
   public String getRequiredGcpProject(UUID workspaceId) {
-    return getGcpProject(workspaceId).orElseThrow(
+    return getGcpProject(workspaceId)
+        .orElseThrow(
             () -> new CloudContextRequiredException("Operation requires GCP cloud context"));
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlight.java
@@ -41,7 +41,8 @@ public class CreateGcpContextFlight extends Flight {
 
     addStep(new SetProjectBillingStep(crl.getCloudBillingClientCow()));
     addStep(new CreateCustomGcpRolesStep(crl.getIamCow()), retryRule);
-    addStep(new StoreGcpContextStep(appContext.getWorkspaceDao(), workspaceId), retryRule);
+    addStep(
+        new StoreGcpContextStep(appContext.getGcpCloudContextService(), workspaceId), retryRule);
     addStep(new SyncSamGroupsStep(appContext.getSamService(), workspaceId, userRequest), retryRule);
     addStep(new GcpCloudSyncStep(crl.getCloudResourceManagerCow()), retryRule);
     addStep(new SetGcpContextOutputStep());

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlight.java
@@ -42,7 +42,8 @@ public class DeleteGcpContextFlight extends Flight {
             appContext.getResourceDao(), workspaceId, CLOUD_PLATFORM),
         retryRule);
     addStep(
-        new DeleteProjectStep(appContext.getCrlService(), appContext.getGcpCloudContextService()),
+        new DeleteGcpProjectStep(
+            appContext.getCrlService(), appContext.getGcpCloudContextService()),
         retryRule);
     addStep(
         new DeleteGcpContextStep(appContext.getGcpCloudContextService(), workspaceId), retryRule);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlight.java
@@ -42,7 +42,9 @@ public class DeleteGcpContextFlight extends Flight {
             appContext.getResourceDao(), workspaceId, CLOUD_PLATFORM),
         retryRule);
     addStep(
-        new DeleteProjectStep(appContext.getCrlService(), appContext.getWorkspaceDao()), retryRule);
-    addStep(new DeleteGcpContextStep(appContext.getWorkspaceDao(), workspaceId), retryRule);
+        new DeleteProjectStep(appContext.getCrlService(), appContext.getGcpCloudContextService()),
+        retryRule);
+    addStep(
+        new DeleteGcpContextStep(appContext.getGcpCloudContextService(), workspaceId), retryRule);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextStep.java
@@ -3,7 +3,7 @@ package bio.terra.workspace.service.workspace.flight;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,17 +11,17 @@ import org.slf4j.LoggerFactory;
 /** Deletes a workspace's Google cloud context from the DAO. */
 public class DeleteGcpContextStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(DeleteGcpContextStep.class);
-  private final WorkspaceDao workspaceDao;
+  private final GcpCloudContextService gcpCloudContextService;
   private final UUID workspaceId;
 
-  protected DeleteGcpContextStep(WorkspaceDao workspaceDao, UUID workspaceId) {
-    this.workspaceDao = workspaceDao;
+  protected DeleteGcpContextStep(GcpCloudContextService gcpCloudContextService, UUID workspaceId) {
+    this.gcpCloudContextService = gcpCloudContextService;
     this.workspaceId = workspaceId;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws InterruptedException {
-    workspaceDao.deleteGcpCloudContext(workspaceId);
+    gcpCloudContextService.deleteGcpCloudContext(workspaceId);
     return StepResult.getStepResultSuccess();
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpProjectStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteGcpProjectStep.java
@@ -24,12 +24,12 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Undo always fails for this step.
  */
-public class DeleteProjectStep implements Step {
+public class DeleteGcpProjectStep implements Step {
   private final CrlService crl;
   private final GcpCloudContextService gcpCloudContextService;
-  private final Logger logger = LoggerFactory.getLogger(DeleteProjectStep.class);
+  private final Logger logger = LoggerFactory.getLogger(DeleteGcpProjectStep.class);
 
-  public DeleteProjectStep(CrlService crl, GcpCloudContextService gcpCloudContextService) {
+  public DeleteGcpProjectStep(CrlService crl, GcpCloudContextService gcpCloudContextService) {
     this.crl = crl;
     this.gcpCloudContextService = gcpCloudContextService;
   }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteProjectStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteProjectStep.java
@@ -7,8 +7,8 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.GcpUtils;
-import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import java.io.IOException;
 import java.util.Optional;
@@ -26,12 +26,12 @@ import org.slf4j.LoggerFactory;
  */
 public class DeleteProjectStep implements Step {
   private final CrlService crl;
-  private final WorkspaceDao workspaceDao;
+  private final GcpCloudContextService gcpCloudContextService;
   private final Logger logger = LoggerFactory.getLogger(DeleteProjectStep.class);
 
-  public DeleteProjectStep(CrlService crl, WorkspaceDao workspaceDao) {
+  public DeleteProjectStep(CrlService crl, GcpCloudContextService gcpCloudContextService) {
     this.crl = crl;
-    this.workspaceDao = workspaceDao;
+    this.gcpCloudContextService = gcpCloudContextService;
   }
 
   @Override
@@ -72,6 +72,6 @@ public class DeleteProjectStep implements Step {
             flightContext
                 .getInputParameters()
                 .get(WorkspaceFlightMapKeys.WORKSPACE_ID, String.class));
-    return workspaceDao.getGcpCloudContext(workspaceId);
+    return gcpCloudContextService.getGcpCloudContext(workspaceId);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/StoreGcpContextStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/StoreGcpContextStep.java
@@ -35,8 +35,6 @@ public class StoreGcpContextStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    String projectId = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
-
     // Delete the cloud context, but only if it is the one with our flight id
     workspaceDao.deleteGcpCloudContextWithCheck(workspaceId, flightContext.getFlightId());
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/StoreGcpContextStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/StoreGcpContextStep.java
@@ -6,6 +6,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import java.util.UUID;
 
@@ -14,11 +15,11 @@ import java.util.UUID;
  * context for the workspace.
  */
 public class StoreGcpContextStep implements Step {
-  private final WorkspaceDao workspaceDao;
+  private final GcpCloudContextService gcpCloudContextService;
   private final UUID workspaceId;
 
-  public StoreGcpContextStep(WorkspaceDao workspaceDao, UUID workspaceId) {
-    this.workspaceDao = workspaceDao;
+  public StoreGcpContextStep(GcpCloudContextService gcpCloudContextService, UUID workspaceId) {
+    this.gcpCloudContextService = gcpCloudContextService;
     this.workspaceId = workspaceId;
   }
 
@@ -28,7 +29,7 @@ public class StoreGcpContextStep implements Step {
 
     // Create the cloud context; throws if the context already exists. We let
     // Stairway handle that.
-    workspaceDao.createGcpCloudContext(
+    gcpCloudContextService.createGcpCloudContext(
         workspaceId, new GcpCloudContext(projectId), flightContext.getFlightId());
     return StepResult.getStepResultSuccess();
   }
@@ -36,7 +37,7 @@ public class StoreGcpContextStep implements Step {
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
     // Delete the cloud context, but only if it is the one with our flight id
-    workspaceDao.deleteGcpCloudContextWithCheck(workspaceId, flightContext.getFlightId());
+    gcpCloudContextService.deleteGcpCloudContextWithCheck(workspaceId, flightContext.getFlightId());
     return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/StoreGcpContextStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/StoreGcpContextStep.java
@@ -28,7 +28,8 @@ public class StoreGcpContextStep implements Step {
 
     // Create the cloud context; throws if the context already exists. We let
     // Stairway handle that.
-    workspaceDao.createGcpCloudContext(workspaceId, new GcpCloudContext(projectId));
+    workspaceDao.createGcpCloudContext(
+        workspaceId, new GcpCloudContext(projectId), flightContext.getFlightId());
     return StepResult.getStepResultSuccess();
   }
 
@@ -36,8 +37,8 @@ public class StoreGcpContextStep implements Step {
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
     String projectId = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
 
-    // Delete the cloud context, but only if it is the one with our project id
-    workspaceDao.deleteGcpCloudContextWithIdCheck(workspaceId, projectId);
+    // Delete the cloud context, but only if it is the one with our flight id
+    workspaceDao.deleteGcpCloudContextWithCheck(workspaceId, flightContext.getFlightId());
     return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
@@ -46,7 +46,8 @@ public class WorkspaceDeleteFlight extends Flight {
             userRequest),
         retryRule);
     addStep(
-        new DeleteProjectStep(appContext.getCrlService(), appContext.getWorkspaceDao()), retryRule);
+        new DeleteProjectStep(appContext.getCrlService(), appContext.getGcpCloudContextService()),
+        retryRule);
     // Workspace authz is handled differently depending on whether WSM owns the underlying Sam
     // resource or not, as indicated by the workspace stage enum.
     switch (workspaceStage) {

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
@@ -46,7 +46,8 @@ public class WorkspaceDeleteFlight extends Flight {
             userRequest),
         retryRule);
     addStep(
-        new DeleteProjectStep(appContext.getCrlService(), appContext.getGcpCloudContextService()),
+        new DeleteGcpProjectStep(
+            appContext.getCrlService(), appContext.getGcpCloudContextService()),
         retryRule);
     // Workspace authz is handled differently depending on whether WSM owns the underlying Sam
     // resource or not, as indicated by the workspace stage enum.

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/GcpCloudContext.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/GcpCloudContext.java
@@ -5,6 +5,7 @@ import bio.terra.workspace.generated.model.ApiGcpContext;
 import bio.terra.workspace.service.workspace.exceptions.InvalidSerializedVersionException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 
 public class GcpCloudContext {
   private final String gcpProjectId;
@@ -22,26 +23,26 @@ public class GcpCloudContext {
     return new ApiGcpContext().projectId(getGcpProjectId());
   }
 
-  public static final long GCP_CLOUD_CONTEXT_DB_VERSION = 1;
-
   public String serialize() {
     GcpCloudContextV1 dbContext = GcpCloudContextV1.from(getGcpProjectId());
     return DbSerDes.toJson(dbContext);
   }
 
-  public static GcpCloudContext deserialize(String json) {
+  public static @Nullable GcpCloudContext deserialize(@Nullable String json) {
     if (json == null) {
       return null;
     }
 
     GcpCloudContextV1 result = DbSerDes.fromJson(json, GcpCloudContextV1.class);
-    if (result.version != GCP_CLOUD_CONTEXT_DB_VERSION) {
+    if (result.version != GcpCloudContextV1.GCP_CLOUD_CONTEXT_DB_VERSION) {
       throw new InvalidSerializedVersionException("Invalid serialized version");
     }
     return new GcpCloudContext(result.gcpProjectId);
   }
 
   public static class GcpCloudContextV1 {
+    public static final long GCP_CLOUD_CONTEXT_DB_VERSION = 1;
+
     /** Version marker to store in the db so that we can update the format later if we need to. */
     @JsonProperty public final long version = GCP_CLOUD_CONTEXT_DB_VERSION;
 

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/GcpCloudContext.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/GcpCloudContext.java
@@ -1,6 +1,8 @@
 package bio.terra.workspace.service.workspace.model;
 
+import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.generated.model.ApiGcpContext;
+import bio.terra.workspace.service.workspace.exceptions.InvalidSerializedVersionException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -18,5 +20,37 @@ public class GcpCloudContext {
 
   public ApiGcpContext toApi() {
     return new ApiGcpContext().projectId(getGcpProjectId());
+  }
+
+  public static final long GCP_CLOUD_CONTEXT_DB_VERSION = 1;
+
+  public String serialize() {
+    GcpCloudContextV1 dbContext = GcpCloudContextV1.from(getGcpProjectId());
+    return DbSerDes.toJson(dbContext);
+  }
+
+  public static GcpCloudContext deserialize(String json) {
+    if (json == null) {
+      return null;
+    }
+
+    GcpCloudContextV1 result = DbSerDes.fromJson(json, GcpCloudContextV1.class);
+    if (result.version != GCP_CLOUD_CONTEXT_DB_VERSION) {
+      throw new InvalidSerializedVersionException("Invalid serialized version");
+    }
+    return new GcpCloudContext(result.gcpProjectId);
+  }
+
+  public static class GcpCloudContextV1 {
+    /** Version marker to store in the db so that we can update the format later if we need to. */
+    @JsonProperty public final long version = GCP_CLOUD_CONTEXT_DB_VERSION;
+
+    @JsonProperty public String gcpProjectId;
+
+    public static GcpCloudContextV1 from(String googleProjectId) {
+      GcpCloudContextV1 result = new GcpCloudContextV1();
+      result.gcpProjectId = googleProjectId;
+      return result;
+    }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/Workspace.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/Workspace.java
@@ -26,7 +26,6 @@ public class Workspace {
   private final SpendProfileId spendProfileId;
   private final Map<String, String> properties;
   private final WorkspaceStage workspaceStage;
-  private final GcpCloudContext gcpCloudContext;
 
   public Workspace(
       UUID workspaceId,
@@ -34,15 +33,13 @@ public class Workspace {
       String description,
       SpendProfileId spendProfileId,
       Map<String, String> properties,
-      WorkspaceStage workspaceStage,
-      GcpCloudContext gcpCloudContext) {
+      WorkspaceStage workspaceStage) {
     this.workspaceId = workspaceId;
     this.displayName = displayName;
     this.description = description;
     this.spendProfileId = spendProfileId;
     this.properties = properties;
     this.workspaceStage = workspaceStage;
-    this.gcpCloudContext = gcpCloudContext;
   }
 
   /** The globally unique identifier of this workspace */
@@ -81,11 +78,6 @@ public class Workspace {
     return workspaceStage;
   }
 
-  /** Optional GCP cloud context */
-  public Optional<GcpCloudContext> getGcpCloudContext() {
-    return Optional.ofNullable(gcpCloudContext);
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -101,7 +93,6 @@ public class Workspace {
         .append(spendProfileId, workspace.spendProfileId)
         .append(properties, workspace.properties)
         .append(workspaceStage, workspace.workspaceStage)
-        .append(gcpCloudContext, workspace.gcpCloudContext)
         .isEquals();
   }
 
@@ -114,7 +105,6 @@ public class Workspace {
         .append(spendProfileId)
         .append(properties)
         .append(workspaceStage)
-        .append(gcpCloudContext)
         .toHashCode();
   }
 
@@ -130,7 +120,6 @@ public class Workspace {
     private SpendProfileId spendProfileId;
     private Map<String, String> properties;
     private WorkspaceStage workspaceStage;
-    private GcpCloudContext gcpCloudContext;
 
     public Builder workspaceId(UUID workspaceId) {
       this.workspaceId = workspaceId;
@@ -162,11 +151,6 @@ public class Workspace {
       return this;
     }
 
-    public Builder gcpCloudContext(GcpCloudContext gcpCloudContext) {
-      this.gcpCloudContext = gcpCloudContext;
-      return this;
-    }
-
     public Workspace build() {
       // Always have a map, even if it is empty
       if (properties == null) {
@@ -176,13 +160,7 @@ public class Workspace {
         throw new MissingRequiredFieldsException("Workspace requires id and stage");
       }
       return new Workspace(
-          workspaceId,
-          displayName,
-          description,
-          spendProfileId,
-          properties,
-          workspaceStage,
-          gcpCloudContext);
+          workspaceId, displayName, description, spendProfileId, properties, workspaceStage);
     }
   }
 }

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <include file="changesets/20210301_revised_initial_schema.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20210917_cloud_context.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20210917_cloud_context.yaml
+++ b/service/src/main/resources/db/changesets/20210917_cloud_context.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+- changeSet:
+    id: add flight id to cloud context for flight idempotency
+    author: dd
+    changes:
+    - addColumn:
+        tableName: cloud_context
+        columns:
+          - column:
+              name: creating_flight
+              type: text
+              remarks: |
+                This is used to ensure that when undoing a failing cloud context create
+                flight, we do not delete an existing cloud context.

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -42,7 +42,9 @@ public class ResourceDaoTest extends BaseUnitTest {
             .build();
     workspaceDao.createWorkspace(workspace);
     workspaceDao.createGcpCloudContext(
-        workspace.getWorkspaceId(), new GcpCloudContext("my-project-id"));
+        workspace.getWorkspaceId(),
+        new GcpCloudContext("my-project-id"),
+        "flight-creategcpworkspace");
     return workspace.getWorkspaceId();
   }
 

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -14,6 +14,7 @@ import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDataset
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.ControlledResource;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.Workspace;
@@ -26,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class ResourceDaoTest extends BaseUnitTest {
   @Autowired ResourceDao resourceDao;
   @Autowired WorkspaceDao workspaceDao;
+  @Autowired GcpCloudContextService gcpCloudContextService;
 
   /**
    * Creates a workspaces with a GCP cloud context and stores it in the database. Returns the
@@ -41,7 +43,7 @@ public class ResourceDaoTest extends BaseUnitTest {
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     workspaceDao.createWorkspace(workspace);
-    workspaceDao.createGcpCloudContext(
+    gcpCloudContextService.createGcpCloudContext(
         workspace.getWorkspaceId(),
         new GcpCloudContext("my-project-id"),
         "flight-creategcpworkspace");

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -241,7 +241,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
       // delete with mismatched flight id - it should not delete
       gcpCloudContextService.deleteGcpCloudContextWithCheck(workspaceId, "mismatched-flight-id");
 
-      // Make sure the contxt is still there
+      // Make sure the context is still there
       cloudContext = gcpCloudContextService.getGcpCloudContext(workspaceId);
       assertTrue(cloudContext.isPresent());
       assertEquals(projectId, cloudContext.get().getGcpProjectId());

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -18,6 +18,7 @@ import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateWorkspaceException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import bio.terra.workspace.service.workspace.model.GcpCloudContext.GcpCloudContextV1;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -276,7 +277,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
       final String json = "{\"version\":1,\"gcpProjectId\":\"foo\"}";
       GcpCloudContext.GcpCloudContextV1 gcpCloudContextV1 =
           persistenceObjectMapper.readValue(json, GcpCloudContext.GcpCloudContextV1.class);
-      assertEquals(GcpCloudContext.GCP_CLOUD_CONTEXT_DB_VERSION, gcpCloudContextV1.version);
+      assertEquals(GcpCloudContextV1.GCP_CLOUD_CONTEXT_DB_VERSION, gcpCloudContextV1.version);
       assertEquals("foo", gcpCloudContextV1.gcpProjectId);
 
       GcpCloudContext gcpCloudContext = GcpCloudContext.deserialize(json);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -46,6 +46,7 @@ import bio.terra.workspace.service.resource.controlled.flight.update.UpdateBigQu
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
+import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.bigquery.model.Dataset;
@@ -87,6 +88,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @Autowired private StairwayComponent stairwayComponent;
   @Autowired private UserAccessUtils userAccessUtils;
   @Autowired private WorkspaceConnectedTestUtils workspaceUtils;
+  @Autowired private WorkspaceService workspaceService;
 
   private static Workspace reusableWorkspace;
 
@@ -118,6 +120,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void createAiNotebookInstanceDo() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
+    UUID workspaceId = workspace.getWorkspaceId();
     String instanceId = "create-ai-notebook-instance-do";
     ApiGcpAiNotebookInstanceCreationParameters creationParameters =
         ControlledResourceFixtures.defaultNotebookCreationParameters()
@@ -162,13 +165,9 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             workspace.getWorkspaceId(), resource.getResourceId(), user.getAuthenticatedRequest()));
 
     InstanceName instanceName =
-        resource.toInstanceName(workspace.getGcpCloudContext().get().getGcpProjectId());
+        resource.toInstanceName(workspaceService.getRequiredGcpProject(workspaceId));
     Instance instance =
-        crlService
-            .getAIPlatformNotebooksCow()
-            .instances()
-            .get(resource.toInstanceName(workspace.getGcpCloudContext().get().getGcpProjectId()))
-            .execute();
+        crlService.getAIPlatformNotebooksCow().instances().get(instanceName).execute();
 
     // Test that the user has permissions from WRITER roles on the notebooks instance. Only notebook
     // instance level permissions can be checked on the notebook instance test IAM permissions
@@ -283,7 +282,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     assertEquals(
         FlightStatus.ERROR, stairwayComponent.get().getFlightState(jobId).getFlightStatus());
 
-    String projectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
     assertNotFound(resource.toInstanceName(projectId), crlService.getAIPlatformNotebooksCow());
 
     String serviceAccountId =
@@ -357,7 +356,8 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     ControlledAiNotebookInstanceResource resource =
         createDefaultPrivateAiNotebookInstance("delete-ai-notebook-instance-do", user);
-    String projectId = reusableWorkspace(user).getGcpCloudContext().get().getGcpProjectId();
+    String projectId =
+        workspaceService.getRequiredGcpProject(reusableWorkspace(user).getWorkspaceId());
     InstanceName instanceName = resource.toInstanceName(projectId);
 
     AIPlatformNotebooksCow notebooks = crlService.getAIPlatformNotebooksCow();
@@ -469,7 +469,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void createGetUpdateDeleteBqDataset() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
-
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
     String datasetId = "my_test_dataset";
     String location = "us-central1";
 
@@ -518,11 +518,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     assertEquals(newDescription, updatedResource.getDescription());
 
     Dataset updatedDatasetFromCloud =
-        crlService
-            .createWsmSaBigQueryCow()
-            .datasets()
-            .get(workspace.getGcpCloudContext().get().getGcpProjectId(), datasetId)
-            .execute();
+        crlService.createWsmSaBigQueryCow().datasets().get(projectId, datasetId).execute();
     assertEquals(
         newDefaultTableLifetime * 1000L, updatedDatasetFromCloud.getDefaultTableExpirationMs());
     assertEquals(
@@ -546,7 +542,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void createBqDatasetDo() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
-    String projectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
 
     String datasetId = uniqueDatasetId();
     String location = "us-central1";
@@ -600,7 +596,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void createBqDatasetUndo() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
-    String projectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
 
     String datasetId = uniqueDatasetId();
     String location = "us-central1";
@@ -657,7 +653,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void deleteBqDatasetDo() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
-    String projectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
 
     String datasetId = uniqueDatasetId();
     String location = "us-central1";
@@ -710,7 +706,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void deleteBqDatasetUndo() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
-    String projectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
 
     String datasetId = uniqueDatasetId();
     String location = "us-central1";
@@ -764,7 +760,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void updateBqDatasetDo() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
-    String projectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
 
     // create the dataset
     String datasetId = uniqueDatasetId();
@@ -829,7 +825,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void updateBqDatasetUndo() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
-    String projectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
 
     // create the dataset
     String datasetId = uniqueDatasetId();
@@ -910,7 +906,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void updateBqDatasetWithUndefinedExpirationTimes() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
-    String projectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
 
     // create the dataset, with expiration times initially defined
     String datasetId = uniqueDatasetId();
@@ -987,7 +983,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   public void updateBqDatasetWithInvalidExpirationTimes() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
-    String projectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
 
     // create the dataset, with expiration times initially undefined
     String datasetId = uniqueDatasetId();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -182,7 +182,8 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
 
     InstanceName instanceName =
         resource.toInstanceName(
-            workspaceService.getRequiredGcpProject(workspaceId, user.getAuthenticatedRequest()));
+            workspaceService.getAuthorizedRequiredGcpProject(
+                workspaceId, user.getAuthenticatedRequest()));
     Instance instance =
         crlService.getAIPlatformNotebooksCow().instances().get(instanceName).execute();
 
@@ -300,7 +301,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
         FlightStatus.ERROR, stairwayComponent.get().getFlightState(jobId).getFlightStatus());
 
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
     assertNotFound(resource.toInstanceName(projectId), crlService.getAIPlatformNotebooksCow());
 
@@ -376,7 +377,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     ControlledAiNotebookInstanceResource resource =
         createDefaultPrivateAiNotebookInstance("delete-ai-notebook-instance-do", user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             reusableWorkspace(user).getWorkspaceId(), user.getAuthenticatedRequest());
     InstanceName instanceName = resource.toInstanceName(projectId);
 
@@ -474,7 +475,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
     String datasetId = "my_test_dataset";
     String location = "us-central1";
@@ -549,7 +550,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
 
     String datasetId = uniqueDatasetId();
@@ -605,7 +606,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
 
     String datasetId = uniqueDatasetId();
@@ -664,7 +665,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
 
     String datasetId = uniqueDatasetId();
@@ -719,7 +720,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
 
     String datasetId = uniqueDatasetId();
@@ -775,7 +776,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
 
     // create the dataset
@@ -842,7 +843,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
 
     // create the dataset
@@ -925,7 +926,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
 
     // create the dataset, with expiration times initially defined
@@ -1004,7 +1005,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
     Workspace workspace = reusableWorkspace(user);
     String projectId =
-        workspaceService.getRequiredGcpProject(
+        workspaceService.getAuthorizedRequiredGcpProject(
             workspace.getWorkspaceId(), user.getAuthenticatedRequest());
 
     // create the dataset, with expiration times initially undefined

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -119,8 +119,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   public void createAiNotebookInstanceDo() throws Exception {
     UserAccessUtils.TestUser user = userAccessUtils.defaultUser();
-    Workspace workspace = reusableWorkspace(user);
-    UUID workspaceId = workspace.getWorkspaceId();
+    UUID workspaceId = reusableWorkspace(user).getWorkspaceId();
     String instanceId = "create-ai-notebook-instance-do";
     ApiGcpAiNotebookInstanceCreationParameters creationParameters =
         ControlledResourceFixtures.defaultNotebookCreationParameters()
@@ -128,7 +127,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .location(DEFAULT_NOTEBOOK_LOCATION);
     ControlledAiNotebookInstanceResource.Builder resourceBuilder =
         ControlledResourceFixtures.makeDefaultAiNotebookInstance()
-            .workspaceId(workspace.getWorkspaceId())
+            .workspaceId(workspaceId)
             .name(instanceId)
             .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
             .managedBy(ManagedByType.MANAGED_BY_USER)
@@ -162,7 +161,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     assertEquals(
         resource,
         controlledResourceService.getControlledResource(
-            workspace.getWorkspaceId(), resource.getResourceId(), user.getAuthenticatedRequest()));
+            workspaceId, resource.getResourceId(), user.getAuthenticatedRequest()));
 
     InstanceName instanceName =
         resource.toInstanceName(workspaceService.getRequiredGcpProject(workspaceId));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
@@ -25,7 +25,7 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateGcsBucketStep;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.BucketInfo.LifecycleRule;
@@ -46,7 +46,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
   @Mock private FlightContext mockFlightContext;
   @Mock private CrlService mockCrlService;
   @Mock private StorageCow mockStorageCow;
-  @Mock private WorkspaceService mockWorkspaceService;
+  @Mock private GcpCloudContextService mockGcpCloudContextService;
   @Mock private BucketCow mockBucketCow;
 
   @Captor private ArgumentCaptor<BucketInfo> bucketInfoCaptor;
@@ -56,7 +56,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
   @BeforeEach
   public void setup() {
     doReturn(mockStorageCow).when(mockCrlService).createStorageCow(any(String.class));
-    when(mockWorkspaceService.getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
+    when(mockGcpCloudContextService.getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
     when(mockStorageCow.create(bucketInfoCaptor.capture())).thenReturn(mockBucketCow);
   }
 
@@ -69,7 +69,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
         new CreateGcsBucketStep(
             mockCrlService,
             ControlledResourceFixtures.getBucketResource(creationParameters.getName()),
-            mockWorkspaceService);
+            mockGcpCloudContextService);
 
     final FlightMap inputFlightMap = new FlightMap();
     inputFlightMap.put(
@@ -122,7 +122,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
         new CreateGcsBucketStep(
             mockCrlService,
             ControlledResourceFixtures.getBucketResource(bucketName),
-            mockWorkspaceService);
+            mockGcpCloudContextService);
 
     final FlightMap inputFlightMap = new FlightMap();
     inputFlightMap.put(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
@@ -17,6 +17,7 @@ import bio.terra.workspace.service.resource.WsmResource;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.flight.create.StoreMetadataStep;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
@@ -27,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class StoreControlledResourceMetadataStepTest extends BaseUnitTest {
   @Autowired private WorkspaceDao workspaceDao;
+  @Autowired private GcpCloudContextService gcpCloudContextService;
   @Autowired private ResourceDao resourceDao;
 
   @Mock private FlightContext mockFlightContext;
@@ -42,7 +44,7 @@ public class StoreControlledResourceMetadataStepTest extends BaseUnitTest {
             .workspaceId(workspaceId)
             .build();
     workspaceDao.createWorkspace(workspace);
-    workspaceDao.createGcpCloudContext(
+    gcpCloudContextService.createGcpCloudContext(
         workspaceId, new GcpCloudContext("fake-project"), "flight-testentersinfo");
 
     StoreMetadataStep storeGoogleBucketMetadataStep = new StoreMetadataStep(resourceDao);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
@@ -42,7 +42,8 @@ public class StoreControlledResourceMetadataStepTest extends BaseUnitTest {
             .workspaceId(workspaceId)
             .build();
     workspaceDao.createWorkspace(workspace);
-    workspaceDao.createGcpCloudContext(workspaceId, new GcpCloudContext("fake-project"));
+    workspaceDao.createGcpCloudContext(
+        workspaceId, new GcpCloudContext("fake-project"), "flight-testentersinfo");
 
     StoreMetadataStep storeGoogleBucketMetadataStep = new StoreMetadataStep(resourceDao);
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/UpdateBigQueryDatasetStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/UpdateBigQueryDatasetStepTest.java
@@ -22,7 +22,7 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.BigQueryApiConversions;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.flight.update.UpdateBigQueryDatasetStep;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.google.api.services.bigquery.model.Dataset;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -41,7 +41,7 @@ public class UpdateBigQueryDatasetStepTest extends BaseUnitTest {
   @Mock private CrlService mockCrlService;
   @Mock private FlightContext mockFlightContext;
   @Mock private BigQueryCow mockBigQueryCow;
-  @Mock private WorkspaceService mockWorkspaceService;
+  @Mock private GcpCloudContextService mockGcpCloudContextService;
   Dataset mockExistingDataset = new Dataset();
 
   @Captor private ArgumentCaptor<Dataset> datasetCaptor;
@@ -75,11 +75,11 @@ public class UpdateBigQueryDatasetStepTest extends BaseUnitTest {
     final ControlledBigQueryDatasetResource datasetResource =
         makeDefaultControlledBigQueryDatasetResource().build();
     doReturn(PROJECT_ID)
-        .when(mockWorkspaceService)
+        .when(mockGcpCloudContextService)
         .getRequiredGcpProject(datasetResource.getWorkspaceId());
 
     updateBigQueryDatasetStep =
-        new UpdateBigQueryDatasetStep(datasetResource, mockCrlService, mockWorkspaceService);
+        new UpdateBigQueryDatasetStep(datasetResource, mockCrlService, mockGcpCloudContextService);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/UpdateGcsBucketStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/UpdateGcsBucketStepTest.java
@@ -25,7 +25,7 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.flight.update.UpdateGcsBucketStep;
-import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import com.google.cloud.storage.BucketInfo.LifecycleRule;
 import com.google.cloud.storage.BucketInfo.LifecycleRule.DeleteLifecycleAction;
@@ -51,7 +51,7 @@ public class UpdateGcsBucketStepTest extends BaseUnitTest {
   @Mock private CrlService mockCrlService;
   @Mock private FlightContext mockFlightContext;
   @Mock private StorageCow mockStorageCow;
-  @Mock private WorkspaceService mockWorkspaceService;
+  @Mock private GcpCloudContextService mockGcpCloudContextService;
 
   @Captor private ArgumentCaptor<List<LifecycleRule>> lifecycleRulesCaptor;
   @Captor private ArgumentCaptor<StorageClass> storageClassCaptor;
@@ -83,11 +83,11 @@ public class UpdateGcsBucketStepTest extends BaseUnitTest {
     final ControlledGcsBucketResource bucketResource =
         makeDefaultControlledGcsBucketResource().build();
     doReturn(PROJECT_ID)
-        .when(mockWorkspaceService)
+        .when(mockGcpCloudContextService)
         .getRequiredGcpProject(bucketResource.getWorkspaceId());
 
     updateGcsBucketStep =
-        new UpdateGcsBucketStep(bucketResource, mockCrlService, mockWorkspaceService);
+        new UpdateGcsBucketStep(bucketResource, mockCrlService, mockGcpCloudContextService);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,7 +39,6 @@ import bio.terra.workspace.service.workspace.exceptions.StageDisabledException;
 import bio.terra.workspace.service.workspace.flight.DeleteProjectStep;
 import bio.terra.workspace.service.workspace.flight.DeleteWorkspaceAuthzStep;
 import bio.terra.workspace.service.workspace.flight.DeleteWorkspaceStateStep;
-import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceRequest;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
@@ -400,9 +398,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     jobService.waitForJob(jobId);
     assertNull(jobService.retrieveJobResult(jobId, Object.class, USER_REQUEST).getException());
     Workspace workspace = workspaceService.getWorkspace(request.workspaceId(), USER_REQUEST);
-    String projectId =
-        workspace.getGcpCloudContext().map(GcpCloudContext::getGcpProjectId).orElse(null);
-    assertNotNull(projectId);
+    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
 
     // Verify project exists by retrieving it.
     crl.getCloudResourceManagerCow().projects().get(projectId).execute();
@@ -429,12 +425,10 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         request.workspaceId(), jobId, USER_REQUEST, "/fake/value");
     jobService.waitForJob(jobId);
     assertNull(jobService.retrieveJobResult(jobId, Object.class, USER_REQUEST).getException());
-    Workspace workspace = workspaceService.getWorkspace(request.workspaceId(), USER_REQUEST);
-    assertTrue(workspace.getGcpCloudContext().isPresent());
+    assertTrue(workspaceService.getGcpCloudContext(request.workspaceId()).isPresent());
 
     workspaceService.deleteGcpCloudContext(request.workspaceId(), USER_REQUEST);
-    workspace = workspaceService.getWorkspace(request.workspaceId(), USER_REQUEST);
-    assertTrue(workspace.getGcpCloudContext().isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(request.workspaceId()).isEmpty());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -398,7 +398,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     jobService.waitForJob(jobId);
     assertNull(jobService.retrieveJobResult(jobId, Object.class, USER_REQUEST).getException());
     Workspace workspace = workspaceService.getWorkspace(request.workspaceId(), USER_REQUEST);
-    String projectId = workspaceService.getRequiredGcpProject(workspace.getWorkspaceId());
+    String projectId =
+        workspaceService.getRequiredGcpProject(workspace.getWorkspaceId(), USER_REQUEST);
 
     // Verify project exists by retrieving it.
     crl.getCloudResourceManagerCow().projects().get(projectId).execute();
@@ -425,10 +426,11 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         request.workspaceId(), jobId, USER_REQUEST, "/fake/value");
     jobService.waitForJob(jobId);
     assertNull(jobService.retrieveJobResult(jobId, Object.class, USER_REQUEST).getException());
-    assertTrue(workspaceService.getGcpCloudContext(request.workspaceId()).isPresent());
+    assertTrue(
+        workspaceService.getGcpCloudContext(request.workspaceId(), USER_REQUEST).isPresent());
 
     workspaceService.deleteGcpCloudContext(request.workspaceId(), USER_REQUEST);
-    assertTrue(workspaceService.getGcpCloudContext(request.workspaceId()).isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(request.workspaceId(), USER_REQUEST).isEmpty());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -62,7 +62,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
 
-    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId, userRequest).isEmpty());
 
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
@@ -76,9 +76,9 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
     String projectId =
         flightState.getResultMap().get().get(WorkspaceFlightMapKeys.GCP_PROJECT_ID, String.class);
 
-    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isPresent());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId, userRequest).isPresent());
 
-    String contextProjectId = workspaceService.getRequiredGcpProject(workspaceId);
+    String contextProjectId = workspaceService.getRequiredGcpProject(workspaceId, userRequest);
     assertEquals(projectId, contextProjectId);
 
     Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
@@ -97,7 +97,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
   void errorRevertsChanges() throws Exception {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId, userRequest).isEmpty());
 
     // Submit a flight class that always errors.
     FlightDebugInfo debugInfo = FlightDebugInfo.newBuilder().lastStepFailure(true).build();
@@ -109,7 +109,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
             STAIRWAY_FLIGHT_TIMEOUT,
             debugInfo);
     assertEquals(FlightStatus.ERROR, flightState.getFlightStatus());
-    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId, userRequest).isEmpty());
 
     String projectId =
         flightState.getResultMap().get().get(WorkspaceFlightMapKeys.GCP_PROJECT_ID, String.class);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -24,7 +24,6 @@ import bio.terra.workspace.service.resource.controlled.mappings.CustomGcpIamRole
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.CloudSyncRoleMapping;
 import bio.terra.workspace.service.workspace.WorkspaceService;
-import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceRequest;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.google.api.services.cloudresourcemanager.v3.model.Binding;
@@ -62,8 +61,8 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
   void successCreatesProjectAndContext() throws Exception {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    Workspace workspace = workspaceService.getWorkspace(workspaceId, userRequest);
-    assertTrue(workspace.getGcpCloudContext().isEmpty());
+
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
 
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
@@ -77,10 +76,9 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
     String projectId =
         flightState.getResultMap().get().get(WorkspaceFlightMapKeys.GCP_PROJECT_ID, String.class);
 
-    workspace = workspaceService.getWorkspace(workspaceId, userRequest);
-    assertTrue(workspace.getGcpCloudContext().isPresent());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isPresent());
 
-    String contextProjectId = workspace.getGcpCloudContext().get().getGcpProjectId();
+    String contextProjectId = workspaceService.getRequiredGcpProject(workspaceId);
     assertEquals(projectId, contextProjectId);
 
     Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
@@ -99,8 +97,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
   void errorRevertsChanges() throws Exception {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    Workspace workspace = workspaceService.getWorkspace(workspaceId, userRequest);
-    assertTrue(workspace.getGcpCloudContext().isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
 
     // Submit a flight class that always errors.
     FlightDebugInfo debugInfo = FlightDebugInfo.newBuilder().lastStepFailure(true).build();
@@ -112,9 +109,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
             STAIRWAY_FLIGHT_TIMEOUT,
             debugInfo);
     assertEquals(FlightStatus.ERROR, flightState.getFlightStatus());
-
-    workspace = workspaceService.getWorkspace(workspaceId, userRequest);
-    assertTrue(workspace.getGcpCloudContext().isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
 
     String projectId =
         flightState.getResultMap().get().get(WorkspaceFlightMapKeys.GCP_PROJECT_ID, String.class);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -62,7 +62,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
 
-    assertTrue(workspaceService.getGcpCloudContext(workspaceId, userRequest).isEmpty());
+    assertTrue(workspaceService.getAuthorizedGcpCloudContext(workspaceId, userRequest).isEmpty());
 
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
@@ -76,9 +76,10 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
     String projectId =
         flightState.getResultMap().get().get(WorkspaceFlightMapKeys.GCP_PROJECT_ID, String.class);
 
-    assertTrue(workspaceService.getGcpCloudContext(workspaceId, userRequest).isPresent());
+    assertTrue(workspaceService.getAuthorizedGcpCloudContext(workspaceId, userRequest).isPresent());
 
-    String contextProjectId = workspaceService.getRequiredGcpProject(workspaceId, userRequest);
+    String contextProjectId =
+        workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
     assertEquals(projectId, contextProjectId);
 
     Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
@@ -97,7 +98,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
   void errorRevertsChanges() throws Exception {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    assertTrue(workspaceService.getGcpCloudContext(workspaceId, userRequest).isEmpty());
+    assertTrue(workspaceService.getAuthorizedGcpCloudContext(workspaceId, userRequest).isEmpty());
 
     // Submit a flight class that always errors.
     FlightDebugInfo debugInfo = FlightDebugInfo.newBuilder().lastStepFailure(true).build();
@@ -109,7 +110,7 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
             STAIRWAY_FLIGHT_TIMEOUT,
             debugInfo);
     assertEquals(FlightStatus.ERROR, flightState.getFlightStatus());
-    assertTrue(workspaceService.getGcpCloudContext(workspaceId, userRequest).isEmpty());
+    assertTrue(workspaceService.getAuthorizedGcpCloudContext(workspaceId, userRequest).isEmpty());
 
     String projectId =
         flightState.getResultMap().get().get(WorkspaceFlightMapKeys.GCP_PROJECT_ID, String.class);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.workspace.flight;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.stairway.FlightDebugInfo;
@@ -18,8 +19,7 @@ import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.WorkspaceService;
-import bio.terra.workspace.service.workspace.model.GcpCloudContext;
-import bio.terra.workspace.service.workspace.model.Workspace;
+import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.model.WorkspaceRequest;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
@@ -68,10 +68,12 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
             null);
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
 
-    Workspace workspace = workspaceService.getWorkspace(workspaceId, userRequest);
-    String projectId =
-        workspace.getGcpCloudContext().map(GcpCloudContext::getGcpProjectId).orElse(null);
+    String projectId = workspaceService.getGcpProject(workspaceId).orElse(null);
     assertNotNull(projectId);
+
+    // validate that required project does not throw and gives the same answer
+    String projectId2 = workspaceService.getRequiredGcpProject(workspaceId);
+    assertEquals(projectId, projectId2);
 
     Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
     assertEquals("ACTIVE", project.getState());
@@ -99,8 +101,12 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
             debugInfo);
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
 
-    workspace = workspaceService.getWorkspace(workspaceId, userRequest);
-    assertTrue(workspace.getGcpCloudContext().isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
+
+    // make sure required really requires
+    assertThrows(
+        CloudContextRequiredException.class,
+        () -> workspaceService.getRequiredGcpProject(workspaceId));
 
     project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
     assertEquals("DELETE_REQUESTED", project.getState());
@@ -144,16 +150,14 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
     assertEquals(FlightStatus.FATAL, flightState.getFlightStatus());
 
     // Because this flight cannot be undone, the context should still be deleted even after undoing.
-    Workspace workspace = workspaceService.getWorkspace(workspaceId, userRequest);
-    assertTrue(workspace.getGcpCloudContext().isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
   }
 
   @Test
   void deleteNonExistentContextIsOk() throws Exception {
     UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    Workspace workspace = workspaceService.getWorkspace(workspaceId, userRequest);
-    assertTrue(workspace.getGcpCloudContext().isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
 
     FlightMap inputParameters = new FlightMap();
     inputParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString());
@@ -165,9 +169,7 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
             DELETION_FLIGHT_TIMEOUT,
             null);
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
-
-    workspace = workspaceService.getWorkspace(workspaceId, userRequest);
-    assertTrue(workspace.getGcpCloudContext().isEmpty());
+    assertTrue(workspaceService.getGcpCloudContext(workspaceId).isEmpty());
   }
 
   /** Creates a workspace, returning its workspaceId. */

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
@@ -75,7 +75,7 @@ public class WorkspaceDeleteFlightTest extends BaseConnectedTest {
     Map<String, StepStatus> doFailures = new HashMap<>();
     doFailures.put(
         DeleteControlledSamResourcesStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    doFailures.put(DeleteProjectStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    doFailures.put(DeleteGcpProjectStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     doFailures.put(DeleteWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     doFailures.put(DeleteWorkspaceStateStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     FlightDebugInfo debugInfo = FlightDebugInfo.newBuilder().doStepFailures(doFailures).build();


### PR DESCRIPTION
This refactor is in preparation for Azure and in support of the PoC.I initially made these
changes in the PoC branch, but they touch a lot of files that have nothing to do with the
PoC.

There are three main changes. First, remove cloud context from workspace object. Having
it there makes the DAO complex. Also, most use cases in flights do not need to fetch the
workspace object, but can get the cloud context with the workspace id and use it to get
the GCP project id. Added helper methods in WorkspaceService for getting the context and
the project id.

Second, add a `creating_flight` column to the cloud_context table. Use that instead of
the project id for delete checking. Azure does not have a per-context unique id to check.
The flight id provides a general solution to ensure that the undo of a cloud context
create will only delete the context that it created.

Third, moved the serdes for GcpCloudContext into the GcpCloudContext class instead of
having it in the DAO. Seems tidier to me that way: cloud context knows how to serialize
and deserialize itself.