### PR TITLE
[PF-1222] Make JobBuilder fully fluent

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/job/JobBuilder.java
+++ b/service/src/main/java/bio/terra/workspace/service/job/JobBuilder.java
@@ -1,55 +1,72 @@
 package bio.terra.workspace.service.job;
 
+import bio.terra.common.exception.MissingRequiredFieldException;
+import bio.terra.common.stairway.StairwayComponent;
+import bio.terra.common.stairway.TracingHook;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.common.utils.MdcHook;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.job.exception.InvalidJobIdException;
 import bio.terra.workspace.service.job.exception.InvalidJobParameterException;
 import io.opencensus.contrib.spring.aop.Traced;
+import org.apache.commons.lang3.StringUtils;
 
 public class JobBuilder {
-
-  private final JobService jobServiceRef;
-  private final Class<? extends Flight> flightClass;
+  private final JobService jobService;
+  private final StairwayComponent stairwayComponent;
+  private final MdcHook mdcHook;
   private final FlightMap jobParameterMap;
-  private final String jobId;
+  private Class<? extends Flight> flightClass;
+  private String jobId;
+  private String description;
+  private Object request;
+  private AuthenticatedUserRequest userRequest;
 
-  // constructor only takes required parameters
-  public JobBuilder(
-      String description,
-      String jobId,
-      Class<? extends Flight> flightClass,
-      Object request,
-      AuthenticatedUserRequest userRequest,
-      JobService jobServiceRef) {
-    this.jobServiceRef = jobServiceRef;
-    this.flightClass = flightClass;
-    this.jobId = jobId;
-
-    // initialize with required parameters
+  public JobBuilder(JobService jobService, StairwayComponent stairwayComponent, MdcHook mdcHook) {
+    this.jobService = jobService;
+    this.stairwayComponent = stairwayComponent;
+    this.mdcHook = mdcHook;
     this.jobParameterMap = new FlightMap();
-    jobParameterMap.put(JobMapKeys.DESCRIPTION.getKeyName(), description);
-    jobParameterMap.put(JobMapKeys.REQUEST.getKeyName(), request);
-    jobParameterMap.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), userRequest);
-    jobParameterMap.put(JobMapKeys.SUBJECT_ID.getKeyName(), userRequest.getSubjectId());
   }
 
-  // use addParameter method for optional parameter
-  // returns the JobBuilder object to allow method chaining
+  public JobBuilder flightClass(Class<? extends Flight> flightClass) {
+    this.flightClass = flightClass;
+    return this;
+  }
+
+  public JobBuilder jobId(String jobId) {
+    if (jobId != null) {
+      // If clients provide a non-null job ID, it cannot be whitespace-only
+      if (StringUtils.isWhitespace(jobId)) {
+        throw new InvalidJobIdException("jobId cannot be whitespace-only.");
+      }
+    }
+    this.jobId = jobId;
+    return this;
+  }
+
+  public JobBuilder description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  public JobBuilder request(Object request) {
+    this.request = request;
+    return this;
+  }
+
+  public JobBuilder userRequest(AuthenticatedUserRequest userRequest) {
+    this.userRequest = userRequest;
+    return this;
+  }
+
   public JobBuilder addParameter(String keyName, Object val) {
     if (keyName == null) {
       throw new InvalidJobParameterException("Parameter name cannot be null.");
     }
-
-    // check that keyName doesn't match one of the required parameter names
-    // i.e. disallow overwriting one of the required parameters
-    if (JobMapKeys.isRequiredKey(keyName)) {
-      throw new InvalidJobParameterException(
-          "Required parameters can only be set by the constructor. (" + keyName + ")");
-    }
-
     // note that this call overwrites a parameter if it already exists
     jobParameterMap.put(keyName, val);
-
     return this;
   }
 
