### PR TITLE
[PF-1167][PF-1056] Add missing validate() calls, other validation cleanup

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -219,6 +219,20 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
         resource.getMetadata().getDescription());
     assertEquals(UPDATED_RESOURCE_NAME, resource.getMetadata().getName());
     assertEquals(UPDATED_DESCRIPTION, resource.getMetadata().getDescription());
+    // However, invalid updates are rejected.
+    String invalidName = "!!!invalid_name!!!";
+    ApiException invalidUpdateEx =
+        assertThrows(
+            ApiException.class,
+            () ->
+                updateBucketAttempt(
+                    resourceApi,
+                    resourceId,
+                    invalidName,
+                    /*updatedDescription=*/ null,
+                    /*updateParameters=*/ null));
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, invalidUpdateEx.getCode());
+
     final Bucket retrievedUpdatedBucket =
         ownerStorageClient.get(
             bucketName, BucketGetOption.fields(BucketField.LIFECYCLE, BucketField.STORAGE_CLASS));
@@ -342,7 +356,7 @@ public class ControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBas
       UUID resourceId,
       @Nullable String updatedResourceName,
       @Nullable String updatedDescription,
-      GcpGcsBucketUpdateParameters updateParameters)
+      @Nullable GcpGcsBucketUpdateParameters updateParameters)
       throws ApiException {
     var body =
         new UpdateControlledGcpGcsBucketRequestBody()

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -78,7 +78,6 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                 CloningInstructions.fromApiModel(body.getMetadata().getCloningInstructions()))
             .bucketName(body.getBucket().getBucketName())
             .build();
-    resource.validate();
 
     ReferencedResource referenceResource =
         referenceResourceService.createReferenceResource(resource, getAuthenticatedInfo());
@@ -137,7 +136,6 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
             .projectId(body.getDataset().getProjectId())
             .datasetName(body.getDataset().getDatasetId())
             .build();
-    resource.validate();
 
     ReferencedResource referenceResource =
         referenceResourceService.createReferenceResource(resource, getAuthenticatedInfo());
@@ -200,7 +198,6 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
             .instanceName(body.getSnapshot().getInstanceName())
             .snapshotId(body.getSnapshot().getSnapshot())
             .build();
