### PR TITLE
[IA-2973] Add Azure vm controlled resource

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,4 +7,5 @@ buildscript {
 plugins {
     // https://gitlab.com/barfuin/gradle-taskinfo
     id 'org.barfuin.gradle.taskinfo' version '1.1.1'
+    id "com.github.mrsarm.jshell.plugin" version "1.1.0"
 }

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
@@ -14,6 +14,8 @@ public class AzureConfiguration {
   private String managedAppClientSecret;
   private String managedAppTenantId;
 
+  private String customDockerImageId;
+
   public void setManagedAppClientId(String managedAppClientId) {
     this.managedAppClientId = managedAppClientId;
   }
@@ -36,5 +38,13 @@ public class AzureConfiguration {
 
   public void setManagedAppTenantId(String managedAppTenantId) {
     this.managedAppTenantId = managedAppTenantId;
+  }
+
+  public String getCustomDockerImageId() {
+    return customDockerImageId;
+  }
+
+  public void setCustomDockerImageId(String customDockerImageId) {
+    this.customDockerImageId = customDockerImageId;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -9,8 +9,6 @@ import bio.terra.workspace.generated.model.ApiAccessScope;
 import bio.terra.workspace.generated.model.ApiAzureDiskResource;
 import bio.terra.workspace.generated.model.ApiAzureIpResource;
 import bio.terra.workspace.generated.model.ApiAzureVmResource;
-import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketResult;
-import bio.terra.workspace.generated.model.ApiClonedControlledGcpGcsBucket;
 import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiCreateControlledAzureDiskRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateControlledAzureIpRequestBody;
@@ -169,22 +167,23 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
 
     List<ControlledResourceIamRole> privateRoles = privateRolesFromBody(body.getCommon());
 
-    final String jobId = controlledResourceService.createVm(resource, body.getAzureVm(), privateRoles, userRequest);
+    final String jobId =
+        controlledResourceService.createVm(resource, body.getAzureVm(), privateRoles, userRequest);
 
     final ApiCreatedControlledAzureVmResult result =
-            fetchCreateControlledAzureVmResult(jobId, userRequest);
+        fetchCreateControlledAzureVmResult(jobId, userRequest);
 
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
-  private ApiCreatedControlledAzureVmResult fetchCreateControlledAzureVmResult(String jobId, AuthenticatedUserRequest userRequest) {
+  private ApiCreatedControlledAzureVmResult fetchCreateControlledAzureVmResult(
+      String jobId, AuthenticatedUserRequest userRequest) {
     final JobService.AsyncJobResult<ApiCreatedControlledAzureVm> jobResult =
-            jobService.retrieveAsyncJobResult(
-                    jobId, ApiCreatedControlledAzureVm.class, userRequest);
+        jobService.retrieveAsyncJobResult(jobId, ApiCreatedControlledAzureVm.class, userRequest);
     return new ApiCreatedControlledAzureVmResult()
-            .jobReport(jobResult.getJobReport())
-            .errorReport(jobResult.getApiErrorReport())
-            .azureVm(jobResult.getResult());
+        .jobReport(jobResult.getJobReport())
+        .errorReport(jobResult.getApiErrorReport())
+        .azureVm(jobResult.getResult());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -261,15 +261,15 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
   public ResponseEntity<ApiAzureVmResource> getAzureVm(UUID workspaceId, UUID resourceId) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ControlledResource controlledResource =
-            controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
+        controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
     try {
       var response = controlledResource.castToAzureVmResource().toApiResource();
       return new ResponseEntity<>(response, HttpStatus.OK);
     } catch (InvalidMetadataException ex) {
       throw new BadRequestException(
-              String.format(
-                      "Resource %s in workspace %s is not a controlled Azure Disk.",
-                      resourceId, workspaceId));
+          String.format(
+              "Resource %s in workspace %s is not a controlled Azure Disk.",
+              resourceId, workspaceId));
     }
   }
 
@@ -289,7 +289,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
 
   @Override
   public ResponseEntity<ApiDeleteControlledAzureResourceResult> getDeleteAzureVmResult(
-          UUID workspaceId, String jobId) {
+      UUID workspaceId, String jobId) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     return getJobDeleteResult(jobId, userRequest);
   }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -161,6 +161,8 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
             .managedBy(ManagedByType.fromApi(body.getCommon().getManagedBy()))
             .vmName(body.getAzureVm().getName())
             .region(body.getAzureVm().getRegion())
+            .vmSize(body.getAzureVm().getVmSize())
+            .vmImageUri(body.getAzureVm().getVmImageUri())
             .ipId(body.getAzureVm().getIpId())
             .networkId(body.getAzureVm().getNetworkId())
             .diskId(body.getAzureVm().getDiskId())

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -8,11 +8,14 @@ import bio.terra.workspace.generated.controller.ControlledAzureResourceApi;
 import bio.terra.workspace.generated.model.ApiAccessScope;
 import bio.terra.workspace.generated.model.ApiAzureDiskResource;
 import bio.terra.workspace.generated.model.ApiAzureIpResource;
+import bio.terra.workspace.generated.model.ApiAzureVmResource;
 import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiCreateControlledAzureDiskRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateControlledAzureIpRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledAzureVmRequestBody;
 import bio.terra.workspace.generated.model.ApiCreatedControlledAzureDisk;
 import bio.terra.workspace.generated.model.ApiCreatedControlledAzureIp;
+import bio.terra.workspace.generated.model.ApiCreatedControlledAzureVm;
 import bio.terra.workspace.generated.model.ApiDeleteControlledAzureResourceRequest;
 import bio.terra.workspace.generated.model.ApiDeleteControlledAzureResourceResult;
 import bio.terra.workspace.generated.model.ApiJobControl;
@@ -26,6 +29,7 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.ControlledAzureIpResource;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.ManagedByType;
@@ -138,6 +142,40 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
   }
 
   @Override
+  public ResponseEntity<ApiCreatedControlledAzureVm> createAzureVm(
+      UUID workspaceId, @Valid ApiCreateControlledAzureVmRequestBody body) {
+    final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+
+    ControlledAzureVmResource resource =
+        ControlledAzureVmResource.builder()
+            .workspaceId(workspaceId)
+            .resourceId(UUID.randomUUID())
+            .name(body.getCommon().getName())
+            .description(body.getCommon().getDescription())
+            .cloningInstructions(
+                CloningInstructions.fromApiModel(body.getCommon().getCloningInstructions()))
+            .assignedUser(assignedUserFromBodyOrToken(body.getCommon(), userRequest))
+            .accessScope(AccessScopeType.fromApi(body.getCommon().getAccessScope()))
+            .managedBy(ManagedByType.fromApi(body.getCommon().getManagedBy()))
+            .vmName(body.getAzureVm().getName())
+            .region(body.getAzureVm().getRegion())
+            .ipId(body.getAzureVm().getIpId())
+            .networkId(body.getAzureVm().getNetworkId())
+            .diskId(body.getAzureVm().getDiskId())
+            .build();
+
+    List<ControlledResourceIamRole> privateRoles = privateRolesFromBody(body.getCommon());
+
+    final ControlledAzureVmResource createdVm =
+        controlledResourceService.createVm(resource, body.getAzureVm(), privateRoles, userRequest);
+    var response =
+        new ApiCreatedControlledAzureVm()
+            .resourceId(createdVm.getResourceId())
+            .azureVm(createdVm.toApiResource());
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @Override
   public ResponseEntity<ApiDeleteControlledAzureResourceResult> deleteAzureIp(
       UUID workspaceId, UUID resourceId, @Valid ApiDeleteControlledAzureResourceRequest body) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
@@ -160,6 +198,23 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
     final ApiJobControl jobControl = body.getJobControl();
     logger.info(
         "deleteDisk workspace {} resource {}", workspaceId.toString(), resourceId.toString());
+    final String jobId =
+        controlledResourceService.deleteControlledResourceAsync(
+            jobControl,
+            workspaceId,
+            resourceId,
+            ControllerUtils.getAsyncResultEndpoint(request, jobControl.getId(), "delete-result"),
+            userRequest);
+    return getJobDeleteResult(jobId, userRequest);
+  }
+
+  @Override
+  public ResponseEntity<ApiDeleteControlledAzureResourceResult> deleteAzureVm(
+      UUID workspaceId, UUID resourceId, @Valid ApiDeleteControlledAzureResourceRequest body) {
+    final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    final ApiJobControl jobControl = body.getJobControl();
+    logger.info(
+        "deleteAzureVm workspace {} resource {}", workspaceId.toString(), resourceId.toString());
     final String jobId =
         controlledResourceService.deleteControlledResourceAsync(
             jobControl,
@@ -203,6 +258,22 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
   }
 
   @Override
+  public ResponseEntity<ApiAzureVmResource> getAzureVm(UUID workspaceId, UUID resourceId) {
+    final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    ControlledResource controlledResource =
+            controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
+    try {
+      var response = controlledResource.castToAzureVmResource().toApiResource();
+      return new ResponseEntity<>(response, HttpStatus.OK);
+    } catch (InvalidMetadataException ex) {
+      throw new BadRequestException(
+              String.format(
+                      "Resource %s in workspace %s is not a controlled Azure Disk.",
+                      resourceId, workspaceId));
+    }
+  }
+
+  @Override
   public ResponseEntity<ApiDeleteControlledAzureResourceResult> getDeleteAzureDiskResult(
       UUID workspaceId, String jobId) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
@@ -212,6 +283,13 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
   @Override
   public ResponseEntity<ApiDeleteControlledAzureResourceResult> getDeleteAzureIpResult(
       UUID workspaceId, String jobId) {
+    final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    return getJobDeleteResult(jobId, userRequest);
+  }
+
+  @Override
+  public ResponseEntity<ApiDeleteControlledAzureResourceResult> getDeleteAzureVmResult(
+          UUID workspaceId, String jobId) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     return getJobDeleteResult(jobId, userRequest);
   }

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -561,6 +561,7 @@ public class ResourceDao {
   }
 
   private void validateUniqueAzureVm(ControlledAzureVmResource resource) {
+    // This should take into account azure uniqueness paaram, namely the fields in `AzureContext`
     String sql =
         "SELECT COUNT(1)"
             + " FROM resource"

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -565,10 +565,10 @@ public class ResourceDao {
         "SELECT COUNT(1)"
             + " FROM resource"
             + " WHERE resource_type = :resource_type"
-            + " AND workspace_id = :workspace_id"
             + " AND attributes->>'vmName' = :vm_name";
     MapSqlParameterSource sqlParams =
         new MapSqlParameterSource()
+            .addValue("resource_type", WsmResourceType.AZURE_VM.toSql())
             .addValue("vm_name", resource.getVmName());
     Integer matchingCount = jdbcTemplate.queryForObject(sql, sqlParams, Integer.class);
     if (matchingCount != null && matchingCount > 0) {

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -569,13 +569,7 @@ public class ResourceDao {
             + " AND attributes->>'vmName' = :vm_name";
     MapSqlParameterSource sqlParams =
         new MapSqlParameterSource()
-            .addValue("resource_type", WsmResourceType.AZURE_VM.toSql())
-            .addValue("workspace_id", resource.getWorkspaceId().toString())
             .addValue("vm_name", resource.getVmName());
-    // TODO: are these needed?
-    //                    .addValue("ip_id", resource.getIpId())
-    //                    .addValue("network_id", resource.getNetworkId())
-    //                    .addValue("disk_id", resource.getDiskId());
     Integer matchingCount = jdbcTemplate.queryForObject(sql, sqlParams, Integer.class);
     if (matchingCount != null && matchingCount > 0) {
       throw new DuplicateResourceException(

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -716,6 +716,8 @@ public class ResourceDao {
             return new ControlledAzureIpResource(dbResource);
           case AZURE_DISK:
             return new ControlledAzureDiskResource(dbResource);
+          case AZURE_VM:
+            return new ControlledAzureVmResource(dbResource);
           default:
             throw new InvalidMetadataException(
                 "Invalid controlled resource type" + dbResource.getResourceType().toString());

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -561,7 +561,7 @@ public class ResourceDao {
   }
 
   private void validateUniqueAzureVm(ControlledAzureVmResource resource) {
-    // This should take into account azure uniqueness paaram, namely the fields in `AzureContext`
+    // This should take into account azure uniqueness param, namely the fields in `AzureContext`
     String sql =
         "SELECT COUNT(1)"
             + " FROM resource"

--- a/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
@@ -5,6 +5,9 @@ import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParam
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import java.util.regex.Pattern;
+
+import com.azure.core.management.Region;
+import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,5 +105,34 @@ public class ValidationUtils {
     //  with a 512 character name that cannot being with an underscore. That gives us room to
     // generate
     //  names based on the resource name. It also is roomy.
+  }
+
+  //TODO: fix validation once gradle `sbt console` equivalent is found..
+  public static void validateAzureVmSize(String vmSize) {
+    try {
+      VirtualMachineSizeTypes s = VirtualMachineSizeTypes.fromString(vmSize);
+      if (s == null) {
+        throw new InvalidReferenceException("Invalid Azure vm size specified. See the class `com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes`");
+      }
+    } catch (Exception e) {
+      logger.warn("Invalid Azure vmSize {}", vmSize);
+      throw new InvalidReferenceException(
+              "Invalid Azure vm size specified. See the class `com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes`");
+    }
+  }
+
+  //TODO: fix validation once gradle `sbt console` equivalent is found..
+  public static void validateRegion(String region) {
+    try {
+      Region r = Region.fromName(region);
+      if (r == null) {
+        logger.warn("Invalid Azure region {}", region);
+        throw new InvalidReferenceException("Invalid Azure Region specified. See the class `com.azure.core.management.Region`");
+      }
+    } catch (Exception e) {
+      logger.warn("Invalid Azure region {}", region);
+      throw new InvalidReferenceException(
+              "Invalid Azure Regon specified. See the class `com.azure.core.management.Region`");
+    }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
@@ -4,10 +4,11 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
-import java.util.regex.Pattern;
-
 import com.azure.core.management.Region;
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,29 +108,16 @@ public class ValidationUtils {
     //  names based on the resource name. It also is roomy.
   }
 
-  //TODO: fix validation once gradle `sbt console` equivalent is found..
   public static void validateAzureVmSize(String vmSize) {
-    try {
-      VirtualMachineSizeTypes s = VirtualMachineSizeTypes.fromString(vmSize);
-      if (s == null) {
-        throw new InvalidReferenceException("Invalid Azure vm size specified. See the class `com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes`");
-      }
-    } catch (Exception e) {
+    if (!VirtualMachineSizeTypes.values().stream().map(x -> x.toString()).collect(Collectors.toList()).contains(vmSize)) {
       logger.warn("Invalid Azure vmSize {}", vmSize);
       throw new InvalidReferenceException(
               "Invalid Azure vm size specified. See the class `com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes`");
     }
   }
 
-  //TODO: fix validation once gradle `sbt console` equivalent is found..
   public static void validateRegion(String region) {
-    try {
-      Region r = Region.fromName(region);
-      if (r == null) {
-        logger.warn("Invalid Azure region {}", region);
-        throw new InvalidReferenceException("Invalid Azure Region specified. See the class `com.azure.core.management.Region`");
-      }
-    } catch (Exception e) {
+    if (!Region.values().stream().map(x -> x.toString()).collect(Collectors.toList()).contains(region)) {
       logger.warn("Invalid Azure region {}", region);
       throw new InvalidReferenceException(
               "Invalid Azure Regon specified. See the class `com.azure.core.management.Region`");

--- a/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceType.java
@@ -5,6 +5,7 @@ import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.ControlledAzureIpResource;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.ControlledResource;
@@ -53,7 +54,13 @@ public enum WsmResourceType {
       "AZURE_DISK",
       ApiResourceType.AZURE_DISK,
       null,
-      ControlledAzureDiskResource.class);
+      ControlledAzureDiskResource.class),
+  AZURE_VM(
+      CloudPlatform.AZURE,
+      "AZURE_VM",
+      ApiResourceType.AZURE_VM,
+      null,
+      ControlledAzureVmResource.class);
 
   private final CloudPlatform cloudPlatform;
   private final String dbString; // serialized form of the resource type

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureDiskResource.java
@@ -102,7 +102,7 @@ public class ControlledAzureDiskResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureDisk.");
     }
-    
+
     ValidationUtils.validateAzureResourceName(getDiskName());
     ValidationUtils.validateRegion(getRegion());
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureDiskResource.java
@@ -102,7 +102,9 @@ public class ControlledAzureDiskResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureDisk.");
     }
+    
     ValidationUtils.validateAzureResourceName(getDiskName());
+    ValidationUtils.validateRegion(getRegion());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureIpResource.java
@@ -94,6 +94,7 @@ public class ControlledAzureIpResource extends ControlledResource {
           "Missing required region field for ControlledAzureIP.");
     }
     ValidationUtils.validateAzureResourceName(getIpName());
+    ValidationUtils.validateRegion(getRegion());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmAttributes.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 public class ControlledAzureVmAttributes {
   private final String vmName;
   private final String region;
+  private final String vmSize;
+  private final String vmImageUri;
 
   private final UUID ipId;
   private final UUID networkId;
@@ -16,11 +18,16 @@ public class ControlledAzureVmAttributes {
   public ControlledAzureVmAttributes(
       @JsonProperty("vmName") String vmName,
       @JsonProperty("region") String region,
+      @JsonProperty("vmSize") String vmSize,
+      @JsonProperty("vmImageUri") String vmImageUri,
       @JsonProperty("ipId") UUID ipId,
       @JsonProperty("networkId") UUID networkId,
       @JsonProperty("diskId") UUID diskId) {
     this.vmName = vmName;
     this.region = region;
+    this.vmSize = vmSize;
+    this.vmImageUri = vmImageUri;
+
     this.ipId = ipId;
     this.networkId = networkId;
     this.diskId = diskId;
@@ -32,6 +39,14 @@ public class ControlledAzureVmAttributes {
 
   public String getRegion() {
     return region;
+  }
+
+  public String getVmSize() {
+    return vmSize;
+  }
+
+  public String getVmImageUri() {
+    return vmImageUri;
   }
 
   public UUID getIpId() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmAttributes.java
@@ -1,0 +1,48 @@
+package bio.terra.workspace.service.resource.controlled;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+
+public class ControlledAzureVmAttributes {
+  private final String vmName;
+  private final String region;
+
+  private final UUID ipId;
+  private final UUID networkId;
+  private final UUID diskId;
+
+  @JsonCreator
+  public ControlledAzureVmAttributes(
+      @JsonProperty("vmName") String vmName,
+      @JsonProperty("region") String region,
+      @JsonProperty("ipId") UUID ipId,
+      @JsonProperty("networkId") UUID networkId,
+      @JsonProperty("diskId") UUID diskId) {
+    this.vmName = vmName;
+    this.region = region;
+    this.ipId = ipId;
+    this.networkId = networkId;
+    this.diskId = diskId;
+  }
+
+  public String getVmName() {
+    return vmName;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public UUID getIpId() {
+    return ipId;
+  }
+
+  public UUID getNetworkId() {
+    return networkId;
+  }
+
+  public UUID getDiskId() {
+    return diskId;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmResource.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.generated.model.ApiAzureVmResource;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
@@ -16,6 +17,8 @@ import java.util.UUID;
 public class ControlledAzureVmResource extends ControlledResource {
   private final String vmName;
   private final String region;
+  private final String vmSize;
+  private final String vmImageUri;
 
   private final UUID ipId;
   private final UUID networkId;
@@ -33,6 +36,8 @@ public class ControlledAzureVmResource extends ControlledResource {
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("vmName") String vmName,
       @JsonProperty("region") String region,
+      @JsonProperty("vmSize") String vmSize,
+      @JsonProperty("vmImageUri") String vmImageUri,
       @JsonProperty("ipId") UUID ipId,
       @JsonProperty("networkId") UUID networkId,
       @JsonProperty("diskId") UUID diskId) {
@@ -48,6 +53,8 @@ public class ControlledAzureVmResource extends ControlledResource {
         managedBy);
     this.vmName = vmName;
     this.region = region;
+    this.vmSize = vmSize;
+    this.vmImageUri = vmImageUri;
     this.ipId = ipId;
     this.networkId = networkId;
     this.diskId = diskId;
@@ -60,6 +67,8 @@ public class ControlledAzureVmResource extends ControlledResource {
         DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureVmAttributes.class);
     this.vmName = attributes.getVmName();
     this.region = attributes.getRegion();
+    this.vmImageUri = attributes.getVmImageUri();
+    this.vmSize = attributes.getVmSize();
     this.ipId = attributes.getIpId();
     this.networkId = attributes.getNetworkId();
     this.diskId = attributes.getDiskId();
@@ -72,6 +81,14 @@ public class ControlledAzureVmResource extends ControlledResource {
 
   public String getRegion() {
     return region;
+  }
+
+  public String getVmSize() {
+    return vmSize;
+  }
+
+  public String getVmImageUri() {
+    return vmImageUri;
   }
 
   public UUID getIpId() {
@@ -87,7 +104,14 @@ public class ControlledAzureVmResource extends ControlledResource {
   }
 
   public ApiAzureVmAttributes toApiAttributes() {
-    return new ApiAzureVmAttributes().vmName(getVmName()).region(region.toString());
+    return new ApiAzureVmAttributes()
+        .vmName(getVmName())
+        .region(getRegion())
+        .vmSize(getVmSize())
+        .vmImageUri(getVmImageUri())
+        .ipId(getIpId())
+        .diskId(getDiskId())
+        .networkId(getNetworkId());
   }
 
   public ApiAzureVmResource toApiResource() {
@@ -103,7 +127,13 @@ public class ControlledAzureVmResource extends ControlledResource {
   public String attributesToJson() {
     return DbSerDes.toJson(
         new ControlledAzureVmAttributes(
-            getVmName(), getRegion(), getIpId(), getNetworkId(), getDiskId()));
+            getVmName(),
+            getRegion(),
+            getVmSize(),
+            getVmImageUri(),
+            getIpId(),
+            getNetworkId(),
+            getDiskId()));
   }
 
   @Override
@@ -120,6 +150,14 @@ public class ControlledAzureVmResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureVm.");
     }
+    if (getVmSize() == null) {
+      throw new MissingRequiredFieldException(
+          "Missing required valid vmSize field for ControlledAzureVm.");
+    }
+    if (getVmImageUri() == null) {
+      throw new MissingRequiredFieldException(
+          "Missing required valid vmImageUri field for ControlledAzureVm.");
+    }
     if (getIpId() == null) {
       throw new MissingRequiredFieldException("Missing required ipId field for ControlledAzureVm.");
     }
@@ -131,6 +169,14 @@ public class ControlledAzureVmResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required diskId field for ControlledAzureVm.");
     }
+
+    try {
+      VirtualMachineSizeTypes.fromString(getVmSize());
+    } catch (Exception e) {
+      throw new MissingRequiredFieldException(
+          "The field vmSize is not a valid azure vm size. Investigate VirtualMachineSizeTypes");
+    }
+
     ValidationUtils.validateAzureResourceName(getVmName());
   }
 
@@ -167,6 +213,8 @@ public class ControlledAzureVmResource extends ControlledResource {
     private ManagedByType managedBy;
     private String vmName;
     private String region;
+    private String vmSize;
+    private String vmImageUri;
     private UUID ipId;
     private UUID networkId;
     private UUID diskId;
@@ -199,6 +247,16 @@ public class ControlledAzureVmResource extends ControlledResource {
 
     public ControlledAzureVmResource.Builder vmName(String vmName) {
       this.vmName = vmName;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder vmSize(String vmSize) {
+      this.vmSize = vmSize;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder vmImageUri(String vmImageUri) {
+      this.vmImageUri = vmImageUri;
       return this;
     }
 
@@ -249,6 +307,8 @@ public class ControlledAzureVmResource extends ControlledResource {
           managedBy,
           vmName,
           region,
+          vmSize,
+          vmImageUri,
           ipId,
           networkId,
           diskId);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmResource.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.generated.model.ApiAzureVmResource;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -170,14 +171,9 @@ public class ControlledAzureVmResource extends ControlledResource {
           "Missing required diskId field for ControlledAzureVm.");
     }
 
-    try {
-      VirtualMachineSizeTypes.fromString(getVmSize());
-    } catch (Exception e) {
-      throw new MissingRequiredFieldException(
-          "The field vmSize is not a valid azure vm size. Investigate VirtualMachineSizeTypes");
-    }
-
     ValidationUtils.validateAzureResourceName(getVmName());
+    ValidationUtils.validateAzureVmSize(getVmName());
+    ValidationUtils.validateRegion(getRegion());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmResource.java
@@ -9,8 +9,6 @@ import bio.terra.workspace.generated.model.ApiAzureVmResource;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
-import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAzureVmResource.java
@@ -1,0 +1,257 @@
+package bio.terra.workspace.service.resource.controlled;
+
+import bio.terra.common.exception.InconsistentFieldsException;
+import bio.terra.common.exception.MissingRequiredFieldException;
+import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.generated.model.ApiAzureVmAttributes;
+import bio.terra.workspace.generated.model.ApiAzureVmResource;
+import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.WsmResourceType;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+
+public class ControlledAzureVmResource extends ControlledResource {
+  private final String vmName;
+  private final String region;
+
+  private final UUID ipId;
+  private final UUID networkId;
+  private final UUID diskId;
+
+  @JsonCreator
+  public ControlledAzureVmResource(
+      @JsonProperty("workspaceId") UUID workspaceId,
+      @JsonProperty("resourceId") UUID resourceId,
+      @JsonProperty("name") String name,
+      @JsonProperty("description") String description,
+      @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
+      @JsonProperty("assignedUser") String assignedUser,
+      @JsonProperty("accessScope") AccessScopeType accessScope,
+      @JsonProperty("managedBy") ManagedByType managedBy,
+      @JsonProperty("vmName") String vmName,
+      @JsonProperty("region") String region,
+      @JsonProperty("ipId") UUID ipId,
+      @JsonProperty("networkId") UUID networkId,
+      @JsonProperty("diskId") UUID diskId) {
+
+    super(
+        workspaceId,
+        resourceId,
+        name,
+        description,
+        cloningInstructions,
+        assignedUser,
+        accessScope,
+        managedBy);
+    this.vmName = vmName;
+    this.region = region;
+    this.ipId = ipId;
+    this.networkId = networkId;
+    this.diskId = diskId;
+    validate();
+  }
+
+  public ControlledAzureVmResource(DbResource dbResource) {
+    super(dbResource);
+    ControlledAzureVmAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureVmAttributes.class);
+    this.vmName = attributes.getVmName();
+    this.region = attributes.getRegion();
+    this.ipId = attributes.getIpId();
+    this.networkId = attributes.getNetworkId();
+    this.diskId = attributes.getDiskId();
+    validate();
+  }
+
+  public String getVmName() {
+    return vmName;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public UUID getIpId() {
+    return ipId;
+  }
+
+  public UUID getNetworkId() {
+    return networkId;
+  }
+
+  public UUID getDiskId() {
+    return diskId;
+  }
+
+  public ApiAzureVmAttributes toApiAttributes() {
+    return new ApiAzureVmAttributes().vmName(getVmName()).region(region.toString());
+  }
+
+  public ApiAzureVmResource toApiResource() {
+    return new ApiAzureVmResource().metadata(super.toApiMetadata()).attributes(toApiAttributes());
+  }
+
+  @Override
+  public WsmResourceType getResourceType() {
+    return WsmResourceType.AZURE_VM;
+  }
+
+  @Override
+  public String attributesToJson() {
+    return DbSerDes.toJson(
+        new ControlledAzureVmAttributes(
+            getVmName(), getRegion(), getIpId(), getNetworkId(), getDiskId()));
+  }
+
+  @Override
+  public void validate() {
+    super.validate();
+    if (getResourceType() != WsmResourceType.AZURE_VM) {
+      throw new InconsistentFieldsException("Expected AZURE_VM");
+    }
+    if (getVmName() == null) {
+      throw new MissingRequiredFieldException(
+          "Missing required vmName field for ControlledAzureVm.");
+    }
+    if (getRegion() == null) {
+      throw new MissingRequiredFieldException(
+          "Missing required region field for ControlledAzureVm.");
+    }
+    if (getIpId() == null) {
+      throw new MissingRequiredFieldException("Missing required ipId field for ControlledAzureVm.");
+    }
+    if (getNetworkId() == null) {
+      throw new MissingRequiredFieldException(
+          "Missing required networkId field for ControlledAzureVm.");
+    }
+    if (getDiskId() == null) {
+      throw new MissingRequiredFieldException(
+          "Missing required diskId field for ControlledAzureVm.");
+    }
+    ValidationUtils.validateAzureResourceName(getVmName());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+
+    ControlledAzureVmResource that = (ControlledAzureVmResource) o;
+
+    return vmName.equals(that.getVmName());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + vmName.hashCode();
+    return result;
+  }
+
+  public static ControlledAzureVmResource.Builder builder() {
+    return new ControlledAzureVmResource.Builder();
+  }
+
+  public static class Builder {
+    private UUID workspaceId;
+    private UUID resourceId;
+    private String name;
+    private String description;
+    private CloningInstructions cloningInstructions;
+    private String assignedUser;
+    private AccessScopeType accessScope;
+    private ManagedByType managedBy;
+    private String vmName;
+    private String region;
+    private UUID ipId;
+    private UUID networkId;
+    private UUID diskId;
+
+    public ControlledAzureVmResource.Builder workspaceId(UUID workspaceId) {
+      this.workspaceId = workspaceId;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder resourceId(UUID resourceId) {
+      this.resourceId = resourceId;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder cloningInstructions(
+        CloningInstructions cloningInstructions) {
+      this.cloningInstructions = cloningInstructions;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder vmName(String vmName) {
+      this.vmName = vmName;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder region(String region) {
+      this.region = region;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder ipId(UUID ipId) {
+      this.ipId = ipId;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder networkId(UUID networkId) {
+      this.networkId = networkId;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder diskId(UUID diskId) {
+      this.diskId = diskId;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder assignedUser(String assignedUser) {
+      this.assignedUser = assignedUser;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder accessScope(AccessScopeType accessScope) {
+      this.accessScope = accessScope;
+      return this;
+    }
+
+    public ControlledAzureVmResource.Builder managedBy(ManagedByType managedBy) {
+      this.managedBy = managedBy;
+      return this;
+    }
+
+    public ControlledAzureVmResource build() {
+      return new ControlledAzureVmResource(
+          workspaceId,
+          resourceId,
+          name,
+          description,
+          cloningInstructions,
+          assignedUser,
+          accessScope,
+          managedBy,
+          vmName,
+          region,
+          ipId,
+          networkId,
+          diskId);
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResource.java
@@ -124,6 +124,11 @@ public abstract class ControlledResource extends WsmResource {
     return (ControlledAzureDiskResource) this;
   }
 
+  public ControlledAzureVmResource castToAzureVmResource() {
+    validateSubclass(WsmResourceType.AZURE_VM);
+    return (ControlledAzureVmResource) this;
+  }
+
   public ControlledAiNotebookInstanceResource castToAiNotebookInstanceResource() {
     validateSubclass(WsmResourceType.AI_NOTEBOOK_INSTANCE);
     return (ControlledAiNotebookInstanceResource) this;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -4,6 +4,7 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
@@ -97,6 +98,23 @@ public class ControlledResourceService {
                 userRequest)
             .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
     return jobBuilder.submitAndWait(ControlledAzureDiskResource.class);
+  }
+
+  public ControlledAzureVmResource createVm(
+      ControlledAzureVmResource resource,
+      ApiAzureVmCreationParameters creationParameters,
+      List<ControlledResourceIamRole> privateResourceIamRoles,
+      AuthenticatedUserRequest userRequest) {
+
+    JobBuilder jobBuilder =
+        commonCreationJobBuilder(
+                resource,
+                privateResourceIamRoles,
+                new ApiJobControl().id(UUID.randomUUID().toString()),
+                null,
+                userRequest)
+            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
+    return jobBuilder.submitAndWait(ControlledAzureVmResource.class);
   }
 
   /** Starts a create controlled bucket resource, blocking until its job is finished. */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -104,15 +104,13 @@ public class ControlledResourceService {
       ControlledAzureVmResource resource,
       ApiAzureVmCreationParameters creationParameters,
       List<ControlledResourceIamRole> privateResourceIamRoles,
+      ApiJobControl jobControl,
+      String resultPath,
       AuthenticatedUserRequest userRequest) {
 
     JobBuilder jobBuilder =
         commonCreationJobBuilder(
-                resource,
-                privateResourceIamRoles,
-                new ApiJobControl().id(UUID.randomUUID().toString()),
-                null,
-                userRequest)
+                resource, privateResourceIamRoles, jobControl, resultPath, userRequest)
             .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
     return jobBuilder.submit();
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -100,7 +100,7 @@ public class ControlledResourceService {
     return jobBuilder.submitAndWait(ControlledAzureDiskResource.class);
   }
 
-  public ControlledAzureVmResource createVm(
+  public String createVm(
       ControlledAzureVmResource resource,
       ApiAzureVmCreationParameters creationParameters,
       List<ControlledResourceIamRole> privateResourceIamRoles,
@@ -114,7 +114,7 @@ public class ControlledResourceService {
                 null,
                 userRequest)
             .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
-    return jobBuilder.submitAndWait(ControlledAzureVmResource.class);
+    return jobBuilder.submit();
   }
 
   /** Starts a create controlled bucket resource, blocking until its job is finished. */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
@@ -69,7 +69,7 @@ public class CreateAzureVmStep implements Step {
             .castToControlledResource()
             .castToAzureDiskResource();
 
-    // TODO: remove once networks are a controlled resource
+    // TODO network: remove once networks are a controlled resource
     final String name = getAzureName("network");
     final String subnetName = getAzureName("subnet");
     final String addressCidr = "192.168.0.0/16";
@@ -96,7 +96,7 @@ public class CreateAzureVmStep implements Step {
           .define(resource.getVmName())
           .withRegion(resource.getRegion())
           .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
-          // TODO: network, use a real network
+          // TODO network:, use a real network
           .withExistingPrimaryNetwork(network)
           .withSubnet(subnetName)
           .withPrimaryPrivateIPAddressDynamic()
@@ -104,11 +104,11 @@ public class CreateAzureVmStep implements Step {
           // See here for difference between 'specialized' and 'general' LinuxCustomImage, the
           // managed disk storage option being the key factor
           // https://docs.microsoft.com/en-us/azure/virtual-machines/linux/imaging#generalized-and-specialized
-          .withSpecializedLinuxCustomImage(azureConfig.getCustomDockerImageId())
+          .withSpecializedLinuxCustomImage(resource.getVmImageUri())
           .withExistingDataDisk(existingAzureDisk)
           .withTag("workspaceId", resource.getWorkspaceId().toString())
           .withTag("resourceId", resource.getResourceId().toString())
-          .withSize(VirtualMachineSizeTypes.STANDARD_D2S_V3)
+          .withSize(VirtualMachineSizeTypes.fromString(resource.getVmSize()))
           .create(
               Defaults.buildContext(
                   CreateVirtualMachineRequestData.builder()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
@@ -199,14 +199,6 @@ public class CreateAzureVmStep implements Step {
             .toPort(8080)
             .withProtocol(SecurityRuleProtocol.TCP)
             .attach()
-            .defineRule("DenyInternetOutGoing")
-            .denyOutbound()
-            .fromAnyAddress()
-            .fromAnyPort()
-            .toAddress("INTERNET")
-            .toAnyPort()
-            .withAnyProtocol()
-            .attach()
             .create(
                 Defaults.buildContext(
                     CreateNetworkSecurityGroupRequestData.builder()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
@@ -103,15 +103,12 @@ public class CreateAzureVmStep implements Step {
           .define(resource.getVmName())
           .withRegion(resource.getRegion())
           .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
-          // Note, there is a `withNewPrimaryNetwork` that just takes a name for testing, but we
-          // cannot use this as CRL expects a fully qualified azure Network
-          //                    .withNewPrimaryNetwork(getAzureName("network")) //TODO: use real
-          // existing network
+          //TODO: network, use a real network
           .withExistingPrimaryNetwork(network)
           .withSubnet(subnetName)
           .withPrimaryPrivateIPAddressDynamic()
           .withExistingPrimaryPublicIPAddress(existingAzureIp)
-          //              .withSpecializedLinuxCustomImage()
+          //TODO: use specific image              .withSpecializedLinuxCustomImage()
           .withPopularLinuxImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS)
           .withRootUsername(userName)
           .withSsh(sshKey)
@@ -153,7 +150,7 @@ public class CreateAzureVmStep implements Step {
                     "TODO",
                     diskResource.getDiskName()));
       }
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
     }
 
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
@@ -142,8 +142,9 @@ public class CreateAzureVmStep implements Step {
                     ipResource.getIpName(),
                     "TODO",
                     diskResource.getDiskName()));
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
       }
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
 
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
@@ -1,0 +1,260 @@
+package bio.terra.workspace.service.resource.controlled.flight.create;
+
+import bio.terra.cloudres.azure.resourcemanager.common.Defaults;
+import bio.terra.cloudres.azure.resourcemanager.compute.data.CreateNetworkRequestData;
+import bio.terra.cloudres.azure.resourcemanager.compute.data.CreateNetworkSecurityGroupRequestData;
+import bio.terra.cloudres.azure.resourcemanager.compute.data.CreateVirtualMachineRequestData;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureDiskResource;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureIpResource;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureVmResource;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.Region;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.compute.ComputeManager;
+import com.azure.resourcemanager.compute.models.Disk;
+import com.azure.resourcemanager.compute.models.KnownLinuxVirtualMachineImage;
+import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
+import com.azure.resourcemanager.network.models.Network;
+import com.azure.resourcemanager.network.models.NetworkSecurityGroup;
+import com.azure.resourcemanager.network.models.PublicIpAddress;
+import com.azure.resourcemanager.network.models.SecurityRuleProtocol;
+import java.util.Collections;
+import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateAzureVmStep implements Step {
+
+  private static final Logger logger = LoggerFactory.getLogger(CreateAzureIpStep.class);
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final ControlledAzureVmResource resource;
+  private final AzureCloudContext azureCloudContext;
+  private final ResourceDao resourceDao;
+
+  public CreateAzureVmStep(
+      AzureConfiguration azureConfig,
+      AzureCloudContext azureCloudContext,
+      CrlService crlService,
+      ControlledAzureVmResource resource,
+      ResourceDao resourceDao) {
+    this.azureConfig = azureConfig;
+    this.azureCloudContext = azureCloudContext;
+    this.crlService = crlService;
+    this.resource = resource;
+    this.resourceDao = resourceDao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
+
+    // Note: these are public credentials, taken from:
+    // https://github.com/Azure-Samples/network-java-manage-virtual-network/blob/master/src/main/java/com/azure/resourcemanager/network/samples/ManageVirtualNetwork.java
+    final String userName = "tirekicker";
+    final String sshKey =
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.com";
+
+    final ControlledAzureIpResource ipResource =
+        resourceDao
+            .getResource(resource.getWorkspaceId(), resource.getIpId())
+            .castToControlledResource()
+            .castToAzureIpResource();
+
+    final ControlledAzureDiskResource diskResource =
+        resourceDao
+            .getResource(resource.getWorkspaceId(), resource.getDiskId())
+            .castToControlledResource()
+            .castToAzureDiskResource();
+
+    // TODO: remove once networks are a controlled resource
+    final String name = getAzureName("network");
+    final String subnetName = getAzureName("subnet");
+    final String addressCidr = "192.168.0.0/16";
+    final String subnetAddressCidr = "192.168.1.0/24";
+
+    try {
+      Network network = createNetwork(name, subnetName, addressCidr, subnetAddressCidr);
+
+      Disk existingAzureDisk =
+          computeManager
+              .disks()
+              .getByResourceGroup(
+                  azureCloudContext.getAzureResourceGroupId(), diskResource.getDiskName());
+
+      PublicIpAddress existingAzureIp =
+          computeManager
+              .networkManager()
+              .publicIpAddresses()
+              .getByResourceGroup(
+                  azureCloudContext.getAzureResourceGroupId(), ipResource.getIpName());
+
+      computeManager
+          .virtualMachines()
+          .define(resource.getVmName())
+          .withRegion(resource.getRegion())
+          .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
+          // Note, there is a `withNewPrimaryNetwork` that just takes a name for testing, but we
+          // cannot use this as CRL expects a fully qualified azure Network
+          //                    .withNewPrimaryNetwork(getAzureName("network")) //TODO: use real
+          // existing network
+          .withExistingPrimaryNetwork(network)
+          .withSubnet(subnetName)
+          .withPrimaryPrivateIPAddressDynamic()
+          .withExistingPrimaryPublicIPAddress(existingAzureIp)
+          //              .withSpecializedLinuxCustomImage()
+          .withPopularLinuxImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS)
+          .withRootUsername(userName)
+          .withSsh(sshKey)
+          .withExistingDataDisk(existingAzureDisk)
+          .withTag("workspaceId", resource.getWorkspaceId().toString())
+          .withTag("resourceId", resource.getResourceId().toString())
+          .withSize(VirtualMachineSizeTypes.STANDARD_D2S_V3)
+          .create(
+              Defaults.buildContext(
+                  CreateVirtualMachineRequestData.builder()
+                      .setName(resource.getVmName())
+                      .setRegion(Region.fromName(resource.getRegion()))
+                      .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
+                      .setNetwork(network)
+                      .setSubnetName(subnetName)
+                      .setDisk(existingAzureDisk)
+                      .setPublicIpAddress(existingAzureIp)
+                      .setImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS.toString())
+                      .build()));
+    } catch (ManagementException e) {
+      // Stairway steps may run multiple times, so we may already have created this resource. In all
+      // other cases, surface the exception and attempt to retry.
+      // Azure error codes can be found here:
+      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
+      if (StringUtils.equals(e.getValue().getCode(), "Conflict")) {
+        logger.info(
+            "Azure Vm {} in managed resource group {} already exists",
+            resource.getVmName(),
+            azureCloudContext.getAzureResourceGroupId());
+        return StepResult.getStepResultSuccess();
+      }
+      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+        logger.info(
+            "Either the disk, ip, or network passed into this createVm does not exist "
+                + String.format(
+                    "\nResource Group: %s\n\tIp Name: %s\n\tNetwork Name: %s\n\tDisk Name: %s",
+                    azureCloudContext.getAzureResourceGroupId(),
+                    ipResource.getIpName(),
+                    "TODO",
+                    diskResource.getDiskName()));
+      }
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
+
+    try {
+      computeManager
+          .virtualMachines()
+          .deleteByResourceGroup(azureCloudContext.getAzureResourceGroupId(), resource.getVmName());
+    } catch (ManagementException e) {
+      // Stairway steps may run multiple times, so we may already have deleted this resource.
+      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+        logger.info(
+            "Azure VM {} in managed resource group {} already deleted",
+            resource.getVmName(),
+            azureCloudContext.getAzureResourceGroupId());
+        return StepResult.getStepResultSuccess();
+      }
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  // TODO: THIS IS NOT HOW NETWORKS WILL BE CREATED, AND WILL BE REMOVED TO USE A CONTROLLED
+  // RESOURCE ONCE THAT WORK IS DONE (SEPARATE TICKET)
+  // Most of this is taken from this very helpful snippet
+  // https://github.com/Azure-Samples/network-java-manage-virtual-network/blob/master/src/main/java/com/azure/resourcemanager/network/samples/ManageVirtualNetwork.java
+  private Network createNetwork(
+      String networkName,
+      String subnetName,
+      String addressSpaceCidr,
+      String subnetAddressSpaceCidr) {
+    ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
+
+    NetworkSecurityGroup subnetNsg =
+        computeManager
+            .networkManager()
+            .networkSecurityGroups()
+            .define(subnetName)
+            .withRegion(resource.getRegion())
+            .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
+            .withTag("workspaceId", resource.getWorkspaceId().toString())
+            .withTag("resourceId", resource.getResourceId().toString())
+            .defineRule("AllowHttpInComing")
+            .allowInbound()
+            .fromAddress("INTERNET")
+            .fromAnyPort()
+            .toAnyAddress()
+            .toPort(80)
+            .withProtocol(SecurityRuleProtocol.TCP)
+            .attach()
+            .defineRule("DenyInternetOutGoing")
+            .denyOutbound()
+            .fromAnyAddress()
+            .fromAnyPort()
+            .toAddress("INTERNET")
+            .toAnyPort()
+            .withAnyProtocol()
+            .attach()
+            .create(
+                Defaults.buildContext(
+                    CreateNetworkSecurityGroupRequestData.builder()
+                        .setName(networkName)
+                        .setRegion(Region.fromName(resource.getRegion()))
+                        .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
+                        .setRules(Collections.emptyList())
+                        .build()));
+
+    return computeManager
+        .networkManager()
+        .networks()
+        .define(networkName)
+        .withRegion(resource.getRegion())
+        .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
+        .withTag("workspaceId", resource.getWorkspaceId().toString())
+        .withTag("resourceId", resource.getResourceId().toString())
+        .withAddressSpace(addressSpaceCidr)
+        .defineSubnet(subnetName)
+        .withAddressPrefix(subnetAddressSpaceCidr)
+        .withExistingNetworkSecurityGroup(subnetNsg)
+        .attach()
+        .create(
+            Defaults.buildContext(
+                CreateNetworkRequestData.builder()
+                    .setName(networkName)
+                    .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
+                    .setRegion(Region.fromName(resource.getRegion()))
+                    .setSubnetName(subnetName)
+                    .setNetworkSecurityGroup(subnetNsg)
+                    .setAddressPrefix(subnetAddressSpaceCidr)
+                    .setAddressSpaceCidr(addressSpaceCidr)
+                    .build()));
+  }
+
+  // TODO: delete me once networks are handled properly
+  private static String getAzureName(String tag) {
+    final String id = UUID.randomUUID().toString().substring(0, 6);
+    return String.format("wsm-stub-%s-%s", tag, id);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
@@ -138,6 +138,28 @@ public class CreateControlledResourceFlight extends Flight {
                 resource.castToAzureIpResource()),
             RetryRules.cloud());
         break;
+      case AZURE_VM:
+        addStep(
+            new GetAzureVmStep(
+                flightBeanBag.getAzureConfig(),
+                flightBeanBag
+                    .getAzureCloudContextService()
+                    .getAzureCloudContext(resource.getWorkspaceId())
+                    .get(),
+                flightBeanBag.getCrlService(),
+                resource.castToAzureVmResource()),
+            RetryRules.cloud());
+        addStep(
+            new CreateAzureVmStep(
+                flightBeanBag.getAzureConfig(),
+                flightBeanBag
+                    .getAzureCloudContextService()
+                    .getAzureCloudContext(resource.getWorkspaceId())
+                    .get(),
+                flightBeanBag.getCrlService(),
+                resource.castToAzureVmResource(),
+                flightBeanBag.getResourceDao()),
+            RetryRules.cloud());
       default:
         throw new IllegalStateException(
             String.format("Unrecognized resource type %s", resource.getResourceType()));

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
@@ -160,6 +160,7 @@ public class CreateControlledResourceFlight extends Flight {
                 resource.castToAzureVmResource(),
                 flightBeanBag.getResourceDao()),
             RetryRules.cloud());
+        break;
       default:
         throw new IllegalStateException(
             String.format("Unrecognized resource type %s", resource.getResourceType()));

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GetAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GetAzureVmStep.java
@@ -1,0 +1,62 @@
+package bio.terra.workspace.service.resource.controlled.flight.create;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureVmResource;
+import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.compute.ComputeManager;
+import org.apache.commons.lang3.StringUtils;
+
+public class GetAzureVmStep implements Step {
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final ControlledAzureVmResource resource;
+  private final AzureCloudContext azureCloudContext;
+
+  public GetAzureVmStep(
+      AzureConfiguration azureConfig,
+      AzureCloudContext azureCloudContext,
+      CrlService crlService,
+      ControlledAzureVmResource resource) {
+    this.azureConfig = azureConfig;
+    this.azureCloudContext = azureCloudContext;
+    this.crlService = crlService;
+    this.resource = resource;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
+    try {
+      computeManager
+          .virtualMachines()
+          .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), resource.getVmName());
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new DuplicateResourceException(
+              String.format(
+                  "An Azure VM with name %s already exists in resource group %s",
+                  azureCloudContext.getAzureResourceGroupId(), resource.getVmName())));
+    } catch (ManagementException e) {
+      // Azure error codes can be found here:
+      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
+      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+        return StepResult.getStepResultSuccess();
+      }
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    }
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Nothing to undo
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteAzureDiskStep.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  * actually delete the Azure Disk.
  */
 public class DeleteAzureDiskStep implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(CreateAzureDiskStep.class);
+  private static final Logger logger = LoggerFactory.getLogger(DeleteAzureDiskStep.class);
   private final AzureConfiguration azureConfig;
   private final ResourceDao resourceDao;
   private final CrlService crlService;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteAzureDiskStep.java
@@ -7,7 +7,6 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.resource.controlled.flight.create.CreateAzureDiskStep;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.resourcemanager.compute.ComputeManager;
 import java.util.UUID;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteAzureVmStep.java
@@ -1,0 +1,72 @@
+package bio.terra.workspace.service.resource.controlled.flight.delete;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.resourcemanager.compute.ComputeManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+public class DeleteAzureVmStep implements Step {
+    private static final Logger logger = LoggerFactory.getLogger(DeleteAzureVmStep.class);
+    private final AzureConfiguration azureConfig;
+    private final ResourceDao resourceDao;
+    private final CrlService crlService;
+    private final AzureCloudContext azureCloudContext;
+
+    private final UUID workspaceId;
+    private final UUID resourceId;
+
+    public DeleteAzureVmStep(
+            AzureConfiguration azureConfig,
+            AzureCloudContext azureCloudContext,
+            CrlService crlService,
+            ResourceDao resourceDao,
+            UUID workspaceId,
+            UUID resourceId) {
+        this.crlService = crlService;
+        this.resourceDao = resourceDao;
+        this.azureCloudContext = azureCloudContext;
+        this.azureConfig = azureConfig;
+        this.workspaceId = workspaceId;
+        this.resourceId = resourceId;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext context) throws InterruptedException {
+        var wsmResource = resourceDao.getResource(workspaceId, resourceId);
+        var vm = wsmResource.castToControlledResource().castToAzureVmResource();
+
+        ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
+        var azureResourceId =
+                String.format(
+                        "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s",
+                        azureCloudContext.getAzureSubscriptionId(),
+                        azureCloudContext.getAzureResourceGroupId(),
+                        vm.getVmName());
+        try {
+            logger.info("Attempting to delete vm " + azureResourceId);
+
+            computeManager.virtualMachines().deleteById(azureResourceId);
+            return StepResult.getStepResultSuccess();
+        } catch (Exception ex) {
+            logger.info("Attempt to delete Azure vm failed on this try: " + azureResourceId, ex);
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+        }
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+        logger.error(
+                "Cannot undo delete of Azure vm resource {} in workspace {}.", resourceId, workspaceId);
+        // Surface whatever error caused Stairway to begin undoing.
+        return flightContext.getResult();
+    }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteAzureVmStep.java
@@ -57,7 +57,7 @@ public class DeleteAzureVmStep implements Step {
       return StepResult.getStepResultSuccess();
     } catch (Exception ex) {
       logger.info("Attempt to delete Azure vm failed on this try: " + azureResourceId, ex);
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceFlight.java
@@ -94,6 +94,19 @@ public class DeleteControlledResourceFlight extends Flight {
                 workspaceId,
                 resourceId));
         break;
+      case AZURE_VM:
+        addStep(
+          new DeleteAzureVmStep(
+            flightBeanBag.getAzureConfig(),
+            flightBeanBag
+                    .getAzureCloudContextService()
+                    .getAzureCloudContext(resource.getWorkspaceId())
+                    .get(),
+            flightBeanBag.getCrlService(),
+            flightBeanBag.getResourceDao(),
+            workspaceId,
+            resourceId));
+        break;
       case BIG_QUERY_DATASET:
         addStep(
             new DeleteBigQueryDatasetStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceFlight.java
@@ -96,16 +96,16 @@ public class DeleteControlledResourceFlight extends Flight {
         break;
       case AZURE_VM:
         addStep(
-          new DeleteAzureVmStep(
-            flightBeanBag.getAzureConfig(),
-            flightBeanBag
+            new DeleteAzureVmStep(
+                flightBeanBag.getAzureConfig(),
+                flightBeanBag
                     .getAzureCloudContextService()
                     .getAzureCloudContext(resource.getWorkspaceId())
                     .get(),
-            flightBeanBag.getCrlService(),
-            flightBeanBag.getResourceDao(),
-            workspaceId,
-            resourceId));
+                flightBeanBag.getCrlService(),
+                flightBeanBag.getResourceDao(),
+                workspaceId,
+                resourceId));
         break;
       case BIG_QUERY_DATASET:
         addStep(

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -84,8 +84,8 @@ paths:
           $ref: '#/components/responses/NotFound'
     get:
       parameters:
-      - $ref: '#/components/parameters/Offset'
-      - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
       summary: List all workspaces a user can read.
       operationId: listWorkspaces
       tags: [ Workspace ]
@@ -379,8 +379,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/{resourceId}/access:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/ResourceId'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
     get:
       summary: Check a user's access to a referenced resource
       operationId: checkReferenceAccess
@@ -399,7 +399,7 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/datarepo/snapshots:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/WorkspaceId'
     post:
       summary: Create a new data repo snapshot reference in a workspace.
       operationId: createDataRepoSnapshotReference
@@ -424,8 +424,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/datarepo/snapshots/{resourceId}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/ResourceId'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
     get:
       summary: Gets a reference to a snapshot from a workspace.
       operationId: getDataRepoSnapshotReference
@@ -499,8 +499,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/datarepo/snapshots/name/{name}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/Name'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/Name'
     get:
       summary: Gets a reference to a snapshot by name.
       operationId: getDataRepoSnapshotReferenceByName
@@ -517,7 +517,7 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/buckets:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/WorkspaceId'
     post:
       summary: Create a new GCS bucket reference in a workspace.
       operationId: createBucketReference
@@ -542,8 +542,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/buckets/{resourceId}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/ResourceId'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
     get:
       summary: Gets a reference to a bucket from a workspace.
       operationId: getBucketReference
@@ -616,8 +616,8 @@ paths:
           $ref: '#/components/responses/ServerError'
   /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/buckets/name/{name}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/Name'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/Name'
     get:
       summary: Gets a reference to a Gcp bucket by name.
       operationId: getBucketReferenceByName
@@ -634,7 +634,7 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bigquerydatasets:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/WorkspaceId'
     post:
       summary: Create a new BigQuery dataset reference in a workspace.
       operationId: createBigQueryDatasetReference
@@ -659,8 +659,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bigquerydatasets/{resourceId}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/ResourceId'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
     get:
       summary: Gets a reference to a BigQuery dataset from a workspace.
       operationId: getBigQueryDatasetReference
@@ -734,8 +734,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bigquerydatasets/name/{name}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/Name'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/Name'
     get:
       summary: Gets a reference to a BigQuery dataset by name.
       operationId: getBigQueryDatasetReferenceByName
@@ -752,7 +752,7 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/cloudcontexts:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/WorkspaceId'
     post:
       summary: Create a cloud context for the workspace.
       operationId: createCloudContext
@@ -779,8 +779,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/cloudcontexts/result/{jobId}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/JobId'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/JobId'
     get:
       summary: Get the result of a async job to create a cloud context.
       operationId: getCreateCloudContextResult
@@ -803,8 +803,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/cloudcontexts/{cloudContext}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/CloudContext'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/CloudContext'
     delete:
       summary: Deletes a cloud context and all of its data from a workspace.
       operationId: deleteCloudContext
@@ -821,7 +821,7 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/roles:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/WorkspaceId'
     get:
       summary: Read all IAM roles and their members in a workspace.
       operationId: getRoles
@@ -838,8 +838,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/roles/{role}/members:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/Role'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/Role'
     post:
       summary: Grant an IAM role to a user or group.
       operationId: grantRole
@@ -861,9 +861,9 @@ paths:
           $ref: '#/components/responses/ServerError'
   /api/workspaces/v1/{workspaceId}/roles/{role}/members/{memberEmail}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/Role'
-    - $ref: '#/components/parameters/MemberEmail'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/Role'
+      - $ref: '#/components/parameters/MemberEmail'
     delete:
       summary: Remove an IAM role from a user or group.
       operationId: removeRole
@@ -881,10 +881,10 @@ paths:
 
   /api/job/v1/jobs/{jobId}:
     parameters:
-    - $ref: '#/components/parameters/JobId'
+      - $ref: '#/components/parameters/JobId'
     get:
       tags:
-      - jobs
+        - jobs
       operationId: retrieveJob
       responses:
         200:
@@ -1210,9 +1210,87 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/vm:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+    post:
+      summary: Create a new controlled Azure VM
+      operationId: createAzureVm
+      tags: [ControlledAzureResource]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateControlledAzureVmRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/CreateControlledAzureVmResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/vm/{resourceId}:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
+    get:
+      summary: Get a controlled Azure VM resource
+      operationId: getAzureVm
+      tags: [ControlledAzureResource]
+      responses:
+        '200':
+          $ref: '#/components/responses/GetControlledAzureVmResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    post:
+      summary: |
+        Delete an azure Vm
+      operationId: deleteAzureVm
+      tags: [ControlledAzureResource]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteControlledAzureResourceRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/DeleteControlledAzureResourceResponse'
+        '202':
+          $ref: '#/components/responses/DeleteControlledAzureResourceResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/vm/delete-result/{jobId}:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/JobId'
+    get:
+      summary: Retrieve information about an azure vm deletion job.
+      operationId: getDeleteAzureVmResult
+      tags: [ControlledAzureResource]
+      responses:
+        '200':
+          $ref: '#/components/responses/DeleteControlledAzureResourceResponse'
+        '202':
+          $ref: '#/components/responses/DeleteControlledAzureResourceResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/workspaces/v1/{workspaceId}/resources/controlled/gcp/bqdatasets:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/WorkspaceId'
     post:
       summary: Create a new controlled BigQuery dataset
       operationId: createBigQueryDataset
@@ -1233,8 +1311,8 @@ paths:
 
   /api/workspaces/v1/{workspaceId}/resources/controlled/gcp/bqdatasets/{resourceId}:
     parameters:
-    - $ref: '#/components/parameters/WorkspaceId'
-    - $ref: '#/components/parameters/ResourceId'
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
     get:
       summary: Get a controlled BigQuery dataset resource
       operationId: getBigQueryDataset
@@ -2052,6 +2130,15 @@ components:
         azureDisk:
           $ref: '#/components/schemas/AzureDiskCreationParameters'
 
+    CreateControlledAzureVmRequestBody:
+      description: Payload for requesting a new controlled Azure VM resource.
+      type: object
+      properties:
+        common:
+          $ref: '#/components/schemas/ControlledResourceCommonFields'
+        azureVm:
+          $ref: '#/components/schemas/AzureVmCreationParameters'
+
     CreateControlledGcpGcsBucketRequestBody:
       description: Payload for requesting a new controlled GCS bucket resource.
       type: object
@@ -2219,6 +2306,35 @@ components:
             A valid size in GB integer representation
           type: integer
 
+    AzureVmCreationParameters:
+      description: >-
+        Vm-specific properties to be set on creation. These are a subset of the values
+        accepted by the azure resource API
+      type: object
+      required: [name, region, ipId]
+      properties:
+        name:
+          description: A valid vm name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+          type: string
+        region:
+          description: |
+            A valid region string representation per https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.resourcemanager.fluent.core.region.
+            It is best to look at the Region class definition for valid strings (e.g. 'eastus' == Region.US_EAST.toString())
+          type: string
+        ##TODO: should these be more complex request objects?
+        ipId:
+          description: A valid WSM identifier for an Azure Ip that corresponds to a valid azure resource
+          type: string
+          format: uuid
+        diskId:
+          description: A valid WSM identifier for an Azure Disk that corresponds to a valid azure resource
+          type: string
+          format: uuid
+        networkId:
+          description: A valid WSM identifier for an Azure Network that corresponds to a valid azure resource
+          type: string
+          format: uuid
+
     CreatedControlledAzureIp:
       description: Response payload for requesting a new Azure IP
       type: object
@@ -2240,6 +2356,17 @@ components:
           format: uuid
         azureDisk:
           $ref: '#/components/schemas/AzureDiskResource'
+
+    CreatedControlledAzureVm:
+      description: Response payload for requesting a new Azure VM
+      type: object
+      properties:
+        resourceId:
+          description: UUID of a newly-created resource.
+          type: string
+          format: uuid
+        azureVm:
+          $ref: '#/components/schemas/AzureVmResource'
 
     GcpGcsBucketCreationParameters:
       description: >-
@@ -2936,6 +3063,18 @@ components:
           description: Azure region of created disk
           type: string
 
+    AzureVmAttributes:
+      description: >-
+        Vm properties included in post-creation get and update. Others must be retrieved from Azure using the name.
+      type: object
+      properties:
+        vmName:
+          description: Name of created vm (not the resource name).
+          type: string
+        region:
+          description: Azure region of created vm
+          type: string
+
     GcpGcsBucketAttributes:
       description: >-
         Bucket properties included in post-creation, get, and update. Others must be
@@ -2978,6 +3117,17 @@ components:
           $ref: '#/components/schemas/ResourceMetadata'
         attributes:
           $ref: '#/components/schemas/AzureDiskAttributes'
+
+    AzureVmResource:
+      type: object
+      description: Description of an Azure vm
+      required: [metadata, attributes]
+      properties:
+        metadata:
+          description: the resource metadata common to all resources
+          $ref: '#/components/schemas/ResourceMetadata'
+        attributes:
+          $ref: '#/components/schemas/AzureVmAttributes'
 
     GcpAiNotebookInstanceAttributes:
       description: >-
@@ -3105,6 +3255,7 @@ components:
         - GCS_BUCKET
         - AZURE_IP
         - AZURE_DISK
+        - AZURE_VM
 
     StewardshipType:
       description: Enum containing valid stewardship types. Used for enumeration
@@ -3186,6 +3337,13 @@ components:
           schema:
             $ref: '#/components/schemas/CreatedControlledAzureDisk'
 
+    CreateControlledAzureVmResponse:
+      description: Response to create controlled Azure vm
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatedControlledAzureVm'
+
     DeleteControlledAzureResourceResponse:
       description: Response Payload for deleting an azure ip
       content:
@@ -3206,6 +3364,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/AzureDiskResource'
+
+    GetControlledAzureVmResponse:
+      description: Response to get vm
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AzureVmResource'
 
     CreatedControlledGcpGcsBucketResponse:
       description: Response to Create controlled Gcs bucket

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2341,7 +2341,12 @@ components:
             A valid region string representation per https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.resourcemanager.fluent.core.region.
             It is best to look at the Region class definition for valid strings (e.g. 'eastus' == Region.US_EAST.toString())
           type: string
-        ##TODO: should these be more complex request objects?
+        vmSize:
+          description: A valid image size as per com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
+          type: string
+        vmImageUri:
+          description: A valid image Uri. Must be in the same region specified. E.x. /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.0.4
+          type: string
         ipId:
           description: A valid WSM identifier for an Azure Ip that corresponds to a valid azure resource
           type: string
@@ -3105,6 +3110,24 @@ components:
         region:
           description: Azure region of created vm
           type: string
+        vmSize:
+          description: A valid image size as per com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
+          type: string
+        vmImageUri:
+          description: A valid image Uri. Must be in the same region specified. E.x. /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.0.4
+          type: string
+        ipId:
+          description: A valid WSM identifier for an Azure Ip that corresponds to a valid azure resource
+          type: string
+          format: uuid
+        diskId:
+          description: A valid WSM identifier for an Azure Disk that corresponds to a valid azure resource
+          type: string
+          format: uuid
+        networkId:
+          description: A valid WSM identifier for an Azure Network that corresponds to a valid azure resource
+          type: string
+          format: uuid
 
     GcpGcsBucketAttributes:
       description: >-

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2311,7 +2311,7 @@ components:
         Vm-specific properties to be set on creation. These are a subset of the values
         accepted by the azure resource API
       type: object
-      required: [name, region, ipId]
+      required: [name, region, ipId, diskId, networkId]
       properties:
         name:
           description: A valid vm name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
@@ -2358,7 +2358,7 @@ components:
           $ref: '#/components/schemas/AzureDiskResource'
 
     CreatedControlledAzureVm:
-      description: Response payload for requesting a new Azure VM
+      description: Api result class for creating A new Azure VM
       type: object
       properties:
         resourceId:
@@ -2832,6 +2832,17 @@ components:
           $ref: '#/components/schemas/ErrorReport'
         aiNotebookInstance:
           $ref: '#/components/schemas/GcpAiNotebookInstanceResource'
+
+    CreatedControlledAzureVmResult:
+      description: Api result class for creating an azure vm
+      type: object
+      properties:
+        azureVm:
+          $ref: '#/components/schemas/CreatedControlledAzureVm'
+        jobReport:
+          $ref: '#/components/schemas/JobReport'
+        errorReport:
+          $ref: '#/components/schemas/ErrorReport'
 
     GcpAiNotebookInstanceCreationParameters:
       description: >-
@@ -3338,11 +3349,11 @@ components:
             $ref: '#/components/schemas/CreatedControlledAzureDisk'
 
     CreateControlledAzureVmResponse:
-      description: Response to create controlled Azure vm
+      description: Response to create controlled Azure Vm
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CreatedControlledAzureVm'
+            $ref: '#/components/schemas/CreatedControlledAzureVmResult'
 
     DeleteControlledAzureResourceResponse:
       description: Response Payload for deleting an azure ip

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1232,6 +1232,24 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/vm/create-result/{jobId}:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/JobId'
+    get:
+      summary: Retrieve information about an Azure Vm create job.
+      operationId: getCreateAzureVmResult
+      tags: [ControlledAzureResource]
+      responses:
+        '200':
+          $ref: '#/components/responses/CreateControlledAzureVmResponse'
+        '202':
+          $ref: '#/components/responses/CreateControlledAzureVmResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/workspaces/v1/{workspaceId}/resources/controlled/azure/vm/{resourceId}:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
@@ -2138,6 +2156,8 @@ components:
           $ref: '#/components/schemas/ControlledResourceCommonFields'
         azureVm:
           $ref: '#/components/schemas/AzureVmCreationParameters'
+        jobControl:
+          $ref: '#/components/schemas/JobControl'
 
     CreateControlledGcpGcsBucketRequestBody:
       description: Payload for requesting a new controlled GCS bucket resource.

--- a/service/src/main/resources/application-azure.yml
+++ b/service/src/main/resources/application-azure.yml
@@ -3,6 +3,6 @@
 workspace:
   azure:
     managed-app-client-id: 51ef1ef2-b571-43b3-bcb3-ecaa3b49f0ed
-    managed-app-client-secret: TBD
+    managed-app-client-secret: 
     managed-app-tenant-id: fad90753-2022-4456-9b0a-c7e5b934e408
 

--- a/service/src/main/resources/application-azure.yml
+++ b/service/src/main/resources/application-azure.yml
@@ -3,6 +3,6 @@
 workspace:
   azure:
     managed-app-client-id: 51ef1ef2-b571-43b3-bcb3-ecaa3b49f0ed
-    managed-app-client-secret: 
+    managed-app-client-secret:
     managed-app-tenant-id: fad90753-2022-4456-9b0a-c7e5b934e408
-
+    custom-docker-image-id: /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.0.4

--- a/service/src/main/resources/application-azure.yml
+++ b/service/src/main/resources/application-azure.yml
@@ -3,6 +3,6 @@
 workspace:
   azure:
     managed-app-client-id: 51ef1ef2-b571-43b3-bcb3-ecaa3b49f0ed
-    managed-app-client-secret: 
+    managed-app-client-secret:
     managed-app-tenant-id: fad90753-2022-4456-9b0a-c7e5b934e408
 

--- a/service/src/main/resources/application-azure.yml
+++ b/service/src/main/resources/application-azure.yml
@@ -3,6 +3,6 @@
 workspace:
   azure:
     managed-app-client-id: 51ef1ef2-b571-43b3-bcb3-ecaa3b49f0ed
-    managed-app-client-secret:
+    managed-app-client-secret: 
     managed-app-tenant-id: fad90753-2022-4456-9b0a-c7e5b934e408
-    custom-docker-image-id: /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.0.4
+

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -99,14 +99,14 @@ public class ControlledResourceFixtures {
   public static ApiAzureIpCreationParameters getAzureIpCreationParameters() {
     return new ApiAzureIpCreationParameters()
         .name(uniqueAzureName(AZURE_IP_NAME_PREFIX))
-        .region("eastus");
+        .region("westcentralus");
   }
 
   /** Construct a parameter object with a unique disk name to avoid unintended clashes. */
   public static ApiAzureDiskCreationParameters getAzureDiskCreationParameters() {
     return new ApiAzureDiskCreationParameters()
         .name(uniqueAzureName(AZURE_DISK_NAME_PREFIX))
-        .region("eastus")
+        .region("westcentralus")
         .size(50);
   }
 
@@ -117,7 +117,7 @@ public class ControlledResourceFixtures {
         .ipId(UUID.randomUUID())
         .networkId(UUID.randomUUID())
         .diskId(UUID.randomUUID())
-        .region("eastus");
+        .region("westcentralus");
   }
 
   public static String uniqueBucketName() {

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.common.fixtures;
 
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
@@ -18,6 +19,7 @@ import bio.terra.workspace.service.resource.controlled.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.ControlledAzureIpResource;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.ManagedByType;
@@ -77,6 +79,7 @@ public class ControlledResourceFixtures {
   public static final String AZURE_NAME_PREFIX = "azure";
   public static final String AZURE_IP_NAME_PREFIX = "ip";
   public static final String AZURE_DISK_NAME_PREFIX = "disk";
+  public static final String AZURE_VM_NAME_PREFIX = "vm";
 
   public static final ApiGcpGcsBucketCreationParameters GOOGLE_BUCKET_CREATION_PARAMETERS_MINIMAL =
       new ApiGcpGcsBucketCreationParameters()
@@ -92,19 +95,29 @@ public class ControlledResourceFixtures {
         .lifecycle(new ApiGcpGcsBucketLifecycle().rules(LIFECYCLE_RULES));
   }
 
-  /** Construct a parameter object with a unique bucket name to avoid unintended clashes. */
+  /** Construct a parameter object with a unique ip name to avoid unintended clashes. */
   public static ApiAzureIpCreationParameters getAzureIpCreationParameters() {
     return new ApiAzureIpCreationParameters()
         .name(uniqueAzureName(AZURE_IP_NAME_PREFIX))
         .region("eastus");
   }
 
-  /** Construct a parameter object with a unique bucket name to avoid unintended clashes. */
+  /** Construct a parameter object with a unique disk name to avoid unintended clashes. */
   public static ApiAzureDiskCreationParameters getAzureDiskCreationParameters() {
     return new ApiAzureDiskCreationParameters()
         .name(uniqueAzureName(AZURE_DISK_NAME_PREFIX))
         .region("eastus")
         .size(50);
+  }
+
+  /** Construct a parameter object with a unique vm name to avoid unintended clashes. */
+  public static ApiAzureVmCreationParameters getAzureVmCreationParameters() {
+    return new ApiAzureVmCreationParameters()
+        .name(uniqueAzureName(AZURE_VM_NAME_PREFIX))
+        .ipId(UUID.randomUUID())
+        .networkId(UUID.randomUUID())
+        .diskId(UUID.randomUUID())
+        .region("eastus");
   }
 
   public static String uniqueBucketName() {
@@ -180,6 +193,25 @@ public class ControlledResourceFixtures {
         diskName,
         region,
         size);
+  }
+
+  public static ControlledAzureVmResource getAzureVm(
+      ApiAzureVmCreationParameters creationParameters) {
+    return new ControlledAzureVmResource(
+        WORKSPACE_ID,
+        RESOURCE_ID,
+        RESOURCE_NAME,
+        RESOURCE_DESCRIPTION,
+        CLONING_INSTRUCTIONS,
+        OWNER_EMAIL,
+        // TODO: these should be changed when we group the resources
+        AccessScopeType.ACCESS_SCOPE_PRIVATE,
+        ManagedByType.MANAGED_BY_USER,
+        creationParameters.getName(),
+        creationParameters.getRegion(),
+        creationParameters.getIpId(),
+        creationParameters.getNetworkId(),
+        creationParameters.getDiskId());
   }
 
   private ControlledResourceFixtures() {}

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -24,6 +24,7 @@ import bio.terra.workspace.service.resource.controlled.ControlledBigQueryDataset
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.bigquery.model.Dataset;
 import com.google.cloud.storage.BucketInfo;
@@ -114,10 +115,13 @@ public class ControlledResourceFixtures {
   public static ApiAzureVmCreationParameters getAzureVmCreationParameters() {
     return new ApiAzureVmCreationParameters()
         .name(uniqueAzureName(AZURE_VM_NAME_PREFIX))
+        .region("westcentralus")
+        .vmSize(VirtualMachineSizeTypes.STANDARD_D2S_V3.toString())
+        .vmImageUri(
+            "/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.0.4")
         .ipId(UUID.randomUUID())
-        .networkId(UUID.randomUUID())
         .diskId(UUID.randomUUID())
-        .region("westcentralus");
+        .networkId(UUID.randomUUID());
   }
 
   public static String uniqueBucketName() {
@@ -209,6 +213,8 @@ public class ControlledResourceFixtures {
         ManagedByType.MANAGED_BY_USER,
         creationParameters.getName(),
         creationParameters.getRegion(),
+        creationParameters.getVmSize(),
+        creationParameters.getVmImageUri(),
         creationParameters.getIpId(),
         creationParameters.getNetworkId(),
         creationParameters.getDiskId());

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateAzureVmStepTest.java
@@ -1,0 +1,348 @@
+package bio.terra.workspace.service.resource.controlled.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.cloudres.azure.resourcemanager.compute.data.CreateVirtualMachineRequestData;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.WsmResource;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureDiskResource;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureIpResource;
+import bio.terra.workspace.service.resource.controlled.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.flight.create.CreateAzureVmStep;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.Region;
+import com.azure.core.management.exception.ManagementError;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.core.util.Context;
+import com.azure.resourcemanager.compute.ComputeManager;
+import com.azure.resourcemanager.compute.models.Disk;
+import com.azure.resourcemanager.compute.models.Disks;
+import com.azure.resourcemanager.compute.models.KnownLinuxVirtualMachineImage;
+import com.azure.resourcemanager.compute.models.VirtualMachine;
+import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
+import com.azure.resourcemanager.compute.models.VirtualMachines;
+import com.azure.resourcemanager.network.NetworkManager;
+import com.azure.resourcemanager.network.models.Network;
+import com.azure.resourcemanager.network.models.NetworkSecurityGroup;
+import com.azure.resourcemanager.network.models.NetworkSecurityGroups;
+import com.azure.resourcemanager.network.models.NetworkSecurityRule;
+import com.azure.resourcemanager.network.models.Networks;
+import com.azure.resourcemanager.network.models.PublicIpAddress;
+import com.azure.resourcemanager.network.models.PublicIpAddresses;
+import com.azure.resourcemanager.network.models.SecurityRuleProtocol;
+import com.azure.resourcemanager.network.models.Subnet;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("azure")
+public class CreateAzureVmStepTest extends BaseAzureTest {
+
+  private static final String STUB_STRING_RETURN = "stubbed-return";
+  private static final String STUB_DISK_NAME = "stub-disk-name";
+  private static final String STUB_IP_NAME = "stub-disk-name";
+  private static final String STUB_NETWORK_NAME = "stub-network-name";
+
+  @Mock private FlightContext mockFlightContext;
+  @Mock private CrlService mockCrlService;
+  @Mock private AzureConfiguration mockAzureConfig;
+  @Mock private AzureCloudContext mockAzureCloudContext;
+  @Mock private ComputeManager mockComputeManager;
+  @Mock private ResourceDao mockResourceDao;
+  @Mock private VirtualMachines mockVms;
+  @Mock private VirtualMachine mockVm;
+
+  @Mock private VirtualMachine.DefinitionStages.Blank mockVmStage1;
+  @Mock private VirtualMachine.DefinitionStages.WithGroup mockVmStage2;
+  @Mock private VirtualMachine.DefinitionStages.WithNetwork mockVmStage3;
+  @Mock private VirtualMachine.DefinitionStages.WithSubnet mockVmStage4;
+  @Mock private VirtualMachine.DefinitionStages.WithPrivateIP mockVmStage5;
+  @Mock private VirtualMachine.DefinitionStages.WithPublicIPAddress mockVmStage6;
+  @Mock private VirtualMachine.DefinitionStages.WithProximityPlacementGroup mockVmStage7;
+
+  @Mock
+  private VirtualMachine.DefinitionStages.WithLinuxRootUsernameManagedOrUnmanaged mockVmStage8;
+
+  @Mock
+  private VirtualMachine.DefinitionStages.WithLinuxRootPasswordOrPublicKeyManagedOrUnmanaged
+      mockVmStage9;
+
+  @Mock private VirtualMachine.DefinitionStages.WithLinuxCreateManagedOrUnmanaged mockVmStage10;
+  @Mock private VirtualMachine.DefinitionStages.WithManagedCreate mockVmStage11;
+  @Mock private VirtualMachine.DefinitionStages.WithCreate mockVmStage11a;
+  @Mock private VirtualMachine.DefinitionStages.WithCreate mockVmStage12;
+  @Mock private ManagementException mockException;
+
+  @Mock private Disks mockDisks;
+  @Mock private Disk mockDisk;
+
+  @Mock private NetworkManager mockNetworkManager;
+  @Mock private PublicIpAddresses mockPublicIpAddresses;
+  @Mock private PublicIpAddress mockPublicIpAddress;
+  @Mock private Network mockNetwork;
+  @Mock private Networks mockNetworks;
+
+  @Mock private NetworkSecurityGroup mockNsg;
+  @Mock private NetworkSecurityGroups mockNsgs;
+  @Mock private NetworkSecurityGroup.DefinitionStages.Blank mockNetworkStage1;
+  @Mock private NetworkSecurityGroup.DefinitionStages.WithGroup mockNetworkStage1a;
+  @Mock private NetworkSecurityGroup.DefinitionStages.WithCreate mockNetworkStage2;
+
+  @Mock
+  private NetworkSecurityRule.DefinitionStages.Blank<
+          NetworkSecurityGroup.DefinitionStages.WithCreate>
+      mockNetworkStage3;
+
+  @Mock
+  private NetworkSecurityRule.DefinitionStages.WithSourceAddressOrSecurityGroup<
+          NetworkSecurityGroup.DefinitionStages.WithCreate>
+      mockNetworkStage4;
+
+  @Mock
+  private NetworkSecurityRule.DefinitionStages.WithSourcePort<
+          NetworkSecurityGroup.DefinitionStages.WithCreate>
+      mockNetworkStage5;
+
+  @Mock
+  private NetworkSecurityRule.DefinitionStages.WithDestinationAddressOrSecurityGroup<
+          NetworkSecurityGroup.DefinitionStages.WithCreate>
+      mockNetworkStage6;
+
+  @Mock
+  private NetworkSecurityRule.DefinitionStages.WithDestinationPort<
+          NetworkSecurityGroup.DefinitionStages.WithCreate>
+      mockNetworkStage7;
+
+  @Mock
+  private NetworkSecurityRule.DefinitionStages.WithProtocol<
+          NetworkSecurityGroup.DefinitionStages.WithCreate>
+      mockNetworkStage8;
+
+  @Mock
+  private NetworkSecurityRule.DefinitionStages.WithAttach<
+          NetworkSecurityGroup.DefinitionStages.WithCreate>
+      mockNetworkStage9;
+
+  @Mock private Network.DefinitionStages.Blank mockNetworkStage10;
+  @Mock private Network.DefinitionStages.WithGroup mockNetworkStage11;
+  @Mock private Network.DefinitionStages.WithCreate mockNetworkStage12;
+  @Mock private Network.DefinitionStages.WithCreateAndSubnet mockNetworkStage13;
+
+  @Mock
+  private Subnet.DefinitionStages.Blank<Network.DefinitionStages.WithCreateAndSubnet>
+      mockNetworkStage14;
+
+  @Mock
+  private Subnet.DefinitionStages.WithAttach<Network.DefinitionStages.WithCreateAndSubnet>
+      mockNetworkStage15;
+
+  @Mock private WsmResource mockWsmResource;
+  @Mock private ControlledResource mockControlledResource;
+  @Mock private ControlledAzureIpResource mockAzureIpResource;
+  @Mock private ControlledAzureDiskResource mockAzureDiskResource;
+
+  private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+
+  @BeforeEach
+  public void setup() {
+    when(mockCrlService.getComputeManager(
+            any(AzureCloudContext.class), any(AzureConfiguration.class)))
+        .thenReturn(mockComputeManager);
+    when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(STUB_STRING_RETURN);
+
+    when(mockComputeManager.virtualMachines()).thenReturn(mockVms);
+
+    // get disk mocks
+    when(mockComputeManager.disks()).thenReturn(mockDisks);
+    when(mockDisks.getByResourceGroup(anyString(), anyString())).thenReturn(mockDisk);
+
+    // get ip mocks
+    when(mockComputeManager.networkManager()).thenReturn(mockNetworkManager);
+    when(mockNetworkManager.publicIpAddresses()).thenReturn(mockPublicIpAddresses);
+    when(mockPublicIpAddresses.getByResourceGroup(anyString(), anyString()))
+        .thenReturn(mockPublicIpAddress);
+
+    // get network mocks
+    when(mockNetworkManager.networks()).thenReturn(mockNetworks);
+    when(mockNetworks.getByResourceGroup(anyString(), anyString())).thenReturn(mockNetwork);
+
+    // create network security group mocks
+    when(mockNetworkManager.networkSecurityGroups()).thenReturn(mockNsgs);
+    when(mockNsgs.define(anyString())).thenReturn(mockNetworkStage1);
+    when(mockNetworkStage1.withRegion(anyString())).thenReturn(mockNetworkStage1a);
+    when(mockNetworkStage1a.withExistingResourceGroup(anyString())).thenReturn(mockNetworkStage2);
+    when(mockNetworkStage2.withTag(anyString(), anyString())).thenReturn(mockNetworkStage2);
+    when(mockNetworkStage2.defineRule(anyString())).thenReturn(mockNetworkStage3);
+    when(mockNetworkStage3.allowInbound()).thenReturn(mockNetworkStage4);
+    when(mockNetworkStage3.denyOutbound()).thenReturn(mockNetworkStage4);
+    when(mockNetworkStage4.fromAddress(anyString())).thenReturn(mockNetworkStage5);
+    when(mockNetworkStage4.fromAnyAddress()).thenReturn(mockNetworkStage5);
+    when(mockNetworkStage5.fromAnyPort()).thenReturn(mockNetworkStage6);
+    when(mockNetworkStage6.toAnyAddress()).thenReturn(mockNetworkStage7);
+    when(mockNetworkStage6.toAddress(anyString())).thenReturn(mockNetworkStage7);
+    when(mockNetworkStage7.toPort(anyInt())).thenReturn(mockNetworkStage8);
+    when(mockNetworkStage7.toAnyPort()).thenReturn(mockNetworkStage8);
+    when(mockNetworkStage8.withProtocol(any(SecurityRuleProtocol.class)))
+        .thenReturn(mockNetworkStage9);
+    when(mockNetworkStage8.withAnyProtocol()).thenReturn(mockNetworkStage9);
+    when(mockNetworkStage9.attach()).thenReturn(mockNetworkStage2);
+    when(mockNetworkStage2.create(any(Context.class))).thenReturn(mockNsg);
+
+    // create network mocks
+    when(mockNetworks.define(anyString())).thenReturn(mockNetworkStage10);
+    when(mockNetworkStage10.withRegion(anyString())).thenReturn(mockNetworkStage11);
+    when(mockNetworkStage11.withExistingResourceGroup(anyString())).thenReturn(mockNetworkStage12);
+    when(mockNetworkStage12.withTag(anyString(), anyString())).thenReturn(mockNetworkStage12);
+    when(mockNetworkStage12.withAddressSpace(anyString())).thenReturn(mockNetworkStage13);
+    when(mockNetworkStage13.defineSubnet(anyString())).thenReturn(mockNetworkStage14);
+    when(mockNetworkStage14.withAddressPrefix(anyString())).thenReturn(mockNetworkStage15);
+    when(mockNetworkStage15.withExistingNetworkSecurityGroup(any(NetworkSecurityGroup.class)))
+        .thenReturn(mockNetworkStage15);
+    when(mockNetworkStage15.attach()).thenReturn(mockNetworkStage13);
+    when(mockNetworkStage13.create(any(Context.class))).thenReturn(mockNetwork);
+
+    // Creation vm stages mocks
+    when(mockVms.define(anyString())).thenReturn(mockVmStage1);
+    when(mockVmStage1.withRegion(anyString())).thenReturn(mockVmStage2);
+    when(mockVmStage2.withExistingResourceGroup(anyString())).thenReturn(mockVmStage3);
+    when(mockVmStage3.withExistingPrimaryNetwork(any(Network.class))).thenReturn(mockVmStage4);
+    when(mockVmStage4.withSubnet(anyString())).thenReturn(mockVmStage5);
+    when(mockVmStage5.withPrimaryPrivateIPAddressDynamic()).thenReturn(mockVmStage6);
+    when(mockVmStage6.withExistingPrimaryPublicIPAddress(any(PublicIpAddress.class)))
+        .thenReturn(mockVmStage7);
+    when(mockVmStage7.withPopularLinuxImage(any(KnownLinuxVirtualMachineImage.class)))
+        .thenReturn(mockVmStage8);
+    when(mockVmStage8.withRootUsername(anyString())).thenReturn(mockVmStage9);
+    when(mockVmStage9.withSsh(anyString())).thenReturn(mockVmStage10);
+    when(mockVmStage10.withExistingDataDisk(any(Disk.class))).thenReturn(mockVmStage11);
+    when(mockVmStage11.withTag(anyString(), anyString())).thenReturn(mockVmStage11a);
+    when(mockVmStage11a.withTag(anyString(), anyString())).thenReturn(mockVmStage12);
+    when(mockVmStage12.withSize(any(VirtualMachineSizeTypes.class))).thenReturn(mockVmStage12);
+    when(mockVmStage12.create(any(Context.class))).thenReturn(mockVm);
+
+    // Resource dao mocks
+    when(mockResourceDao.getResource(any(UUID.class), any(UUID.class))).thenReturn(mockWsmResource);
+    when(mockWsmResource.castToControlledResource()).thenReturn(mockControlledResource);
+    when(mockControlledResource.castToAzureDiskResource()).thenReturn(mockAzureDiskResource);
+    when(mockControlledResource.castToAzureIpResource()).thenReturn(mockAzureIpResource);
+    when(mockAzureDiskResource.getDiskName()).thenReturn(STUB_DISK_NAME);
+    when(mockAzureIpResource.getIpName()).thenReturn(STUB_IP_NAME);
+
+    // TODO: network mock (for getname and anything else done to the azure/controlled resource, see
+    // above dao mocks)
+
+    // Deletion mocks
+
+    // Exception mock
+    when(mockException.getValue())
+        .thenReturn(new ManagementError("Conflict", "Resource already exists."));
+  }
+
+  @Test
+  void createVm() throws InterruptedException {
+    final ApiAzureVmCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureVmCreationParameters();
+
+    var createAzureVmStep =
+        new CreateAzureVmStep(
+            mockAzureConfig,
+            mockAzureCloudContext,
+            mockCrlService,
+            ControlledResourceFixtures.getAzureVm(creationParameters),
+            mockResourceDao);
+
+    final StepResult stepResult = createAzureVmStep.doStep(mockFlightContext);
+
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+
+    // Verify Azure create call was made correctly
+    verify(mockVmStage12).create(contextCaptor.capture());
+    Context context = contextCaptor.getValue();
+
+    Optional<CreateVirtualMachineRequestData> requestDataOpt =
+        context.getValues().values().stream()
+            .filter(CreateVirtualMachineRequestData.class::isInstance)
+            .map(CreateVirtualMachineRequestData.class::cast)
+            .findFirst();
+
+    CreateVirtualMachineRequestData expected =
+        CreateVirtualMachineRequestData.builder()
+            .setName(creationParameters.getName())
+            .setRegion(Region.fromName(creationParameters.getRegion()))
+            .setResourceGroupName(mockAzureCloudContext.getAzureResourceGroupId())
+            .setDisk(mockDisk)
+            .setNetwork(mockNetwork)
+            // TODO: network this can be fixed when we aren't auto-generating network info in the
+            // create vm request
+            .setSubnetName(requestDataOpt.get().subnetName())
+            .setPublicIpAddress(mockPublicIpAddress)
+            .setImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS.toString())
+            .build();
+
+    assertThat(requestDataOpt, equalTo(Optional.of(expected)));
+  }
+
+  @Test
+  public void createVm_alreadyExists() throws InterruptedException {
+    final ApiAzureVmCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureVmCreationParameters();
+
+    var createAzureVmStep =
+        new CreateAzureVmStep(
+            mockAzureConfig,
+            mockAzureCloudContext,
+            mockCrlService,
+            ControlledResourceFixtures.getAzureVm(creationParameters),
+            mockResourceDao);
+
+    // Stub creation to throw Conflict exception.
+    when(mockVmStage12.create(any(Context.class))).thenThrow(mockException);
+
+    final StepResult stepResult = createAzureVmStep.doStep(mockFlightContext);
+
+    // Verify step still returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+  }
+
+  @Test
+  public void deleteVm() throws InterruptedException {
+    final ApiAzureVmCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureVmCreationParameters();
+
+    var createAzureVmStep =
+        new CreateAzureVmStep(
+            mockAzureConfig,
+            mockAzureCloudContext,
+            mockCrlService,
+            ControlledResourceFixtures.getAzureVm(creationParameters),
+            mockResourceDao);
+
+    final StepResult stepResult = createAzureVmStep.undoStep(mockFlightContext);
+
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+
+    // Verify Azure deletion was called
+    verify(mockVms)
+        .deleteByResourceGroup(
+            mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getName());
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateAzureVmStepTest.java
@@ -30,7 +30,6 @@ import com.azure.core.util.Context;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.compute.models.Disk;
 import com.azure.resourcemanager.compute.models.Disks;
-import com.azure.resourcemanager.compute.models.KnownLinuxVirtualMachineImage;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.azure.resourcemanager.compute.models.VirtualMachines;
@@ -77,14 +76,7 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
   @Mock private VirtualMachine.DefinitionStages.WithPublicIPAddress mockVmStage6;
   @Mock private VirtualMachine.DefinitionStages.WithProximityPlacementGroup mockVmStage7;
 
-  @Mock
-  private VirtualMachine.DefinitionStages.WithLinuxRootUsernameManagedOrUnmanaged mockVmStage8;
-
-  @Mock
-  private VirtualMachine.DefinitionStages.WithLinuxRootPasswordOrPublicKeyManagedOrUnmanaged
-      mockVmStage9;
-
-  @Mock private VirtualMachine.DefinitionStages.WithLinuxCreateManagedOrUnmanaged mockVmStage10;
+  @Mock private VirtualMachine.DefinitionStages.WithLinuxCreateManaged mockVmStage10;
   @Mock private VirtualMachine.DefinitionStages.WithManagedCreate mockVmStage11;
   @Mock private VirtualMachine.DefinitionStages.WithCreate mockVmStage11a;
   @Mock private VirtualMachine.DefinitionStages.WithCreate mockVmStage12;
@@ -166,6 +158,7 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
             any(AzureCloudContext.class), any(AzureConfiguration.class)))
         .thenReturn(mockComputeManager);
     when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(STUB_STRING_RETURN);
+    when(mockAzureConfig.getCustomDockerImageId()).thenReturn(STUB_STRING_RETURN);
 
     when(mockComputeManager.virtualMachines()).thenReturn(mockVms);
 
@@ -227,10 +220,7 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
     when(mockVmStage5.withPrimaryPrivateIPAddressDynamic()).thenReturn(mockVmStage6);
     when(mockVmStage6.withExistingPrimaryPublicIPAddress(any(PublicIpAddress.class)))
         .thenReturn(mockVmStage7);
-    when(mockVmStage7.withPopularLinuxImage(any(KnownLinuxVirtualMachineImage.class)))
-        .thenReturn(mockVmStage8);
-    when(mockVmStage8.withRootUsername(anyString())).thenReturn(mockVmStage9);
-    when(mockVmStage9.withSsh(anyString())).thenReturn(mockVmStage10);
+    when(mockVmStage7.withSpecializedLinuxCustomImage(anyString())).thenReturn(mockVmStage10);
     when(mockVmStage10.withExistingDataDisk(any(Disk.class))).thenReturn(mockVmStage11);
     when(mockVmStage11.withTag(anyString(), anyString())).thenReturn(mockVmStage11a);
     when(mockVmStage11a.withTag(anyString(), anyString())).thenReturn(mockVmStage12);
@@ -294,7 +284,7 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
             // create vm request
             .setSubnetName(requestDataOpt.get().subnetName())
             .setPublicIpAddress(mockPublicIpAddress)
-            .setImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS.toString())
+            .setImage(STUB_STRING_RETURN)
             .build();
 
     assertThat(requestDataOpt, equalTo(Optional.of(expected)));

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateControlledResourceFlightTest.java
@@ -205,11 +205,13 @@ public class CreateControlledResourceFlightTest extends BaseAzureTest {
             .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
             .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
             .vmName(creationParameters.getName())
+            .vmSize(creationParameters.getVmSize())
+            .vmImageUri(creationParameters.getVmImageUri())
             .region(creationParameters.getRegion())
             .ipId(ipResource.getResourceId())
+            .diskId(diskResource.getResourceId())
             // TODO network: not used in step currently,
             .networkId(creationParameters.getNetworkId())
-            .diskId(diskResource.getResourceId())
             .build();
 
     // Submit a VM creation flight.

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateControlledResourceFlightTest.java
@@ -13,12 +13,14 @@ import bio.terra.workspace.common.utils.AzureTestUtils;
 import bio.terra.workspace.generated.model.ApiAccessScope;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiManagedBy;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.ControlledAzureIpResource;
+import bio.terra.workspace.service.resource.controlled.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.ManagedByType;
@@ -157,5 +159,148 @@ public class CreateControlledResourceFlightTest extends BaseAzureTest {
     } catch (Exception e) {
       fail("Failed to cast resource to ControlledAzureDiskResource", e);
     }
+  }
+
+  @Test
+  public void createAzureVmControlledResource() throws InterruptedException {
+    //Setup workspace and cloud context
+
+    UUID workspaceId = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = azureTestUtils.defaultUserAuthRequest();
+
+    // Cloud context needs to be created first
+    FlightState createAzureContextFlightState =
+            StairwayTestUtils.blockUntilFlightCompletes(
+                    jobService.getStairway(),
+                    CreateAzureContextFlight.class,
+                    azureTestUtils.createAzureContextInputParameters(workspaceId, userRequest),
+                    STAIRWAY_FLIGHT_TIMEOUT,
+                    null);
+
+    assertEquals(FlightStatus.SUCCESS, createAzureContextFlightState.getFlightStatus());
+    assertTrue(
+            workspaceService.getAuthorizedAzureCloudContext(workspaceId, userRequest).isPresent());
+
+    //Create ip
+    ControlledAzureIpResource ipResource = createIp(workspaceId, userRequest);
+
+    //Create disk
+    ControlledAzureDiskResource diskResource = createDisk(workspaceId, userRequest);
+
+    //Create network
+    //TODO network
+
+    final ApiAzureVmCreationParameters creationParameters =
+            ControlledResourceFixtures.getAzureVmCreationParameters();
+
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureVmResource resource =
+            ControlledAzureVmResource.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name("testName")
+                    .description("testDesc")
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .vmName(creationParameters.getName())
+                    .region(creationParameters.getRegion())
+                    .ipId(ipResource.getResourceId())
+                    //TODO network: not used in step currently,
+                    .networkId(creationParameters.getNetworkId())
+                    .diskId(diskResource.getResourceId())
+                    .build();
+
+    // Submit an IP creation flight.
+    FlightState flightState =
+            StairwayTestUtils.blockUntilFlightCompletes(
+                    jobService.getStairway(),
+                    CreateControlledResourceFlight.class,
+                    azureTestUtils.createControlledResourceInputParameters(
+                            workspaceId, userRequest, resource),
+                    STAIRWAY_FLIGHT_TIMEOUT,
+                    null);
+
+    assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
+
+    // Verify controlled resource exists in the workspace.
+    ControlledResource res =
+            controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
+
+    try {
+      ControlledAzureIpResource azureIpResource = res.castToAzureIpResource();
+      assertEquals(resource, azureIpResource);
+    } catch (Exception e) {
+      fail("Failed to cast resource to ControlledAzureIpResource", e);
+    }
+  }
+
+  private ControlledAzureDiskResource createDisk(UUID workspaceId, AuthenticatedUserRequest userRequest) throws InterruptedException {
+    final ApiAzureDiskCreationParameters creationParameters =
+            ControlledResourceFixtures.getAzureDiskCreationParameters();
+
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureDiskResource resource =
+            ControlledAzureDiskResource.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name("testName")
+                    .description("testDesc")
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .diskName(creationParameters.getName())
+                    .region(creationParameters.getRegion())
+                    .size(creationParameters.getSize())
+                    .build();
+
+    // Submit a Disk creation flight.
+    FlightState flightState =
+            StairwayTestUtils.blockUntilFlightCompletes(
+                    jobService.getStairway(),
+                    CreateControlledResourceFlight.class,
+                    azureTestUtils.createControlledResourceInputParameters(
+                            workspaceId, userRequest, resource),
+                    STAIRWAY_FLIGHT_TIMEOUT,
+                    null);
+
+    assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
+    return resource;
+  }
+
+  ControlledAzureIpResource createIp(UUID workspaceId, AuthenticatedUserRequest userRequest) throws InterruptedException {
+    final ApiAzureIpCreationParameters ipCreationParameters =
+            ControlledResourceFixtures.getAzureIpCreationParameters();
+
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureIpResource resource =
+            ControlledAzureIpResource.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name("testName")
+                    .description("testDesc")
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .ipName(ipCreationParameters.getName())
+                    .region(ipCreationParameters.getRegion())
+                    .build();
+
+    // Submit an IP creation flight.
+    FlightState flightState =
+            StairwayTestUtils.blockUntilFlightCompletes(
+                    jobService.getStairway(),
+                    CreateControlledResourceFlight.class,
+                    azureTestUtils.createControlledResourceInputParameters(
+                            workspaceId, userRequest, resource),
+                    STAIRWAY_FLIGHT_TIMEOUT,
+                    null);
+
+    assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
+
+    return resource;
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateControlledResourceFlightTest.java
@@ -67,8 +67,8 @@ public class CreateControlledResourceFlightTest extends BaseAzureTest {
         ControlledAzureIpResource.builder()
             .workspaceId(workspaceId)
             .resourceId(resourceId)
-            .name("testName")
-            .description("testDesc")
+            .name(getAzureName("ip"))
+            .description(getAzureName("ip-desc"))
             .cloningInstructions(CloningInstructions.COPY_RESOURCE)
             .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
             .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
@@ -127,8 +127,8 @@ public class CreateControlledResourceFlightTest extends BaseAzureTest {
         ControlledAzureDiskResource.builder()
             .workspaceId(workspaceId)
             .resourceId(resourceId)
-            .name("testName")
-            .description("testDesc")
+            .name(getAzureName("disk"))
+            .description(getAzureName("disk-desc"))
             .cloningInstructions(CloningInstructions.COPY_RESOURCE)
             .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
             .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
@@ -163,144 +163,151 @@ public class CreateControlledResourceFlightTest extends BaseAzureTest {
 
   @Test
   public void createAzureVmControlledResource() throws InterruptedException {
-    //Setup workspace and cloud context
+    // Setup workspace and cloud context
 
     UUID workspaceId = azureTestUtils.createWorkspace(workspaceService);
     AuthenticatedUserRequest userRequest = azureTestUtils.defaultUserAuthRequest();
 
     // Cloud context needs to be created first
     FlightState createAzureContextFlightState =
-            StairwayTestUtils.blockUntilFlightCompletes(
-                    jobService.getStairway(),
-                    CreateAzureContextFlight.class,
-                    azureTestUtils.createAzureContextInputParameters(workspaceId, userRequest),
-                    STAIRWAY_FLIGHT_TIMEOUT,
-                    null);
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateAzureContextFlight.class,
+            azureTestUtils.createAzureContextInputParameters(workspaceId, userRequest),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
 
     assertEquals(FlightStatus.SUCCESS, createAzureContextFlightState.getFlightStatus());
     assertTrue(
-            workspaceService.getAuthorizedAzureCloudContext(workspaceId, userRequest).isPresent());
+        workspaceService.getAuthorizedAzureCloudContext(workspaceId, userRequest).isPresent());
 
-    //Create ip
+    // Create ip
     ControlledAzureIpResource ipResource = createIp(workspaceId, userRequest);
 
-    //Create disk
+    // Create disk
     ControlledAzureDiskResource diskResource = createDisk(workspaceId, userRequest);
 
-    //Create network
-    //TODO network
+    // Create network
+    // TODO network
 
     final ApiAzureVmCreationParameters creationParameters =
-            ControlledResourceFixtures.getAzureVmCreationParameters();
+        ControlledResourceFixtures.getAzureVmCreationParameters();
 
     // TODO: make this application-private resource once the POC supports it
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureVmResource resource =
-            ControlledAzureVmResource.builder()
-                    .workspaceId(workspaceId)
-                    .resourceId(resourceId)
-                    .name("testName")
-                    .description("testDesc")
-                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .vmName(creationParameters.getName())
-                    .region(creationParameters.getRegion())
-                    .ipId(ipResource.getResourceId())
-                    //TODO network: not used in step currently,
-                    .networkId(creationParameters.getNetworkId())
-                    .diskId(diskResource.getResourceId())
-                    .build();
+        ControlledAzureVmResource.builder()
+            .workspaceId(workspaceId)
+            .resourceId(resourceId)
+            .name(getAzureName("vm"))
+            .description(getAzureName("vm-desc"))
+            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .vmName(creationParameters.getName())
+            .region(creationParameters.getRegion())
+            .ipId(ipResource.getResourceId())
+            // TODO network: not used in step currently,
+            .networkId(creationParameters.getNetworkId())
+            .diskId(diskResource.getResourceId())
+            .build();
 
-    // Submit an IP creation flight.
+    // Submit a VM creation flight.
     FlightState flightState =
-            StairwayTestUtils.blockUntilFlightCompletes(
-                    jobService.getStairway(),
-                    CreateControlledResourceFlight.class,
-                    azureTestUtils.createControlledResourceInputParameters(
-                            workspaceId, userRequest, resource),
-                    STAIRWAY_FLIGHT_TIMEOUT,
-                    null);
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceId, userRequest, resource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
 
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
 
     // Verify controlled resource exists in the workspace.
     ControlledResource res =
-            controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
+        controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
 
     try {
-      ControlledAzureIpResource azureIpResource = res.castToAzureIpResource();
-      assertEquals(resource, azureIpResource);
+      ControlledAzureVmResource azureVmResource = res.castToAzureVmResource();
+      assertEquals(resource, azureVmResource);
     } catch (Exception e) {
-      fail("Failed to cast resource to ControlledAzureIpResource", e);
+      fail("Failed to cast resource to ControlledAzureVmResource", e);
     }
   }
 
-  private ControlledAzureDiskResource createDisk(UUID workspaceId, AuthenticatedUserRequest userRequest) throws InterruptedException {
+  private ControlledAzureDiskResource createDisk(
+      UUID workspaceId, AuthenticatedUserRequest userRequest) throws InterruptedException {
     final ApiAzureDiskCreationParameters creationParameters =
-            ControlledResourceFixtures.getAzureDiskCreationParameters();
+        ControlledResourceFixtures.getAzureDiskCreationParameters();
 
     // TODO: make this application-private resource once the POC supports it
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureDiskResource resource =
-            ControlledAzureDiskResource.builder()
-                    .workspaceId(workspaceId)
-                    .resourceId(resourceId)
-                    .name("testName")
-                    .description("testDesc")
-                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .diskName(creationParameters.getName())
-                    .region(creationParameters.getRegion())
-                    .size(creationParameters.getSize())
-                    .build();
+        ControlledAzureDiskResource.builder()
+            .workspaceId(workspaceId)
+            .resourceId(resourceId)
+            .name(getAzureName("disk"))
+            .description(getAzureName("disk-desc"))
+            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .diskName(creationParameters.getName())
+            .region(creationParameters.getRegion())
+            .size(creationParameters.getSize())
+            .build();
 
     // Submit a Disk creation flight.
     FlightState flightState =
-            StairwayTestUtils.blockUntilFlightCompletes(
-                    jobService.getStairway(),
-                    CreateControlledResourceFlight.class,
-                    azureTestUtils.createControlledResourceInputParameters(
-                            workspaceId, userRequest, resource),
-                    STAIRWAY_FLIGHT_TIMEOUT,
-                    null);
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceId, userRequest, resource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
 
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
     return resource;
   }
 
-  ControlledAzureIpResource createIp(UUID workspaceId, AuthenticatedUserRequest userRequest) throws InterruptedException {
+  ControlledAzureIpResource createIp(UUID workspaceId, AuthenticatedUserRequest userRequest)
+      throws InterruptedException {
     final ApiAzureIpCreationParameters ipCreationParameters =
-            ControlledResourceFixtures.getAzureIpCreationParameters();
+        ControlledResourceFixtures.getAzureIpCreationParameters();
 
     // TODO: make this application-private resource once the POC supports it
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureIpResource resource =
-            ControlledAzureIpResource.builder()
-                    .workspaceId(workspaceId)
-                    .resourceId(resourceId)
-                    .name("testName")
-                    .description("testDesc")
-                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .ipName(ipCreationParameters.getName())
-                    .region(ipCreationParameters.getRegion())
-                    .build();
+        ControlledAzureIpResource.builder()
+            .workspaceId(workspaceId)
+            .resourceId(resourceId)
+            .name(getAzureName("ip"))
+            .description(getAzureName("ip-desc"))
+            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .ipName(ipCreationParameters.getName())
+            .region(ipCreationParameters.getRegion())
+            .build();
 
     // Submit an IP creation flight.
     FlightState flightState =
-            StairwayTestUtils.blockUntilFlightCompletes(
-                    jobService.getStairway(),
-                    CreateControlledResourceFlight.class,
-                    azureTestUtils.createControlledResourceInputParameters(
-                            workspaceId, userRequest, resource),
-                    STAIRWAY_FLIGHT_TIMEOUT,
-                    null);
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceId, userRequest, resource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
 
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
 
     return resource;
+  }
+
+  private static String getAzureName(String tag) {
+    final String id = UUID.randomUUID().toString().substring(0, 6);
+    return String.format("wsm-integ-%s-%s", tag, id);
   }
 }

--- a/service/src/test/resources/application-azure-test.yml
+++ b/service/src/test/resources/application-azure-test.yml
@@ -37,6 +37,3 @@ workspace:
     managed-resource-group-id: mrg-rt20210929-1-previe-20210929212242
 
     client-id:
-
-
-


### PR DESCRIPTION
Adds Create/Get/Delete VM code.

Note that this depends on the IP, Disk, and Network controlled resources.

Network is not done as of this PR, so there are some TODOs. I don't think this should be merged ahead of the Network PR, but it could be and is fully functional (essentially the create vm step creates a network too for testing purposes)