### PR TITLE
[No ticket] Fix unit tests which fail on Github

### DIFF
--- a/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationUnitTest.java
@@ -104,7 +104,7 @@ public class ApplicationUnitTest extends BaseUnitTest {
   }
 
   // This test writes to the database, so conflicts with the missingConfigTest
-  @DirtiesContext(methodMode = MethodMode.AFTER_METHOD)
+  @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
   @Test
   public void processAppTest() {
     // Each "pass" in the test represents starting up with a different configuration.
@@ -167,7 +167,7 @@ public class ApplicationUnitTest extends BaseUnitTest {
   }
 
   // This test writes to the database, so conflicts with the processAppTest
-  @DirtiesContext(methodMode = MethodMode.AFTER_METHOD)
+  @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
   @Test
   public void missingConfigTest() {
     // Create two applications


### PR DESCRIPTION
The unit test `processAppTest` was consistently failing when run on Github with `DuplicateKeyExceptions` from the DB, indicating it was not being cleaned up properly. I've switched the `DirtiesContext` annotation so the test will restart before each of the marked tests instead of after, which should handle this problem more consistently.

No ticket because this only affects unit test code.