### PR TITLE
[PF-1169] Fix tests which fail to clean up Sam workspaces

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
+++ b/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
@@ -257,7 +257,9 @@ public class CloneGcsBucket extends WorkspaceAllocateTestScriptBase {
   }
 
   @Override
-  protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) {
+  protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doCleanup(testUsers, workspaceApi);
     if (destinationWorkspaceId != null) {
       try {
         final WorkspaceApi cloningUserWorkspaceApi =

--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -183,7 +183,9 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
   }
 
   @Override
-  protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi) {
+  protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doCleanup(testUsers, workspaceApi);
     if (destinationWorkspaceId != null) {
       try {
         workspaceApi.deleteWorkspace(destinationWorkspaceId);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -75,13 +75,19 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
+// Per-class lifecycle on this test to allow a shared workspace object across tests, which saves
+// time creating and deleting GCP contexts.
+@TestInstance(Lifecycle.PER_CLASS)
 public class ControlledResourceServiceTest extends BaseConnectedTest {
   /** The default roles to use when creating user private AI notebook instance resources */
   private static final List<ControlledResourceIamRole> DEFAULT_ROLES =
@@ -180,6 +186,15 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @AfterEach
   public void resetFlightDebugInfo() {
     jobService.setFlightDebugInfoForTest(null);
+  }
+
+  /**
+   * After running all tests, delete the shared workspace.
+   */
+  @AfterAll
+  private void cleanUpSharedWorkspace() {
+    user = userAccessUtils.defaultUser();
+    workspaceService.deleteWorkspace(reusableWorkspace.getWorkspaceId(), user.getAuthenticatedRequest());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -188,13 +188,12 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     jobService.setFlightDebugInfoForTest(null);
   }
 
-  /**
-   * After running all tests, delete the shared workspace.
-   */
+  /** After running all tests, delete the shared workspace. */
   @AfterAll
   private void cleanUpSharedWorkspace() {
     user = userAccessUtils.defaultUser();
-    workspaceService.deleteWorkspace(reusableWorkspace.getWorkspaceId(), user.getAuthenticatedRequest());
+    workspaceService.deleteWorkspace(
+        reusableWorkspace.getWorkspaceId(), user.getAuthenticatedRequest());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -478,7 +478,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
    * <p>This provides default values for jobId (random UUID), spend profile (Optional.empty()), and
    * workspace stage (MC_WORKSPACE).
    *
-   * Because the tests in this class mock Sam, we do not need to explicitly clean up workspaces
+   * <p>Because the tests in this class mock Sam, we do not need to explicitly clean up workspaces
    * created here.
    */
   private WorkspaceRequest.Builder defaultRequestBuilder(UUID workspaceId) {

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -477,6 +477,9 @@ class WorkspaceServiceTest extends BaseConnectedTest {
    *
    * <p>This provides default values for jobId (random UUID), spend profile (Optional.empty()), and
    * workspace stage (MC_WORKSPACE).
+   *
+   * Because the tests in this class mock Sam, we do not need to explicitly clean up workspaces
+   * created here.
    */
   private WorkspaceRequest.Builder defaultRequestBuilder(UUID workspaceId) {
     return WorkspaceRequest.builder()

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -242,7 +242,12 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
     return retrySteps;
   }
 
-  /** Creates a workspace, returning its workspaceId. */
+  /**
+   * Creates a workspace, returning its workspaceId.
+   *
+   * Because the tests in this class mock Sam and Janitor service cleans up GCP projects, we do not
+   * need to explicitly clean up the workspaces created here.
+   */
   private UUID createWorkspace(@Nullable SpendProfileId spendProfileId) {
     WorkspaceRequest request =
         WorkspaceRequest.builder()

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGoogleContextFlightTest.java
@@ -245,8 +245,8 @@ class CreateGoogleContextFlightTest extends BaseConnectedTest {
   /**
    * Creates a workspace, returning its workspaceId.
    *
-   * Because the tests in this class mock Sam and Janitor service cleans up GCP projects, we do not
-   * need to explicitly clean up the workspaces created here.
+   * <p>Because the tests in this class mock Sam and Janitor service cleans up GCP projects, we do
+   * not need to explicitly clean up the workspaces created here.
    */
   private UUID createWorkspace(@Nullable SpendProfileId spendProfileId) {
     WorkspaceRequest request =

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,10 +53,28 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
   @Autowired private SpendConnectedTestUtils spendUtils;
   @Autowired private UserAccessUtils userAccessUtils;
 
+  private UUID workspaceId;
+
+  @BeforeEach
+  public void setup() {
+    // Create a new workspace at the start of each test.
+    WorkspaceRequest request =
+        WorkspaceRequest.builder()
+            .workspaceId(UUID.randomUUID())
+            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+            .spendProfileId(Optional.of(spendUtils.defaultSpendId()))
+            .build();
+    workspaceId =  workspaceService.createWorkspace(request, userAccessUtils.defaultUserAuthRequest());
+  }
+
+  @AfterEach
+  public void tearDown() {
+    workspaceService.deleteWorkspace(workspaceId, userAccessUtils.defaultUserAuthRequest());
+  }
+
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void deleteContextDo() throws Exception {
-    UUID workspaceId = createWorkspace();
     FlightMap createParameters = new FlightMap();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     createParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString());
@@ -118,7 +138,6 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void deleteContextUndo() throws Exception {
-    UUID workspaceId = createWorkspace();
     FlightMap createParameters = new FlightMap();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     createParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString());
@@ -156,7 +175,6 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
 
   @Test
   void deleteNonExistentContextIsOk() throws Exception {
-    UUID workspaceId = createWorkspace();
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     assertTrue(workspaceService.getAuthorizedGcpCloudContext(workspaceId, userRequest).isEmpty());
 
@@ -171,16 +189,5 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
             null);
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
     assertTrue(workspaceService.getAuthorizedGcpCloudContext(workspaceId, userRequest).isEmpty());
-  }
-
-  /** Creates a workspace, returning its workspaceId. */
-  private UUID createWorkspace() {
-    WorkspaceRequest request =
-        WorkspaceRequest.builder()
-            .workspaceId(UUID.randomUUID())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .spendProfileId(Optional.of(spendUtils.defaultSpendId()))
-            .build();
-    return workspaceService.createWorkspace(request, userAccessUtils.defaultUserAuthRequest());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGoogleContextFlightTest.java
@@ -64,7 +64,8 @@ class DeleteGoogleContextFlightTest extends BaseConnectedTest {
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .spendProfileId(Optional.of(spendUtils.defaultSpendId()))
             .build();
-    workspaceId =  workspaceService.createWorkspace(request, userAccessUtils.defaultUserAuthRequest());
+    workspaceId =
+        workspaceService.createWorkspace(request, userAccessUtils.defaultUserAuthRequest());
   }
 
   @AfterEach


### PR DESCRIPTION
Recently our tests started failing because our test users were in too many groups, which was mainly due to tests not cleaning up Sam workspaces after they finish. This change adds cleanup for all connected and integration tests which weren't previously cleaning up.