### PR TITLE
PF-1201: Generate sensible resrouce id when it is not specified for Controlled resources

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneBigQueryDataset.java
+++ b/integration/src/main/java/scripts/testscripts/CloneBigQueryDataset.java
@@ -70,10 +70,10 @@ public class CloneBigQueryDataset extends WorkspaceAllocateTestScriptBase {
 
     // Construct the source dataset
     nameSuffix = UUID.randomUUID().toString();
-    final String sourceResourceName = (RESOURCE_PREFIX + nameSuffix).replace('-', '_');
+    final String datasetResourceName = (RESOURCE_PREFIX + nameSuffix).replace('-', '_');
     sourceDataset =
         makeControlledBigQueryDatasetUserShared(
-            sourceOwnerResourceApi, getWorkspaceId(), sourceResourceName, null);
+            sourceOwnerResourceApi, getWorkspaceId(), datasetResourceName, null, null);
 
     ResourceModifier.populateBigQueryDataset(sourceDataset, sourceOwnerUser, sourceProjectId);
 
@@ -185,6 +185,8 @@ public class CloneBigQueryDataset extends WorkspaceAllocateTestScriptBase {
     assertEquals(
         sourceDataset.getAttributes().getDatasetId(),
         clonedResource.getAttributes().getDatasetId());
+    assertEquals(
+        sourceDataset.getMetadata().getName(), sourceDataset.getAttributes().getDatasetId());
 
     // compare dataset contents
     final BigQuery bigQueryClient =

--- a/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
+++ b/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
@@ -102,6 +102,7 @@ public class CloneGcsBucket extends WorkspaceAllocateTestScriptBase {
             sourceResourceName,
             CloningInstructionsEnum.NOTHING);
     sourceBucketName = sourceBucket.getGcpBucket().getAttributes().getBucketName();
+    assertNotNull(sourceBucketName);
 
     // Make the cloning user a reader on the existing workspace
     sourceOwnerWorkspaceApi.grantRole(

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -72,10 +72,10 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
   private GcpBigQueryDatasetResource privateDataset;
   private GcpGcsBucketResource sourceBucketReference;
   private GcpGcsObjectResource sourceBucketFileReference;
-  private String copyDefinitionDatasetName;
-  private String copyResourceDatasetName;
+  private String copyDefinitionDatasetResourceName;
+  private String copyResourceDatasetResourceName;
   private String nameSuffix;
-  private String privateDatasetName;
+  private String privateDatasetResourceName;
   private String sharedBucketSourceResourceName;
   private String sourceProjectId;
   private TestUserSpecification cloningUser;
@@ -157,33 +157,36 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
     ResourceModifier.addFileToBucket(copyDefinitionSourceBucket, sourceOwnerUser, sourceProjectId);
 
     // Create a BigQuery Dataset with tables and COPY_DEFINITION
-    copyDefinitionDatasetName = "copy_definition_" + nameSuffix.replace('-', '_');
+    copyDefinitionDatasetResourceName = "copy_definition_" + nameSuffix.replace('-', '_');
     copyDefinitionDataset =
         makeControlledBigQueryDatasetUserShared(
             sourceOwnerResourceApi,
             getWorkspaceId(),
-            copyDefinitionDatasetName,
+            copyDefinitionDatasetResourceName,
+            null,
             CloningInstructionsEnum.DEFINITION);
     ResourceModifier.populateBigQueryDataset(
         copyDefinitionDataset, sourceOwnerUser, sourceProjectId);
 
     // Create a BigQuery dataset with tables and COPY_RESOURCE
-    copyResourceDatasetName = "copy_resource_dataset";
+    copyResourceDatasetResourceName = "copy_resource_dataset";
     copyResourceDataset =
         makeControlledBigQueryDatasetUserShared(
             sourceOwnerResourceApi,
             getWorkspaceId(),
-            copyResourceDatasetName,
+            copyResourceDatasetResourceName,
+            null,
             CloningInstructionsEnum.RESOURCE);
     ResourceModifier.populateBigQueryDataset(copyResourceDataset, sourceOwnerUser, sourceProjectId);
 
     // Create a private BQ dataset
-    privateDatasetName = "private_dataset";
+    privateDatasetResourceName = "private_dataset";
     privateDataset =
         makeControlledBigQueryDatasetUserPrivate(
             sourceOwnerResourceApi,
             getWorkspaceId(),
-            privateDatasetName,
+            privateDatasetResourceName,
+            null,
             CloningInstructionsEnum.RESOURCE);
 
     // Create reference to GCS bucket with COPY_REFERENCE
@@ -379,7 +382,8 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
 
     final BigQuery bigQueryClient =
         ClientTestUtils.getGcpBigQueryClient(cloningUser, destinationProjectId);
-    assertDatasetHasNoTables(destinationProjectId, bigQueryClient, copyDefinitionDatasetName);
+    assertDatasetHasNoTables(
+        destinationProjectId, bigQueryClient, copyDefinitionDatasetResourceName);
 
     // verify clone resource dataset succeeded and has rows and tables
     final ResourceCloneDetails copyResourceDatasetDetails =
@@ -405,7 +409,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
                 "SELECT * FROM `"
                     + destinationProjectId
                     + "."
-                    + copyResourceDatasetName
+                    + copyResourceDatasetResourceName
                     + ".employee`;")
             .build();
     final TableResult employeeTableResult = bigQueryClient.query(employeeQueryJobConfiguration);

--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
@@ -118,6 +118,7 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
             CloningInstructionsEnum.NOTHING,
             null);
     bucketName = createdBucket.getGcpBucket().getAttributes().getBucketName();
