### PR TITLE
[PF-1264] Split up WSM application testing profiles

### DIFF
--- a/service/src/test/java/bio/terra/workspace/connected/ApplicationAccessUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/ApplicationAccessUtils.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("connected-test & configuration-test")
+@Profile("connected-test & app-test")
 public class ApplicationAccessUtils {
 
   @Autowired UserAccessUtils userAccessUtils;

--- a/service/src/test/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupServiceTest.java
@@ -47,7 +47,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 
 // Use application configuration profile in addition to the standard connected test profile.
-@ActiveProfiles({"connected-test", "configuration-test"})
+@ActiveProfiles({"connected-test", "app-test"})
 public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
 
   // The name of the "member" policy created by default for groups. If this is ever used for

--- a/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationConfigurationTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationConfigurationTest.java
@@ -41,7 +41,10 @@ public class ApplicationConfigurationTest extends BaseTest {
       } else if (wsmApp.getApplicationId().equals(CARMEN_UUID)) {
         checkCarmen(wsmApp);
       } else if (wsmApp.getApplicationId().equals(TEST_WSM_APP_UUID)) {
-        checkTestWsmApp(wsmApp);
+        // Do not enforce that the WSM test app (used in connected tests, rather than just unit
+        // tests) matches a hardcoded specification. Other deployments need to override this app
+        // as they cannot impersonate terra-dev service accounts.
+        continue;
       } else {
         fail();
       }
@@ -60,14 +63,5 @@ public class ApplicationConfigurationTest extends BaseTest {
     assertEquals("musical performance framework", carmenApp.getDescription());
     assertEquals("carmen@terra-dev.iam.gserviceaccount.com", carmenApp.getServiceAccount());
     assertEquals(WsmApplicationState.DEPRECATED, carmenApp.getState());
-  }
-
-  private void checkTestWsmApp(WsmApplication testApp) {
-    assertEquals("TestWsmApp", testApp.getDisplayName());
-    assertEquals("WSM test application", testApp.getDescription());
-    // Note that SAs (and all other emails) are always stored as lowercase strings.
-    assertEquals(
-        "Elizabeth.Shadowmoon@test.firecloud.org".toLowerCase(), testApp.getServiceAccount());
-    assertEquals(WsmApplicationState.OPERATING, testApp.getState());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationConfigurationTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationConfigurationTest.java
@@ -26,25 +26,18 @@ public class ApplicationConfigurationTest extends BaseTest {
 
   private static final UUID LEO_UUID = UUID.fromString("4BD1D59D-5827-4375-A41D-BBC65919F269");
   private static final UUID CARMEN_UUID = UUID.fromString("EB9D37F5-BAD7-4951-AE9A-86B3F03F4DD7");
-  private static final UUID TEST_WSM_APP_UUID =
-      UUID.fromString("E4C0924A-3D7D-4D3D-8DE4-3D2CF50C3818");
 
   @Test
   public void configurationTest() {
     // This test has to be in sync with the contents of application-configuration-test.yml
     List<WsmApplication> wsmApps = appDao.listApplications();
-    assertEquals(wsmApps.size(), 3);
+    assertEquals(2, wsmApps.size());
 
     for (WsmApplication wsmApp : wsmApps) {
       if (wsmApp.getApplicationId().equals(LEO_UUID)) {
         checkLeo(wsmApp);
       } else if (wsmApp.getApplicationId().equals(CARMEN_UUID)) {
         checkCarmen(wsmApp);
-      } else if (wsmApp.getApplicationId().equals(TEST_WSM_APP_UUID)) {
-        // Do not enforce that the WSM test app (used in connected tests, rather than just unit
-        // tests) matches a hardcoded specification. Other deployments need to override this app
-        // as they cannot impersonate terra-dev service accounts.
-        continue;
       } else {
         fail();
       }

--- a/service/src/test/resources/application-app-test.yml
+++ b/service/src/test/resources/application-app-test.yml
@@ -1,0 +1,10 @@
+workspace:
+  application:
+    test-app-sa: Elizabeth.Shadowmoon@test.firecloud.org
+    configurations:
+    # This app uses a test user as the SA, so we can actually impersonate credentials.
+    - identifier: E4C0924A-3D7D-4D3D-8DE4-3D2CF50C3818
+      name: TestWsmApp
+      description: WSM test application
+      service-account: Elizabeth.Shadowmoon@test.firecloud.org
+      state: operating

--- a/service/src/test/resources/application-configuration-test.yml
+++ b/service/src/test/resources/application-configuration-test.yml
@@ -1,13 +1,9 @@
+# This configuration is specifically used to test WSM reading application configuration files.
+# These are not real applications. If you need a real application for connected tests, use
+# the app-test profile instead (see application-app-test.yml).
 workspace:
   application:
-    test-app-sa: Elizabeth.Shadowmoon@test.firecloud.org
     configurations:
-      - # This app uses a test user as the SA, so we can actually impersonate credentials.
-        identifier: E4C0924A-3D7D-4D3D-8DE4-3D2CF50C3818
-        name: TestWsmApp
-        description: WSM test application
-        service-account: Elizabeth.Shadowmoon@test.firecloud.org
-        state: operating
       -
         identifier: 4BD1D59D-5827-4375-A41D-BBC65919F269
         name: Leo


### PR DESCRIPTION
This change separates the real application configuration used for the `PrivateResourceCleanupServiceTest` connected test from the fake application configuration used by the `ApplicationConfigurationTest` unit test. Future tests which need an application should use the `app-test` profile to include this valid application configuration.

This change allows me to override the real application used in non-Broad deployment tests without also having to ignore/break the hardcoded values being checked in the unit test.