### PR TITLE
[PF-1110] Fix test flakiness via wsm/cloud retries

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -60,7 +60,7 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
             referencedGcpResourceApi, getWorkspaceId(), bucketReferenceName);
 
     sourceBigQueryDatasetReference =
-        ResourceMaker.makeBigQueryReference(
+        ResourceMaker.makeBigQueryDatasetReference(
             referencedGcpResourceApi, getWorkspaceId(), DATASET_RESOURCE_NAME);
 
     sourceBigQueryDataTableReference =

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -201,7 +201,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
 
     // create reference to BQ dataset with COPY_NOTHING
     sourceDatasetReference =
-        ResourceMaker.makeBigQueryReference(
+        ResourceMaker.makeBigQueryDatasetReference(
             referencedGcpResourceApi, getWorkspaceId(), "dataset_resource_1");
     sourceDataTableReference =
         ResourceMaker.makeBigQueryDataTableReference(

--- a/integration/src/main/java/scripts/testscripts/DeleteGcpContextWithControlledResource.java
+++ b/integration/src/main/java/scripts/testscripts/DeleteGcpContextWithControlledResource.java
@@ -52,7 +52,8 @@ public class DeleteGcpContextWithControlledResource extends WorkspaceAllocateTes
     // Create a referenced BigQuery dataset
     String resourceName = "my-resource-name-" + UUID.randomUUID().toString();
     GcpBigQueryDatasetResource referencedDataset =
-        ResourceMaker.makeBigQueryReference(referencedResourceApi, getWorkspaceId(), resourceName);
+        ResourceMaker.makeBigQueryDatasetReference(
+            referencedResourceApi, getWorkspaceId(), resourceName);
     UUID referencedResourceId = referencedDataset.getMetadata().getResourceId();
     logger.info("Created referenced dataset {}", referencedResourceId);
 

--- a/integration/src/main/java/scripts/testscripts/EnumerateResources.java
+++ b/integration/src/main/java/scripts/testscripts/EnumerateResources.java
@@ -309,7 +309,8 @@ public class EnumerateResources extends DataRepoTestScriptBase {
         case 0:
           {
             GcpBigQueryDatasetResource resource =
-                ResourceMaker.makeBigQueryReference(referencedGcpResourceApi, workspaceId, name);
+                ResourceMaker.makeBigQueryDatasetReference(
+                    referencedGcpResourceApi, workspaceId, name);
             resourceList.add(resource.getMetadata());
             break;
           }

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -158,8 +158,10 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
 
     // Private resource user can write object to bucket
     Blob createdBlob =
-        privateUserStorageClient.create(
-            blobInfo, GCS_BLOB_CONTENT.getBytes(StandardCharsets.UTF_8));
+        ClientTestUtils.getWithRetryOnException(
+            () ->
+                privateUserStorageClient.create(
+                    blobInfo, GCS_BLOB_CONTENT.getBytes(StandardCharsets.UTF_8)));
     logger.info("Private resource user can write {} to private resource", blobInfo.getName());
 
     // Private user can read their bucket

--- a/integration/src/main/java/scripts/testscripts/ValidateReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/ValidateReferencedResources.java
@@ -44,7 +44,7 @@ public class ValidateReferencedResources extends DataRepoTestScriptBase {
 
     String bqReferenceName = RandomStringUtils.random(6, true, false);
     GcpBigQueryDatasetResource bqReference =
-        ResourceMaker.makeBigQueryReference(
+        ResourceMaker.makeBigQueryDatasetReference(
             referencedGcpResourceApi, getWorkspaceId(), bqReferenceName);
     bqResourceId = bqReference.getMetadata().getResourceId();
 

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -60,7 +60,8 @@ public class ResourceMaker {
   private static final long DELETE_BUCKET_POLL_SECONDS = 15;
 
   public static GcpBigQueryDatasetResource makeBigQueryReference(
-      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name) throws ApiException {
+      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
+      throws ApiException, InterruptedException {
 
     var body =
         new CreateGcpBigQueryDatasetReferenceRequestBody()
@@ -74,11 +75,13 @@ public class ResourceMaker {
                     .datasetId(TEST_BQ_DATASET_NAME)
                     .projectId(TEST_BQ_DATASET_PROJECT));
 
-    return resourceApi.createBigQueryDatasetReference(body, workspaceId);
+    return ClientTestUtils.getWithRetryOnException(
+        () -> resourceApi.createBigQueryDatasetReference(body, workspaceId));
   }
 
   public static GcpBigQueryDataTableResource makeBigQueryDataTableReference(
-      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name) throws ApiException {
+      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
+      throws ApiException, InterruptedException {
 
     var body =
         new CreateGcpBigQueryDataTableReferenceRequestBody()
@@ -93,7 +96,8 @@ public class ResourceMaker {
                     .projectId(TEST_BQ_DATASET_PROJECT)
                     .dataTableId(TEST_BQ_DATATABLE_NAME));
 
-    return resourceApi.createBigQueryDataTableReference(body, workspaceId);
+    return ClientTestUtils.getWithRetryOnException(
+        () -> resourceApi.createBigQueryDataTableReference(body, workspaceId));
   }
 
   public static DataRepoSnapshotResource makeDataRepoSnapshotReference(
@@ -102,7 +106,7 @@ public class ResourceMaker {
       String name,
       String dataRepoSnapshotId,
       String dataRepoInstanceName)
-      throws ApiException {
+      throws ApiException, InterruptedException {
 
     var body =
         new CreateDataRepoSnapshotReferenceRequestBody()
@@ -116,7 +120,8 @@ public class ResourceMaker {
                     .snapshot(dataRepoSnapshotId)
                     .instanceName(dataRepoInstanceName));
 
-    return resourceApi.createDataRepoSnapshotReference(body, workspaceId);
+    return ClientTestUtils.getWithRetryOnException(
+        () -> resourceApi.createDataRepoSnapshotReference(body, workspaceId));
   }
 
   public static GcpGcsBucketResource makeGcsBucketReference(
@@ -124,7 +129,7 @@ public class ResourceMaker {
       UUID workspaceId,
       String name,
       @Nullable CloningInstructionsEnum cloningInstructions)
-      throws ApiException {
+      throws ApiException, InterruptedException {
 
     var body =
         new CreateGcpGcsBucketReferenceRequestBody()
@@ -137,11 +142,13 @@ public class ResourceMaker {
                     .name(name))
             .bucket(new GcpGcsBucketAttributes().bucketName(TEST_BUCKET_NAME));
 
-    return resourceApi.createBucketReference(body, workspaceId);
+    return ClientTestUtils.getWithRetryOnException(
+        () -> resourceApi.createBucketReference(body, workspaceId));
   }
 
   public static GcpGcsBucketResource makeGcsBucketReference(
-      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name) throws ApiException {
+      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
+      throws ApiException, InterruptedException {
     return makeGcsBucketReference(resourceApi, workspaceId, name, null);
   }
 

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -59,6 +59,12 @@ public class ResourceMaker {
   private static final Logger logger = LoggerFactory.getLogger(ResourceMaker.class);
   private static final long DELETE_BUCKET_POLL_SECONDS = 15;
 
+  /**
+   * Calls WSM to create a referenced BigQuery dataset in the specified workspace.
+   *
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
+   * not expect a user to be able to create a reference).
+   */
   public static GcpBigQueryDatasetResource makeBigQueryDatasetReference(
       ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
       throws ApiException, InterruptedException {
@@ -79,6 +85,12 @@ public class ResourceMaker {
         () -> resourceApi.createBigQueryDatasetReference(body, workspaceId));
   }
 
+  /**
+   * Calls WSM to create a referenced BigQuery table in the specified workspace.
+   *
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
+   * not expect a user to be able to create a reference).
+   */
   public static GcpBigQueryDataTableResource makeBigQueryDataTableReference(
       ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
       throws ApiException, InterruptedException {
@@ -100,6 +112,7 @@ public class ResourceMaker {
         () -> resourceApi.createBigQueryDataTableReference(body, workspaceId));
   }
 
+  /** Calls WSM to create a referenced TDR snapshot in the specified workspace. */
   public static DataRepoSnapshotResource makeDataRepoSnapshotReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceId,
@@ -123,6 +136,12 @@ public class ResourceMaker {
     return resourceApi.createDataRepoSnapshotReference(body, workspaceId);
   }
 
+  /**
+   * Calls WSM to create a referenced GCS bucket in the specified workspace.
+   *
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
+   * not expect a user to be able to create a reference).
+   */
   public static GcpGcsBucketResource makeGcsBucketReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceId,

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -59,7 +59,7 @@ public class ResourceMaker {
   private static final Logger logger = LoggerFactory.getLogger(ResourceMaker.class);
   private static final long DELETE_BUCKET_POLL_SECONDS = 15;
 
-  public static GcpBigQueryDatasetResource makeBigQueryReference(
+  public static GcpBigQueryDatasetResource makeBigQueryDatasetReference(
       ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
       throws ApiException, InterruptedException {
 
@@ -106,7 +106,7 @@ public class ResourceMaker {
       String name,
       String dataRepoSnapshotId,
       String dataRepoInstanceName)
-      throws ApiException, InterruptedException {
+      throws ApiException {
 
     var body =
         new CreateDataRepoSnapshotReferenceRequestBody()
@@ -120,8 +120,7 @@ public class ResourceMaker {
                     .snapshot(dataRepoSnapshotId)
                     .instanceName(dataRepoInstanceName));
 
-    return ClientTestUtils.getWithRetryOnException(
-        () -> resourceApi.createDataRepoSnapshotReference(body, workspaceId));
+    return resourceApi.createDataRepoSnapshotReference(body, workspaceId);
   }
 
   public static GcpGcsBucketResource makeGcsBucketReference(

--- a/integration/src/main/java/scripts/utils/ResourceModifier.java
+++ b/integration/src/main/java/scripts/utils/ResourceModifier.java
@@ -51,6 +51,12 @@ public class ResourceModifier {
 
   private static final Logger logger = LoggerFactory.getLogger(ResourceModifier.class);
 
+  /**
+   * Add a simple text file to a GCS bucket.
+   *
+   * <p>This method retries on all GCP exceptions, do not use it for the negative case (where you do
+   * not expect a user to be able to create a file in the bucket).
+   */
   public static Blob addFileToBucket(
       CreatedControlledGcpGcsBucket bucket, TestUserSpecification bucketWriter, String gcpProjectId)
       throws IOException, InterruptedException {
@@ -81,6 +87,9 @@ public class ResourceModifier {
   /**
    * Create two tables with multiple rows in them into the provided dataset. Uses a mixture of
    * streaming and DDL insertion to demonstrate the difference in copy job behavior.
+   *
+   * <p>This method retries on all GCP exceptions, do not use it for the negative case (where you do
+   * not expect a user to be able to create tables in a dataset).
    *
    * @param dataset - empty BigQuery dataset
    * @param ownerUser - User who owns the dataset


### PR DESCRIPTION
This change fixes integration test flakiness I accidentally introduced in #486. That change made creating referenced resources flaky because:
- Previously, test users had access to our test referenced resources directly, so they would always have access as soon as we checked for it.
- After #486, we sometimes check referenced resource access using the test users' pet SAs instead of their credentials directly, depending on whether their workspace has a GCP context or not.
- Pet SAs have access to the referenced resources via the proxy group. That means the access check on these cloud objects now depends on Google Group propagation, which can take up to 5 minutes. Until the pet SA's membership in the proxy group propagates through GCP, the pet SA will not have access to the referenced cloud object.

This fixes the flakiness by adding retries to some WSM and GCP calls in our integration tests to handle the propagation delay.