### PR TITLE
[no ticket] Fix Azure VM creation failure due to invalid image

### DIFF
--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -141,8 +141,10 @@ public class ControlledResourceFixtures {
         .name(uniqueAzureName(AZURE_VM_NAME_PREFIX))
         .region("westcentralus")
         .vmSize(VirtualMachineSizeTypes.STANDARD_D2S_V3.toString())
+            // TODO: it'd be nice to support standard Linux images instead of only custom image URIs.
+            // The below image is a Jupyter image and should be stable.
         .vmImageUri(
-            "/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.0.4")
+            "/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.1.0")
         .ipId(UUID.randomUUID())
         .diskId(UUID.randomUUID())
         .networkId(UUID.randomUUID());

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -141,8 +141,8 @@ public class ControlledResourceFixtures {
         .name(uniqueAzureName(AZURE_VM_NAME_PREFIX))
         .region("westcentralus")
         .vmSize(VirtualMachineSizeTypes.STANDARD_D2S_V3.toString())
-            // TODO: it'd be nice to support standard Linux images instead of only custom image URIs.
-            // The below image is a Jupyter image and should be stable.
+        // TODO: it'd be nice to support standard Linux images instead of only custom image URIs.
+        // The below image is a Jupyter image and should be stable.
         .vmImageUri(
             "/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.1.0")
         .ipId(UUID.randomUUID())

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -141,7 +141,7 @@ public class ControlledResourceFixtures {
         .name(uniqueAzureName(AZURE_VM_NAME_PREFIX))
         .region("westcentralus")
         .vmSize(VirtualMachineSizeTypes.STANDARD_D2S_V3.toString())
-        // TODO: it'd be nice to support standard Linux images instead of only custom image URIs.
+        // TODO: it'd be nice to support standard Linux OSes in addition to custom image URIs.
         // The below image is a Jupyter image and should be stable.
         .vmImageUri(
             "/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.1.0")

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/CreateAzureVmStepTest.java
@@ -288,8 +288,7 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
             .setNetwork(mockNetwork)
             .setSubnetName(STUB_SUBNET_NAME)
             .setPublicIpAddress(mockPublicIpAddress)
-            .setImage(
-                "/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.0.4")
+            .setImage(ControlledResourceFixtures.getAzureVmCreationParameters().getVmImageUri())
             .build();
 
     assertThat(requestDataOpt, equalTo(Optional.of(expected)));


### PR DESCRIPTION
This should fix the failing VM test.

At first I thought I'd use a stable Linux image, but discovered VM creation as implemented only accepts a custom Linux image. It might be nice in the future to make the custom image optional, and support more generic OS types.