### PR TITLE
QA-1607: Bump version of TestRunner to 0.0.9-SNAPSHOT.

### DIFF
--- a/.github/workflows/QA-1607-test.yml
+++ b/.github/workflows/QA-1607-test.yml
@@ -1,0 +1,120 @@
+# This workflow runs the WSM full regression tests, including perf, integration, and
+# resilience suites.
+
+name: QA-1607 Tests 1
+
+on:
+  push
+
+jobs:
+  QA-1607-tests:
+
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Install postgres:
+      # - Create the file repository configuration.
+      # - Import the repository signing key.
+      # - Update the package lists.
+      # - Install the latest version of PostgreSQL. If you want a specific version, use 'postgresql-12' or similar instead of 'postgresql':
+      - name: Install the latest postgres
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo sh -c 'curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - '
+          sudo apt-get update
+          sudo apt-get -y install postgresql
+
+      - name: Set up AdoptOpenJDK 11
+        uses: joschi/setup-jdk@v2
+        with:
+          java-version: 11
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Get Vault token
+        id: vault-token-step
+        env:
+          VAULT_ADDR: https://clotho.broadinstitute.org:8200
+        run: |
+          VAULT_TOKEN=$(docker run --rm --cap-add IPC_LOCK \
+            -e "VAULT_ADDR=${VAULT_ADDR}" \
+            vault:1.1.0 \
+            vault write -field token \
+              auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
+              secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+          echo ::set-output name=vault-token::$VAULT_TOKEN
+          echo ::add-mask::$VAULT_TOKEN
+
+      - name: Write config
+        id: config
+        uses: ./.github/actions/write-config
+        with:
+          vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
+          target: wsmtest
+
+      # The ArgoCD sync triggers the synchronization of the wsmtest cluster. Typically,
+      # the cluster is reset within a few seconds. However, it is possible for it to take
+      # minutes or hours. We have no way to check that the sync is complete. We sleep
+      # for a bit and just accept that in some crazy long cases, these tests will fail.
+      # The sync is bracketed by /version probes so we have the pre and post sync versions
+      # in the log.
+      - name: ArgoCD sync
+        run: |
+          version=$(curl https://workspace.wsmtest.integ.envs.broadinstitute.org/version)
+          echo "$(date "+%Y-%m-%dT%H:%M:%S") pre-sync wsmtest version: $version"
+          curl --fail --silent --show-error --location --request POST \
+          'https://ap-argocd.dsp-devops.broadinstitute.org/api/v1/applications/workspacemanager-wsmtest/sync' \
+          --header "Authorization: Bearer ${{ secrets.WSMTEST_SYNC_ARGOCD_TOKEN }}" \
+          | jq .operation
+          sleep 120
+          version=$(curl https://workspace.wsmtest.integ.envs.broadinstitute.org/version)
+          echo "$(date "+%Y-%m-%dT%H:%M:%S") post-sync wsmtest version: $version"
+
+      - name: clean databases before integration suite
+        if: always()
+        uses: ./.github/actions/clean-databases
+
+      - name: Run the integration test suite
+        id: integration-test
+        if: always()
+        uses: ./.github/actions/integration-test
+        with:
+          test-server: workspace-wsmtest.json
+          test: suites/FullIntegration.json
+
+      - name: clean databases before perf suite
+        if: always()
+        uses: ./.github/actions/clean-databases
+
+      - name: Run the perf test suite
+        id: perf-test
+        if: always()
+        uses: ./.github/actions/integration-test
+        with:
+          test-server: workspace-wsmtest.json
+          test: suites/BasicPerf.json
+
+      - name: clean databases before resiliency suite
+        if: always()
+        uses: ./.github/actions/clean-databases
+
+      - name: Run the resiliency test suite
+        id: resiliency-test
+        if: always()
+        uses: ./.github/actions/integration-test
+        with:
+          test-server: workspace-wsmtest.json
+          test: suites/BasicResiliency.json
+

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -4,7 +4,7 @@ plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
     id 'application'
     // Terra Test Runner Plugin
-    id 'bio.terra.test-runner-plugin' version '0.0.8-SNAPSHOT'
+    id 'bio.terra.test-runner-plugin' version '0.0.9-SNAPSHOT'
 }
 
 dependencies {
@@ -28,7 +28,7 @@ dependencies {
         googleNotebook = "v1-rev20201110-1.30.10"
 
         datarepoClient = "1.0.155-SNAPSHOT"
-        testRunnerVersion = "0.0.7-SNAPSHOT"
+        testRunnerVersion = "0.0.9-SNAPSHOT"
         samClient = "0.1-61135c7"
     }
     implementation group: 'org.apache.commons', name: 'commons-math3', version: "${apacheMath}"

--- a/integration/gradle.lockfile
+++ b/integration/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 bio.terra:datarepo-client:1.0.155-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra:terra-test-runner:0.0.7-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:terra-test-runner:0.0.9-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.2.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.2.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath


### PR DESCRIPTION
Bump `TestRunner` version to `0.0.9-SNAPSHOT` to support using test config file names from `TestSuite` to group different test runs.

For detailed context, please refer to PR#[20](https://github.com/DataBiosphere/terra-test-runner/pull/20).