### PR TITLE
[PF-1011] Remove Hermione from WSM integration tests

### DIFF
--- a/integration/src/main/resources/configs/integration/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/DataReferenceLifecycle.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
-  "testUserFiles": ["hermione.json"]
+  "testUserFiles": ["bella.json"]
 }

--- a/integration/src/main/resources/configs/integration/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/integration/EnumerateDataReferences.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
-  "testUserFiles": ["hermione.json"]
+  "testUserFiles": ["bella.json"]
 }

--- a/integration/src/main/resources/configs/integration/alpha/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/alpha/DataReferenceLifecycle.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile", "d56f4db5-b6c6-4a7e-8be2-ff6aa21c4fa6", "terra"]
     }
   ],
-  "testUserFiles": ["hermione.json"]
+  "testUserFiles": ["bella.json"]
 }

--- a/integration/src/main/resources/configs/integration/alpha/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/integration/alpha/EnumerateDataReferences.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile", "d56f4db5-b6c6-4a7e-8be2-ff6aa21c4fa6", "terra"]
     }
   ],
-  "testUserFiles": ["hermione.json"]
+  "testUserFiles": ["bella.json"]
 }

--- a/integration/src/main/resources/configs/integration/staging/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/staging/DataReferenceLifecycle.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile", "3e858a77-ea11-4f55-96f4-e6e45b71b7bf", "terra"]
     }
   ],
-  "testUserFiles": ["hermione.json"]
+  "testUserFiles": ["bella.json"]
 }

--- a/integration/src/main/resources/configs/integration/staging/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/integration/staging/EnumerateDataReferences.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile", "3e858a77-ea11-4f55-96f4-e6e45b71b7bf", "terra"]
     }
   ],
-  "testUserFiles": ["hermione.json"]
+  "testUserFiles": ["bella.json"]
 }

--- a/integration/src/main/resources/testusers/hermione.json
+++ b/integration/src/main/resources/testusers/hermione.json
@@ -1,5 +1,0 @@
-{
-  "name": "hermione",
-  "userEmail": "hermione.owner@test.firecloud.org",
-  "delegatorServiceAccountFile": "delegate-user-sa.json"
-}

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -666,7 +666,7 @@ public class SamService {
     // Set up the master OWNER user in Sam for all controlled resources, if it's not already.
     initializeWsmServiceAccount();
     ResourcesApi resourceApi = samResourcesApi(userRequest.getRequiredToken());
-    FullyQualifiedResourceId  workspaceParentFqId =
+    FullyQualifiedResourceId workspaceParentFqId =
         new FullyQualifiedResourceId()
             .resourceId(resource.getWorkspaceId().toString())
             .resourceTypeName(SamConstants.SAM_WORKSPACE_RESOURCE);


### PR DESCRIPTION
`hermione.owner` is a shared test user that's also used by Rawls and possibly other services' tests. For the sake of test isolation, we should use test users exclusive to WSM for the integration tests here.

Outside of this PR I've given `bella.redwalker` read access to the appropriate TDR snapshots in dev, alpha, and staging.