### PR TITLE
[PF-1149] Add errorOnUnknownEnum flag to swagger

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -129,6 +129,7 @@ swaggerSources {
                 "--api-package", "${artifactGroup}.generated.controller",
                 "--model-package", "${artifactGroup}.generated.model",
                 "--model-name-prefix", "Api",
+                "--additional-properties", "errorOnUnknownEnum=true",
                 "-D", "interfaceOnly=true," +
                       "useTags=true," +
                       "dateLibrary=java8"


### PR DESCRIPTION
This change means WSM will reject requests with invalid enum values with 400 status codes instead of accepting the invalid values and silently coercing them to `null`.