+    assertNotNull(bucketName);
     logger.info("Created no-assigned-user bucket {}", bucketName);
 
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {
@@ -144,6 +145,7 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
             CloningInstructionsEnum.NOTHING,
             privateUser);
     bucketName = createdBucket.getGcpBucket().getAttributes().getBucketName();
+    assertNotNull(bucketName);
     logger.info("Created assigned-reader bucket {}", bucketName);
 
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {
@@ -170,6 +172,7 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
             CloningInstructionsEnum.NOTHING,
             privateUser);
     bucketName = createdBucket.getGcpBucket().getAttributes().getBucketName();
+    assertNotNull(bucketName);
     logger.info("Created assigned-writer bucket {}", bucketName);
 
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {

--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationSharedGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationSharedGcsBucketLifecycle.java
@@ -117,6 +117,7 @@ public class ControlledApplicationSharedGcsBucketLifecycle extends WorkspaceAllo
             bucketResourceName,
             CloningInstructionsEnum.NOTHING);
     bucketName = createdBucket.getGcpBucket().getAttributes().getBucketName();
+    assertNotNull(bucketName);
     logger.info("Created bucket {}", bucketName);
 
     // Try to disable; should error because you cannot disable an app if it owns resources

--- a/integration/src/main/java/scripts/testscripts/DeleteGcpContextWithControlledResource.java
+++ b/integration/src/main/java/scripts/testscripts/DeleteGcpContextWithControlledResource.java
@@ -23,7 +23,7 @@ public class DeleteGcpContextWithControlledResource extends WorkspaceAllocateTes
   private static final Logger logger =
       LoggerFactory.getLogger(DeleteGcpContextWithControlledResource.class);
 
-  private static final String DATASET_NAME = "wsmtest_dataset";
+  private static final String DATASET_RESOURCE_NAME = "wsmtest_dataset";
 
   @Override
   protected void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
@@ -40,7 +40,7 @@ public class DeleteGcpContextWithControlledResource extends WorkspaceAllocateTes
     // Create a controlled BigQuery dataset
     GcpBigQueryDatasetResource controlledDataset =
         ResourceMaker.makeControlledBigQueryDatasetUserShared(
-            controlledResourceApi, getWorkspaceId(), DATASET_NAME, null);
+            controlledResourceApi, getWorkspaceId(), DATASET_RESOURCE_NAME, null, null);
     UUID controlledResourceId = controlledDataset.getMetadata().getResourceId();
     logger.info("Created controlled dataset {}", controlledResourceId);
 

--- a/integration/src/main/java/scripts/testscripts/DeleteWorkspaceWithControlledResource.java
+++ b/integration/src/main/java/scripts/testscripts/DeleteWorkspaceWithControlledResource.java
@@ -22,7 +22,7 @@ public class DeleteWorkspaceWithControlledResource extends WorkspaceAllocateTest
   private static final Logger logger =
       LoggerFactory.getLogger(DeleteGcpContextWithControlledResource.class);
 
-  private static final String DATASET_NAME = "wsmtest_dataset";
+  private static final String DATASET_RESOURCE_NAME = "wsmtest_dataset";
 
   @Override
   protected void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
@@ -37,7 +37,7 @@ public class DeleteWorkspaceWithControlledResource extends WorkspaceAllocateTest
     // Create a shared BigQuery dataset
     GcpBigQueryDatasetResource createdDataset =
         ResourceMaker.makeControlledBigQueryDatasetUserShared(
-            resourceApi, getWorkspaceId(), DATASET_NAME, null);
+            resourceApi, getWorkspaceId(), DATASET_RESOURCE_NAME, null, null);
     UUID resourceId = createdDataset.getMetadata().getResourceId();
     logger.info("Created controlled dataset {}", resourceId);
 

--- a/integration/src/main/java/scripts/testscripts/EnumerateResources.java
+++ b/integration/src/main/java/scripts/testscripts/EnumerateResources.java
@@ -353,7 +353,11 @@ public class EnumerateResources extends DataRepoTestScriptBase {
           {
             GcpBigQueryDatasetResource resource =
                 ResourceMaker.makeControlledBigQueryDatasetUserShared(
-                    controlledGcpResourceApi, workspaceId, name, CloningInstructionsEnum.NOTHING);
+                    controlledGcpResourceApi,
+                    workspaceId,
+                    name,
+                    null,
+                    CloningInstructionsEnum.NOTHING);
             resourceList.add(resource.getMetadata());
             break;
           }

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -2,6 +2,7 @@ package scripts.testscripts;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -155,10 +156,12 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             privateUserResourceApi,
             getWorkspaceId(),
             RESOURCE_PREFIX + UUID.randomUUID().toString(),
