### PR TITLE
[PF-1043] Fix bad variable name; add test

### DIFF
--- a/integration/src/main/java/scripts/testscripts/Jobs.java
+++ b/integration/src/main/java/scripts/testscripts/Jobs.java
@@ -1,0 +1,69 @@
+package scripts.testscripts;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.JobsApi;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.model.CloudPlatform;
+import bio.terra.workspace.model.CreateCloudContextRequest;
+import bio.terra.workspace.model.CreateCloudContextResult;
+import bio.terra.workspace.model.JobControl;
+import bio.terra.workspace.model.JobReport;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scripts.utils.ClientTestUtils;
+import scripts.utils.WorkspaceAllocateTestScriptBase;
+
+/** Tests of the JobsAPI */
+public class Jobs extends WorkspaceAllocateTestScriptBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(Jobs.class);
+
+  @Override
+  protected void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doSetup(testUsers, workspaceApi);
+    // Note the 0th user is the owner of the workspace, pulled out in the super class.
+    assertThat(
+        "There must be at least two test users defined for this test.",
+        testUsers != null && testUsers.size() > 1);
+
+    // TODO: when we implement list we will want the second user to test for job
+    //  visibility, so leave the setup here.
+  }
+
+  @Override
+  public void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
+      throws Exception {
+    JobsApi jobsApi = ClientTestUtils.getJobsClient(testUser, server);
+
+    // The purpose of this test is to exercise the jobsApi so we
+    // create a cloud context - something that will run async
+    String contextJobId = UUID.randomUUID().toString();
+    var createContext =
+        new CreateCloudContextRequest()
+            .cloudPlatform(CloudPlatform.GCP)
+            .jobControl(new JobControl().id(contextJobId));
+
+    logger.info("Creating GCP cloud context");
+    CreateCloudContextResult contextResult =
+        workspaceApi.createCloudContext(createContext, getWorkspaceId());
+    JobReport jobReport = contextResult.getJobReport();
+
+    while (ClientTestUtils.jobIsRunning(jobReport)) {
+      TimeUnit.SECONDS.sleep(10);
+      jobReport = jobsApi.retrieveJob(contextJobId);
+    }
+    logger.info("Create GCP context status is {}", jobReport.getStatus().toString());
+  }
+
+  @Override
+  protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doCleanup(testUsers, workspaceApi);
+  }
+}

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -10,6 +10,7 @@ import bio.terra.testrunner.common.utils.AuthenticationUtils;
 import bio.terra.testrunner.runner.config.ServerSpecification;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
+import bio.terra.workspace.api.JobsApi;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.ResourceApi;
 import bio.terra.workspace.api.WorkspaceApi;
@@ -186,6 +187,12 @@ public class ClientTestUtils {
       TestUserSpecification testUser, ServerSpecification server) throws IOException {
     final ApiClient apiClient = getClientForTestUser(testUser, server);
     return new ResourceApi(apiClient);
+  }
+
+  public static JobsApi getJobsClient(TestUserSpecification testUser, ServerSpecification server)
+      throws IOException {
+    final ApiClient apiClient = getClientForTestUser(testUser, server);
+    return new JobsApi(apiClient);
   }
 
   /**

--- a/integration/src/main/resources/configs/integration/Jobs.json
+++ b/integration/src/main/resources/configs/integration/Jobs.json
@@ -1,0 +1,18 @@
+{
+  "name": "Jobs",
+  "description": "Test the JobsApi",
+  "serverSpecificationFile": "workspace-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "Jobs",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 10,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parameters": ["wm-default-spend-profile"]
+    }
+  ],
+  "testUserFiles": ["bella.json", "elijah.json"]
+}

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -17,6 +17,7 @@
     "integration/EnumerateDataReferences.json",
     "integration/EnumerateResources.json",
     "integration/GetRoles.json",
+    "integration/Jobs.json",
     "integration/ListWorkspaces.json",
     "integration/PrivateControlledAiNotebookInstanceLifecycle.json",
     "integration/PrivateControlledGcsBucketLifecycle.json",

--- a/service/src/main/java/bio/terra/workspace/app/controller/JobsApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/JobsApiController.java
@@ -34,9 +34,9 @@ public class JobsApiController implements JobsApi {
   }
 
   @Override
-  public ResponseEntity<ApiJobReport> retrieveJob(@PathVariable("id") String id) {
+  public ResponseEntity<ApiJobReport> retrieveJob(@PathVariable("jobId") String jobId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    ApiJobReport jobReport = jobService.retrieveJob(id, userRequest);
+    ApiJobReport jobReport = jobService.retrieveJob(jobId, userRequest);
     return new ResponseEntity<>(jobReport, HttpStatus.valueOf(jobReport.getStatusCode()));
   }
 }


### PR DESCRIPTION
Chris Book is blocked by this bug. The fix is trivial: the path variable is `jobId` not `id`.
The rest of the code is for the integration test to verify that it works.

