### PR TITLE
PF-1234: Add GCS object level access check support

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -68,8 +68,8 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
             referencedGcpResourceApi, getWorkspaceId(), bucketReferenceName);
 
     sourceBucketFileReference =
-        ResourceMaker.makeGcsBucketFileInFineGrainedBucketReference(
-            referencedGcpResourceApi, getWorkspaceId(), bucketFileReferenceName);
+        ResourceMaker.makeGcsBucketFileReference(
+            referencedGcpResourceApi, getWorkspaceId(), bucketFileReferenceName, TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS, TEST_FILE_IN_FINE_GRAINED_BUCKET);
 
     sourceBigQueryDatasetReference =
         ResourceMaker.makeBigQueryDatasetReference(

--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -85,8 +85,7 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
             "reference_to_foo_folder",
             null,
             TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS,
-            TEST_FOLDER_IN_FINE_GRAINED_BUCKET
-        );
+            TEST_FOLDER_IN_FINE_GRAINED_BUCKET);
 
     sourceBigQueryDatasetReference =
         ResourceMaker.makeBigQueryDatasetReference(

--- a/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/CloneReferencedResources.java
@@ -1,8 +1,9 @@
 package scripts.testscripts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static scripts.utils.ClientTestUtils.TEST_BUCKET_FILE_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME;
+import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS;
+import static scripts.utils.ClientTestUtils.TEST_FILE_IN_FINE_GRAINED_BUCKET;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
@@ -67,7 +68,7 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
             referencedGcpResourceApi, getWorkspaceId(), bucketReferenceName);
 
     sourceBucketFileReference =
-        ResourceMaker.makeGcsBucketFileReference(
+        ResourceMaker.makeGcsBucketFileInFineGrainedBucketReference(
             referencedGcpResourceApi, getWorkspaceId(), bucketFileReferenceName);
 
     sourceBigQueryDatasetReference =
@@ -165,10 +166,10 @@ public class CloneReferencedResources extends DataRepoTestScriptBase {
         CLONED_BUCKET_FILE_RESOURCE_NAME,
         cloneBucketFileReferenceResult.getResource().getMetadata().getName());
     assertEquals(
-        TEST_BUCKET_NAME,
+        TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS,
         cloneBucketFileReferenceResult.getResource().getAttributes().getBucketName());
     assertEquals(
-        TEST_BUCKET_FILE_NAME,
+        TEST_FILE_IN_FINE_GRAINED_BUCKET,
         cloneBucketFileReferenceResult.getResource().getAttributes().getFileName());
 
     final var cloneBigQueryDatasetRequestBody =

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -186,6 +186,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
     final ApiClient apiClient = ClientTestUtils.getClientForTestUser(sourceOwnerUser, server);
     final var referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
     final String bucketReferenceName = RandomStringUtils.random(16, true, false);
+    final String bucketFileReferenceName = RandomStringUtils.random(16, true, false);
 
     sourceBucketReference =
         ResourceMaker.makeGcsBucketReference(
@@ -196,7 +197,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
 
     sourceBucketFileReference =
         ResourceMaker.makeGcsBucketFileReference(
-            referencedGcpResourceApi, getWorkspaceId(), "a reference to hello_world.txt");
+            referencedGcpResourceApi, getWorkspaceId(), "clone to hello_world.txt");
 
     // create reference to BQ dataset with COPY_NOTHING
     sourceDatasetReference =

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -202,7 +202,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
         ResourceMaker.makeGcsObjectReference(
             referencedGcpResourceApi,
             getWorkspaceId(),
-            "a_reference_to_hello_world_txt",
+            "a_reference_to_foo_monkey_sees_monkey_dos",
             CloningInstructionsEnum.REFERENCE,
             TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS,
             TEST_FILE_IN_FINE_GRAINED_BUCKET);

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static scripts.utils.ClientTestUtils.TEST_BUCKET_FILE_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS;
 import static scripts.utils.ClientTestUtils.TEST_FILE_IN_FINE_GRAINED_BUCKET;
 import static scripts.utils.ClientTestUtils.getOrFail;
@@ -189,9 +188,8 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
 
     // Create reference to GCS bucket with COPY_REFERENCE
     final ApiClient apiClient = ClientTestUtils.getClientForTestUser(sourceOwnerUser, server);
-    final var referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
+    ReferencedGcpResourceApi referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
     final String bucketReferenceName = RandomStringUtils.random(16, true, false);
-    final String bucketFileReferenceName = RandomStringUtils.random(16, true, false);
 
     sourceBucketReference =
         ResourceMaker.makeGcsBucketReference(
@@ -202,8 +200,12 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
 
     sourceBucketFileReference =
         ResourceMaker.makeGcsBucketFileReference(
-            referencedGcpResourceApi, getWorkspaceId(), bucketFileReferenceName,
-            TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS, TEST_FILE_IN_FINE_GRAINED_BUCKET);
+            referencedGcpResourceApi,
+            getWorkspaceId(),
+            "a_reference_to_hello_world_txt",
+            CloningInstructionsEnum.REFERENCE,
+            TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS,
+            TEST_FILE_IN_FINE_GRAINED_BUCKET);
 
     // create reference to BQ dataset with COPY_NOTHING
     sourceDatasetReference =

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -30,8 +30,8 @@ import bio.terra.workspace.model.ControlledResourceIamRole;
 import bio.terra.workspace.model.CreatedControlledGcpGcsBucket;
 import bio.terra.workspace.model.GcpBigQueryDataTableResource;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
-import bio.terra.workspace.model.GcpGcsBucketFileResource;
 import bio.terra.workspace.model.GcpGcsBucketResource;
+import bio.terra.workspace.model.GcpGcsObjectResource;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.ResourceCloneDetails;
@@ -71,7 +71,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
   private GcpBigQueryDatasetResource copyResourceDataset;
   private GcpBigQueryDatasetResource privateDataset;
   private GcpGcsBucketResource sourceBucketReference;
-  private GcpGcsBucketFileResource sourceBucketFileReference;
+  private GcpGcsObjectResource sourceBucketFileReference;
   private String copyDefinitionDatasetName;
   private String copyResourceDatasetName;
   private String nameSuffix;
@@ -199,7 +199,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
             CloningInstructionsEnum.REFERENCE);
 
     sourceBucketFileReference =