+            /*bucketName=*/ null,
             AccessScope.PRIVATE_ACCESS,
             ManagedBy.USER,
             CloningInstructionsEnum.NOTHING,
             privateUserFull);
+    assertNotNull(userFullBucket.getGcpBucket().getAttributes().getBucketName());
     deleteBucket(workspaceOwnerResourceApi, userFullBucket.getResourceId());
 
     // Supply just the roles, but no email
@@ -170,12 +173,30 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             privateUserResourceApi,
             getWorkspaceId(),
             RESOURCE_PREFIX + UUID.randomUUID().toString(),
+            /*bucketName=*/ null,
             AccessScope.PRIVATE_ACCESS,
             ManagedBy.USER,
             CloningInstructionsEnum.NOTHING,
             privateUserNoEmail);
-
+    assertNotNull(userNoEmailBucket.getGcpBucket().getAttributes().getBucketName());
     deleteBucket(workspaceOwnerResourceApi, userNoEmailBucket.getResourceId());
+
+    String uniqueBucketName =
+        String.format("terra_%s_bucket", UUID.randomUUID().toString().replace("-", "_"));
+    CreatedControlledGcpGcsBucket bucketWithBucketNameSpecified =
+        ResourceMaker.makeControlledGcsBucket(
+            privateUserResourceApi,
+            getWorkspaceId(),
+            RESOURCE_PREFIX + UUID.randomUUID().toString(),
+            /*bucketName=*/ uniqueBucketName,
+            AccessScope.PRIVATE_ACCESS,
+            ManagedBy.USER,
+            CloningInstructionsEnum.NOTHING,
+            privateUserFull);
+    assertEquals(
+        uniqueBucketName,
+        bucketWithBucketNameSpecified.getGcpBucket().getAttributes().getBucketName());
+    deleteBucket(workspaceOwnerResourceApi, bucketWithBucketNameSpecified.getResourceId());
   }
 
   private CreatedControlledGcpGcsBucket createPrivateBucket(ControlledGcpResourceApi resourceApi)

--- a/integration/src/main/java/scripts/testscripts/RemoveUser.java
+++ b/integration/src/main/java/scripts/testscripts/RemoveUser.java
@@ -93,16 +93,20 @@ public class RemoveUser extends WorkspaceAllocateTestScriptBase {
     ResourceModifier.addFileToBucket(privateBucket, privateResourceUser, projectId);
 
     // Create a private BQ dataset for privateResourceUser and populate it.
-    String datasetId = RandomStringUtils.randomAlphabetic(8).toLowerCase();
+    String datasetResourceName = RandomStringUtils.randomAlphabetic(8).toLowerCase();
     privateDataset =
         ResourceMaker.makeControlledBigQueryDatasetUserPrivate(
-            privateUserResourceApi, getWorkspaceId(), datasetId, CloningInstructionsEnum.NOTHING);
+            privateUserResourceApi,
+            getWorkspaceId(),
+            datasetResourceName,
+            null,
+            CloningInstructionsEnum.NOTHING);
     ResourceModifier.populateBigQueryDataset(privateDataset, privateResourceUser, projectId);
     // Create a private notebook for privateResourceUser.
     String notebookInstanceId = RandomStringUtils.randomAlphabetic(8).toLowerCase();
     privateNotebook =
         ResourceMaker.makeControlledNotebookUserPrivate(
-            getWorkspaceId(), notebookInstanceId, privateResourceUser, privateUserResourceApi);
+            getWorkspaceId(), notebookInstanceId, privateUserResourceApi);
   }
 
   @Override

--- a/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
@@ -1,5 +1,5 @@
 {
-  "name": "ControlledApplicationLifecycle",
+  "name": "ControlledApplicationSharedGcsBucketLifecycle",
   "description": "Controlled application resource tests.",
   "serverSpecificationFile": "workspace-local.json",
   "kubernetes": {},

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -40,7 +40,6 @@ import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.JobService.AsyncJobResult;
-import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.controlled.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.ControlledAiNotebookInstanceResource;
@@ -345,7 +344,10 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
             .accessScope(AccessScopeType.fromApi(body.getCommon().getAccessScope()))
             .managedBy(managedBy)
             .applicationId(controlledResourceService.getAssociatedApp(managedBy, userRequest))
-            .datasetName(body.getDataset().getDatasetId() == null? body.getCommon().getName():body.getDataset().getDatasetId())
+            .datasetName(
+                body.getDataset().getDatasetId() == null
+                    ? body.getCommon().getName()
+                    : body.getDataset().getDatasetId())
             .build();
 
     final ControlledBigQueryDatasetResource createdDataset =

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -53,6 +53,7 @@ import bio.terra.workspace.service.resource.controlled.exception.InvalidControll
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -345,9 +346,8 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
             .managedBy(managedBy)
             .applicationId(controlledResourceService.getAssociatedApp(managedBy, userRequest))
             .datasetName(
-                body.getDataset().getDatasetId() == null
-                    ? body.getCommon().getName()
-                    : body.getDataset().getDatasetId())
+                Optional.ofNullable(body.getDataset().getDatasetId())
+                    .orElse(body.getCommon().getName()))
             .build();
 
     final ControlledBigQueryDatasetResource createdDataset =
