### PR TITLE
[PF-1206][PF-1194] Share heavyweight Client objects across requests, remove warnings

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/buffer/BufferService.java
+++ b/service/src/main/java/bio/terra/workspace/service/buffer/BufferService.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.service.buffer.exception.BufferServiceAPIException;
 import bio.terra.workspace.service.buffer.exception.BufferServiceAuthorizationException;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.io.IOException;
+import javax.ws.rs.client.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,14 +24,16 @@ public class BufferService {
   private final Logger logger = LoggerFactory.getLogger(BufferService.class);
 
   private final BufferServiceConfiguration bufferServiceConfiguration;
+  private final Client commonHttpClient;
 
   @Autowired
   public BufferService(BufferServiceConfiguration bufferServiceConfiguration) {
     this.bufferServiceConfiguration = bufferServiceConfiguration;
+    this.commonHttpClient = new ApiClient().getHttpClient();
   }
 
   private ApiClient getApiClient(String accessToken) {
-    ApiClient client = new ApiClient();
+    ApiClient client = new ApiClient().setHttpClient(commonHttpClient);
     client.setAccessToken(accessToken);
     return client;
   }

--- a/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
@@ -155,11 +155,12 @@ public class CrlService {
     assertCrlInUse();
     try {
       return new Bigquery.Builder(
-          Defaults.httpTransport(),
-          Defaults.jsonFactory(),
-          new HttpCredentialsAdapter(
-              GoogleCredentials.getApplicationDefault().createScoped(BigqueryScopes.all())))
-          .setApplicationName(clientConfig.getClientName()).build();
+              Defaults.httpTransport(),
+              Defaults.jsonFactory(),
+              new HttpCredentialsAdapter(
+                  GoogleCredentials.getApplicationDefault().createScoped(BigqueryScopes.all())))
+          .setApplicationName(clientConfig.getClientName())
+          .build();
     } catch (IOException | GeneralSecurityException e) {
       throw new CrlInternalException("Error creating naked BigQuery client.");
     }
@@ -261,11 +262,12 @@ public class CrlService {
   public Storage createWsmSaNakedStorageClient() {
     try {
       return new Storage.Builder(
-          Defaults.httpTransport(),
-          Defaults.jsonFactory(),
-          new HttpCredentialsAdapter(
-              GoogleCredentials.getApplicationDefault().createScoped(StorageScopes.all())))
-          .setApplicationName(clientConfig.getClientName()).build();
+              Defaults.httpTransport(),
+              Defaults.jsonFactory(),
+              new HttpCredentialsAdapter(
+                  GoogleCredentials.getApplicationDefault().createScoped(StorageScopes.all())))
+          .setApplicationName(clientConfig.getClientName())
+          .build();
     } catch (IOException | GeneralSecurityException e) {
       throw new CrlInternalException("Error creating naked Storage client.");
     }

--- a/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
@@ -154,11 +154,12 @@ public class CrlService {
   public Bigquery createWsmSaNakedBigQueryClient() {
     assertCrlInUse();
     try {
-      return new Bigquery(
+      return new Bigquery.Builder(
           Defaults.httpTransport(),
           Defaults.jsonFactory(),
           new HttpCredentialsAdapter(
-              GoogleCredentials.getApplicationDefault().createScoped(BigqueryScopes.all())));
+              GoogleCredentials.getApplicationDefault().createScoped(BigqueryScopes.all())))
+          .setApplicationName(clientConfig.getClientName()).build();
     } catch (IOException | GeneralSecurityException e) {
       throw new CrlInternalException("Error creating naked BigQuery client.");
     }
@@ -259,11 +260,12 @@ public class CrlService {
    */
   public Storage createWsmSaNakedStorageClient() {
     try {
-      return new Storage(
+      return new Storage.Builder(
           Defaults.httpTransport(),
           Defaults.jsonFactory(),
           new HttpCredentialsAdapter(
-              GoogleCredentials.getApplicationDefault().createScoped(StorageScopes.all())));
+              GoogleCredentials.getApplicationDefault().createScoped(StorageScopes.all())))
+          .setApplicationName(clientConfig.getClientName()).build();
     } catch (IOException | GeneralSecurityException e) {
       throw new CrlInternalException("Error creating naked Storage client.");
     }

--- a/service/src/main/java/bio/terra/workspace/service/datarepo/DataRepoService.java
+++ b/service/src/main/java/bio/terra/workspace/service/datarepo/DataRepoService.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.service.datarepo.exception.DataRepoInternalServerErro
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.util.HashMap;
+import javax.ws.rs.client.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,16 +20,18 @@ import org.springframework.stereotype.Component;
 public class DataRepoService {
 
   private final DataRepoConfiguration dataRepoConfiguration;
+  private final Client commonHttpClient;
 
   @Autowired
   public DataRepoService(DataRepoConfiguration dataRepoConfiguration) {
     this.dataRepoConfiguration = dataRepoConfiguration;
+    commonHttpClient = new ApiClient().getHttpClient();
   }
 
   private final Logger logger = LoggerFactory.getLogger(DataRepoService.class);
 
   private ApiClient getApiClient(String accessToken) {
-    ApiClient client = new ApiClient();
+    ApiClient client = new ApiClient().setHttpClient(commonHttpClient);
     client.setAccessToken(accessToken);
     return client;
   }

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -78,7 +78,8 @@ public class SamService {
   private ApiClient getApiClient(String accessToken) {
     // OkHttpClient objects manage their own thread pools, so it's much more performant to share one
     // across requests.
-    ApiClient apiClient = new ApiClient().setHttpClient(commonHttpClient).setBasePath(samConfig.getBasePath());
+    ApiClient apiClient =
+        new ApiClient().setHttpClient(commonHttpClient).setBasePath(samConfig.getBasePath());
     apiClient.setAccessToken(accessToken);
     return apiClient;
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
@@ -79,8 +79,8 @@ public class ValidationUtils {
           "Invalid GCS bucket name specified. Bucket names cannot have prefix goog. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
     }
     for (String google : GOOGLE_NAMES) {
-      logger.warn("Invalid bucket name {}", name);
       if (name.contains(google)) {
+        logger.warn("Invalid bucket name {}", name);
         throw new InvalidNameException(
             "Invalid GCS bucket name specified. Bucket names cannot contains google or mis-spelled google. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
       }


### PR DESCRIPTION
This change refactors behavior for WSM's calls to downstream services so that all requests now share a common HTTP client object. Previously, we created a new client object for each call to a remote service. However per documentation, these clients are heavyweight objects (e.g. each `OkHttpClient` underneath a Sam `ApiClient` creates and manages its own threadpool), and this led to a large number of idle threads (peak of ~850 while running integration tests, or ~1700 while running integration tests + CLI tests). After this change, WSM peaked at ~130 threads while running integration + CLI tests, and did not increase as significantly under additional load.

I also fixed a few warnings that kept showing up in logs.