### PR TITLE
[PF-1031] gha fix

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install the latest postgres
         run: |
             sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-            sudo curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+            sudo sh -c 'curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - '
             sudo apt-get update
             sudo apt-get -y install postgresql
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -23,10 +23,10 @@ jobs:
       # - Install the latest version of PostgreSQL. If you want a specific version, use 'postgresql-12' or similar instead of 'postgresql':
       - name: Install the latest postgres
         run: |
-            sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-            curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-            apt-get update
-            apt-get -y install postgresql
+            sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+            sudo curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+            sudo apt-get update
+            sudo apt-get -y install postgresql
 
       - name: Set up AdoptOpenJDK 11
         uses: joschi/setup-jdk@v2


### PR DESCRIPTION
DevOps made changes to the self-hosted runners and that broke our tests. After several attempts (see [slack conversation](https://broadinstitute.slack.com/archives/CADM7MZ35/p1633353466459200)) we have re-settled on a working state.

This change adds `sudo` to the postgres install commands. That fixes the change that switched us off running as `root`.