@@ -396,7 +396,9 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
             .managedBy(managedBy)
             .applicationId(controlledResourceService.getAssociatedApp(managedBy, userRequest))
             .location(body.getAiNotebookInstance().getLocation())
-            .instanceId(body.getAiNotebookInstance().getInstanceId())
+            .instanceId(
+                Optional.ofNullable(body.getAiNotebookInstance().getInstanceId())
+                    .orElse(body.getCommon().getName()))
             .build();
 
     String jobId =

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -345,7 +345,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
             .accessScope(AccessScopeType.fromApi(body.getCommon().getAccessScope()))
             .managedBy(managedBy)
             .applicationId(controlledResourceService.getAssociatedApp(managedBy, userRequest))
-            .datasetName(body.getDataset().getDatasetId())
+            .datasetName(body.getDataset().getDatasetId() == null? body.getCommon().getName():body.getDataset().getDatasetId())
             .build();
 
     final ControlledBigQueryDatasetResource createdDataset =
@@ -376,7 +376,6 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
       UUID workspaceId, @Valid ApiCreateControlledGcpAiNotebookInstanceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
 
-    ValidationUtils.validate(body.getAiNotebookInstance());
     PrivateUserRole privateUserRole =
         computePrivateUserRole(workspaceId, body.getCommon(), userRequest);
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResource.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.RandomStringUtils;
 
 /** A {@link ControlledResource} for a Google AI Platform Notebook instance. */
 public class ControlledAiNotebookInstanceResource extends ControlledResource {
@@ -148,8 +147,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
   }
 
   public static String generateUniqueInstanceId() {
-    return String.format("terra-%s-notebook",
-        UUID.randomUUID());
+    return String.format("terra-%s-notebook", UUID.randomUUID());
   }
 
   /** Builder for {@link ControlledAiNotebookInstanceResource}. */