@@ -59,7 +76,8 @@ public class JobBuilder {
    * @return jobID of submitted flight
    */
   public String submit() {
-    return jobServiceRef.submit(flightClass, jobParameterMap, jobId);
+    validateAndDefault();
+    return jobService.submit(flightClass, jobParameterMap, jobId);
   }
 
   /**
@@ -70,6 +88,41 @@ public class JobBuilder {
    */
   @Traced
   public <T> T submitAndWait(Class<T> resultClass) {
-    return jobServiceRef.submitAndWait(flightClass, jobParameterMap, resultClass, jobId);
+    validateAndDefault();
+    return jobService.submitAndWait(flightClass, jobParameterMap, resultClass, jobId);
+  }
+
+  // Check the inputs, supply defaults and finalize the input parameter map
+  private void validateAndDefault() {
+    if (flightClass == null) {
+      throw new MissingRequiredFieldException("Missing flight class: flightClass");
+    }
+
+    // Default to a generated job id
+    if (jobId == null) {
+      jobId = stairwayComponent.get().createFlightId();
+    }
+
+    // Always add the MDC logging and tracing span parameters for the mdc hook
+    addParameter(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext());
+    addParameter(
+        TracingHook.SUBMISSION_SPAN_CONTEXT_MAP_KEY, TracingHook.serializeCurrentTracingContext());
+
+    // Convert the any other members that were set into parameters. However, if they wer
+    // explicitly added with addParameter during construction, we do not overwrite them.
+    if (shouldInsert(JobMapKeys.DESCRIPTION, description)) {
+      addParameter(JobMapKeys.DESCRIPTION.getKeyName(), description);
+    }
+    if (shouldInsert(JobMapKeys.REQUEST, request)) {
+      addParameter(JobMapKeys.REQUEST.getKeyName(), request);
+    }
+    if (shouldInsert(JobMapKeys.AUTH_USER_INFO, userRequest)) {
+      addParameter(JobMapKeys.AUTH_USER_INFO.getKeyName(), userRequest);
+      addParameter(JobMapKeys.SUBJECT_ID.getKeyName(), userRequest.getSubjectId());
+    }
+  }
+
+  private boolean shouldInsert(JobMapKeys mapKey, Object value) {
+    return (value != null && !jobParameterMap.containsKey(mapKey.getKeyName()));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/service/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -26,7 +26,6 @@ import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.exception.DuplicateJobIdException;
 import bio.terra.workspace.service.job.exception.InternalStairwayException;
-import bio.terra.workspace.service.job.exception.InvalidJobIdException;
 import bio.terra.workspace.service.job.exception.InvalidResultStateException;
 import bio.terra.workspace.service.job.exception.JobNotCompleteException;
 import bio.terra.workspace.service.job.exception.JobNotFoundException;
@@ -85,24 +84,9 @@ public class JobService {
     this.objectMapper = objectMapper;
   }
 
-  // creates a new JobBuilder object and returns it.
-  public JobBuilder newJob(
-      String description,
-      String jobId,
-      Class<? extends Flight> flightClass,
-      Object request,
-      AuthenticatedUserRequest userRequest) {
-
-    // If clients provide a non-null job ID, it cannot be whitespace-only
-    if (StringUtils.isWhitespace(jobId)) {
-      throw new InvalidJobIdException("jobId cannot be whitespace-only.");
-    }
-
-    return new JobBuilder(description, jobId, flightClass, request, userRequest, this)
-        .addParameter(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext())
-        .addParameter(
-            TracingHook.SUBMISSION_SPAN_CONTEXT_MAP_KEY,
-            TracingHook.serializeCurrentTracingContext());
+  // Fully fluent style of JobBuilder
+  public JobBuilder newJob() {
+    return new JobBuilder(this, stairwayComponent, mdcHook);
   }
 
   // submit a new job to stairway

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -103,12 +103,11 @@ public class ControlledResourceService {
             resource.getBucketName(), resource.getResourceId(), resource.getName());
     final JobBuilder jobBuilder =
         jobService
-            .newJob(
-                jobDescription,
-                UUID.randomUUID().toString(), // no need to track ID
-                UpdateControlledGcsBucketResourceFlight.class,
-                resource,
-                userRequest)
+            .newJob()
+            .description(jobDescription)
+            .flightClass(UpdateControlledGcsBucketResourceFlight.class)
+            .request(resource)
+            .userRequest(userRequest)
             .addParameter(ControlledResourceKeys.UPDATE_PARAMETERS, updateParameters)
             .addParameter(ResourceKeys.RESOURCE_NAME, resourceName)
             .addParameter(ResourceKeys.RESOURCE_DESCRIPTION, resourceDescription);
@@ -163,12 +162,12 @@ public class ControlledResourceService {
 
     final JobBuilder jobBuilder =
         jobService
-            .newJob(
-                jobDescription,
-                jobControl.getId(),
-                CloneControlledGcsBucketResourceFlight.class,
-                sourceBucketResource,
-                userRequest)
+            .newJob()
+            .description(jobDescription)
+            .jobId(jobControl.getId())
+            .flightClass(CloneControlledGcsBucketResourceFlight.class)
+            .request(sourceBucketResource)
+            .userRequest(userRequest)
             .addParameter(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, destinationWorkspaceId)
             .addParameter(ResourceKeys.RESOURCE_NAME, destinationResourceName)
             .addParameter(ResourceKeys.RESOURCE_DESCRIPTION, destinationDescription)
@@ -210,12 +209,11 @@ public class ControlledResourceService {
             resource.getDatasetName(), resource.getResourceId(), resource.getName());
     final JobBuilder jobBuilder =
         jobService
-            .newJob(
-                jobDescription,
-                UUID.randomUUID().toString(), // no need to track ID
-                UpdateControlledBigQueryDatasetResourceFlight.class,
-                resource,
-                userRequest)
+            .newJob()
+            .description(jobDescription)
+            .flightClass(UpdateControlledBigQueryDatasetResourceFlight.class)
+            .request(resource)
+            .userRequest(userRequest)
             .addParameter(ControlledResourceKeys.UPDATE_PARAMETERS, updateParameters)
             .addParameter(ResourceKeys.RESOURCE_NAME, resourceName)
             .addParameter(ResourceKeys.RESOURCE_DESCRIPTION, resourceDescription);
@@ -265,12 +263,12 @@ public class ControlledResourceService {
             sourceDatasetResource.getName());
     final JobBuilder jobBuilder =
         jobService
-            .newJob(
-                jobDescription,
-                jobControl.getId(),
-                CloneControlledGcpBigQueryDatasetResourceFlight.class,
-                sourceDatasetResource,
-                userRequest)
+            .newJob()
+            .description(jobDescription)
+            .jobId(jobControl.getId())
+            .flightClass(CloneControlledGcpBigQueryDatasetResourceFlight.class)
+            .request(sourceDatasetResource)
+            .userRequest(userRequest)
             .addParameter(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, destinationWorkspaceId)
             .addParameter(ResourceKeys.RESOURCE_NAME, destinationResourceName)
             .addParameter(ResourceKeys.RESOURCE_DESCRIPTION, destinationDescription)
@@ -339,14 +337,13 @@ public class ControlledResourceService {
             "Create controlled resource %s; id %s; name %s",
             resource.getResourceType(), resource.getResourceId(), resource.getName());
 
-    // Get or create a job id for the flight
-    String jobId =
-        Optional.ofNullable(jobControl)
-            .map(ApiJobControl::getId)
-            .orElse(UUID.randomUUID().toString());
-
     return jobService
-        .newJob(jobDescription, jobId, CreateControlledResourceFlight.class, resource, userRequest)
+        .newJob()
+        .description(jobDescription)
+        .jobId(Optional.ofNullable(jobControl).map(ApiJobControl::getId).orElse(null))
+        .flightClass(CreateControlledResourceFlight.class)
+        .request(resource)
+        .userRequest(userRequest)
         .addParameter(ControlledResourceKeys.PRIVATE_RESOURCE_IAM_ROLE, privateResourceIamRole)
         .addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath);
   }
@@ -487,7 +484,11 @@ public class ControlledResourceService {
     final String jobDescription = "Delete controlled resource; id: " + resourceId.toString();
 
     return jobService
-        .newJob(jobDescription, jobId, DeleteControlledResourceFlight.class, null, userRequest)
+        .newJob()
+        .description(jobDescription)
+        .jobId(jobId)
+        .flightClass(DeleteControlledResourceFlight.class)
+        .userRequest(userRequest)
         .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString())
         .addParameter(ResourceKeys.RESOURCE_ID, resourceId.toString())
         .addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath);

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
@@ -63,12 +63,11 @@ public class ReferencedResourceService {
     // we can supply the right target class.
     JobBuilder createJob =
         jobService
-            .newJob(
-                jobDescription,
-                UUID.randomUUID().toString(),
-                CreateReferenceResourceFlight.class,
-                resource,
-                userRequest)
+            .newJob()
+            .description(jobDescription)
+            .flightClass(CreateReferenceResourceFlight.class)
+            .request(resource)
+            .userRequest(userRequest)
             .addParameter(
                 WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE,
                 resource.getResourceType().name());
@@ -128,12 +127,11 @@ public class ReferencedResourceService {
     if (resource != null) {
       JobBuilder createJob =
           jobService
-              .newJob(
-                  "Update reference target",
-                  UUID.randomUUID().toString(),
-                  UpdateReferenceResourceFlight.class,
-                  resource,
-                  userRequest)
+              .newJob()
+              .description("Update reference target")
+              .flightClass(UpdateReferenceResourceFlight.class)
+              .request(resource)
+              .userRequest(userRequest)
               .addParameter(
                   WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE,
                   resource.getResourceType().name())

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -79,6 +79,7 @@ public class WorkspaceService {
             .newJob()
             .description(description)
             .flightClass(WorkspaceCreateFlight.class)
+            .request(workspace)
             .userRequest(userRequest)
             .addParameter(
                 WorkspaceFlightMapKeys.WORKSPACE_ID, workspace.getWorkspaceId().toString())
@@ -248,6 +249,7 @@ public class WorkspaceService {
         .description("Clone GCP Workspace " + sourceWorkspaceId.toString())
         .flightClass(CloneGcpWorkspaceFlight.class)
         .userRequest(userRequest)
+        .request(destinationWorkspace)
         .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, sourceWorkspaceId)
         .addParameter(
             ControlledResourceKeys.SOURCE_WORKSPACE_ID,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -75,12 +75,24 @@ public class WorkspaceService {
     String description = "Create workspace " + workspace.getWorkspaceId().toString();
 
     JobBuilder createJob =
-        jobService.newJob(
-            description,
-            UUID.randomUUID().toString(),
-            WorkspaceCreateFlight.class,
-            workspace,
-            userRequest);
+        jobService
+            .newJob()
+            .description(description)
+            .flightClass(WorkspaceCreateFlight.class)
+            .userRequest(userRequest)
+            .addParameter(
+                WorkspaceFlightMapKeys.WORKSPACE_ID, workspace.getWorkspaceId().toString())
+            .addParameter(
+                WorkspaceFlightMapKeys.WORKSPACE_STAGE, workspace.getWorkspaceStage().name())
+            .addParameter(
+                WorkspaceFlightMapKeys.DISPLAY_NAME, workspace.getDisplayName().orElse(""))
+            .addParameter(
+                WorkspaceFlightMapKeys.DESCRIPTION, workspace.getDescription().orElse(""));
+
+    if (workspace.getSpendProfileId().isPresent()) {
+      createJob.addParameter(
+          WorkspaceFlightMapKeys.SPEND_PROFILE_ID, workspace.getSpendProfileId().get().getId());
+    }
     return createJob.submitAndWait(UUID.class);
   }
 
@@ -171,12 +183,10 @@ public class WorkspaceService {
     String description = "Delete workspace " + id;
     JobBuilder deleteJob =
         jobService
-            .newJob(
-                description,
-                UUID.randomUUID().toString(),
-                WorkspaceDeleteFlight.class,
-                null, // Delete does not have a useful request body
-                userRequest)
+            .newJob()
+            .description(description)
+            .flightClass(WorkspaceDeleteFlight.class)
+            .userRequest(userRequest)
             .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, id.toString())
             .addParameter(
                 WorkspaceFlightMapKeys.WORKSPACE_STAGE, workspace.getWorkspaceStage().name());
@@ -208,12 +218,11 @@ public class WorkspaceService {
     stageService.assertMcWorkspace(workspace, "createCloudContext");
 
     jobService
-        .newJob(
-            "Create GCP Cloud Context " + workspaceId,
-            jobId,
-            CreateGcpContextFlightV2.class,
-            /* request= */ null,
-            userRequest)
+        .newJob()
+        .description("Create GCP Cloud Context " + workspaceId)
+        .jobId(jobId)
+        .flightClass(CreateGcpContextFlightV2.class)
+        .userRequest(userRequest)
         .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString())
         .addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath)
         .submit();
@@ -235,12 +244,10 @@ public class WorkspaceService {
     stageService.assertMcWorkspace(sourceWorkspace, "cloneGcpWorkspace");
 
     return jobService
-        .newJob(
-            "Clone GCP Workspace " + sourceWorkspaceId.toString(),
-            UUID.randomUUID().toString(),
-            CloneGcpWorkspaceFlight.class,
-            destinationWorkspace,
-            userRequest)
+        .newJob()
+        .description("Clone GCP Workspace " + sourceWorkspaceId.toString())
+        .flightClass(CloneGcpWorkspaceFlight.class)
+        .userRequest(userRequest)
         .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, sourceWorkspaceId)
         .addParameter(
             ControlledResourceKeys.SOURCE_WORKSPACE_ID,
@@ -259,12 +266,10 @@ public class WorkspaceService {
         validateWorkspaceAndAction(userRequest, workspaceId, SamConstants.SamWorkspaceAction.WRITE);
     stageService.assertMcWorkspace(workspace, "deleteGcpCloudContext");
     jobService
-        .newJob(
-            "Delete GCP Context " + workspaceId,
-            UUID.randomUUID().toString(),
-            DeleteGcpContextFlight.class,
-            /* request= */ null,
-            userRequest)
+        .newJob()
+        .description("Delete GCP Context " + workspaceId)
+        .flightClass(DeleteGcpContextFlight.class)
+        .userRequest(userRequest)
         .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString())
         .submitAndWait(null);
   }
@@ -331,14 +336,13 @@ public class WorkspaceService {
       return;
     }
     jobService
-        .newJob(
+        .newJob()
+        .description(
             String.format(
                 "Remove role %s from user %s in workspace %s",
-                role.name(), targetUserEmail, workspaceId),
-            UUID.randomUUID().toString(),
-            RemoveUserFromWorkspaceFlight.class,
-            /* request= */ null,
-            executingUserRequest)
+                role.name(), targetUserEmail, workspaceId))
+        .flightClass(RemoveUserFromWorkspaceFlight.class)
+        .userRequest(executingUserRequest)
         .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString())
         .addParameter(WorkspaceFlightMapKeys.USER_TO_REMOVE, targetUserEmail)
         .addParameter(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, role)

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WsmApplicationService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WsmApplicationService.java
@@ -102,12 +102,10 @@ public class WsmApplicationService {
 
     JobBuilder job =
         jobService
-            .newJob(
-                description,
-                UUID.randomUUID().toString(),
-                ApplicationAbleFlight.class,
-                null,
-                userRequest)
+            .newJob()
+            .description(description)
+            .flightClass(ApplicationAbleFlight.class)
+            .userRequest(userRequest)
             .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId)
             .addParameter(WorkspaceFlightMapKeys.APPLICATION_ID, applicationId)
             .addParameter(WsmApplicationKeys.APPLICATION_ABLE_ENUM, ableEnum);

--- a/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -64,8 +64,12 @@ class JobServiceTest extends BaseUnitTest {
     assertThrows(
         InvalidJobIdException.class,
         () ->
-            jobService.newJob(
-                "description", testJobId, JobServiceTestFlight.class, null, testUser));
+            jobService
+                .newJob()
+                .description("description")
+                .jobId(testJobId)
+                .flightClass(JobServiceTestFlight.class)
+                .userRequest(testUser));
   }
 
   @Test
@@ -74,8 +78,12 @@ class JobServiceTest extends BaseUnitTest {
     assertThrows(
         InvalidJobIdException.class,
         () ->
-            jobService.newJob(
-                "description", testJobId, JobServiceTestFlight.class, null, testUser));
+            jobService
+                .newJob()
+                .description("description")
+                .jobId(testJobId)
+                .flightClass(JobServiceTestFlight.class)
+                .userRequest(testUser));
   }
 
   @Test
@@ -174,7 +182,13 @@ class JobServiceTest extends BaseUnitTest {
   // Submit a flight; wait for it to finish; return the flight id
   private String runFlight(String description) {
     String jobId = UUID.randomUUID().toString();
-    jobService.newJob(description, jobId, JobServiceTestFlight.class, null, testUser).submit();
+    jobService
+        .newJob()
+        .description(description)
+        .jobId(jobId)
+        .flightClass(JobServiceTestFlight.class)
+        .userRequest(testUser)
+        .submit();
     jobService.waitForJob(jobId);
     return jobId;
   }

--- a/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -181,12 +181,13 @@ class JobServiceTest extends BaseUnitTest {
   // Submit a flight; wait for it to finish; return the flight id
   // Use the jobId defaulting in the JobBuilder
   private String runFlight(String description) {
-    String jobId = jobService
-        .newJob()
-        .description(description)
-        .flightClass(JobServiceTestFlight.class)
-        .userRequest(testUser)
-        .submit();
+    String jobId =
+        jobService
+            .newJob()
+            .description(description)
+            .flightClass(JobServiceTestFlight.class)
+            .userRequest(testUser)
+            .submit();
     jobService.waitForJob(jobId);
     return jobId;
   }

--- a/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -19,7 +19,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -180,12 +179,11 @@ class JobServiceTest extends BaseUnitTest {
   }
 
   // Submit a flight; wait for it to finish; return the flight id
+  // Use the jobId defaulting in the JobBuilder
   private String runFlight(String description) {
-    String jobId = UUID.randomUUID().toString();
-    jobService
+    String jobId = jobService
         .newJob()
         .description(description)
-        .jobId(jobId)
         .flightClass(JobServiceTestFlight.class)
         .userRequest(testUser)
         .submit();


### PR DESCRIPTION
The original WSM JobBuilder was taken from TDR where all of the constructor parameters are required. That didn't match our usage, where we often do not supply all of the inputs. Further, we were minting job ids in many different places.

This rewrites the JobBuilder in a fully fluent style, so we only set what we use. It takes charge of all validation, defaulting, and filling in of the MdcHook and TracingHook parameters. Those tasks were previously split between JobService and JobBuilder.