-    resource.validate();
 
     ReferencedResource referenceResource =
         referenceResourceService.createReferenceResource(resource, getAuthenticatedInfo());

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -143,6 +143,7 @@ public class WorkspaceApiController implements WorkspaceApi {
   public ResponseEntity<ApiWorkspaceDescriptionList> listWorkspaces(Integer offset, Integer limit) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     logger.info("Listing workspaces for {}", userRequest.getEmail());
+    ControllerValidationUtils.validatePaginationParams(offset, limit);
     List<Workspace> workspaces = workspaceService.listWorkspaces(userRequest, offset, limit);
     var response =
         new ApiWorkspaceDescriptionList()

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -70,7 +70,7 @@ public final class ControllerValidationUtils {
   public static void validateEmail(String email) {
     if (!EMAIL_VALIDATION_PATTERN.matcher(email).matches()) {
       logger.warn("User provided invalid email for group or user: " + email);
-      throw new ValidationException("Invalid user or group email provided, see logs for details");
+      throw new ValidationException("Invalid user or group email provided");
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/service/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -119,7 +119,7 @@ public class JobService {
       // be checked separately. Allowing duplicate FlightIds is useful for ensuring idempotent
       // behavior of flights.
       logger.warn("Received duplicate job ID: {}", jobId);
-      throw new DuplicateJobIdException("Received duplicate jobId, see logs for details", ex);
+      throw new DuplicateJobIdException("Received duplicate jobId", ex);
     } catch (StairwayException | InterruptedException stairwayEx) {
       throw new InternalStairwayException(stairwayEx);
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
@@ -52,6 +52,8 @@ public class ControlledResourceMetadataManager {
     if (name != null) {
       ValidationUtils.validateResourceName(name);
     }
+    // Description may also be null, but this validator accepts null descriptions.
+    ValidationUtils.validateResourceDescriptionName(description);
     resourceDao.updateResource(workspaceId, resourceId, name, description);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedBigQueryDatasetResource.java
@@ -45,6 +45,7 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
     super(workspaceId, resourceId, name, description, cloningInstructions);
     this.projectId = projectId;
     this.datasetName = datasetName;
+    validate();
   }
 
   /**
@@ -62,6 +63,7 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
         DbSerDes.fromJson(dbResource.getAttributes(), ReferencedBigQueryDatasetAttributes.class);
     this.projectId = attributes.getProjectId();
     this.datasetName = attributes.getDatasetName();
+    validate();
   }
 
   public static ReferencedBigQueryDatasetResource.Builder builder() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedDataRepoSnapshotResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedDataRepoSnapshotResource.java
@@ -44,6 +44,7 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
     super(workspaceId, resourceId, name, description, cloningInstructions);
     this.instanceName = instanceName;
     this.snapshotId = snapshotId;
+    validate();
   }
 
   /**
@@ -60,6 +61,7 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
         DbSerDes.fromJson(dbResource.getAttributes(), ReferencedDataRepoSnapshotAttributes.class);
     this.instanceName = attributes.getInstanceName();
     this.snapshotId = attributes.getSnapshotId();
+    validate();
   }
 
   public static ReferencedDataRepoSnapshotResource.Builder builder() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
@@ -7,6 +7,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.job.JobBuilder;
 import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.WorkspaceCloneUtils;
 import bio.terra.workspace.service.resource.referenced.flight.create.CreateReferenceResourceFlight;
 import bio.terra.workspace.service.workspace.WorkspaceService;
@@ -42,7 +43,6 @@ public class ReferencedResourceService {
       ReferencedResource resource, AuthenticatedUserRequest userRequest) {
     workspaceService.validateWorkspaceAndAction(
         userRequest, resource.getWorkspaceId(), SamConstants.SAM_CREATE_REFERENCED_RESOURCE);
-    resource.validate();
 
     String jobDescription =
         String.format(
@@ -89,6 +89,12 @@ public class ReferencedResourceService {
       AuthenticatedUserRequest userRequest) {
     workspaceService.validateWorkspaceAndAction(
         userRequest, workspaceId, SamConstants.SAM_UPDATE_REFERENCED_RESOURCE);
+    // Name may be null if the user is not updating it in this request.
+    if (name != null) {
+      ValidationUtils.validateResourceName(name);
+    }
+    // Description may also be null, but this validator accepts null descriptions.
+    ValidationUtils.validateResourceDescriptionName(description);
     resourceDao.updateResource(workspaceId, resourceId, name, description);
   }
 

--- a/service/src/test/java/bio/terra/workspace/serdes/ControlledGcsBucketResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/serdes/ControlledGcsBucketResourceTest.java
@@ -17,14 +17,6 @@ import org.junit.jupiter.api.Test;
 public class ControlledGcsBucketResourceTest extends BaseUnitTest {
 
   @Test
-  public void testValidateOk() {
-    ControlledGcsBucketResource gcsBucketResource =
-        ControlledResourceFixtures.makeDefaultControlledGcsBucketResource().build();
-    // will throw if anything is amiss
-    gcsBucketResource.validate();
-  }
-
-  @Test
   public void testValidateThrows() {
     assertThrows(
         MissingRequiredFieldException.class,

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -138,6 +138,15 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
             workspaceId, referenceResource.getResourceId(), USER_REQUEST);
     assertThat(referenceResource.getName(), equalTo(updatedName2));
     assertThat(referenceResource.getDescription(), equalTo(updatedDescription2));
+
+    // Update to invalid name is rejected.
+    String invalidName = "!!!!invalid_name!!!";
+    assertThrows(
+        InvalidNameException.class,
+        () ->
+            referenceResourceService.updateReferenceResource(
+                workspaceId, referenceResource.getResourceId(), invalidName, null, USER_REQUEST));
+    // Update to invalid description
   }
 
   /**
@@ -210,60 +219,56 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
 
     @Test
     void testInvalidWorkspaceId() {
-      referenceResource =
-          new ReferencedDataRepoSnapshotResource(
-              null,
-              UUID.randomUUID(),
-              "aname",
-              null,
-              CloningInstructions.COPY_NOTHING,
-              DATA_REPO_INSTANCE_NAME,
-              "polaroid");
       assertThrows(
           MissingRequiredFieldException.class,
-          () -> referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST));
+          () ->
+              new ReferencedDataRepoSnapshotResource(
+                  null,
+                  UUID.randomUUID(),
+                  "aname",
+                  null,
+                  CloningInstructions.COPY_NOTHING,
+                  DATA_REPO_INSTANCE_NAME,
+                  "polaroid"));
     }
 
     @Test
     void testInvalidName() {
-      referenceResource =
-          new ReferencedDataRepoSnapshotResource(
-              workspaceId,
-              UUID.randomUUID(),
-              null,
-              null,
-              CloningInstructions.COPY_NOTHING,
-              DATA_REPO_INSTANCE_NAME,
-              "polaroid");
       assertThrows(
           MissingRequiredFieldException.class,
-          () -> referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST));
+          () ->
+              new ReferencedDataRepoSnapshotResource(
+                  workspaceId,
+                  UUID.randomUUID(),
+                  null,
+                  null,
+                  CloningInstructions.COPY_NOTHING,
+                  DATA_REPO_INSTANCE_NAME,
+                  "polaroid"));
     }
 
     @Test
     void testInvalidCloningInstructions() {
-      referenceResource =
-          new ReferencedDataRepoSnapshotResource(
-              workspaceId,
-              UUID.randomUUID(),
-              "aname",
-              null,
-              null,
-              DATA_REPO_INSTANCE_NAME,
-              "polaroid");
       assertThrows(
           MissingRequiredFieldException.class,
-          () -> referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST));
+          () ->
+              new ReferencedDataRepoSnapshotResource(
+                  workspaceId,
+                  UUID.randomUUID(),
+                  "aname",
+                  null,
+                  null,
+                  DATA_REPO_INSTANCE_NAME,
+                  "polaroid"));
     }
 
     @Test
     void testInvalidResourceId() {
-      referenceResource =
-          new ReferencedDataRepoSnapshotResource(
-              workspaceId, null, "aname", null, null, DATA_REPO_INSTANCE_NAME, "polaroid");
       assertThrows(
           MissingRequiredFieldException.class,
-          () -> referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST));
+          () ->
+              new ReferencedDataRepoSnapshotResource(
+                  workspaceId, null, "aname", null, null, DATA_REPO_INSTANCE_NAME, "polaroid"));
     }
   }
 
@@ -312,18 +317,17 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
       UUID resourceId = UUID.randomUUID();
       String resourceName = "testdatarepo-" + resourceId.toString();
 
-      ReferencedDataRepoSnapshotResource resource =
-          new ReferencedDataRepoSnapshotResource(
-              workspaceId,
-              resourceId,
-              resourceName,
-              "description of " + resourceName,
-              CloningInstructions.COPY_NOTHING,
-              null,
-              "polaroid");
       assertThrows(
           MissingRequiredFieldException.class,
-          () -> referenceResourceService.createReferenceResource(resource, USER_REQUEST));
+          () ->
+              new ReferencedDataRepoSnapshotResource(
+                  workspaceId,
+                  resourceId,
+                  resourceName,
+                  "description of " + resourceName,
+                  CloningInstructions.COPY_NOTHING,
+                  null,
+                  "polaroid"));
     }
 
     @Test
@@ -331,18 +335,17 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
       UUID resourceId = UUID.randomUUID();
       String resourceName = "testdatarepo-" + resourceId.toString();
 
-      ReferencedDataRepoSnapshotResource resource =
-          new ReferencedDataRepoSnapshotResource(
-              workspaceId,
-              resourceId,
-              resourceName,
-              "description of " + resourceName,
-              CloningInstructions.COPY_NOTHING,
-              DATA_REPO_INSTANCE_NAME,
-              null);
       assertThrows(
           MissingRequiredFieldException.class,
-          () -> referenceResourceService.createReferenceResource(resource, USER_REQUEST));
+          () ->
+              new ReferencedDataRepoSnapshotResource(
+                  workspaceId,
+                  resourceId,
+                  resourceName,
+                  "description of " + resourceName,
+                  CloningInstructions.COPY_NOTHING,
+                  DATA_REPO_INSTANCE_NAME,
+                  null));
     }
 
     @Test
@@ -538,18 +541,17 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         UUID resourceId = UUID.randomUUID();
         String resourceName = "testdatarepo-" + resourceId.toString();
 
-        ReferencedBigQueryDatasetResource resource =
-            new ReferencedBigQueryDatasetResource(
-                workspaceId,
-                resourceId,
-                resourceName,
-                "description of " + resourceName,
-                CloningInstructions.COPY_NOTHING,
-                null,
-                "testbq-datasetname");
         assertThrows(
             MissingRequiredFieldException.class,
-            () -> referenceResourceService.createReferenceResource(resource, USER_REQUEST));
+            () ->
+                new ReferencedBigQueryDatasetResource(
+                    workspaceId,
+                    resourceId,
+                    resourceName,
+                    "description of " + resourceName,
+                    CloningInstructions.COPY_NOTHING,
+                    null,
+                    "testbq-datasetname"));
       }
 
       @Test
@@ -557,18 +559,17 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         UUID resourceId = UUID.randomUUID();
         String resourceName = "testdatarepo-" + resourceId.toString();
 
-        ReferencedBigQueryDatasetResource resource =
-            new ReferencedBigQueryDatasetResource(
-                workspaceId,
-                resourceId,
-                resourceName,
-                "description of " + resourceName,
-                CloningInstructions.COPY_NOTHING,
-                "testbq-projectid",
-                "");
         assertThrows(
             MissingRequiredFieldException.class,
-            () -> referenceResourceService.createReferenceResource(resource, USER_REQUEST));
+            () ->
+                new ReferencedBigQueryDatasetResource(
+                    workspaceId,
+                    resourceId,
+                    resourceName,
+                    "description of " + resourceName,
+                    CloningInstructions.COPY_NOTHING,
+                    "testbq-projectid",
+                    ""));
       }
 
       @Test
@@ -576,18 +577,17 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         UUID resourceId = UUID.randomUUID();
         String resourceName = "testdatarepo-" + resourceId.toString();
 
-        ReferencedBigQueryDatasetResource resource =
-            new ReferencedBigQueryDatasetResource(
-                workspaceId,
-                resourceId,
-                resourceName,
-                "description of " + resourceName,
-                CloningInstructions.COPY_NOTHING,
-                "testbq-projectid",
-                "Nor do datasets; neither ' nor *");
         assertThrows(
             InvalidReferenceException.class,
-            () -> referenceResourceService.createReferenceResource(resource, USER_REQUEST));
+            () ->
+                new ReferencedBigQueryDatasetResource(
+                    workspaceId,
+                    resourceId,
+                    resourceName,
+                    "description of " + resourceName,
+                    CloningInstructions.COPY_NOTHING,
+                    "testbq-projectid",
+                    "Nor do datasets; neither ' nor *"));
       }
 
       @Test


### PR DESCRIPTION
This change:
- Ensures that all descendent classes of `WsmResource` call `validate()` in their constructors to ensure that all `WsmResource` objects are validated 
- Removes unnecessary explicit calls to `validate()` in a few places
- Adds name/description validation to `update` calls for both controlled and referenced resources, as these modify DB values without constructing (and thus validating) `WsmResource` objects
- Removes references to viewing logs in user-facing error messages