@@ -192,7 +190,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
     }
 
     public Builder instanceId(@Nullable String instanceId) {
-      this.instanceId = instanceId == null? generateUniqueInstanceId():instanceId;
+      this.instanceId = instanceId == null ? generateUniqueInstanceId() : instanceId;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResource.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.RandomStringUtils;
 
 /** A {@link ControlledResource} for a Google AI Platform Notebook instance. */
 public class ControlledAiNotebookInstanceResource extends ControlledResource {
@@ -146,6 +147,11 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
     return result;
   }
 
+  public static String generateUniqueInstanceId() {
+    return String.format("terra-%s-notebook",
+        UUID.randomUUID());
+  }
+
   /** Builder for {@link ControlledAiNotebookInstanceResource}. */
   public static class Builder {
     private UUID workspaceId;
@@ -185,8 +191,8 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
       return this;
     }
 
-    public Builder instanceId(String instanceId) {
-      this.instanceId = instanceId;
+    public Builder instanceId(@Nullable String instanceId) {
+      this.instanceId = instanceId == null? generateUniqueInstanceId():instanceId;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResource.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
@@ -189,8 +190,16 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
       return this;
     }
 
-    public Builder instanceId(@Nullable String instanceId) {
-      this.instanceId = instanceId == null ? generateUniqueInstanceId() : instanceId;
+    public Builder instanceId(String instanceId) {
+      try {
+        // If the user doesn't specify a instance id, we will use the resource name by default.
+        // But if the resource name is not a valid instance id, we will need to generate a unique
+        // one.
+        ValidationUtils.validateAiNotebookInstanceId(instanceId);
+        this.instanceId = instanceId;
+      } catch (InvalidReferenceException e) {
+        this.instanceId = generateUniqueInstanceId();
+      }
       return this;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
@@ -109,6 +110,10 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
     return Objects.hash(super.hashCode(), datasetName);
   }
 
+  private static String generateUniqueDatasetId() {
+    return "terra_" + UUID.randomUUID() + "_dataset".replace("-", "_");
+  }
+
   public static class Builder {
     private UUID workspaceId;
     private UUID resourceId;
@@ -148,7 +153,15 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
     }
 
     public ControlledBigQueryDatasetResource.Builder datasetName(String datasetName) {
-      this.datasetName = datasetName;
+      try {
+        // If the user doesn't specify a dataset name, we will use the resource name by default.
+        // But if the resource name is not a valid dataset name, we will need to generate a unique
+        // dataset id.
+        ValidationUtils.validateBqDatasetName(datasetName);
+        this.datasetName = datasetName;
+      } catch (InvalidReferenceException e) {
+        this.datasetName = generateUniqueDatasetId();
+      }
       return this;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketAttributes.java
@@ -2,16 +2,17 @@ package bio.terra.workspace.service.resource.controlled;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 
 public class ControlledGcsBucketAttributes {
-  private final String bucketName;
+  private final @Nullable String bucketName;
 
   @JsonCreator
-  public ControlledGcsBucketAttributes(@JsonProperty("bucketName") String bucketName) {
+  public ControlledGcsBucketAttributes(@JsonProperty("bucketName") @Nullable String bucketName) {
     this.bucketName = bucketName;
   }
 
-  public String getBucketName() {
+  public @Nullable String getBucketName() {
     return bucketName;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketResource.java
@@ -12,8 +12,11 @@ import bio.terra.workspace.service.resource.model.CloningInstructions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.RandomStringUtils;
 
 public class ControlledGcsBucketResource extends ControlledResource {
+
   private final String bucketName;
 
   @JsonCreator
@@ -93,9 +96,15 @@ public class ControlledGcsBucketResource extends ControlledResource {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
 
     ControlledGcsBucketResource that = (ControlledGcsBucketResource) o;
 
@@ -109,7 +118,13 @@ public class ControlledGcsBucketResource extends ControlledResource {
     return result;
   }
 
+  private static String generateBucketName() {
+    return String.format("terra_%s_bucket",
+        UUID.randomUUID()).replace("-", "_");
+  }
+
   public static class Builder {
+
     private UUID workspaceId;
     private UUID resourceId;
     private String name;
@@ -147,8 +162,8 @@ public class ControlledGcsBucketResource extends ControlledResource {
       return this;
     }
 
-    public ControlledGcsBucketResource.Builder bucketName(String bucketName) {
-      this.bucketName = bucketName;
+    public ControlledGcsBucketResource.Builder bucketName(@Nullable String bucketName) {
+      this.bucketName = bucketName == null? generateBucketName():bucketName;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketResource.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.service.resource.WsmResourceType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
@@ -161,7 +162,7 @@ public class ControlledGcsBucketResource extends ControlledResource {
     }
 
     public ControlledGcsBucketResource.Builder bucketName(@Nullable String bucketName) {
-      this.bucketName = bucketName == null ? generateBucketName() : bucketName;
+      this.bucketName = Optional.ofNullable(bucketName).orElse(generateBucketName());
       return this;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketResource.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.RandomStringUtils;
 
 public class ControlledGcsBucketResource extends ControlledResource {
 
@@ -119,8 +118,7 @@ public class ControlledGcsBucketResource extends ControlledResource {
   }
 
   private static String generateBucketName() {
-    return String.format("terra_%s_bucket",
-        UUID.randomUUID()).replace("-", "_");
+    return String.format("terra_%s_bucket", UUID.randomUUID()).replace("-", "_");
   }
 
   public static class Builder {
@@ -163,7 +161,7 @@ public class ControlledGcsBucketResource extends ControlledResource {
     }
 
     public ControlledGcsBucketResource.Builder bucketName(@Nullable String bucketName) {
-      this.bucketName = bucketName == null? generateBucketName():bucketName;
+      this.bucketName = bucketName == null ? generateBucketName() : bucketName;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -42,9 +42,7 @@ import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-/**
- * CRUD methods for controlled objects.
- */
+/** CRUD methods for controlled objects. */
 @Component
 public class ControlledResourceService {
 
@@ -79,9 +77,7 @@ public class ControlledResourceService {
     this.controlledResourceMetadataManager = controlledResourceMetadataManager;
   }
 
-  /**
-   * Starts a create controlled bucket resource, blocking until its job is finished.
-   */
+  /** Starts a create controlled bucket resource, blocking until its job is finished. */
   public ControlledGcsBucketResource createBucket(
       ControlledGcsBucketResource resource,
       ApiGcpGcsBucketCreationParameters creationParameters,
@@ -126,15 +122,15 @@ public class ControlledResourceService {
    * @param jobControl - job service control structure
    * @param userRequest - incoming request
    * @param destinationResourceName - override value for resource name. Re-uses previous name if
-   * null
+   *     null
    * @param destinationDescription - override value for resource description. Re-uses previous value
-   * if null
+   *     if null
    * @param destinationBucketName - GCS bucket name for cloned bucket. If null, a random name will
-   * be generated
+   *     be generated
    * @param destinationLocation - location string for the destination bucket. If null, the source
-   * bucket's location will be used.
+   *     bucket's location will be used.
    * @param cloningInstructionsOverride - cloning instructions for this operation. If null, the
-   * source bucket's cloning instructions will be honored.
+   *     source bucket's cloning instructions will be honored.
    * @return - Job ID of submitted flight
    */
   public String cloneGcsBucket(
@@ -199,9 +195,7 @@ public class ControlledResourceService {
     return jobBuilder.submitAndWait(ControlledBigQueryDatasetResource.class);
   }
 
-  /**
-   * Starts an update controlled BigQuery dataset resource, blocking until its job is finished.
-   */
+  /** Starts an update controlled BigQuery dataset resource, blocking until its job is finished. */
   public ControlledBigQueryDatasetResource updateBqDataset(
       ControlledBigQueryDatasetResource resource,
       @Nullable ApiGcpBigQueryDatasetUpdateParameters updateParameters,
@@ -236,12 +230,12 @@ public class ControlledResourceService {
    * @param userRequest - request object for this call
    * @param destinationResourceName - resource name. Uses source name if null
    * @param destinationDescription - description string for cloned dataset. Source description if
-   * null.
+   *     null.
    * @param destinationDatasetName - name for new resource. Can equal source name. If null, a random
-   * name will be generated
+   *     name will be generated
    * @param destinationLocation - location override. Uses source location if null
    * @param cloningInstructionsOverride - Cloning instructions for this clone operation, overriding
-   * any existing instructions. Existing instructions are used if null.
+   *     any existing instructions. Existing instructions are used if null.
    */
   public String cloneBigQueryDataset(
       UUID sourceWorkspaceId,
@@ -289,9 +283,7 @@ public class ControlledResourceService {
     return jobBuilder.submit();
   }
 
-  /**
-   * Starts a create controlled AI Notebook instance resource job, returning the job id.
-   */
+  /** Starts a create controlled AI Notebook instance resource job, returning the job id. */
   public String createAiNotebookInstance(
       ControlledAiNotebookInstanceResource resource,
       ApiGcpAiNotebookInstanceCreationParameters creationParameters,
@@ -321,9 +313,7 @@ public class ControlledResourceService {
     return jobBuilder.submit();
   }
 
-  /**
-   * Simpler interface for synchronous controlled resource creation
-   */
+  /** Simpler interface for synchronous controlled resource creation */
   private JobBuilder commonCreationJobBuilder(
       ControlledResource resource,
       ControlledResourceIamRole privateResourceIamRole,
@@ -331,9 +321,7 @@ public class ControlledResourceService {
     return commonCreationJobBuilder(resource, privateResourceIamRole, null, null, userRequest);
   }
 
-  /**
-   * Create a JobBuilder for creating controlled resources with the common parameters populated.
-   */
+  /** Create a JobBuilder for creating controlled resources with the common parameters populated. */
   private JobBuilder commonCreationJobBuilder(
       ControlledResource resource,
       @Nullable ControlledResourceIamRole privateResourceIamRole,
@@ -381,8 +369,7 @@ public class ControlledResourceService {
    * @param userRequest the user request
    * @return null if not an application managed resource; application UUID otherwise
    */
-  public @Nullable
-  UUID getAssociatedApp(
+  public @Nullable UUID getAssociatedApp(
       ManagedByType managedBy, AuthenticatedUserRequest userRequest) {
     if (managedBy != ManagedByType.MANAGED_BY_APPLICATION) {
       return null;
@@ -404,9 +391,7 @@ public class ControlledResourceService {
     return resourceDao.getResource(workspaceId, resourceId).castToControlledResource();
   }
 
-  /**
-   * Synchronously delete a controlled resource.
-   */
+  /** Synchronously delete a controlled resource. */
   public void deleteControlledResourceSync(
       UUID workspaceId, UUID resourceId, AuthenticatedUserRequest userRequest) {
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -42,7 +42,9 @@ import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-/** CRUD methods for controlled objects. */
+/**
+ * CRUD methods for controlled objects.
+ */
 @Component
 public class ControlledResourceService {
 
@@ -77,7 +79,9 @@ public class ControlledResourceService {
     this.controlledResourceMetadataManager = controlledResourceMetadataManager;
   }
 
-  /** Starts a create controlled bucket resource, blocking until its job is finished. */
+  /**
+   * Starts a create controlled bucket resource, blocking until its job is finished.
+   */
   public ControlledGcsBucketResource createBucket(
       ControlledGcsBucketResource resource,
       ApiGcpGcsBucketCreationParameters creationParameters,
@@ -122,15 +126,15 @@ public class ControlledResourceService {
    * @param jobControl - job service control structure
    * @param userRequest - incoming request
    * @param destinationResourceName - override value for resource name. Re-uses previous name if
-   *     null
+   * null
    * @param destinationDescription - override value for resource description. Re-uses previous value
-   *     if null
+   * if null
    * @param destinationBucketName - GCS bucket name for cloned bucket. If null, a random name will
-   *     be generated
+   * be generated
    * @param destinationLocation - location string for the destination bucket. If null, the source
-   *     bucket's location will be used.
+   * bucket's location will be used.
    * @param cloningInstructionsOverride - cloning instructions for this operation. If null, the
-   *     source bucket's cloning instructions will be honored.
+   * source bucket's cloning instructions will be honored.
    * @return - Job ID of submitted flight
    */
   public String cloneGcsBucket(
@@ -180,7 +184,10 @@ public class ControlledResourceService {
     return jobBuilder.submit();
   }
 
-  /** Starts a create controlled BigQuery dataset resource, blocking until its job is finished. */
+  /**
+   * Starts a job to create controlled BigQuery dataset resource, blocking until its job is
+   * finished.
+   */
   public ControlledBigQueryDatasetResource createBigQueryDataset(
       ControlledBigQueryDatasetResource resource,
       ApiGcpBigQueryDatasetCreationParameters creationParameters,
@@ -192,7 +199,9 @@ public class ControlledResourceService {
     return jobBuilder.submitAndWait(ControlledBigQueryDatasetResource.class);
   }
 
-  /** Starts an update controlled BigQuery dataset resource, blocking until its job is finished. */
+  /**
+   * Starts an update controlled BigQuery dataset resource, blocking until its job is finished.
+   */
   public ControlledBigQueryDatasetResource updateBqDataset(
       ControlledBigQueryDatasetResource resource,
       @Nullable ApiGcpBigQueryDatasetUpdateParameters updateParameters,
@@ -227,12 +236,12 @@ public class ControlledResourceService {
    * @param userRequest - request object for this call
    * @param destinationResourceName - resource name. Uses source name if null
    * @param destinationDescription - description string for cloned dataset. Source description if
-   *     null.
+   * null.
    * @param destinationDatasetName - name for new resource. Can equal source name. If null, a random
-   *     name will be generated
+   * name will be generated
    * @param destinationLocation - location override. Uses source location if null
    * @param cloningInstructionsOverride - Cloning instructions for this clone operation, overriding
-   *     any existing instructions. Existing instructions are used if null.
+   * any existing instructions. Existing instructions are used if null.
    */
   public String cloneBigQueryDataset(
       UUID sourceWorkspaceId,
@@ -280,7 +289,9 @@ public class ControlledResourceService {
     return jobBuilder.submit();
   }
 
-  /** Starts a create controlled AI Notebook instance resource job, returning the job id. */
+  /**
+   * Starts a create controlled AI Notebook instance resource job, returning the job id.
+   */
   public String createAiNotebookInstance(
       ControlledAiNotebookInstanceResource resource,
       ApiGcpAiNotebookInstanceCreationParameters creationParameters,
@@ -310,7 +321,9 @@ public class ControlledResourceService {
     return jobBuilder.submit();
   }
 
-  /** Simpler interface for synchronous controlled resource creation */
+  /**
+   * Simpler interface for synchronous controlled resource creation
+   */
   private JobBuilder commonCreationJobBuilder(
       ControlledResource resource,
       ControlledResourceIamRole privateResourceIamRole,
@@ -318,7 +331,9 @@ public class ControlledResourceService {
     return commonCreationJobBuilder(resource, privateResourceIamRole, null, null, userRequest);
   }
 
-  /** Create a JobBuilder for creating controlled resources with the common parameters populated. */
+  /**
+   * Create a JobBuilder for creating controlled resources with the common parameters populated.
+   */
   private JobBuilder commonCreationJobBuilder(
       ControlledResource resource,
       @Nullable ControlledResourceIamRole privateResourceIamRole,
@@ -366,7 +381,8 @@ public class ControlledResourceService {
    * @param userRequest the user request
    * @return null if not an application managed resource; application UUID otherwise
    */
-  public @Nullable UUID getAssociatedApp(
+  public @Nullable
+  UUID getAssociatedApp(
       ManagedByType managedBy, AuthenticatedUserRequest userRequest) {
     if (managedBy != ManagedByType.MANAGED_BY_APPLICATION) {
       return null;
@@ -388,7 +404,9 @@ public class ControlledResourceService {
     return resourceDao.getResource(workspaceId, resourceId).castToControlledResource();
   }
 
-  /** Synchronously delete a controlled resource. */
+  /**
+   * Synchronously delete a controlled resource.
+   */
   public void deleteControlledResourceSync(
       UUID workspaceId, UUID resourceId, AuthenticatedUserRequest userRequest) {
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
@@ -70,7 +70,11 @@ public class CreateBigQueryDatasetStep implements Step {
     String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     List<Access> accessConfiguration = buildDatasetAccessConfiguration(projectId);
     DatasetReference datasetId =
-        new DatasetReference().setProjectId(projectId).setDatasetId(resource.getDatasetName());
+        new DatasetReference().setProjectId(projectId)
+            .setDatasetId(
+                resource.getDatasetName() == null?
+                    resource.getName() : resource.getDatasetName()
+            );
     Dataset datasetToCreate =
         new Dataset()
             .setDatasetReference(datasetId)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
@@ -70,11 +70,10 @@ public class CreateBigQueryDatasetStep implements Step {
     String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
     List<Access> accessConfiguration = buildDatasetAccessConfiguration(projectId);
     DatasetReference datasetId =
-        new DatasetReference().setProjectId(projectId)
+        new DatasetReference()
+            .setProjectId(projectId)
             .setDatasetId(
-                resource.getDatasetName() == null?
-                    resource.getName() : resource.getDatasetName()
-            );
+                resource.getDatasetName() == null ? resource.getName() : resource.getDatasetName());
     Dataset datasetToCreate =
         new Dataset()
             .setDatasetReference(datasetId)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Optional;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,7 @@ public class CreateGcsBucketStep implements Step {
     ApiGcpGcsBucketCreationParameters creationParameters =
         inputMap.get(CREATION_PARAMETERS, ApiGcpGcsBucketCreationParameters.class);
     String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
+
     BucketInfo.Builder bucketInfoBuilder =
         BucketInfo.newBuilder(resource.getBucketName())
             .setLocation(creationParameters.getLocation());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Optional;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -3266,7 +3266,7 @@ components:
     GcpBigQueryDatasetResource:
       type: object
       description: A reference to a BigQuery dataset.
-      required: [metadata, dataset]
+      required: [metadata, attributes]
       properties:
         metadata:
           description: the resource metadata common to all resources

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2431,7 +2431,7 @@ components:
           $ref: '#/components/schemas/GcpBigQueryDatasetCreationParameters'
 
     CreateControlledGcpAiNotebookInstanceRequestBody:
-      description: Payload for requesting a new controlled GCS bucket resource.
+      description: Payload for requesting a new controlled GCS Api notebook instance.
       type: object
       required: [common, aiNotebookInstance, jobControl]
       properties:
@@ -2557,7 +2557,7 @@ components:
         Bucket-specific properties to be set on creation. These are a subset of the
         values accepted by the Gcp Storage API.
       type: object
-      required: [name, location]
+      required: [location]
       properties:
         name:
           description: A valid bucket name per https://cloud.google.com/storage/docs/naming-buckets.
@@ -2847,7 +2847,7 @@ components:
         Dataset-specific properties to be set on creation. These are a subset of the
         values accepted by the BigQuery API.
       type: object
-      required: [datasetId, location]
+      required: [location]
       properties:
         datasetId:
           description: A valid dataset name per https://cloud.google.com/bigquery/docs/datasets#dataset-naming
@@ -3049,7 +3049,7 @@ components:
         AI Platform Notebook instance specific properties to be set on creation. These are a subset of the
         values accepted by the GCP AI Platforms API. See https://cloud.google.com/ai-platform/notebooks/docs/reference/rest/v1/projects.locations.instances/create
       type: object
-      required: [instanceId, location, machineType]
+      required: [location, machineType]
       properties:
         instanceId:
           description: >-

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResourceTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.resource.controlled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -10,7 +11,6 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
-import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import org.junit.jupiter.api.Test;
 
 public class ControlledAiNotebookInstanceResourceTest extends BaseUnitTest {
@@ -38,21 +38,30 @@ public class ControlledAiNotebookInstanceResourceTest extends BaseUnitTest {
   }
 
   @Test
-  public void validateInstanceIdPattern() {
-    assertThrows(
-        InvalidReferenceException.class,
-        () ->
-            ControlledResourceFixtures.makeDefaultAiNotebookInstance()
-                .instanceId("Invalid Instance Id %$^%$^")
-                .build());
+  public void
+      instanceIdIsNullAndUseResourceNameInstead_resourceNameIsInvalidInstanceId_generateAUniqueInstanceId() {
+    String resourceName = "Ai_notebook_1";
+    ControlledAiNotebookInstanceResource resource =
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance()
+            .name(resourceName)
+            .instanceId(resourceName)
+            .build();
+
+    assertNotNull(resource.getInstanceId());
+    assertNotEquals(resourceName, resource.getInstanceId());
   }
 
   @Test
-  public void instanceIdIsNull_generateAUniqueInstanceId() {
+  public void
+      instanceIdIsNullAndUseResourceNameInstead_resourceNameIsValidInstanceId_usesResourceName() {
+    String resourceName = "ai-notebook-1";
     ControlledAiNotebookInstanceResource resource =
-        ControlledResourceFixtures.makeDefaultAiNotebookInstance().instanceId(null).build();
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance()
+            .name(resourceName)
+            .instanceId(resourceName)
+            .build();
 
-    assertNotNull(resource.getInstanceId());
+    assertEquals(resourceName, resource.getInstanceId());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResourceTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.resource.controlled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.exception.BadRequestException;
@@ -21,9 +22,6 @@ public class ControlledAiNotebookInstanceResourceTest extends BaseUnitTest {
 
   @Test
   public void validateNoRequiredFieldThrows() {
-    assertThrows(
-        MissingRequiredFieldException.class,
-        () -> ControlledResourceFixtures.makeDefaultAiNotebookInstance().instanceId(null).build());
     assertThrows(
         MissingRequiredFieldException.class,
         () -> ControlledResourceFixtures.makeDefaultAiNotebookInstance().location(null).build());
@@ -47,6 +45,14 @@ public class ControlledAiNotebookInstanceResourceTest extends BaseUnitTest {
             ControlledResourceFixtures.makeDefaultAiNotebookInstance()
                 .instanceId("Invalid Instance Id %$^%$^")
                 .build());
+  }
+
+  @Test
+  public void instanceIdIsNull_generateAUniqueInstanceId() {
+    ControlledAiNotebookInstanceResource resource =
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance().instanceId(null).build();
+
+    assertNotNull(resource.getInstanceId());
   }
 
   @Test


### PR DESCRIPTION
Currently, user needs to specify both resource name and the resource-type specific name (e.g. datasetId, bucket name, etc).

Instead, we can just generate a default name if it's not specified.
To create a BQ dataset, one can say
terra resource create bq-dataset --name=foo
WSM will then create a bq-dataset of resource name foo and datasetId foo given "foo" is a valid dataset name as well. If the resource name is not a valid datasetid, we will generate a unique dataset id terra_uuid_dataset.

For create a GCS bucket, we will create a bucket of name terra_uuid_bucket

For AiNotebook, we will also reuse the resource name if it is a valid ai notebook name. Otherwise, we will generate a unique ai notebook name. 