### PR TITLE
[PF-851] Default test configurations to run locally

### DIFF
--- a/integration/src/main/resources/configs/integration/BasicAuthenticated.json
+++ b/integration/src/main/resources/configs/integration/BasicAuthenticated.json
@@ -8,7 +8,7 @@
     {
       "name": "GetWorkspace",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/BasicUnauthenticated.json
+++ b/integration/src/main/resources/configs/integration/BasicUnauthenticated.json
@@ -8,7 +8,7 @@
     {
       "name": "ServiceStatus",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS"
     }

--- a/integration/src/main/resources/configs/integration/CloneBigQueryDataset.json
+++ b/integration/src/main/resources/configs/integration/CloneBigQueryDataset.json
@@ -8,7 +8,7 @@
     {
       "name": "CloneBigQueryDataset",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 15,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/CloneGcsBucket.json
+++ b/integration/src/main/resources/configs/integration/CloneGcsBucket.json
@@ -8,7 +8,7 @@
     {
       "name": "CloneGcsBucket",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 15,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/CloneReferencedResources.json
+++ b/integration/src/main/resources/configs/integration/CloneReferencedResources.json
@@ -8,7 +8,7 @@
     {
       "name": "CloneReferencedResources",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]

--- a/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
@@ -1,14 +1,14 @@
 {
   "name": "ControlledBigQueryDatasetLifecycle",
   "description": "CRUD controlled BQ dataset tests.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "ControlledBigQueryDatasetLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
@@ -8,7 +8,7 @@
     {
       "name": "ControlledGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 10,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/DataReferenceLifecycle.json
@@ -1,14 +1,14 @@
 {
   "name": "DataReferenceLifecycle",
   "description": "CRUD data reference tests.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "DataReferenceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]

--- a/integration/src/main/resources/configs/integration/DeleteGcpContextWithControlledResource.json
+++ b/integration/src/main/resources/configs/integration/DeleteGcpContextWithControlledResource.json
@@ -1,14 +1,14 @@
 {
   "name": "DeleteGcpContextWithControlledResource",
   "description": "Delete a GCP context which contains a controlled resource.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "DeleteGcpContextWithControlledResource",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/DeleteWorkspaceWithControlledResource.json
+++ b/integration/src/main/resources/configs/integration/DeleteWorkspaceWithControlledResource.json
@@ -1,14 +1,14 @@
 {
   "name": "DeleteWorkspaceWithControlledResource",
   "description": "Delete a workspace which contains a controlled resource.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "DeleteWorkspaceWithControlledResource",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/integration/EnumerateDataReferences.json
@@ -1,14 +1,14 @@
 {
   "name": "EnumerateDataReferences",
   "description": "Test the offset and limit logic for enumerating data references on a workspace.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "EnumerateDataReferences",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]

--- a/integration/src/main/resources/configs/integration/EnumerateResources.json
+++ b/integration/src/main/resources/configs/integration/EnumerateResources.json
@@ -1,14 +1,14 @@
 {
   "name": "EnumerateResources",
   "description": "Exercise enumeration over all resource types",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "EnumerateResources",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]

--- a/integration/src/main/resources/configs/integration/GetRoles.json
+++ b/integration/src/main/resources/configs/integration/GetRoles.json
@@ -1,14 +1,14 @@
 {
   "name": "GetRoles",
   "description": "CRUD for roles",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "GetRoles",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/Jobs.json
+++ b/integration/src/main/resources/configs/integration/Jobs.json
@@ -8,7 +8,7 @@
     {
       "name": "Jobs",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 10,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
@@ -1,14 +1,14 @@
 {
   "name": "PrivateControlledAiNotebookInstanceLifecycle",
   "description": "CRUD user-private GCS AI Platform Notebook instance tests.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "PrivateControlledAiNotebookInstanceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 16,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
@@ -1,14 +1,14 @@
 {
   "name": "PrivateControlledGcsBucketLifecycle",
   "description": "CRUD user-private GCS bucket tests.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "PrivateControlledGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile"]

--- a/integration/src/main/resources/configs/integration/ValidateReferencedResources.json
+++ b/integration/src/main/resources/configs/integration/ValidateReferencedResources.json
@@ -1,14 +1,14 @@
 {
   "name": "ValidateReferencedResources",
   "description": "Exercise reference access validation over all resource types",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "ValidateReferencedResources",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "MINUTES",
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]

--- a/integration/src/main/resources/configs/integration/WorkspaceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/WorkspaceLifecycle.json
@@ -1,14 +1,14 @@
 {
   "name": "WorkspaceLifecycle",
   "description": "CRUD workspace tests.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [
     {
       "name": "WorkspaceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS"
     }

--- a/integration/src/main/resources/configs/integration/alpha/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/alpha/DataReferenceLifecycle.json
@@ -8,7 +8,7 @@
     {
       "name": "DataReferenceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
       "parameters": ["wm-default-spend-profile", "d56f4db5-b6c6-4a7e-8be2-ff6aa21c4fa6", "terra"]

--- a/integration/src/main/resources/configs/integration/alpha/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/integration/alpha/EnumerateDataReferences.json
@@ -8,7 +8,7 @@
     {
       "name": "EnumerateDataReferences",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
       "parameters": ["wm-default-spend-profile", "d56f4db5-b6c6-4a7e-8be2-ff6aa21c4fa6", "terra"]

--- a/integration/src/main/resources/configs/integration/staging/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/staging/DataReferenceLifecycle.json
@@ -8,7 +8,7 @@
     {
       "name": "DataReferenceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
       "parameters": ["wm-default-spend-profile", "3e858a77-ea11-4f55-96f4-e6e45b71b7bf", "terra"]

--- a/integration/src/main/resources/configs/integration/staging/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/integration/staging/EnumerateDataReferences.json
@@ -8,7 +8,7 @@
     {
       "name": "EnumerateDataReferences",
       "numberOfUserJourneyThreadsToRun": 1,
-      "userJourneyThreadPoolSize": 2,
+      "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS",
       "parameters": ["wm-default-spend-profile", "3e858a77-ea11-4f55-96f4-e6e45b71b7bf", "terra"]

--- a/integration/src/main/resources/configs/perf/BasicAuthenticated.json
+++ b/integration/src/main/resources/configs/perf/BasicAuthenticated.json
@@ -1,7 +1,7 @@
 {
   "name": "BasicAuthenticated",
   "description": "Get workspace repeatedly, concurrently. Authentication required.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [

--- a/integration/src/main/resources/configs/perf/BasicUnauthenticated.json
+++ b/integration/src/main/resources/configs/perf/BasicUnauthenticated.json
@@ -1,7 +1,7 @@
 {
   "name": "BasicUnauthenticated",
   "description": "Check the service status repeatedly, concurrently. No authentication required.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [

--- a/integration/src/main/resources/configs/perf/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/perf/DataReferenceLifecycle.json
@@ -1,7 +1,7 @@
 {
   "name": "DataReferenceLifecycle",
   "description": "CRUD data reference tests.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [

--- a/integration/src/main/resources/configs/perf/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/perf/EnumerateDataReferences.json
@@ -1,7 +1,7 @@
 {
   "name": "EnumerateDataReferences",
   "description": "Test the offset and limit logic for enumerating data references on a workspace.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [

--- a/integration/src/main/resources/configs/perf/GetRoles.json
+++ b/integration/src/main/resources/configs/perf/GetRoles.json
@@ -1,7 +1,7 @@
 {
   "name": "GetRoles",
   "description": "CRUD for roles",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [

--- a/integration/src/main/resources/configs/perf/WorkspaceLifecycle.json
+++ b/integration/src/main/resources/configs/perf/WorkspaceLifecycle.json
@@ -1,7 +1,7 @@
 {
   "name": "WorkspaceLifecycle",
   "description": "CRUD workspace tests.",
-  "serverSpecificationFile": "workspace-dev.json",
+  "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},
   "application": {},
   "testScripts": [

--- a/integration/src/main/resources/suites/BasicPerf.json
+++ b/integration/src/main/resources/suites/BasicPerf.json
@@ -1,7 +1,7 @@
 {
   "name": "BasicPerf",
   "description": "Perf tests.",
-  "serverSpecificationFile": "workspace-wsmtest.json",
+  "serverSpecificationFile": "workspace-local.json",
   "testConfigurationFiles": [
     "perf/BasicAuthenticated.json",
     "perf/BasicUnauthenticated.json",

--- a/integration/src/main/resources/suites/BasicResiliency.json
+++ b/integration/src/main/resources/suites/BasicResiliency.json
@@ -1,7 +1,7 @@
 {
   "name": "BasicResiliency",
   "description": "Resiliency tests",
-  "serverSpecificationFile": "workspace-wsmtest.json",
+  "serverSpecificationFile": "workspace-local.json",
   "testConfigurationFiles": [
     "resiliency/DeleteInitialPods.json"
   ]

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -1,7 +1,7 @@
 {
   "name": "FullIntegration",
   "description": "All integration tests - to be run on a K8s environment",
-  "serverSpecificationFile": "workspace-wsmtest.json",
+  "serverSpecificationFile": "workspace-local.json",
   "testConfigurationFiles": [
     "integration/BasicAuthenticated.json",
     "integration/BasicUnauthenticated.json",


### PR DESCRIPTION
This changes the default behavior of the WSM TestRunner tests to run against a local server instead of some running against local and some running against dev. As before, this is only a default value and will be overridden by the `TEST_RUNNER_SERVER_SPECIFICATION` env var. All Github actions which call these tests already explicitly override the environment, so this should only affect developers who do not have this variable set.

I did not modify the default values of the configs in the `dev`, `staging` or `alpha` environment-specific directories, as those can reasonably default to their respective environment.

While changing these files, I also reduced the `userJourneyThreadPoolSize` to 1 for all integration tests which only run a single user thread. We don't need a thread pool of size 2 to run these journeys, though I did not modify configs for the perf tests which do run more than 1 user thread.