### PR TITLE
[PF-1208] Switch from unauthorized to forbidden

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -1,8 +1,8 @@
 package bio.terra.workspace.service.iam;
 
 import bio.terra.cloudres.google.iam.ServiceAccountName;
+import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.InternalServerErrorException;
-import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.sam.SamRetry;
 import bio.terra.common.sam.exception.SamExceptionFactory;
 import bio.terra.workspace.app.configuration.external.SamConfiguration;
@@ -335,7 +335,7 @@ public class SamService {
     boolean isAuthorized = isAuthorized(userRequest, resourceType, resourceId, action);
     final String userEmail = getUserEmailFromSam(userRequest);
     if (!isAuthorized)
-      throw new UnauthorizedException(
+      throw new ForbiddenException(
           String.format(
               "User %s is not authorized to %s resource %s of type %s",
               userEmail, action, resourceId, resourceType));

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
@@ -66,7 +66,7 @@ public class ControlledResourceMetadataManager {
    *
    * <p>Throws InvalidControlledResourceException if the given resource is not controlled.
    *
-   * <p>Throws UnauthorizedException if the user is not permitted to perform the specified action on
+   * <p>Throws ForbiddenException if the user is not permitted to perform the specified action on
    * the resource in question.
    *
    * @param userRequest the user's authenticated request

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -91,8 +91,8 @@ public class WorkspaceService {
    * <p>Throws WorkspaceNotFoundException from getWorkspace if the workspace does not exist,
    * regardless of the user's permission.
    *
-   * <p>Throws SamUnauthorizedException if the user is not permitted to perform the specified action
-   * on the workspace in question.
+   * <p>Throws ForbiddenException if the user is not permitted to perform the specified action on
+   * the workspace in question.
    *
    * <p>Returns the Workspace object if it exists and the user is permitted to perform the specified
    * action.

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
-import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.sam.exception.SamBadRequestException;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
@@ -79,7 +79,7 @@ class SamServiceTest extends BaseConnectedTest {
   void addedReaderCanRead() throws Exception {
     // Before being granted permission, secondary user should be rejected.
     assertThrows(
-        UnauthorizedException.class,
+        ForbiddenException.class,
         () -> workspaceService.getWorkspace(workspaceId, secondaryUserRequest()));
     // After being granted permission, secondary user can read the workspace.
     samService.grantWorkspaceRole(
@@ -95,7 +95,7 @@ class SamServiceTest extends BaseConnectedTest {
 
     // Before being granted permission, secondary user should be rejected.
     assertThrows(
-        UnauthorizedException.class,
+        ForbiddenException.class,
         () ->
             referenceResourceService.createReferenceResource(
                 referenceResource, secondaryUserRequest()));
@@ -114,7 +114,7 @@ class SamServiceTest extends BaseConnectedTest {
   void removedReaderCannotRead() throws Exception {
     // Before being granted permission, secondary user should be rejected.
     assertThrows(
-        UnauthorizedException.class,
+        ForbiddenException.class,
         () -> workspaceService.getWorkspace(workspaceId, secondaryUserRequest()));
     // After being granted permission, secondary user can read the workspace.
     samService.grantWorkspaceRole(
@@ -125,7 +125,7 @@ class SamServiceTest extends BaseConnectedTest {
     samService.removeWorkspaceRole(
         workspaceId, defaultUserRequest(), WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
     assertThrows(
-        UnauthorizedException.class,
+        ForbiddenException.class,
         () -> workspaceService.getWorkspace(workspaceId, secondaryUserRequest()));
   }
 
@@ -134,7 +134,7 @@ class SamServiceTest extends BaseConnectedTest {
     // Note that this request uses the secondary user's authentication token, when only the first
     // user is an owner.
     assertThrows(
-        UnauthorizedException.class,
+        ForbiddenException.class,
         () ->
             samService.grantWorkspaceRole(
                 workspaceId,
@@ -213,7 +213,7 @@ class SamServiceTest extends BaseConnectedTest {
     samService.grantWorkspaceRole(
         workspaceId, defaultUserRequest(), WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
     assertThrows(
-        UnauthorizedException.class,
+        ForbiddenException.class,
         () -> samService.listRoleBindings(workspaceId, secondaryUserRequest()));
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -9,8 +9,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 
 import bio.terra.common.exception.ErrorReportException;
+import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.MissingRequiredFieldException;
-import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.sam.exception.SamExceptionFactory;
 import bio.terra.common.sam.exception.SamInternalServerErrorException;
 import bio.terra.stairway.FlightDebugInfo;
@@ -119,7 +119,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void testGetForbiddenMissingWorkspace() throws Exception {
-    doThrow(new UnauthorizedException("forbid!"))
+    doThrow(new ForbiddenException("forbid!"))
         .when(mockSamService)
         .checkAuthz(any(), any(), any(), any());
     assertThrows(
@@ -132,11 +132,11 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
 
-    doThrow(new UnauthorizedException("forbid!"))
+    doThrow(new ForbiddenException("forbid!"))
         .when(mockSamService)
         .checkAuthz(any(), any(), any(), any());
     assertThrows(
-        UnauthorizedException.class,
+        ForbiddenException.class,
         () -> workspaceService.getWorkspace(request.getWorkspaceId(), USER_REQUEST));
   }
 
@@ -347,7 +347,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void deleteForbiddenMissingWorkspace() throws Exception {
-    doThrow(new UnauthorizedException("forbid!"))
+    doThrow(new ForbiddenException("forbid!"))
         .when(mockSamService)
         .checkAuthz(any(), any(), any(), any());
 
@@ -361,12 +361,12 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
 
-    doThrow(new UnauthorizedException("forbid!"))
+    doThrow(new ForbiddenException("forbid!"))
         .when(mockSamService)
         .checkAuthz(any(), any(), any(), any());
 
     assertThrows(
-        UnauthorizedException.class,
+        ForbiddenException.class,
         () -> workspaceService.deleteWorkspace(request.getWorkspaceId(), USER_REQUEST));
   }
 


### PR DESCRIPTION
Remove the incorrect use of `UnauthorizedException`. Change it to `ForbiddenException`.
The only throw was in SamService. Other changes are in tests that validate the error thrown.
