### PR TITLE
PF-998: When creating a new gcs-bucket with invalid bucket name, handle StorageException correctly by re-throwing an InvalidReferenceException

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
@@ -5,6 +5,7 @@ import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParam
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.service.resource.exception.InvalidNameException;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
+import com.google.common.collect.ImmutableList;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -41,11 +42,46 @@ public class ValidationUtils {
   public static final Pattern RESOURCE_NAME_VALIDATION_PATTERN =
       Pattern.compile("^[a-zA-Z0-9][-_a-zA-Z0-9]{0,1023}$");
 
+  private static final String GOOG_PREFIX = "goog";
+  private static final ImmutableList<String> GOOGLE_NAMES = ImmutableList.of("google", "g00gle");
+
+  /**
+   * Validates gcs-bucket name following Google documentation
+   * https://cloud.google.com/storage/docs/naming-buckets#requirements on a best-effort base.
+   *
+   * This method DOES NOT guarentee that the bucket name is valid.
+   * @param name gcs-bucket name
+   */
   public static void validateBucketName(String name) {
     if (StringUtils.isEmpty(name) || !BUCKET_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
       logger.warn("Invalid bucket name {}", name);
       throw new InvalidReferenceException(
           "Invalid GCS bucket name specified. Names must be 3-222 lowercase letters, numbers, dashes, and underscores. See Google documentation for the full specification.");
+    }
+    String[] substring = name.split("\\.");
+    if (substring.length == 0 && name.length() > 63) {
+      logger.warn("Invalid bucket name {}", name);
+      throw new InvalidReferenceException(
+          "Invalid GCS bucket name specified. Bucket names must contain 3-63 characters. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
+    }
+    for (String s : substring) {
+      if (s.length() > 63) {
+        logger.warn("Invalid bucket name {}", name);
+        throw new InvalidReferenceException(
+            "Invalid GCS bucket name specified. Names containing dots can contain up to 222 characters, but each dot-separated component can be no longer than 63 characters. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
+      }
+    }
+    if (name.startsWith(GOOG_PREFIX)) {
+      logger.warn("Invalid bucket name {}", name);
+      throw new InvalidReferenceException(
+          "Invalid GCS bucket name specified. Bucket names cannot have prefix goog. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
+    }
+    for (String google : GOOGLE_NAMES) {
+      logger.warn("Invalid bucket name {}", name);
+      if (name.contains(google)) {
+        throw new InvalidReferenceException(
+            "Invalid GCS bucket name specified. Bucket names cannot contains google or mis-spelled google. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
+      }
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
@@ -51,6 +51,8 @@ public class ValidationUtils {
    *
    * This method DOES NOT guarentee that the bucket name is valid.
    * @param name gcs-bucket name
+   * @throws InvalidNameException throws exception when the bucket name fails to conform to the
+   * Google naming convention for bucket name.
    */
   public static void validateBucketName(String name) {
     if (StringUtils.isEmpty(name) || !BUCKET_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
@@ -58,13 +60,7 @@ public class ValidationUtils {
       throw new InvalidNameException(
           "Invalid GCS bucket name specified. Names must be 3-222 lowercase letters, numbers, dashes, and underscores. See Google documentation for the full specification.");
     }
-    String[] substring = name.split("\\.");
-    if (substring.length == 0 && name.length() > 63) {
-      logger.warn("Invalid bucket name {}", name);
-      throw new InvalidNameException(
-          "Invalid GCS bucket name specified. Bucket names must contain 3-63 characters. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
-    }
-    for (String s : substring) {
+    for (String s : name.split("\\.")) {
       if (s.length() > 63) {
         logger.warn("Invalid bucket name {}", name);
         throw new InvalidNameException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
@@ -55,31 +55,31 @@ public class ValidationUtils {
   public static void validateBucketName(String name) {
     if (StringUtils.isEmpty(name) || !BUCKET_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
       logger.warn("Invalid bucket name {}", name);
-      throw new InvalidReferenceException(
+      throw new InvalidNameException(
           "Invalid GCS bucket name specified. Names must be 3-222 lowercase letters, numbers, dashes, and underscores. See Google documentation for the full specification.");
     }
     String[] substring = name.split("\\.");
     if (substring.length == 0 && name.length() > 63) {
       logger.warn("Invalid bucket name {}", name);
-      throw new InvalidReferenceException(
+      throw new InvalidNameException(
           "Invalid GCS bucket name specified. Bucket names must contain 3-63 characters. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
     }
     for (String s : substring) {
       if (s.length() > 63) {
         logger.warn("Invalid bucket name {}", name);
-        throw new InvalidReferenceException(
+        throw new InvalidNameException(
             "Invalid GCS bucket name specified. Names containing dots can contain up to 222 characters, but each dot-separated component can be no longer than 63 characters. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
       }
     }
     if (name.startsWith(GOOG_PREFIX)) {
       logger.warn("Invalid bucket name {}", name);
-      throw new InvalidReferenceException(
+      throw new InvalidNameException(
           "Invalid GCS bucket name specified. Bucket names cannot have prefix goog. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
     }
     for (String google : GOOGLE_NAMES) {
       logger.warn("Invalid bucket name {}", name);
       if (name.contains(google)) {
-        throw new InvalidReferenceException(
+        throw new InvalidNameException(
             "Invalid GCS bucket name specified. Bucket names cannot contains google or mis-spelled google. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
       }
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -94,7 +94,7 @@ public class CreateGcsBucketStep implements Step {
       }
       if (storageException.getCode() == HttpStatus.SC_BAD_REQUEST) {
         throw new BadRequestException(
-            "Receive 400 BAD_REQUEST exception when creating a new gcs-bucket", storageException);
+            "Received 400 BAD_REQUEST exception when creating a new gcs-bucket", storageException);
       }
       // Other cloud errors are unexpected here, rethrow.
       throw storageException;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -94,7 +94,7 @@ public class CreateGcsBucketStep implements Step {
       }
       if (storageException.getCode() == HttpStatus.SC_BAD_REQUEST) {
         throw new InvalidReferenceException(
-            "The provided bucket name is invalid, please follow the naming instruction on https://cloud.google.com/storage/docs/naming-buckets#requirements");
+            "Receive 400 BAD_REQUEST exception when creating a new gcs-bucket", storageException);
       }
       // Other cloud errors are unexpected here, rethrow.
       throw storageException;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource.controlled.flight.create;
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS;
 
 import bio.terra.cloudres.google.storage.StorageCow;
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -13,7 +14,6 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.GcsApiConversions;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
-import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.storage.Storage;
@@ -93,7 +93,7 @@ public class CreateGcsBucketStep implements Step {
             "The provided bucket name is already in use, please choose another.", storageException);
       }
       if (storageException.getCode() == HttpStatus.SC_BAD_REQUEST) {
-        throw new InvalidReferenceException(
+        throw new BadRequestException(
             "Receive 400 BAD_REQUEST exception when creating a new gcs-bucket", storageException);
       }
       // Other cloud errors are unexpected here, rethrow.

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.GcsApiConversions;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.storage.Storage;
@@ -28,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CreateGcsBucketStep implements Step {
+
   private static final Logger logger = LoggerFactory.getLogger(CreateGcsBucketStep.class);
   private final CrlService crlService;
   private final ControlledGcsBucketResource resource;
@@ -89,6 +91,10 @@ public class CreateGcsBucketStep implements Step {
       if (storageException.getCode() == HttpStatus.SC_CONFLICT) {
         throw new DuplicateResourceException(
             "The provided bucket name is already in use, please choose another.", storageException);
+      }
+      if (storageException.getCode() == HttpStatus.SC_BAD_REQUEST) {
+        throw new InvalidReferenceException(
+            "The provided bucket name is invalid, please follow the naming instruction on https://cloud.google.com/storage/docs/naming-buckets#requirements");
       }
       // Other cloud errors are unexpected here, rethrow.
       throw storageException;

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -7,6 +7,7 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceContainerImage;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
+import bio.terra.workspace.service.resource.exception.InvalidNameException;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import org.junit.jupiter.api.Test;
 
@@ -104,7 +105,7 @@ public class ValidationUtilsTest extends BaseUnitTest {
   @Test
   public void validateBucketName_nameHas64Character_throwsException() {
     assertThrows(
-        InvalidReferenceException.class,
+        InvalidNameException.class,
         () -> ValidationUtils.validateBucketName(INVALID_STRING));
   }
 
@@ -116,7 +117,7 @@ public class ValidationUtilsTest extends BaseUnitTest {
   @Test
   public void validateBucketName_nameHas2Character_throwsException() {
     assertThrows(
-        InvalidReferenceException.class,
+        InvalidNameException.class,
         () -> ValidationUtils.validateBucketName("aa"));
   }
 
@@ -133,7 +134,7 @@ public class ValidationUtilsTest extends BaseUnitTest {
   @Test
   public void validateBucketName_nameWithDotSeparatorButOneSubstringExceedsLimit_throwsException() {
     assertThrows(
-        InvalidReferenceException.class,
+        InvalidNameException.class,
         () -> ValidationUtils.validateBucketName(INVALID_STRING + "." + MAX_VALID_STRING));
   }
 
@@ -145,28 +146,28 @@ public class ValidationUtilsTest extends BaseUnitTest {
   @Test
   public void validateBucketName_nameStartAndEndWithDot_throwsException() {
     assertThrows(
-        InvalidReferenceException.class,
+        InvalidNameException.class,
         () -> ValidationUtils.validateBucketName(".bucket-name."));
   }
 
   @Test
   public void validateBucketName_nameWithGoogPrefix_throwsException() {
     assertThrows(
-        InvalidReferenceException.class,
+        InvalidNameException.class,
         () -> ValidationUtils.validateBucketName("goog-bucket-name1"));
   }
 
   @Test
   public void validateBucketName_nameContainsGoogle_throwsException() {
     assertThrows(
-        InvalidReferenceException.class,
+        InvalidNameException.class,
         () -> ValidationUtils.validateBucketName("bucket-google-name"));
   }
 
   @Test
   public void validateBucketName_nameContainsG00gle_throwsException() {
     assertThrows(
-        InvalidReferenceException.class,
+        InvalidNameException.class,
         () -> ValidationUtils.validateBucketName("bucket-g00gle-name"));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -11,6 +11,13 @@ import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenc
 import org.junit.jupiter.api.Test;
 
 public class ValidationUtilsTest extends BaseUnitTest {
+
+  private static final String MAX_VALID_STRING = "012345678901234567890123456789012345678901234567890123456789012";
+  private static final String INVALID_STRING = MAX_VALID_STRING + "b";
+  private static final String MAX_VALID_STRING_WITH_DOTS =
+      MAX_VALID_STRING + "." + MAX_VALID_STRING + "." + MAX_VALID_STRING + "."
+          + "012345678901234567890123456789";
+
   @Test
   public void aiNotebookInstanceName() {
     ValidationUtils.validateAiNotebookInstanceId("valid-instance-id-0");
@@ -92,5 +99,74 @@ public class ValidationUtilsTest extends BaseUnitTest {
                             .imageName("image-name")
                             .imageFamily("image-family"))
                     .containerImage(null)));
+  }
+
+  @Test
+  public void validateBucketName_nameHas64Character_throwsException() {
+    assertThrows(
+        InvalidReferenceException.class,
+        () -> ValidationUtils.validateBucketName(INVALID_STRING));
+  }
+
+  @Test
+  public void validateBucketName_nameHas63Character_OK() {
+    ValidationUtils.validateBucketName(MAX_VALID_STRING);
+  }
+
+  @Test
+  public void validateBucketName_nameHas2Character_throwsException() {
+    assertThrows(
+        InvalidReferenceException.class,
+        () -> ValidationUtils.validateBucketName("aa"));
+  }
+
+  @Test
+  public void validateBucketName_nameHas3Character_OK() {
+    ValidationUtils.validateBucketName("123");
+  }
+
+  @Test
+  public void validateBucketName_nameHas222CharacterWithDotSeparator_OK() {
+    ValidationUtils.validateBucketName(MAX_VALID_STRING_WITH_DOTS);
+  }
+
+  @Test
+  public void validateBucketName_nameWithDotSeparatorButOneSubstringExceedsLimit_throwsException() {
+    assertThrows(
+        InvalidReferenceException.class,
+        () -> ValidationUtils.validateBucketName(INVALID_STRING + "." + MAX_VALID_STRING));
+  }
+
+  @Test
+  public void validateBucketName_nameStartAndEndWithNumber_OK() {
+    ValidationUtils.validateBucketName("1-bucket-1");
+  }
+
+  @Test
+  public void validateBucketName_nameStartAndEndWithDot_throwsException() {
+    assertThrows(
+        InvalidReferenceException.class,
+        () -> ValidationUtils.validateBucketName(".bucket-name."));
+  }
+
+  @Test
+  public void validateBucketName_nameWithGoogPrefix_throwsException() {
+    assertThrows(
+        InvalidReferenceException.class,
+        () -> ValidationUtils.validateBucketName("goog-bucket-name1"));
+  }
+
+  @Test
+  public void validateBucketName_nameContainsGoogle_throwsException() {
+    assertThrows(
+        InvalidReferenceException.class,
+        () -> ValidationUtils.validateBucketName("bucket-google-name"));
+  }
+
+  @Test
+  public void validateBucketName_nameContainsG00gle_throwsException() {
+    assertThrows(
+        InvalidReferenceException.class,
+        () -> ValidationUtils.validateBucketName("bucket-g00gle-name"));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -1083,7 +1083,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void createGcsBucketDo_invalidBucketName_throwsInvalidReferenceException() throws Exception {
+  void createGcsBucketDo_invalidBucketName_throwsBadRequestException() throws Exception {
     ControlledGcsBucketResource resource =
         ControlledResourceFixtures.makeDefaultControlledGcsBucketResource()
             .workspaceId(workspace.getWorkspaceId())

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -1090,15 +1090,9 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .workspaceId(workspace.getWorkspaceId())
             .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
             .managedBy(ManagedByType.MANAGED_BY_USER)
-            .bucketName("goog-bucket")
+            .bucketName("192.168.5.4")
             .build();
 
-    // Test idempotency of bucket-specific steps by retrying them once.
-    Map<String, StepStatus> retrySteps = new HashMap<>();
-    retrySteps.put(CreateGcsBucketStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    retrySteps.put(GcsBucketCloudSyncStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    jobService.setFlightDebugInfoForTest(
-        FlightDebugInfo.newBuilder().doStepFailures(retrySteps).build());
     assertThrows(
         InvalidReferenceException.class,
         () ->

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -55,7 +55,6 @@ import bio.terra.workspace.service.resource.controlled.flight.update.UpdateContr
 import bio.terra.workspace.service.resource.controlled.flight.update.UpdateGcsBucketStep;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
-import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
@@ -1094,7 +1093,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .build();
 
     assertThrows(
-        InvalidReferenceException.class,
+        BadRequestException.class,
         () ->
             controlledResourceService.createBucket(
                 resource,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.cloudres.google.storage.BucketCow;
 import bio.terra.cloudres.google.storage.StorageCow;
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
@@ -27,7 +28,6 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateGcsBucketStep;
-import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
@@ -175,7 +175,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
   }
 
   @Test
-  public void createBucket_invalidBucketName_throwsInvalidReferenceException() {
+  public void createBucket_invalidBucketName_throwsBadRequestException() {
     doThrow(new StorageException(400, "bad request"))
         .when(mockStorageCow).create(bucketInfoCaptor.capture());
 
@@ -196,7 +196,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
     doReturn(inputFlightMap).when(mockFlightContext).getInputParameters();
 
     assertThrows(
-        InvalidReferenceException.class,
+        BadRequestException.class,
         () -> createGcsBucketStep.doStep(mockFlightContext)
     );
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
@@ -179,7 +179,8 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
     doThrow(new StorageException(400, "bad request"))
         .when(mockStorageCow).create(bucketInfoCaptor.capture());
 
-    final String bucketName = uniqueName("google-bucket-name");
+    // A bad bucket name that fails to be caught by the WSM validation.
+    final String bucketName = uniqueName("bad-bucket-name");
 
     final CreateGcsBucketStep createGcsBucketStep =
         new CreateGcsBucketStep(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateGcsBucketStepTest.java
@@ -10,8 +10,10 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import bio.terra.cloudres.google.storage.BucketCow;
@@ -25,6 +27,7 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateGcsBucketStep;
+import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
@@ -36,10 +39,12 @@ import com.google.cloud.storage.BucketInfo.LifecycleRule;
 import com.google.cloud.storage.BucketInfo.LifecycleRule.LifecycleAction;
 import com.google.cloud.storage.BucketInfo.LifecycleRule.LifecycleCondition;
 import com.google.cloud.storage.StorageClass;
+import com.google.cloud.storage.StorageException;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -48,18 +53,27 @@ import org.mockito.Mock;
 
 public class CreateGcsBucketStepTest extends BaseUnitTest {
 
-  @Mock private FlightContext mockFlightContext;
-  @Mock private CrlService mockCrlService;
-  @Mock private StorageCow mockStorageCow;
-  @Mock private GcpCloudContextService mockGcpCloudContextService;
-  @Mock private BucketCow mockBucketCow;
+  @Mock
+  private FlightContext mockFlightContext;
+  @Mock
+  private CrlService mockCrlService;
+  @Mock
+  private StorageCow mockStorageCow;
+  @Mock
+  private GcpCloudContextService mockGcpCloudContextService;
+  @Mock
+  private BucketCow mockBucketCow;
 
   // Mocks for pretending the provided bucket does not exist.
-  @Mock private Storage mockStorageClient;
-  @Mock private Storage.Buckets mockBuckets;
-  @Mock private Storage.Buckets.Get mockStorageBucketsGet;
+  @Mock
+  private Storage mockStorageClient;
+  @Mock
+  private Storage.Buckets mockBuckets;
+  @Mock
+  private Storage.Buckets.Get mockStorageBucketsGet;
 
-  @Captor private ArgumentCaptor<BucketInfo> bucketInfoCaptor;
+  @Captor
+  private ArgumentCaptor<BucketInfo> bucketInfoCaptor;
 
   private static final String FAKE_PROJECT_ID = "fakeprojectid";
 
@@ -158,5 +172,31 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
     assertThat(info.getLocation(), equalTo(ControlledResourceFixtures.RESOURCE_LOCATION));
     assertThat(info.getStorageClass(), is(nullValue()));
     assertThat(info.getLifecycleRules(), empty());
+  }
+
+  @Test
+  public void createBucket_invalidBucketName_throwsInvalidReferenceException() {
+    doThrow(new StorageException(400, "bad request"))
+        .when(mockStorageCow).create(bucketInfoCaptor.capture());
+
+    final String bucketName = uniqueName("google-bucket-name");
+
+    final CreateGcsBucketStep createGcsBucketStep =
+        new CreateGcsBucketStep(
+            mockCrlService,
+            ControlledResourceFixtures.getBucketResource(bucketName),
+            mockGcpCloudContextService);
+
+    final FlightMap inputFlightMap = new FlightMap();
+    inputFlightMap.put(
+        WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS,
+        ControlledResourceFixtures.GOOGLE_BUCKET_CREATION_PARAMETERS_MINIMAL);
+    inputFlightMap.makeImmutable();
+    doReturn(inputFlightMap).when(mockFlightContext).getInputParameters();
+
+    assertThrows(
+        InvalidReferenceException.class,
+        () -> createGcsBucketStep.doStep(mockFlightContext)
+    );
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferenceValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferenceValidationUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.exception.InvalidNameException;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +13,7 @@ public class ReferenceValidationUtilsTest extends BaseUnitTest {
   @Test
   public void testInvalidCharInBucketName() {
     assertThrows(
-        InvalidReferenceException.class,
+        InvalidNameException.class,
         () -> ValidationUtils.validateBucketName("INVALIDBUCKETNAME"));
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -24,6 +24,7 @@ import bio.terra.workspace.service.job.exception.InvalidResultStateException;
 import bio.terra.workspace.service.resource.WsmResource;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.resource.exception.InvalidNameException;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
@@ -453,7 +454,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         String resourceName = "testgcs-" + resourceId.toString();
 
         assertThrows(
-            InvalidReferenceException.class,
+            InvalidNameException.class,
             () ->
                 new ReferencedGcsBucketResource(
                     workspaceId,

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ include 'integration'
 // -- Global Variables --
 // For defining shared state and common dependencies
 
-gradle.ext.wsmVersion = "0.254.114-SNAPSHOT"
+gradle.ext.wsmVersion = "0.254.115-SNAPSHOT"
 gradle.ext.openapiSourceFile = "${rootDir}/service/src/main/resources/api/service_openapi.yaml"
 
 // Single place to define the versions of dependencies shared between components.


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PF-998

When creating a controlled resource GCS bucket with an invalid name (too long, contains goog prefix, etc), wsm ValidationUtils cannot catch these cases. Thus a StorageException with status code 400 is thrown. We should handle this case by re-throwing an InvalidReferenceException with useful messages about the error.