### PR TITLE
[PF-1049] Remove required annotation from PrivateResourceUser

### DIFF
--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2058,7 +2058,6 @@ components:
     PrivateResourceUser:
       description: User and role information for a user of a private resource.
       type: object
-      required: [privateResourceIamRoles]
       properties:
         userName:
           description: Optional. Email address for the user of the resource. If not present, the email of the user making this request is used instead.


### PR DESCRIPTION
(reverts one change in #475)
`PrivateResourceUser` is used in both requests and responses. Its `privateResourceIamRoles` field is required in requests (where it is also validated at the app level), but is not populated in response objects (PF-616). This breaks client code that receives a response with a required field not populated.