-        ResourceMaker.makeGcsBucketFileReference(
+        ResourceMaker.makeGcsObjectReference(
             referencedGcpResourceApi,
             getWorkspaceId(),
             "a_reference_to_hello_world_txt",
@@ -465,7 +465,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
     assertEquals(CloneResourceResult.SUCCEEDED, bucketFileReferenceDetails.getResult());
     assertEquals(
         CloningInstructionsEnum.REFERENCE, bucketFileReferenceDetails.getCloningInstructions());
-    assertEquals(ResourceType.GCS_BUCKET_FILE, bucketFileReferenceDetails.getResourceType());
+    assertEquals(ResourceType.GCS_OBJECT, bucketFileReferenceDetails.getResourceType());
     assertEquals(StewardshipType.REFERENCED, bucketFileReferenceDetails.getStewardshipType());
     assertNotNull(bucketFileReferenceDetails.getDestinationResourceId());
     assertNull(bucketFileReferenceDetails.getErrorMessage());

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -7,6 +7,9 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static scripts.utils.ClientTestUtils.TEST_BUCKET_FILE_NAME;
+import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS;
+import static scripts.utils.ClientTestUtils.TEST_FILE_IN_FINE_GRAINED_BUCKET;
 import static scripts.utils.ClientTestUtils.getOrFail;
 import static scripts.utils.GcsBucketTestFixtures.GCS_BLOB_NAME;
 import static scripts.utils.GcsBucketTestFixtures.RESOURCE_PREFIX;
@@ -197,7 +200,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
 
     sourceBucketFileReference =
         ResourceMaker.makeGcsBucketFileReference(
-            referencedGcpResourceApi, getWorkspaceId(), "clone to hello_world.txt");
+            referencedGcpResourceApi, getWorkspaceId(), bucketFileReferenceName, TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS, TEST_FILE_IN_FINE_GRAINED_BUCKET);
 
     // create reference to BQ dataset with COPY_NOTHING
     sourceDatasetReference =

--- a/integration/src/main/java/scripts/testscripts/ValidateReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/ValidateReferencedResources.java
@@ -15,8 +15,8 @@ import bio.terra.workspace.client.ApiClient;
 import bio.terra.workspace.model.DataRepoSnapshotResource;
 import bio.terra.workspace.model.GcpBigQueryDataTableResource;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
-import bio.terra.workspace.model.GcpGcsBucketFileResource;
 import bio.terra.workspace.model.GcpGcsBucketResource;
+import bio.terra.workspace.model.GcpGcsObjectResource;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import java.util.List;
@@ -39,7 +39,7 @@ public class ValidateReferencedResources extends DataRepoTestScriptBase {
   private UUID snapshotResourceId;
   // resource id of the reference to
   // gs://terra_wsm_fine_grained_test_bucket/foo/monkey_sees_monkey_dos.txt
-  private UUID bucketFileResourceId;
+  private UUID bucketTxtFileResourceId;
   // resource id of reference to gs://terra_wsm_fine_grained_test_bucket/foo/
   private UUID fooFolderResourceId;
   // resource id of reference to gs://terra_wsm_fine_grained_test_bucket/foo/**.txt
@@ -92,15 +92,15 @@ public class ValidateReferencedResources extends DataRepoTestScriptBase {
 
     // Reference to gs://terra_wsm_fine_grained_test_bucket/foo/monkey_sees_monkey_dos.txt. Bella
     // and Elijah has READER access to this file.
-    GcpGcsBucketFileResource bucketFileReference =
-        ResourceMaker.makeGcsBucketFileReference(
+    GcpGcsObjectResource bucketFileReference =
+        ResourceMaker.makeGcsObjectReference(
             referencedGcpResourceApi,
             getWorkspaceId(),
             "reference_to_foo_monkey_sees_monkey_dos",
             null,
             TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS,
             TEST_FILE_IN_FINE_GRAINED_BUCKET);
-    bucketFileResourceId = bucketFileReference.getMetadata().getResourceId();
+    bucketTxtFileResourceId = bucketFileReference.getMetadata().getResourceId();
 
     // Reference to gs://terra_wsm_fine_grained_test_bucket. Bella and Elijah has READER access.
     fineGrainedBucketResourceId =
@@ -113,8 +113,8 @@ public class ValidateReferencedResources extends DataRepoTestScriptBase {
             .getResourceId();
 
     // Reference to gs://terra_wsm_fine_grained_test_bucket/foo/. Only Bella has READER access.
-    GcpGcsBucketFileResource bucketFolderReference =
-        ResourceMaker.makeGcsBucketFileReference(
+    GcpGcsObjectResource bucketFolderReference =
+        ResourceMaker.makeGcsObjectReference(
             referencedGcpResourceApi,
             getWorkspaceId(),
             "foo_folder",
@@ -123,8 +123,8 @@ public class ValidateReferencedResources extends DataRepoTestScriptBase {
             TEST_FOLDER_IN_FINE_GRAINED_BUCKET);
     fooFolderResourceId = bucketFolderReference.getMetadata().getResourceId();
 
-    GcpGcsBucketFileResource fooTxtFileReference =
-        ResourceMaker.makeGcsBucketFileReference(
+    GcpGcsObjectResource fooTxtFileReference =
+        ResourceMaker.makeGcsObjectReference(
             referencedGcpResourceApi,
             getWorkspaceId(),
             "foo_txt_files",
@@ -133,8 +133,8 @@ public class ValidateReferencedResources extends DataRepoTestScriptBase {
             "foo/**.txt");
     fooTxtFilesResourceId = fooTxtFileReference.getMetadata().getResourceId();
 
-    GcpGcsBucketFileResource fooAllFilesReference =
-        ResourceMaker.makeGcsBucketFileReference(
+    GcpGcsObjectResource fooAllFilesReference =
+        ResourceMaker.makeGcsObjectReference(
             referencedGcpResourceApi,
             getWorkspaceId(),
             "foo_all_files",
@@ -183,9 +183,9 @@ public class ValidateReferencedResources extends DataRepoTestScriptBase {
     assertFalse(secondUserApi.checkReferenceAccess(getWorkspaceId(), fineGrainedBucketResourceId));
 
     // Reference to gs://terra_wsm_fine_grained_test_bucket/foo/monkey_sees_monkey_dos.txt
-    assertTrue(ownerApi.checkReferenceAccess(getWorkspaceId(), bucketFileResourceId));
-    assertFalse(secondUserApi.checkReferenceAccess(getWorkspaceId(), bucketFileResourceId));
-    assertTrue(thirdUserApi.checkReferenceAccess(getWorkspaceId(), bucketFileResourceId));
+    assertTrue(ownerApi.checkReferenceAccess(getWorkspaceId(), bucketTxtFileResourceId));
+    assertFalse(secondUserApi.checkReferenceAccess(getWorkspaceId(), bucketTxtFileResourceId));
+    assertTrue(thirdUserApi.checkReferenceAccess(getWorkspaceId(), bucketTxtFileResourceId));
 
     // Reference to gs://terra_wsm_fine_grained_test_bucket/foo/. Only Bella has access.
     // folder.

--- a/integration/src/main/java/scripts/testscripts/ValidateReferencedResources.java
+++ b/integration/src/main/java/scripts/testscripts/ValidateReferencedResources.java
@@ -154,7 +154,8 @@ public class ValidateReferencedResources extends DataRepoTestScriptBase {
     ResourceApi fileReaderApi =
         new ResourceApi(ClientTestUtils.getClientForTestUser(fileReaderUser, server));
 
-    // Add noAccessUser and fileReaderUser as workspace reader, though this will not affect permissions on referenced
+    // Add noAccessUser and fileReaderUser as workspace reader, though this will not affect
+    // permissions on referenced
     // external objects.
     workspaceApi.grantRole(
         new GrantRoleRequestBody().memberEmail(noAccessUser.userEmail),
@@ -181,7 +182,8 @@ public class ValidateReferencedResources extends DataRepoTestScriptBase {
     // Reference to gs://terra_wsm_fine_grained_test_bucket
     assertTrue(ownerApi.checkReferenceAccess(getWorkspaceId(), fineGrainedBucketResourceId));
     assertFalse(fileReaderApi.checkReferenceAccess(getWorkspaceId(), fineGrainedBucketResourceId));
-    assertFalse(noAccessUserApi.checkReferenceAccess(getWorkspaceId(), fineGrainedBucketResourceId));
+    assertFalse(
+        noAccessUserApi.checkReferenceAccess(getWorkspaceId(), fineGrainedBucketResourceId));
 
     // Reference to gs://terra_wsm_fine_grained_test_bucket/foo/monkey_sees_monkey_dos.txt
     assertTrue(ownerApi.checkReferenceAccess(getWorkspaceId(), bucketTxtFileResourceId));

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 public class ClientTestUtils {
 
   public static final String TEST_BUCKET_NAME = "terra_wsm_test_resource";
-  public static final String TEST_BUCKET_FILE_NAME = "hello_world.txt";
   public static final String TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS =
       "terra_wsm_fine_grained_test_bucket";
   public static final String TEST_FILE_IN_FINE_GRAINED_BUCKET = "foo/monkey_sees_monkey_dos.txt";

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -52,6 +52,7 @@ public class ClientTestUtils {
   public static final String TEST_BUCKET_FILE_NAME = "hello_world.txt";
   public static final String TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS = "terra_wsm_fine_grained_test_bucket";
   public static final String TEST_FILE_IN_FINE_GRAINED_BUCKET = "foo/monkey_sees_monkey_dos.txt";
+  public static final String TEST_FOLDER_IN_FINE_GRAINED_BUCKET = "foo/";
   public static final String TEST_BQ_DATASET_NAME = "terra_wsm_test_dataset";
   public static final String TEST_BQ_DATATABLE_NAME = "terra wsm test data table";
   public static final String TEST_BQ_DATASET_PROJECT = "terra-kernel-k8s";

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -49,8 +49,9 @@ import org.slf4j.LoggerFactory;
 public class ClientTestUtils {
 
   public static final String TEST_BUCKET_NAME = "terra_wsm_test_resource";
-  public static final String TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS = "terra_wsm_fine_grained_test_bucket";
   public static final String TEST_BUCKET_FILE_NAME = "hello_world.txt";
+  public static final String TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS = "terra_wsm_fine_grained_test_bucket";
+  public static final String TEST_FILE_IN_FINE_GRAINED_BUCKET = "foo/monkey_sees_monkey_dos.txt";
   public static final String TEST_BQ_DATASET_NAME = "terra_wsm_test_dataset";
   public static final String TEST_BQ_DATATABLE_NAME = "terra wsm test data table";
   public static final String TEST_BQ_DATASET_PROJECT = "terra-kernel-k8s";

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 public class ClientTestUtils {
 
   public static final String TEST_BUCKET_NAME = "terra_wsm_test_resource";
+  public static final String TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS = "terra_wsm_fine_grained_test_bucket";
   public static final String TEST_BUCKET_FILE_NAME = "hello_world.txt";
   public static final String TEST_BQ_DATASET_NAME = "terra_wsm_test_dataset";
   public static final String TEST_BQ_DATATABLE_NAME = "terra wsm test data table";

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -50,7 +50,8 @@ public class ClientTestUtils {
 
   public static final String TEST_BUCKET_NAME = "terra_wsm_test_resource";
   public static final String TEST_BUCKET_FILE_NAME = "hello_world.txt";
-  public static final String TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS = "terra_wsm_fine_grained_test_bucket";
+  public static final String TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS =
+      "terra_wsm_fine_grained_test_bucket";
   public static final String TEST_FILE_IN_FINE_GRAINED_BUCKET = "foo/monkey_sees_monkey_dos.txt";
   public static final String TEST_FOLDER_IN_FINE_GRAINED_BUCKET = "foo/";
   public static final String TEST_BQ_DATASET_NAME = "terra_wsm_test_dataset";

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -5,6 +5,7 @@ import static scripts.utils.ClientTestUtils.TEST_BQ_DATASET_PROJECT;
 import static scripts.utils.ClientTestUtils.TEST_BQ_DATATABLE_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_FILE_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME;
+import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS;
 import static scripts.utils.GcsBucketTestFixtures.BUCKET_PREFIX;
 import static scripts.utils.GcsBucketTestFixtures.LIFECYCLE_RULES;
 
@@ -187,6 +188,7 @@ public class ResourceMaker {
             .file(
                 new GcpGcsBucketFileAttributes()
                     .bucketName(TEST_BUCKET_NAME)
+                    //.bucketName(TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS)
                     .fileName(TEST_BUCKET_FILE_NAME));
 
     return ClientTestUtils.getWithRetryOnException(

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -172,7 +172,7 @@ public class ResourceMaker {
         workspaceId,
         name,
         cloningInstructions,
-        /*isBucketWithFineGrainedAccess=*/ false);
+        /*isBucketWithFineGrainedAccess=*/ true);
   }
 
   /**

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -215,33 +215,7 @@ public class ResourceMaker {
    * not expect a user to be able to create a reference).
    */
   public static GcpGcsBucketFileResource makeGcsBucketFileReference(
-      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
-      throws ApiException, InterruptedException {
-    return makeGcsBucketFileReference(resourceApi, workspaceId, name, /*isFineGrainedBucket=*/false);
-  }
-
-  /**
-   * Calls WSM to create a referenced GCS bucket file in the specified workspace.
-   *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
-   * do
-   * not expect a user to be able to create a reference).
-   */
-  public static GcpGcsBucketFileResource makeGcsBucketFileInFineGrainedBucketReference(
-      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
-      throws ApiException, InterruptedException {
-    return makeGcsBucketFileReference(resourceApi, workspaceId, name, /*isFineGrainedBucket=*/true);
-  }
-
-  /**
-   * Calls WSM to create a referenced GCS bucket file in the specified workspace.
-   *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
-   * do
-   * not expect a user to be able to create a reference).
-   */
-  public static GcpGcsBucketFileResource makeGcsBucketFileReference(
-      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name, boolean isFineGrainedBucket)
+      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name, String bucketName, String objectName)
       throws ApiException, InterruptedException {
     var body =
         new CreateGcpGcsBucketFileReferenceRequestBody()
@@ -252,8 +226,8 @@ public class ResourceMaker {
                     .name(name))
             .file(
                 new GcpGcsBucketFileAttributes()
-                    .bucketName(isFineGrainedBucket? TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS: TEST_BUCKET_NAME)
-                    .fileName(isFineGrainedBucket? TEST_FILE_IN_FINE_GRAINED_BUCKET: TEST_BUCKET_FILE_NAME));
+                    .bucketName(bucketName)
+                    .fileName(objectName));
 
     logger.info("Making reference to a gcs bucket file");
     return ClientTestUtils.getWithRetryOnException(

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -21,8 +21,8 @@ import bio.terra.workspace.model.CreateControlledGcpGcsBucketRequestBody;
 import bio.terra.workspace.model.CreateDataRepoSnapshotReferenceRequestBody;
 import bio.terra.workspace.model.CreateGcpBigQueryDataTableReferenceRequestBody;
 import bio.terra.workspace.model.CreateGcpBigQueryDatasetReferenceRequestBody;
-import bio.terra.workspace.model.CreateGcpGcsBucketFileReferenceRequestBody;
 import bio.terra.workspace.model.CreateGcpGcsBucketReferenceRequestBody;
+import bio.terra.workspace.model.CreateGcpGcsObjectReferenceRequestBody;
 import bio.terra.workspace.model.CreatedControlledGcpAiNotebookInstanceResult;
 import bio.terra.workspace.model.CreatedControlledGcpGcsBucket;
 import bio.terra.workspace.model.DataRepoSnapshotAttributes;
@@ -39,10 +39,10 @@ import bio.terra.workspace.model.GcpBigQueryDatasetResource;
 import bio.terra.workspace.model.GcpGcsBucketAttributes;
 import bio.terra.workspace.model.GcpGcsBucketCreationParameters;
 import bio.terra.workspace.model.GcpGcsBucketDefaultStorageClass;
-import bio.terra.workspace.model.GcpGcsBucketFileAttributes;
-import bio.terra.workspace.model.GcpGcsBucketFileResource;
 import bio.terra.workspace.model.GcpGcsBucketLifecycle;
 import bio.terra.workspace.model.GcpGcsBucketResource;
+import bio.terra.workspace.model.GcpGcsObjectAttributes;
+import bio.terra.workspace.model.GcpGcsObjectResource;
 import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.ManagedBy;
@@ -211,12 +211,12 @@ public class ResourceMaker {
   }
 
   /**
-   * Calls WSM to create a referenced GCS bucket file in the specified workspace.
+   * Calls WSM to create a referenced GCS bucket object in the specified workspace.
    *
    * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
    * not expect a user to be able to create a reference).
    */
-  public static GcpGcsBucketFileResource makeGcsBucketFileReference(
+  public static GcpGcsObjectResource makeGcsObjectReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceId,
       String name,
@@ -225,7 +225,7 @@ public class ResourceMaker {
       String objectName)
       throws ApiException, InterruptedException {
     var body =
-        new CreateGcpGcsBucketFileReferenceRequestBody()
+        new CreateGcpGcsObjectReferenceRequestBody()
             .metadata(
                 new ReferenceResourceCommonFields()
                     .cloningInstructions(
@@ -233,11 +233,11 @@ public class ResourceMaker {
                             .orElse(CloningInstructionsEnum.NOTHING))
                     .description("Description of " + name)
                     .name(name))
-            .file(new GcpGcsBucketFileAttributes().bucketName(bucketName).fileName(objectName));
+            .file(new GcpGcsObjectAttributes().bucketName(bucketName).fileName(objectName));
 
     logger.info("Making reference to a gcs bucket file");
     return ClientTestUtils.getWithRetryOnException(
-        () -> resourceApi.createBucketFileReference(body, workspaceId));
+        () -> resourceApi.createGcsObjectReference(body, workspaceId));
   }
 
   public static GcpGcsBucketResource makeGcsBucketReference(

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -3,10 +3,8 @@ package scripts.utils;
 import static scripts.utils.ClientTestUtils.TEST_BQ_DATASET_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BQ_DATASET_PROJECT;
 import static scripts.utils.ClientTestUtils.TEST_BQ_DATATABLE_NAME;
-import static scripts.utils.ClientTestUtils.TEST_BUCKET_FILE_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS;
-import static scripts.utils.ClientTestUtils.TEST_FILE_IN_FINE_GRAINED_BUCKET;
 import static scripts.utils.GcsBucketTestFixtures.BUCKET_PREFIX;
 import static scripts.utils.GcsBucketTestFixtures.LIFECYCLE_RULES;
 
@@ -69,8 +67,7 @@ public class ResourceMaker {
   /**
    * Calls WSM to create a referenced BigQuery dataset in the specified workspace.
    *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
-   * do
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
    * not expect a user to be able to create a reference).
    */
   public static GcpBigQueryDatasetResource makeBigQueryDatasetReference(
@@ -96,8 +93,7 @@ public class ResourceMaker {
   /**
    * Calls WSM to create a referenced BigQuery table in the specified workspace.
    *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
-   * do
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
    * not expect a user to be able to create a reference).
    */
   public static GcpBigQueryDataTableResource makeBigQueryDataTableReference(
@@ -121,9 +117,7 @@ public class ResourceMaker {
         () -> resourceApi.createBigQueryDataTableReference(body, workspaceId));
   }
 
-  /**
-   * Calls WSM to create a referenced TDR snapshot in the specified workspace.
-   */
+  /** Calls WSM to create a referenced TDR snapshot in the specified workspace. */
   public static DataRepoSnapshotResource makeDataRepoSnapshotReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceId,
@@ -150,8 +144,7 @@ public class ResourceMaker {
   /**
    * Calls WSM to create a referenced GCS bucket in the specified workspace.
    *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
-   * do
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
    * not expect a user to be able to create a reference).
    */
   public static GcpGcsBucketResource makeGcsBucketReference(
@@ -160,8 +153,12 @@ public class ResourceMaker {
       String name,
       @Nullable CloningInstructionsEnum cloningInstructions)
       throws ApiException, InterruptedException {
-    return makeGcsBucketReference(resourceApi, workspaceId, name,
-        cloningInstructions, /*isBucketWithFineGrainedAccess=*/false);
+    return makeGcsBucketReference(
+        resourceApi,
+        workspaceId,
+        name,
+        cloningInstructions,
+        /*isBucketWithFineGrainedAccess=*/ false);
   }
 
   public static GcpGcsBucketResource makeGcsBucketWithFineGrainedAccessReference(
@@ -170,15 +167,18 @@ public class ResourceMaker {
       String name,
       @Nullable CloningInstructionsEnum cloningInstructions)
       throws InterruptedException, ApiException {
-    return makeGcsBucketReference(resourceApi, workspaceId, name,
-        cloningInstructions, /*isBucketWithFineGrainedAccess=*/false);
+    return makeGcsBucketReference(
+        resourceApi,
+        workspaceId,
+        name,
+        cloningInstructions,
+        /*isBucketWithFineGrainedAccess=*/ false);
   }
 
   /**
    * Calls WSM to create a referenced GCS bucket in the specified workspace.
    *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
-   * do
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
    * not expect a user to be able to create a reference).
    */
   public static GcpGcsBucketResource makeGcsBucketReference(
@@ -198,9 +198,12 @@ public class ResourceMaker {
                             .orElse(CloningInstructionsEnum.NOTHING))
                     .description("Description of " + name)
                     .name(name))
-            .bucket(new GcpGcsBucketAttributes().bucketName(
-                isBucketWithFineGrainedAccess ? TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS
-                    : TEST_BUCKET_NAME));
+            .bucket(
+                new GcpGcsBucketAttributes()
+                    .bucketName(
+                        isBucketWithFineGrainedAccess
+                            ? TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS
+                            : TEST_BUCKET_NAME));
 
     logger.info("Making reference to a gcs bucket");
     return ClientTestUtils.getWithRetryOnException(
@@ -210,13 +213,14 @@ public class ResourceMaker {
   /**
    * Calls WSM to create a referenced GCS bucket file in the specified workspace.
    *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
-   * do not expect a user to be able to create a reference).
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
+   * not expect a user to be able to create a reference).
    */
   public static GcpGcsBucketFileResource makeGcsBucketFileReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceId,
       String name,
+      @Nullable CloningInstructionsEnum cloningInstructionsEnum,
       String bucketName,
       String objectName)
       throws ApiException, InterruptedException {
@@ -224,13 +228,12 @@ public class ResourceMaker {
         new CreateGcpGcsBucketFileReferenceRequestBody()
             .metadata(
                 new ReferenceResourceCommonFields()
-                    .cloningInstructions(CloningInstructionsEnum.NOTHING)
+                    .cloningInstructions(
+                        Optional.ofNullable(cloningInstructionsEnum)
+                            .orElse(CloningInstructionsEnum.NOTHING))
                     .description("Description of " + name)
                     .name(name))
-            .file(
-                new GcpGcsBucketFileAttributes()
-                    .bucketName(bucketName)
-                    .fileName(objectName));
+            .file(new GcpGcsBucketFileAttributes().bucketName(bucketName).fileName(objectName));
 
     logger.info("Making reference to a gcs bucket file");
     return ClientTestUtils.getWithRetryOnException(

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -6,6 +6,7 @@ import static scripts.utils.ClientTestUtils.TEST_BQ_DATATABLE_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_FILE_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME;
 import static scripts.utils.ClientTestUtils.TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS;
+import static scripts.utils.ClientTestUtils.TEST_FILE_IN_FINE_GRAINED_BUCKET;
 import static scripts.utils.GcsBucketTestFixtures.BUCKET_PREFIX;
 import static scripts.utils.GcsBucketTestFixtures.LIFECYCLE_RULES;
 
@@ -60,6 +61,7 @@ import org.slf4j.LoggerFactory;
 
 // Static methods to create resources
 public class ResourceMaker {
+
   private static final Logger logger = LoggerFactory.getLogger(ResourceMaker.class);
   private static final long DELETE_BUCKET_POLL_SECONDS = 15;
   private static final String BUCKET_LOCATION = "US-CENTRAL1";
@@ -67,7 +69,8 @@ public class ResourceMaker {
   /**
    * Calls WSM to create a referenced BigQuery dataset in the specified workspace.
    *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
+   * do
    * not expect a user to be able to create a reference).
    */
   public static GcpBigQueryDatasetResource makeBigQueryDatasetReference(
@@ -93,7 +96,8 @@ public class ResourceMaker {
   /**
    * Calls WSM to create a referenced BigQuery table in the specified workspace.
    *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
+   * do
    * not expect a user to be able to create a reference).
    */
   public static GcpBigQueryDataTableResource makeBigQueryDataTableReference(
@@ -117,7 +121,9 @@ public class ResourceMaker {
         () -> resourceApi.createBigQueryDataTableReference(body, workspaceId));
   }
 
-  /** Calls WSM to create a referenced TDR snapshot in the specified workspace. */
+  /**
+   * Calls WSM to create a referenced TDR snapshot in the specified workspace.
+   */
   public static DataRepoSnapshotResource makeDataRepoSnapshotReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceId,
@@ -144,7 +150,8 @@ public class ResourceMaker {
   /**
    * Calls WSM to create a referenced GCS bucket in the specified workspace.
    *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
+   * do
    * not expect a user to be able to create a reference).
    */
   public static GcpGcsBucketResource makeGcsBucketReference(
@@ -152,6 +159,34 @@ public class ResourceMaker {
       UUID workspaceId,
       String name,
       @Nullable CloningInstructionsEnum cloningInstructions)
+      throws ApiException, InterruptedException {
+    return makeGcsBucketReference(resourceApi, workspaceId, name,
+        cloningInstructions, /*isBucketWithFineGrainedAccess=*/false);
+  }
+
+  public static GcpGcsBucketResource makeGcsBucketWithFineGrainedAccessReference(
+      ReferencedGcpResourceApi resourceApi,
+      UUID workspaceId,
+      String name,
+      @Nullable CloningInstructionsEnum cloningInstructions)
+      throws InterruptedException, ApiException {
+    return makeGcsBucketReference(resourceApi, workspaceId, name,
+        cloningInstructions, /*isBucketWithFineGrainedAccess=*/false);
+  }
+
+  /**
+   * Calls WSM to create a referenced GCS bucket in the specified workspace.
+   *
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
+   * do
+   * not expect a user to be able to create a reference).
+   */
+  public static GcpGcsBucketResource makeGcsBucketReference(
+      ReferencedGcpResourceApi resourceApi,
+      UUID workspaceId,
+      String name,
+      @Nullable CloningInstructionsEnum cloningInstructions,
+      boolean isBucketWithFineGrainedAccess)
       throws ApiException, InterruptedException {
 
     var body =
@@ -163,8 +198,11 @@ public class ResourceMaker {
                             .orElse(CloningInstructionsEnum.NOTHING))
                     .description("Description of " + name)
                     .name(name))
-            .bucket(new GcpGcsBucketAttributes().bucketName(TEST_BUCKET_NAME));
+            .bucket(new GcpGcsBucketAttributes().bucketName(
+                isBucketWithFineGrainedAccess ? TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS
+                    : TEST_BUCKET_NAME));
 
+    logger.info("Making reference to a gcs bucket");
     return ClientTestUtils.getWithRetryOnException(
         () -> resourceApi.createBucketReference(body, workspaceId));
   }
@@ -172,11 +210,38 @@ public class ResourceMaker {
   /**
    * Calls WSM to create a referenced GCS bucket file in the specified workspace.
    *
-   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you do
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
+   * do
    * not expect a user to be able to create a reference).
    */
   public static GcpGcsBucketFileResource makeGcsBucketFileReference(
       ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
+      throws ApiException, InterruptedException {
+    return makeGcsBucketFileReference(resourceApi, workspaceId, name, /*isFineGrainedBucket=*/false);
+  }
+
+  /**
+   * Calls WSM to create a referenced GCS bucket file in the specified workspace.
+   *
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
+   * do
+   * not expect a user to be able to create a reference).
+   */
+  public static GcpGcsBucketFileResource makeGcsBucketFileInFineGrainedBucketReference(
+      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name)
+      throws ApiException, InterruptedException {
+    return makeGcsBucketFileReference(resourceApi, workspaceId, name, /*isFineGrainedBucket=*/true);
+  }
+
+  /**
+   * Calls WSM to create a referenced GCS bucket file in the specified workspace.
+   *
+   * <p>This method retries on all WSM exceptions, do not use it for the negative case (where you
+   * do
+   * not expect a user to be able to create a reference).
+   */
+  public static GcpGcsBucketFileResource makeGcsBucketFileReference(
+      ReferencedGcpResourceApi resourceApi, UUID workspaceId, String name, boolean isFineGrainedBucket)
       throws ApiException, InterruptedException {
     var body =
         new CreateGcpGcsBucketFileReferenceRequestBody()
@@ -187,10 +252,10 @@ public class ResourceMaker {
                     .name(name))
             .file(
                 new GcpGcsBucketFileAttributes()
-                    .bucketName(TEST_BUCKET_NAME)
-                    //.bucketName(TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS)
-                    .fileName(TEST_BUCKET_FILE_NAME));
+                    .bucketName(isFineGrainedBucket? TEST_BUCKET_NAME_WITH_FINE_GRAINED_ACCESS: TEST_BUCKET_NAME)
+                    .fileName(isFineGrainedBucket? TEST_FILE_IN_FINE_GRAINED_BUCKET: TEST_BUCKET_FILE_NAME));
 
+    logger.info("Making reference to a gcs bucket file");
     return ClientTestUtils.getWithRetryOnException(
         () -> resourceApi.createBucketFileReference(body, workspaceId));
   }

--- a/integration/src/main/resources/configs/integration/ValidateReferencedResources.json
+++ b/integration/src/main/resources/configs/integration/ValidateReferencedResources.json
@@ -14,5 +14,5 @@
       "parameters": ["wm-default-spend-profile", "97b5559a-2f8f-4df3-89ae-5a249173ee0c", "terra"]
     }
   ],
-  "testUserFiles": ["bella.json", "liam.json"]
+  "testUserFiles": ["bella.json", "liam.json", "elijah.json"]
 }

--- a/integration/src/main/resources/testusers/README.md
+++ b/integration/src/main/resources/testusers/README.md
@@ -14,7 +14,7 @@ These include:
 - Usage of the `wm-default-spend-profile` spend profile in Sam
     - Owned by `developer-admins` and Platform Foundations team
     - Read access to the `terra_wsm_test_dataset` BigQuery dataset, `terra wsm test data table` BigQuery data table, and `terra_wsm_test_resource` 
-      GCS bucket, both in the `terra-kernel-k8s` GCP project.
+      GCS bucket with uniform access, `terra_wsm_fine_grained_test_bucket` GCS bucket with fine-grained access, both in the `terra-kernel-k8s` GCP project.
         - Owned by Platform Foundation and App Services teams.
   
 Users have different access to the above resources. Some tests also rely on specific
@@ -25,8 +25,8 @@ doesn't currently exist, consider minting a new test user.
 
 Currently, users have the following access permissions, replicated across environments:
 
-|                                           | TDR Snapshot       | `wm-default-spend-profile` | BQ Dataset `terra_wsm_test_dataset` | BQ Data table `terra wsm test data table` | Bucket `terra_wsm_test_resource` |
-| ----------------------------------------- | ------------------ | -------------------------- | ------------------------ | ------------------------- | ------------------------- |
-| **bella.redwalker**    | :white_check_mark: | :white_check_mark:         | :white_check_mark:       | :white_check_mark:        | :white_check_mark:        |
-| **elijah.thunderlord** | :x:                | :white_check_mark:         | :x:                      | :x:                      | :white_check_mark:        |
-| **liam.dragonmaw**     | :x:                | :x:                        | :x:                      | :x:                      |:x:                       |
+|                                           | TDR Snapshot       | `wm-default-spend-profile` | BQ Dataset `terra_wsm_test_dataset` | BQ Data table `terra wsm test data table` | Bucket `terra_wsm_test_resource` | Bucket `terra_wsm_fine_grained_test_bucket` | Bucket object `terra_wsm_fine_grained_test_bucket/foo/` | Bucket object `terra_wsm_fine_grained_test_bucket/foo/monkey_sees_monkey_dos.txt` |
+| ----------------------------------------- | ------------------ | -------------------------- | ----------------------------------- | ----------------------------------------- | -------------------------------- | ------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **bella.redwalker**                       | :white_check_mark: | :white_check_mark:         | :white_check_mark:                  | :white_check_mark:                        | :white_check_mark:               | :white_check_mark:                          | :white_check_mark:                                      |:white_check_mark:                                                                 |
+| **elijah.thunderlord**                    | :x:                | :white_check_mark:         | :x:                                 | :x:                                       | :white_check_mark:               | :white_check_mark:                          | :x:                                                     | :white_check_mark:                                                                |
+| **liam.dragonmaw**                        | :x:                | :x:                        | :x:                                 | :x:                                       |:x:                               | :x:                                         | :x:                                                     | :x:                                                                               |

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -4,19 +4,19 @@ import bio.terra.workspace.generated.controller.ReferencedGcpResourceApi;
 import bio.terra.workspace.generated.model.ApiCloneReferencedGcpBigQueryDataTableResourceResult;
 import bio.terra.workspace.generated.model.ApiCloneReferencedGcpBigQueryDatasetResourceResult;
 import bio.terra.workspace.generated.model.ApiCloneReferencedGcpDataRepoSnapshotResourceResult;
-import bio.terra.workspace.generated.model.ApiCloneReferencedGcpGcsBucketFileResourceResult;
 import bio.terra.workspace.generated.model.ApiCloneReferencedGcpGcsBucketResourceResult;
+import bio.terra.workspace.generated.model.ApiCloneReferencedGcpGcsObjectResourceResult;
 import bio.terra.workspace.generated.model.ApiCloneReferencedResourceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDataTableReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDatasetReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiCreateGcpGcsBucketFileReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGcpGcsBucketReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpGcsObjectReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableResource;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketFileResource;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
+import bio.terra.workspace.generated.model.ApiGcpGcsObjectResource;
 import bio.terra.workspace.generated.model.ApiUpdateDataReferenceRequestBody;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
@@ -25,8 +25,8 @@ import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDataTableResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedDataRepoSnapshotResource;
-import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketFileResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.resource.referenced.ReferencedGcsObjectResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
@@ -73,12 +73,12 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
 
   // -- GSC Bucket file -- //
   @Override
-  public ResponseEntity<ApiGcpGcsBucketFileResource> createBucketFileReference(
-      UUID workspaceId, @Valid ApiCreateGcpGcsBucketFileReferenceRequestBody body) {
+  public ResponseEntity<ApiGcpGcsObjectResource> createGcsObjectReference(
+      UUID workspaceId, @Valid ApiCreateGcpGcsObjectReferenceRequestBody body) {
 
     // Construct a ReferenceGcsBucketResource object from the API input
     var resource =
-        ReferencedGcsBucketFileResource.builder()
+        ReferencedGcsObjectResource.builder()
             .workspaceId(workspaceId)
             .name(body.getMetadata().getName())
             .description(body.getMetadata().getDescription())
@@ -90,35 +90,30 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
 
     ReferencedResource referenceResource =
         referenceResourceService.createReferenceResource(resource, getAuthenticatedInfo());
-    ApiGcpGcsBucketFileResource response =
-        referenceResource.castToGcsBucketFileResource().toApiModel();
+    ApiGcpGcsObjectResource response = referenceResource.castToGcsObjectResource().toApiModel();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   @Override
-  public ResponseEntity<ApiGcpGcsBucketFileResource> getBucketFileReference(
-      UUID id, UUID referenceId) {
+  public ResponseEntity<ApiGcpGcsObjectResource> getGcsObjectReference(UUID id, UUID referenceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResource(id, referenceId, userRequest);
-    ApiGcpGcsBucketFileResource response =
-        referenceResource.castToGcsBucketFileResource().toApiModel();
+    ApiGcpGcsObjectResource response = referenceResource.castToGcsObjectResource().toApiModel();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   @Override
-  public ResponseEntity<ApiGcpGcsBucketFileResource> getBucketFileReferenceByName(
-      UUID id, String name) {
+  public ResponseEntity<ApiGcpGcsObjectResource> getGcsObjectReferenceByName(UUID id, String name) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResourceByName(id, name, userRequest);
-    ApiGcpGcsBucketFileResource response =
-        referenceResource.castToGcsBucketFileResource().toApiModel();
+    ApiGcpGcsObjectResource response = referenceResource.castToGcsObjectResource().toApiModel();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   @Override
-  public ResponseEntity<Void> updateBucketFileReference(
+  public ResponseEntity<Void> updateGcsObjectReference(
       UUID id, UUID referenceId, ApiUpdateDataReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.updateReferenceResource(
@@ -127,10 +122,10 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> deleteBucketFileReference(UUID workspaceId, UUID resourceId) {
+  public ResponseEntity<Void> deleteGcsObjectReference(UUID workspaceId, UUID resourceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.deleteReferenceResourceForResourceType(
-        workspaceId, resourceId, userRequest, WsmResourceType.GCS_BUCKET_FILE);
+        workspaceId, resourceId, userRequest, WsmResourceType.GCS_OBJECT);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -380,9 +375,8 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<ApiCloneReferencedGcpGcsBucketFileResourceResult>
-      cloneGcpGcsBucketFileReference(
-          UUID workspaceId, UUID resourceId, @Valid ApiCloneReferencedResourceRequestBody body) {
+  public ResponseEntity<ApiCloneReferencedGcpGcsObjectResourceResult> cloneGcpGcsObjectReference(
+      UUID workspaceId, UUID resourceId, @Valid ApiCloneReferencedResourceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
 
     final ReferencedResource sourceReferencedResource =
@@ -395,7 +389,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     if (CloningInstructions.COPY_REFERENCE != effectiveCloningInstructions) {
       // Nothing to clone here
       final var emptyResult =
-          new ApiCloneReferencedGcpGcsBucketFileResourceResult()
+          new ApiCloneReferencedGcpGcsObjectResourceResult()
               .effectiveCloningInstructions(effectiveCloningInstructions.toApiModel())
               .sourceResourceId(sourceReferencedResource.getResourceId())
               .sourceWorkspaceId(sourceReferencedResource.getWorkspaceId())
@@ -413,8 +407,8 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
 
     // Build the correct response type
     final var result =
-        new ApiCloneReferencedGcpGcsBucketFileResourceResult()
-            .resource(clonedReferencedResource.castToGcsBucketFileResource().toApiModel())
+        new ApiCloneReferencedGcpGcsObjectResourceResult()
+            .resource(clonedReferencedResource.castToGcsObjectResource().toApiModel())
             .sourceWorkspaceId(sourceReferencedResource.getWorkspaceId())
             .sourceResourceId(sourceReferencedResource.getResourceId())
             .effectiveCloningInstructions(effectiveCloningInstructions.toApiModel());

--- a/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
@@ -22,8 +22,8 @@ import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDataTableResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedDataRepoSnapshotResource;
-import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketFileResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.resource.referenced.ReferencedGcsObjectResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
@@ -152,11 +152,10 @@ public class ResourceController implements ResourceApi {
               break;
             }
 
-          case GCS_BUCKET_FILE:
+          case GCS_OBJECT:
             {
-              ReferencedGcsBucketFileResource resource =
-                  referencedResource.castToGcsBucketFileResource();
-              union.gcpGcsBucketFile(resource.toApiAttributes());
+              ReferencedGcsObjectResource resource = referencedResource.castToGcsObjectResource();
+              union.gcpGcsObject(resource.toApiAttributes());
               break;
             }
 

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -24,8 +24,8 @@ import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDataTableResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedDataRepoSnapshotResource;
-import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketFileResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.resource.referenced.ReferencedGcsObjectResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedResource;
 import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
@@ -640,8 +640,8 @@ public class ResourceDao {
         switch (dbResource.getResourceType()) {
           case GCS_BUCKET:
             return new ReferencedGcsBucketResource(dbResource);
-          case GCS_BUCKET_FILE:
-            return new ReferencedGcsBucketFileResource(dbResource);
+          case GCS_OBJECT:
+            return new ReferencedGcsObjectResource(dbResource);
           case BIG_QUERY_DATASET:
             return new ReferencedBigQueryDatasetResource(dbResource);
           case BIQ_QUERY_DATA_TABLE:

--- a/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
@@ -35,6 +35,7 @@ import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -361,6 +362,11 @@ public class CrlService {
   public boolean canReadGcsBucketFile(String bucketName, String filePath, AuthenticatedUserRequest userRequest) {
     try {
       StorageCow storage = createStorageCow(null, userRequest);
+      boolean isUniformBucketLevelAccessEnabled =
+          storage.get(bucketName).getBucketInfo().getIamConfiguration().isUniformBucketLevelAccessEnabled();
+      if (isUniformBucketLevelAccessEnabled) {
+        return canReadGcsBucket(bucketName, userRequest);
+      }
       BlobId blobId = BlobId.of(bucketName, filePath);
       // If successfully get the blob, the user have at least READER access.
       BlobCow blobCow = storage.get(blobId);

--- a/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
@@ -356,12 +356,12 @@ public class CrlService {
     }
   }
 
-  public boolean canReadGcsBucketFile(
-      String bucketName, String filePath, AuthenticatedUserRequest userRequest) {
+  public boolean canReadGcsObject(
+      String bucketName, String objectName, AuthenticatedUserRequest userRequest) {
     try {
       StorageCow storage = createStorageCow(null, userRequest);
       // If successfully get the blob, the user have at least READER access.
-      storage.get(BlobId.of(bucketName, filePath));
+      storage.get(BlobId.of(bucketName, objectName));
       return true;
     } catch (StorageException e) {
       if (e.getCode() == HttpStatus.SC_FORBIDDEN) {
@@ -370,7 +370,7 @@ public class CrlService {
       throw new InvalidReferenceException(
           String.format(
               "Error while trying to access GCS blob %s in bucket %s and status code %s",
-              filePath, bucketName),
+              objectName, bucketName),
           e);
     }
   }

--- a/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
@@ -369,9 +369,7 @@ public class CrlService {
       }
       throw new InvalidReferenceException(
           String.format(
-              "Error while trying to access GCS blob %s in bucket %s and status code %s",
-              objectName, bucketName),
-          e);
+              "Error while trying to access GCS blob %s in bucket %s", objectName, bucketName), e);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
@@ -369,7 +369,8 @@ public class CrlService {
       }
       throw new InvalidReferenceException(
           String.format(
-              "Error while trying to access GCS blob %s in bucket %s", objectName, bucketName), e);
+              "Error while trying to access GCS blob %s in bucket %s", objectName, bucketName),
+          e);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
@@ -365,14 +365,15 @@ public class CrlService {
       // If successfully get the blob, the user have at least READER access.
       BlobCow blobCow = storage.get(blobId);
       if (blobCow == null) {
-        throw new InvalidReferenceException(
-            String.format("Error while trying to access GCS blob %s in bucket %s", filePath, bucketName)
-        );
+        return false;
       }
       return true;
     } catch (StorageException e) {
+      if (e.getCode() == HttpStatus.SC_FORBIDDEN) {
+        return false;
+      }
       throw new InvalidReferenceException(
-          String.format("Error while trying to access GCS blob %s in bucket %s", filePath, bucketName));
+          String.format("Error while trying to access GCS blob %s in bucket %s and status code %s", filePath, bucketName));
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
@@ -106,19 +106,25 @@ public class ValidationUtils {
     }
   }
 
-  public static void validateBucketFileName(String fileName) {
-    int nameLength = fileName.getBytes(StandardCharsets.UTF_8).length;
+  /**
+   * Validate GCS object name.
+   *
+   * @param objectName full path to the object in the bucket
+   * @throws InvalidNameException
+   */
+  public static void validateGcsObjectName(String objectName) {
+    int nameLength = objectName.getBytes(StandardCharsets.UTF_8).length;
     if (nameLength < 1 || nameLength > 1024) {
       throw new InvalidNameException(
-          "bucket file names must contain any sequence of valid Unicode characters, of length 1-1024 bytes when UTF-8 encoded");
+          "bucket object names must contain any sequence of valid Unicode characters, of length 1-1024 bytes when UTF-8 encoded");
     }
-    if (fileName.startsWith(ACME_CHALLENGE_PREFIX)) {
+    if (objectName.startsWith(ACME_CHALLENGE_PREFIX)) {
       throw new InvalidNameException(
-          "bucket file name cannot start with .well-known/acme-challenge/");
+          "bucket object name cannot start with .well-known/acme-challenge/");
     }
     for (String disallowedObjectName : DISALLOWED_OBJECT_NAMES) {
-      if (disallowedObjectName.equals(fileName)) {
-        throw new InvalidNameException("bucket file name cannot be . or ..");
+      if (disallowedObjectName.equals(objectName)) {
+        throw new InvalidNameException("bucket object name cannot be . or ..");
       }
     }
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceType.java
@@ -9,8 +9,8 @@ import bio.terra.workspace.service.resource.controlled.ControlledResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDataTableResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedDataRepoSnapshotResource;
-import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketFileResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.resource.referenced.ReferencedGcsObjectResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedResource;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import javax.annotation.Nullable;
@@ -36,11 +36,11 @@ public enum WsmResourceType {
       ApiResourceType.GCS_BUCKET,
       ReferencedGcsBucketResource.class,
       ControlledGcsBucketResource.class),
-  GCS_BUCKET_FILE(
+  GCS_OBJECT(
       CloudPlatform.GCP,
-      "GCS_BUCKET_FILE",
-      ApiResourceType.GCS_BUCKET_FILE,
-      ReferencedGcsBucketFileResource.class,
+      "GCS_OBJECT",
+      ApiResourceType.GCS_OBJECT,
+      ReferencedGcsObjectResource.class,
       /*controlledClass=*/ null),
   BIG_QUERY_DATASET(
       CloudPlatform.GCP,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
@@ -7,8 +7,8 @@ import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDataTableResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedDataRepoSnapshotResource;
-import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketFileResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.resource.referenced.ReferencedGcsObjectResource;
 import bio.terra.workspace.service.resource.referenced.ReferencedResource;
 import bio.terra.workspace.service.workspace.model.WsmCloneResourceResult;
 import java.util.Optional;
@@ -57,10 +57,10 @@ public class WorkspaceCloneUtils {
                 name,
                 description);
         break;
-      case GCS_BUCKET_FILE:
+      case GCS_OBJECT:
         destinationResource =
-            buildDestinationGcsBucketFileReference(
-                sourceReferencedResource.castToGcsBucketFileResource(),
+            buildDestinationGcsObjectReference(
+                sourceReferencedResource.castToGcsObjectResource(),
                 destinationWorkspaceId,
                 name,
                 description);
@@ -125,12 +125,12 @@ public class WorkspaceCloneUtils {
     return resultBuilder.build();
   }
 
-  private static ReferencedResource buildDestinationGcsBucketFileReference(
-      ReferencedGcsBucketFileResource sourceBucketFileResource,
+  private static ReferencedResource buildDestinationGcsObjectReference(
+      ReferencedGcsObjectResource sourceBucketFileResource,
       UUID destinationWorkspaceId,
       @Nullable String name,
       @Nullable String description) {
-    final ReferencedGcsBucketFileResource.Builder resultBuilder =
+    final ReferencedGcsObjectResource.Builder resultBuilder =
         sourceBucketFileResource.toBuilder()
             .workspaceId(destinationWorkspaceId)
             .resourceId(UUID.randomUUID());

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedGcsBucketFileResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedGcsBucketFileResource.java
@@ -115,7 +115,7 @@ public class ReferencedGcsBucketFileResource extends ReferencedResource {
     // have the Storage APIs enabled.
     Optional<AuthenticatedUserRequest> maybePetCreds =
         petSaService.getWorkspacePetCredentials(getWorkspaceId(), userRequest);
-    return crlService.canReadGcsBucket(bucketName, maybePetCreds.orElse(userRequest));
+    return crlService.canReadGcsBucketFile(bucketName, fileName, maybePetCreds.orElse(userRequest));
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedGcsObjectAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedGcsObjectAttributes.java
@@ -3,22 +3,23 @@ package bio.terra.workspace.service.resource.referenced;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class ReferencedGcsBucketFileAttributes {
+public class ReferencedGcsObjectAttributes {
   private final String bucketName;
-  private final String fileName;
+  private final String objectName;
 
   @JsonCreator
-  public ReferencedGcsBucketFileAttributes(
-      @JsonProperty("bucketName") String bucketName, @JsonProperty("fileName") String fileName) {
+  public ReferencedGcsObjectAttributes(
+      @JsonProperty("bucketName") String bucketName,
+      @JsonProperty("objectName") String objectName) {
     this.bucketName = bucketName;
-    this.fileName = fileName;
+    this.objectName = objectName;
   }
 
   public String getBucketName() {
     return bucketName;
   }
 
-  public String getFileName() {
-    return fileName;
+  public String getObjectName() {
+    return objectName;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedGcsObjectResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedGcsObjectResource.java
@@ -5,8 +5,8 @@ import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketFileAttributes;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketFileResource;
+import bio.terra.workspace.generated.model.ApiGcpGcsObjectAttributes;
+import bio.terra.workspace.generated.model.ApiGcpGcsObjectResource;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
@@ -20,9 +20,9 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
-public class ReferencedGcsBucketFileResource extends ReferencedResource {
+public class ReferencedGcsObjectResource extends ReferencedResource {
   private final String bucketName;
-  private final String fileName;
+  private final String objectName;
 
   /**
    * Constructor for serialized form for Stairway use and used by the builder
@@ -33,20 +33,20 @@ public class ReferencedGcsBucketFileResource extends ReferencedResource {
    * @param description description - may be null
    * @param cloningInstructions cloning instructions
    * @param bucketName bucket name
-   * @param fileName name for the file in the bucket
+   * @param objectName name for the file in the bucket
    */
   @JsonCreator
-  public ReferencedGcsBucketFileResource(
+  public ReferencedGcsObjectResource(
       @JsonProperty("workspaceId") UUID workspaceId,
       @JsonProperty("resourceId") UUID resourceId,
       @JsonProperty("name") String name,
       @JsonProperty("description") @Nullable String description,
       @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
       @JsonProperty("bucketName") String bucketName,
-      @JsonProperty("fileName") String fileName) {
+      @JsonProperty("objectName") String objectName) {
     super(workspaceId, resourceId, name, description, cloningInstructions);
     this.bucketName = bucketName;
-    this.fileName = fileName;
+    this.objectName = objectName;
     validate();
   }
 
@@ -55,12 +55,12 @@ public class ReferencedGcsBucketFileResource extends ReferencedResource {
    *
    * @param dbResource database form of resources
    */
-  public ReferencedGcsBucketFileResource(DbResource dbResource) {
+  public ReferencedGcsObjectResource(DbResource dbResource) {
     super(dbResource);
-    ReferencedGcsBucketFileAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ReferencedGcsBucketFileAttributes.class);
+    ReferencedGcsObjectAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ReferencedGcsObjectAttributes.class);
     this.bucketName = attributes.getBucketName();
-    this.fileName = attributes.getFileName();
+    this.objectName = attributes.getObjectName();
     validate();
   }
 
@@ -68,42 +68,42 @@ public class ReferencedGcsBucketFileResource extends ReferencedResource {
     return bucketName;
   }
 
-  public String getFileName() {
-    return fileName;
+  public String getObjectName() {
+    return objectName;
   }
 
-  public ApiGcpGcsBucketFileAttributes toApiAttributes() {
-    return new ApiGcpGcsBucketFileAttributes().bucketName(getBucketName()).fileName(getFileName());
+  public ApiGcpGcsObjectAttributes toApiAttributes() {
+    return new ApiGcpGcsObjectAttributes().bucketName(getBucketName()).fileName(getObjectName());
   }
 
-  public ApiGcpGcsBucketFileResource toApiModel() {
-    return new ApiGcpGcsBucketFileResource()
+  public ApiGcpGcsObjectResource toApiModel() {
+    return new ApiGcpGcsObjectResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());
   }
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.GCS_BUCKET_FILE;
+    return WsmResourceType.GCS_OBJECT;
   }
 
   @Override
   public String attributesToJson() {
-    return DbSerDes.toJson(new ReferencedGcsBucketFileAttributes(bucketName, fileName));
+    return DbSerDes.toJson(new ReferencedGcsObjectAttributes(bucketName, objectName));
   }
 
   @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.GCS_BUCKET_FILE) {
-      throw new InconsistentFieldsException("Expected GCS_BUCKET_FILE");
+    if (getResourceType() != WsmResourceType.GCS_OBJECT) {
+      throw new InconsistentFieldsException("Expected GCS_OBJECT");
     }
-    if (Strings.isNullOrEmpty(getBucketName()) || Strings.isNullOrEmpty(getFileName())) {
+    if (Strings.isNullOrEmpty(getBucketName()) || Strings.isNullOrEmpty(getObjectName())) {
       throw new MissingRequiredFieldException(
-          "Missing required field for ReferenceGcsBucketFileResource.");
+          "Missing required field for ReferenceGcsObjectResource.");
     }
     ValidationUtils.validateBucketName(getBucketName());
-    ValidationUtils.validateBucketFileName(getFileName());
+    ValidationUtils.validateGcsObjectName(getObjectName());
   }
 
   @Override
@@ -115,7 +115,7 @@ public class ReferencedGcsBucketFileResource extends ReferencedResource {
     // have the Storage APIs enabled.
     Optional<AuthenticatedUserRequest> maybePetCreds =
         petSaService.getWorkspacePetCredentials(getWorkspaceId(), userRequest);
-    return crlService.canReadGcsBucketFile(bucketName, fileName, maybePetCreds.orElse(userRequest));
+    return crlService.canReadGcsObject(bucketName, objectName, maybePetCreds.orElse(userRequest));
   }
 
   /**
@@ -127,7 +127,7 @@ public class ReferencedGcsBucketFileResource extends ReferencedResource {
   public Builder toBuilder() {
     return builder()
         .bucketName(getBucketName())
-        .fileName(getFileName())
+        .fileName(getObjectName())
         .cloningInstructions(getCloningInstructions())
         .description(getDescription())
         .name(getName())
@@ -183,9 +183,9 @@ public class ReferencedGcsBucketFileResource extends ReferencedResource {
       return this;
     }
 
-    public ReferencedGcsBucketFileResource build() {
+    public ReferencedGcsObjectResource build() {
       // On the create path, we can omit the resourceId and have it filled in by the builder.
-      return new ReferencedGcsBucketFileResource(
+      return new ReferencedGcsObjectResource(
           workspaceId,
           Optional.ofNullable(resourceId).orElse(UUID.randomUUID()),
           name,

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResource.java
@@ -54,9 +54,9 @@ public abstract class ReferencedResource extends WsmResource {
     return (ReferencedGcsBucketResource) this;
   }
 
-  public ReferencedGcsBucketFileResource castToGcsBucketFileResource() {
-    validateSubclass(WsmResourceType.GCS_BUCKET_FILE);
-    return (ReferencedGcsBucketFileResource) this;
+  public ReferencedGcsObjectResource castToGcsObjectResource() {
+    validateSubclass(WsmResourceType.GCS_OBJECT);
+    return (ReferencedGcsObjectResource) this;
   }
 
   /**

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -607,22 +607,22 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bucket/files:
+  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bucket/objects:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'
     post:
-      summary: Create a new GCS bucket file reference in a workspace.
-      operationId: createBucketFileReference
+      summary: Create a new GCS object reference in a workspace.
+      operationId: createGcsObjectReference
       tags: [ReferencedGcpResource]
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateGcpGcsBucketFileReferenceRequestBody'
+              $ref: '#/components/schemas/CreateGcpGcsObjectReferenceRequestBody'
       responses:
         '200':
-          $ref: '#/components/responses/GcpGcsBucketFileReferenceResponse'
+          $ref: '#/components/responses/GcpGcsObjectReferenceResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -632,17 +632,17 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bucket/files/{resourceId}:
+  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bucket/objects/{resourceId}:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'
     - $ref: '#/components/parameters/ResourceId'
     get:
-      summary: Gets a reference to a bucket file from a workspace.
-      operationId: getBucketFileReference
+      summary: Gets a reference to a GCS object from a workspace.
+      operationId: getGcsObjectReference
       tags: [ReferencedGcpResource]
       responses:
         '200':
-          $ref: '#/components/responses/GcpGcsBucketFileReferenceResponse'
+          $ref: '#/components/responses/GcpGcsObjectReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -650,8 +650,8 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     patch:
-      summary: Update name or description of a bucket file reference in a workspace.
-      operationId: updateBucketFileReference
+      summary: Update name or description of a GCS object reference in a workspace.
+      operationId: updateGcsObjectReference
       tags: [ReferencedGcpResource]
       requestBody:
         required: true
@@ -669,8 +669,8 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
-      summary: Delete Gcp bucket file reference
-      operationId: deleteBucketFileReference
+      summary: Delete Gcp GCS object reference
+      operationId: deleteGcsObjectReference
       tags: [ReferencedGcpResource]
       responses:
         '204':
@@ -681,13 +681,13 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bucket/files/{resourceId}/clone:
+  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bucket/objects/{resourceId}/clone:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'
     - $ref: '#/components/parameters/ResourceId'
     post:
-      summary: Clone a referenced GCS Bucket file resource
-      operationId: cloneGcpGcsBucketFileReference
+      summary: Clone a referenced GCS object resource
+      operationId: cloneGcpGcsObjectReference
       tags: [ReferencedGcpResource]
       requestBody:
         required: true
@@ -697,7 +697,7 @@ paths:
               $ref: '#/components/schemas/CloneReferencedResourceRequestBody'
       responses:
         '200':
-          $ref: '#/components/responses/CloneReferencedGcpGcsBucketFileResourceResponse'
+          $ref: '#/components/responses/CloneReferencedGcpGcsObjectResourceResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -706,17 +706,17 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bucket/files/name/{name}:
+  /api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bucket/objects/name/{name}:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'
     - $ref: '#/components/parameters/Name'
     get:
-      summary: Gets a reference to a Gcp bucket file by name.
-      operationId: getBucketFileReferenceByName
+      summary: Gets a reference to a Gcp GCS object by name.
+      operationId: getGcsObjectReferenceByName
       tags: [ReferencedGcpResource]
       responses:
         '200':
-          $ref: '#/components/responses/GcpGcsBucketFileReferenceResponse'
+          $ref: '#/components/responses/GcpGcsObjectReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -2173,15 +2173,15 @@ components:
         snapshot:
           $ref: '#/components/schemas/DataRepoSnapshotAttributes'
 
-    CreateGcpGcsBucketFileReferenceRequestBody:
+    CreateGcpGcsObjectReferenceRequestBody:
       type: object
-      description: A request to create a reference to a GCS bucket file.
+      description: A request to create a reference to a GCS object.
       required: [ metadata, file ]
       properties:
         metadata:
           $ref: '#/components/schemas/ReferenceResourceCommonFields'
         file:
-          $ref: '#/components/schemas/GcpGcsBucketFileAttributes'
+          $ref: '#/components/schemas/GcpGcsObjectAttributes'
 
     CreateGcpGcsBucketReferenceRequestBody:
       type: object
@@ -2611,9 +2611,9 @@ components:
           format: uuid
         resource:
           $ref: '#/components/schemas/GcpGcsBucketResource'
-    CloneReferencedGcpGcsBucketFileResourceResult:
+    CloneReferencedGcpGcsObjectResourceResult:
       description: >-
-        API result class for cloning a referenced GCS Bucket file resource. Includes source workspace
+        API result class for cloning a referenced GCS object resource. Includes source workspace
         and resource IDs for provenance. If the effective cloning instructions are not
         COPY_REFERENCE, then no clone is created and the resource is null.
       type: object
@@ -2629,7 +2629,7 @@ components:
           type: string
           format: uuid
         resource:
-          $ref: '#/components/schemas/GcpGcsBucketFileResource'
+          $ref: '#/components/schemas/GcpGcsObjectResource'
     CloneReferencedGcpBigQueryDatasetResourceResult:
       description: >-
         API result class for cloning a referenced BigQuery dataset resource. Includes source workspace
@@ -3119,9 +3119,9 @@ components:
         attributes:
           $ref: '#/components/schemas/GcpBigQueryDatasetAttributes'
 
-    GcpGcsBucketFileAttributes:
+    GcpGcsObjectAttributes:
       description: >-
-        Bucket file properties included in post-creation, get, and update. Others must be
+        GCS object properties included in post-creation, get, and update. Others must be
         retrieved from GCS using the name.
       type: object
       required: [ bucketName, fileName ]
@@ -3133,16 +3133,16 @@ components:
           description: Full path to the file in the gcs bucket.
           type: string
 
-    GcpGcsBucketFileResource:
+    GcpGcsObjectResource:
       type: object
-      description: Description of a GCS bucket file.
+      description: Description of a GCS object.
       required: [ metadata, attributes ]
       properties:
         metadata:
           description: the resource metadata common to all resources
           $ref: '#/components/schemas/ResourceMetadata'
         attributes:
-          $ref: '#/components/schemas/GcpGcsBucketFileAttributes'
+          $ref: '#/components/schemas/GcpGcsObjectAttributes'
 
     GcpGcsBucketAttributes:
       description: >-
@@ -3209,8 +3209,8 @@ components:
           $ref: '#/components/schemas/DataRepoSnapshotAttributes'
         gcpGcsBucket:
           $ref: '#/components/schemas/GcpGcsBucketAttributes'
-        gcpGcsBucketFile:
-          $ref: '#/components/schemas/GcpGcsBucketFileAttributes'
+        gcpGcsObject:
+          $ref: '#/components/schemas/GcpGcsObjectAttributes'
         gcpAiNotebookInstance:
           $ref: '#/components/schemas/GcpAiNotebookInstanceAttributes'
 
@@ -3295,7 +3295,7 @@ components:
         - BIG_QUERY_DATA_TABLE
         - DATA_REPO_SNAPSHOT
         - GCS_BUCKET
-        - GCS_BUCKET_FILE
+        - GCS_OBJECT
 
     StewardshipType:
       description: Enum containing valid stewardship types. Used for enumeration
@@ -3342,12 +3342,12 @@ components:
           schema:
             $ref: '#/components/schemas/DataRepoSnapshotResource'
 
-    GcpGcsBucketFileReferenceResponse:
-      description: Response containing a reference to a Gcp bucket file.
+    GcpGcsObjectReferenceResponse:
+      description: Response containing a reference to a Gcp GCS object.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/GcpGcsBucketFileResource'
+            $ref: '#/components/schemas/GcpGcsObjectResource'
 
     GcpGcsBucketReferenceResponse:
       description: Response containing a reference to a Gcp bucket.
@@ -3451,12 +3451,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CreateCloudContextResult'
-    CloneReferencedGcpGcsBucketFileResourceResponse:
-      description: Response for successful GCS Bucket file reference clone
+    CloneReferencedGcpGcsObjectResourceResponse:
+      description: Response for successful GCS object reference clone
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CloneReferencedGcpGcsBucketFileResourceResult'
+            $ref: '#/components/schemas/CloneReferencedGcpGcsObjectResourceResult'
     CloneReferencedGcpGcsBucketResourceResponse:
       description: Response for successful GCS Bucket reference clone
       content:

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -193,19 +193,19 @@ public class ValidationUtilsTest extends BaseUnitTest {
 
   @Test
   public void validateBucketFileName_disallowName_throwException() {
-    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateBucketFileName("."));
+    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateGcsObjectName("."));
   }
 
   @Test
   public void validateBucketFileName_emptyOrNullString_throwsException() {
-    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateBucketFileName(""));
+    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateGcsObjectName(""));
   }
 
   @Test
   public void validateBucketFileName_startsWithAcmeChallengePrefix_throwsException() {
     String file = ".well-known/acme-challenge/hello.txt";
 
-    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateBucketFileName(file));
+    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateGcsObjectName(file));
   }
 
   @Test
@@ -213,16 +213,16 @@ public class ValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InvalidNameException.class,
         () ->
-            ValidationUtils.validateBucketFileName(
+            ValidationUtils.validateGcsObjectName(
                 RandomStringUtils.random(1025, /*letters=*/ true, /*numbers=*/ true)));
   }
 
   @Test
   public void validateBucketFileName_legalFileName_validate() {
-    ValidationUtils.validateBucketFileName("hello.txt");
-    ValidationUtils.validateBucketFileName(
+    ValidationUtils.validateGcsObjectName("hello.txt");
+    ValidationUtils.validateGcsObjectName(
         RandomStringUtils.random(1024, /*letters=*/ true, /*numbers=*/ true));
-    ValidationUtils.validateBucketFileName("你好.png");
+    ValidationUtils.validateGcsObjectName("你好.png");
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -406,11 +406,11 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         doReturn(true).when(mockCrlService).canReadGcsBucket(any(), any());
       }
 
-      private ReferencedGcsBucketFileResource makeGcsBucketFileResource() {
+      private ReferencedGcsObjectResource makeGcsBucketFileResource() {
         UUID resourceId = UUID.randomUUID();
         String resourceName = "testgcs-" + resourceId.toString();
 
-        return new ReferencedGcsBucketFileResource(
+        return new ReferencedGcsObjectResource(
             workspaceId,
             resourceId,
             resourceName,
@@ -425,13 +425,13 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         referenceResource = makeGcsBucketFileResource();
         assertEquals(referenceResource.getStewardshipType(), StewardshipType.REFERENCED);
 
-        ReferencedGcsBucketFileResource resource = referenceResource.castToGcsBucketFileResource();
-        assertEquals(resource.getResourceType(), WsmResourceType.GCS_BUCKET_FILE);
+        ReferencedGcsObjectResource resource = referenceResource.castToGcsObjectResource();
+        assertEquals(resource.getResourceType(), WsmResourceType.GCS_OBJECT);
 
         ReferencedResource resultReferenceResource =
             referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST);
-        ReferencedGcsBucketFileResource resultResource =
-            resultReferenceResource.castToGcsBucketFileResource();
+        ReferencedGcsObjectResource resultResource =
+            resultReferenceResource.castToGcsObjectResource();
         assertEquals(resource, resultResource);
 
         assertTrue(
@@ -444,14 +444,14 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         ReferencedResource byname =
             referenceResourceService.getReferenceResourceByName(
                 workspaceId, resource.getName(), USER_REQUEST);
-        assertNotNull(byid.castToGcsBucketFileResource());
-        assertEquals(byid.castToGcsBucketFileResource(), byname.castToGcsBucketFileResource());
+        assertNotNull(byid.castToGcsObjectResource());
+        assertEquals(byid.castToGcsObjectResource(), byname.castToGcsObjectResource());
 
         referenceResourceService.deleteReferenceResourceForResourceType(
             workspaceId,
             referenceResource.getResourceId(),
             USER_REQUEST,
-            WsmResourceType.GCS_BUCKET_FILE);
+            WsmResourceType.GCS_OBJECT);
       }
 
       private ReferencedGcsBucketResource makeGcsBucketResource() {
@@ -509,7 +509,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         assertThrows(
             MissingRequiredFieldException.class,
             () ->
-                new ReferencedGcsBucketFileResource(
+                new ReferencedGcsObjectResource(
                     workspaceId,
                     resourceId,
                     resourceName,

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -404,9 +404,10 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
       void setup() throws Exception {
         // Make the Verify step always succeed
         doReturn(true).when(mockCrlService).canReadGcsBucket(any(), any());
+        doReturn(true).when(mockCrlService).canReadGcsObject(any(), any(), any());
       }
 
-      private ReferencedGcsObjectResource makeGcsBucketFileResource() {
+      private ReferencedGcsObjectResource makeGcsObjectReference() {
         UUID resourceId = UUID.randomUUID();
         String resourceName = "testgcs-" + resourceId.toString();
 
@@ -417,12 +418,12 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
             "description of " + resourceName,
             CloningInstructions.COPY_DEFINITION,
             /*bucketName=*/ "theres-a-hole-in-the-bottom-of-the",
-            /*fileName=*/ "balloon");
+            /*objectName=*/ "balloon");
       }
 
       @Test
-      void gcsBucketFileReference() {
-        referenceResource = makeGcsBucketFileResource();
+      void gcsObjectReference() {
+        referenceResource = makeGcsObjectReference();
         assertEquals(referenceResource.getStewardshipType(), StewardshipType.REFERENCED);
 
         ReferencedGcsObjectResource resource = referenceResource.castToGcsObjectResource();
@@ -503,7 +504,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
       }
 
       @Test
-      void missingBucketFileName_throwsException() {
+      void missingObjectName_throwsException() {
         UUID resourceId = UUID.randomUUID();
         String resourceName = "testgcs-" + resourceId.toString();
         assertThrows(


### PR DESCRIPTION
Also rename Gcs bucket file to object because that's the term cloud storage uses to refer to things in the bucket. 