### PR TITLE
PF-1085: Makes location an optional field when creating a controlled resources

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
+++ b/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
@@ -104,7 +104,6 @@ public class CloneGcsBucket extends WorkspaceAllocateTestScriptBase {
     sourceBucketName = sourceBucket.getGcpBucket().getAttributes().getBucketName();
     assertNotNull(sourceBucketName);
 
-
     // Make the cloning user a reader on the existing workspace
     sourceOwnerWorkspaceApi.grantRole(
         new GrantRoleRequestBody().memberEmail(cloningUser.userEmail),

--- a/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
+++ b/integration/src/main/java/scripts/testscripts/CloneGcsBucket.java
@@ -104,6 +104,7 @@ public class CloneGcsBucket extends WorkspaceAllocateTestScriptBase {
     sourceBucketName = sourceBucket.getGcpBucket().getAttributes().getBucketName();
     assertNotNull(sourceBucketName);
 
+
     // Make the cloning user a reader on the existing workspace
     sourceOwnerWorkspaceApi.grantRole(
         new GrantRoleRequestBody().memberEmail(cloningUser.userEmail),

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -114,7 +114,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
         resourceUserApi);
 
     createAControlledAiNotebookInstanceWithLocationSpecified(resourceUserApi);
-    
+
     String instanceName =
         String.format(
             "projects/%s/locations/%s/instances/%s",
@@ -208,7 +208,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
   private void
   createAControlledAiNotebookInstanceWithLocationSpecified(
       ControlledGcpResourceApi resourceUserApi) throws ApiException, InterruptedException {
-    String location = "us-east1-a";
+    String location = "us-east1-b";
     CreatedControlledGcpAiNotebookInstanceResult resourceWithSpecifiedLocation =
         ResourceMaker.makeControlledNotebookUserPrivate(
             getWorkspaceId(), /*instanceId=*/ null, location, resourceUserApi);

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -82,7 +82,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
         ClientTestUtils.getControlledGcpResourceClient(resourceUser, server);
     CreatedControlledGcpAiNotebookInstanceResult creationResult =
         ResourceMaker.makeControlledNotebookUserPrivate(
-            getWorkspaceId(), instanceId, /*location=*/null, resourceUserApi);
+            getWorkspaceId(), instanceId, /*location=*/ null, resourceUserApi);
 
     UUID resourceId = creationResult.getAiNotebookInstance().getMetadata().getResourceId();
 
@@ -107,8 +107,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
     assertEquals(
         "us-central1-a",
         resource.getAttributes().getLocation(),
-        "When location is not set, use the default location"
-    );
+        "When location is not set, use the default location");
 
     createAControlledAiNotebookInstanceWithoutSpecifiedInstanceId_validInstanceIdIsGenerated(
         resourceUserApi);
@@ -189,7 +188,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
           ControlledGcpResourceApi resourceUserApi) throws ApiException, InterruptedException {
     CreatedControlledGcpAiNotebookInstanceResult resourceWithNotebookInstanceIdNotSpecified =
         ResourceMaker.makeControlledNotebookUserPrivate(
-            getWorkspaceId(), /*instanceId=*/ null, /*location=*/null, resourceUserApi);
+            getWorkspaceId(), /*instanceId=*/ null, /*location=*/ null, resourceUserApi);
     assertNotNull(
         resourceWithNotebookInstanceIdNotSpecified
             .getAiNotebookInstance()
@@ -205,22 +204,19 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
             .getResourceId());
   }
 
-  private void
-  createAControlledAiNotebookInstanceWithLocationSpecified(
+  private void createAControlledAiNotebookInstanceWithLocationSpecified(
       ControlledGcpResourceApi resourceUserApi) throws ApiException, InterruptedException {
     String location = "us-east1-b";
     CreatedControlledGcpAiNotebookInstanceResult resourceWithSpecifiedLocation =
         ResourceMaker.makeControlledNotebookUserPrivate(
             getWorkspaceId(), /*instanceId=*/ null, location, resourceUserApi);
-    assertEquals(location,
+    assertEquals(
+        location,
         resourceWithSpecifiedLocation.getAiNotebookInstance().getAttributes().getLocation());
     resourceUserApi.deleteAiNotebookInstance(
         new DeleteControlledGcpAiNotebookInstanceRequest()
             .jobControl(new JobControl().id(UUID.randomUUID().toString())),
         getWorkspaceId(),
-        resourceWithSpecifiedLocation
-            .getAiNotebookInstance()
-            .getMetadata()
-            .getResourceId());
+        resourceWithSpecifiedLocation.getAiNotebookInstance().getMetadata().getResourceId());
   }
 }

--- a/integration/src/main/java/scripts/testscripts/RemoveUser.java
+++ b/integration/src/main/java/scripts/testscripts/RemoveUser.java
@@ -106,7 +106,7 @@ public class RemoveUser extends WorkspaceAllocateTestScriptBase {
     String notebookInstanceId = RandomStringUtils.randomAlphabetic(8).toLowerCase();
     privateNotebook =
         ResourceMaker.makeControlledNotebookUserPrivate(
-            getWorkspaceId(), notebookInstanceId, privateUserResourceApi);
+            getWorkspaceId(), notebookInstanceId, /*location=*/null, privateUserResourceApi);
   }
 
   @Override

--- a/integration/src/main/java/scripts/testscripts/RemoveUser.java
+++ b/integration/src/main/java/scripts/testscripts/RemoveUser.java
@@ -106,7 +106,7 @@ public class RemoveUser extends WorkspaceAllocateTestScriptBase {
     String notebookInstanceId = RandomStringUtils.randomAlphabetic(8).toLowerCase();
     privateNotebook =
         ResourceMaker.makeControlledNotebookUserPrivate(
-            getWorkspaceId(), notebookInstanceId, /*location=*/null, privateUserResourceApi);
+            getWorkspaceId(), notebookInstanceId, /*location=*/ null, privateUserResourceApi);
   }
 
   @Override

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -528,8 +528,7 @@ public class ResourceMaker {
                     .description("Description of " + resourceName)
                     .name(resourceName)
                     .privateResourceUser(privateUser))
-            .dataset(
-                new GcpBigQueryDatasetCreationParameters().datasetId(datasetId));
+            .dataset(new GcpBigQueryDatasetCreationParameters().datasetId(datasetId));
 
     logger.info(
         "Creating {} {} dataset {} workspace {}",
@@ -581,7 +580,10 @@ public class ResourceMaker {
    * method calls the asynchronous creation endpoint and polls until the creation job completes.
    */
   public static CreatedControlledGcpAiNotebookInstanceResult makeControlledNotebookUserPrivate(
-      UUID workspaceId, @Nullable String instanceId, @Nullable String location, ControlledGcpResourceApi resourceApi)
+      UUID workspaceId,
+      @Nullable String instanceId,
+      @Nullable String location,
+      ControlledGcpResourceApi resourceApi)
       throws ApiException, InterruptedException {
     // Fill out the minimum required fields to arbitrary values.
     var creationParameters =

--- a/integration/src/main/java/scripts/utils/ResourceMaker.java
+++ b/integration/src/main/java/scripts/utils/ResourceMaker.java
@@ -65,7 +65,6 @@ public class ResourceMaker {
 
   private static final Logger logger = LoggerFactory.getLogger(ResourceMaker.class);
   private static final long DELETE_BUCKET_POLL_SECONDS = 15;
-  private static final String BUCKET_LOCATION = "US-CENTRAL1";
 
   /**
    * Calls WSM to create a referenced BigQuery dataset in the specified workspace.
@@ -408,8 +407,7 @@ public class ResourceMaker {
                 new GcpGcsBucketCreationParameters()
                     .name(bucketName)
                     .defaultStorageClass(GcpGcsBucketDefaultStorageClass.STANDARD)
-                    .lifecycle(new GcpGcsBucketLifecycle().rules(LIFECYCLE_RULES))
-                    .location(BUCKET_LOCATION));
+                    .lifecycle(new GcpGcsBucketLifecycle().rules(LIFECYCLE_RULES)));
 
     logger.info(
         "Creating {} {} bucket in workspace {}", managedBy.name(), accessScope.name(), workspaceId);
@@ -531,9 +529,7 @@ public class ResourceMaker {
                     .name(resourceName)
                     .privateResourceUser(privateUser))
             .dataset(
-                new GcpBigQueryDatasetCreationParameters()
-                    .datasetId(datasetId)
-                    .location("US-CENTRAL1"));
+                new GcpBigQueryDatasetCreationParameters().datasetId(datasetId));
 
     logger.info(
         "Creating {} {} dataset {} workspace {}",
@@ -585,19 +581,20 @@ public class ResourceMaker {
    * method calls the asynchronous creation endpoint and polls until the creation job completes.
    */
   public static CreatedControlledGcpAiNotebookInstanceResult makeControlledNotebookUserPrivate(
-      UUID workspaceId, @Nullable String instanceId, ControlledGcpResourceApi resourceApi)
+      UUID workspaceId, @Nullable String instanceId, @Nullable String location, ControlledGcpResourceApi resourceApi)
       throws ApiException, InterruptedException {
     // Fill out the minimum required fields to arbitrary values.
     var creationParameters =
         new GcpAiNotebookInstanceCreationParameters()
             .instanceId(instanceId)
-            .location("us-east1-b")
             .machineType("e2-standard-2")
             .vmImage(
                 new GcpAiNotebookInstanceVmImage()
                     .projectId("deeplearning-platform-release")
                     .imageFamily("r-latest-cpu-experimental"));
-
+    if (location != null) {
+      creationParameters.location(location);
+    }
     var commonParameters =
         new ControlledResourceCommonFields()
             .name(RandomStringUtils.randomAlphabetic(6))

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -107,6 +107,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
             .managedBy(managedBy)
             .applicationId(controlledResourceService.getAssociatedApp(managedBy, userRequest))
             .bucketName(body.getGcsBucket().getName())
+            .bucketLocation(body.getGcsBucket().getLocation())
             .build();
 
     final ControlledGcsBucketResource createdBucket =
@@ -340,6 +341,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
             .datasetName(
                 Optional.ofNullable(body.getDataset().getDatasetId())
                     .orElse(body.getCommon().getName()))
+            .datasetLocation(body.getDataset().getLocation())
             .build();
 
     final ControlledBigQueryDatasetResource createdDataset =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledAiNotebookInstanceResource.java
@@ -26,6 +26,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
 
   protected static final int MAX_INSTANCE_NAME_LENGTH = 63;
   protected static final String AUTO_NAME_DATE_FORMAT = "-yyyyMMdd-HHmmss";
+  private static final String DEFAULT_LOCATION = "us-central1-a";
   private final String instanceId;
   private final String location;
 
@@ -255,8 +256,8 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
       return this;
     }
 
-    public Builder location(String location) {
-      this.location = location;
+    public Builder location(@Nullable String location) {
+      this.location = Optional.ofNullable(location).orElse(DEFAULT_LOCATION);
       return this;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetAttributes.java
@@ -5,13 +5,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ControlledBigQueryDatasetAttributes {
   private final String datasetName;
+  private final String datasetLocation;
 
   @JsonCreator
-  public ControlledBigQueryDatasetAttributes(@JsonProperty("datasetName") String datasetName) {
+  public ControlledBigQueryDatasetAttributes(@JsonProperty("datasetName") String datasetName,
+      @JsonProperty("datasetLocation") String datasetLocation) {
     this.datasetName = datasetName;
+    this.datasetLocation = datasetLocation;
   }
 
   public String getDatasetName() {
     return datasetName;
+  }
+
+  public String getDatasetLocation() {
+    return datasetLocation;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetAttributes.java
@@ -8,7 +8,8 @@ public class ControlledBigQueryDatasetAttributes {
   private final String datasetLocation;
 
   @JsonCreator
-  public ControlledBigQueryDatasetAttributes(@JsonProperty("datasetName") String datasetName,
+  public ControlledBigQueryDatasetAttributes(
+      @JsonProperty("datasetName") String datasetName,
       @JsonProperty("datasetLocation") String datasetLocation) {
     this.datasetName = datasetName;
     this.datasetLocation = datasetLocation;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
@@ -106,7 +106,8 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
 
   @Override
   public String attributesToJson() {
-    return DbSerDes.toJson(new ControlledBigQueryDatasetAttributes(getDatasetName(), getDatasetLocation()));
+    return DbSerDes.toJson(
+        new ControlledBigQueryDatasetAttributes(getDatasetName(), getDatasetLocation()));
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
@@ -16,10 +16,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import liquibase.pro.packaged.J;
 
 public class ControlledBigQueryDatasetResource extends ControlledResource {
-  private static final String DEFAULT_LOCATION = "US-CENTRAL1";
+  private static final String DEFAULT_LOCATION = "us-central1";
   private final String datasetName;
   private final String datasetLocation;
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 import liquibase.pro.packaged.J;
 
 public class ControlledBigQueryDatasetResource extends ControlledResource {
-  private static final String DEFAULT_LOCATION = "us-central1";
+  private static final String DEFAULT_LOCATION = "US-CENTRAL1";
   private final String datasetName;
   private final String datasetLocation;
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledBigQueryDatasetResource.java
@@ -16,9 +16,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
+import liquibase.pro.packaged.J;
 
 public class ControlledBigQueryDatasetResource extends ControlledResource {
+  private static final String DEFAULT_LOCATION = "us-central1";
   private final String datasetName;
+  private final String datasetLocation;
 
   @JsonCreator
   public ControlledBigQueryDatasetResource(
@@ -32,7 +35,8 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
       @JsonProperty("accessScope") AccessScopeType accessScope,
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") UUID applicationId,
-      @JsonProperty("datasetName") String datasetName) {
+      @JsonProperty("datasetName") String datasetName,
+      @JsonProperty("datasetLocation") String datasetLocation) {
 
     super(
         workspaceId,
@@ -46,6 +50,7 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
         applicationId,
         privateResourceState);
     this.datasetName = datasetName;
+    this.datasetLocation = datasetLocation;
     validate();
   }
 
@@ -54,6 +59,7 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
     ControlledBigQueryDatasetAttributes attributes =
         DbSerDes.fromJson(dbResource.getAttributes(), ControlledBigQueryDatasetAttributes.class);
     this.datasetName = attributes.getDatasetName();
+    this.datasetLocation = attributes.getDatasetLocation();
     validate();
   }
 
@@ -80,6 +86,10 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
     return datasetName;
   }
 
+  public String getDatasetLocation() {
+    return datasetLocation;
+  }
+
   public ApiGcpBigQueryDatasetAttributes toApiAttributes(String projectId) {
     return new ApiGcpBigQueryDatasetAttributes().projectId(projectId).datasetId(getDatasetName());
   }
@@ -97,7 +107,7 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
 
   @Override
   public String attributesToJson() {
-    return DbSerDes.toJson(new ControlledBigQueryDatasetAttributes(getDatasetName()));
+    return DbSerDes.toJson(new ControlledBigQueryDatasetAttributes(getDatasetName(), getDatasetLocation()));
   }
 
   @Override
@@ -146,6 +156,7 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
     private ManagedByType managedBy;
     private UUID applicationId;
     private String datasetName;
+    private String datasetLocation;
 
     public ControlledBigQueryDatasetResource.Builder workspaceId(UUID workspaceId) {
       this.workspaceId = workspaceId;
@@ -217,6 +228,11 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
       return this;
     }
 
+    public Builder datasetLocation(@Nullable String location) {
+      this.datasetLocation = Optional.ofNullable(location).orElse(DEFAULT_LOCATION);
+      return this;
+    }
+
     public ControlledBigQueryDatasetResource build() {
       return new ControlledBigQueryDatasetResource(
           workspaceId,
@@ -229,7 +245,8 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
           accessScope,
           managedBy,
           applicationId,
-          datasetName);
+          datasetName,
+          datasetLocation);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketAttributes.java
@@ -2,14 +2,14 @@ package bio.terra.workspace.service.resource.controlled;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import javax.annotation.Nullable;
 
 public class ControlledGcsBucketAttributes {
   private final String bucketName;
   private final String bucketLocation;
 
   @JsonCreator
-  public ControlledGcsBucketAttributes(@JsonProperty("bucketName") String bucketName,
+  public ControlledGcsBucketAttributes(
+      @JsonProperty("bucketName") String bucketName,
       @JsonProperty("bucketLocation") String bucketLocation) {
     this.bucketName = bucketName;
     this.bucketLocation = bucketLocation;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketAttributes.java
@@ -5,14 +5,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nullable;
 
 public class ControlledGcsBucketAttributes {
-  private final @Nullable String bucketName;
+  private final String bucketName;
+  private final String bucketLocation;
 
   @JsonCreator
-  public ControlledGcsBucketAttributes(@JsonProperty("bucketName") @Nullable String bucketName) {
+  public ControlledGcsBucketAttributes(@JsonProperty("bucketName") String bucketName,
+      @JsonProperty("bucketLocation") String bucketLocation) {
     this.bucketName = bucketName;
+    this.bucketLocation = bucketLocation;
   }
 
-  public @Nullable String getBucketName() {
+  public String getBucketName() {
     return bucketName;
+  }
+
+  public String getBucketLocation() {
+    return bucketLocation;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledGcsBucketResource.java
@@ -17,7 +17,10 @@ import javax.annotation.Nullable;
 
 public class ControlledGcsBucketResource extends ControlledResource {
 
+  private static final String DEFAULT_LOCATION = "US-CENTRAL1";
+
   private final String bucketName;
+  private final String bucketLocation;
 
   @JsonCreator
   public ControlledGcsBucketResource(
@@ -31,7 +34,8 @@ public class ControlledGcsBucketResource extends ControlledResource {
       @JsonProperty("accessScope") AccessScopeType accessScope,
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") UUID applicationId,
-      @JsonProperty("bucketName") String bucketName) {
+      @JsonProperty("bucketName") String bucketName,
+      @JsonProperty("bucketLocation") String bucketLocation) {
 
     super(
         workspaceId,
@@ -45,6 +49,7 @@ public class ControlledGcsBucketResource extends ControlledResource {
         applicationId,
         privateResourceState);
     this.bucketName = bucketName;
+    this.bucketLocation = bucketLocation;
     validate();
   }
 
@@ -53,6 +58,7 @@ public class ControlledGcsBucketResource extends ControlledResource {
     ControlledGcsBucketAttributes attributes =
         DbSerDes.fromJson(dbResource.getAttributes(), ControlledGcsBucketAttributes.class);
     this.bucketName = attributes.getBucketName();
+    this.bucketLocation = attributes.getBucketLocation();
     validate();
   }
 
@@ -79,6 +85,10 @@ public class ControlledGcsBucketResource extends ControlledResource {
     return bucketName;
   }
 
+  public String getBucketLocation() {
+    return bucketLocation;
+  }
+
   public ApiGcpGcsBucketAttributes toApiAttributes() {
     return new ApiGcpGcsBucketAttributes().bucketName(getBucketName());
   }
@@ -96,7 +106,7 @@ public class ControlledGcsBucketResource extends ControlledResource {
 
   @Override
   public String attributesToJson() {
-    return DbSerDes.toJson(new ControlledGcsBucketAttributes(getBucketName()));
+    return DbSerDes.toJson(new ControlledGcsBucketAttributes(getBucketName(), getBucketLocation()));
   }
 
   @Override
@@ -153,6 +163,7 @@ public class ControlledGcsBucketResource extends ControlledResource {
     private ManagedByType managedBy;
     private UUID applicationId;
     private String bucketName;
+    private String bucketLocation;
 
     public ControlledGcsBucketResource.Builder workspaceId(UUID workspaceId) {
       this.workspaceId = workspaceId;
@@ -216,6 +227,11 @@ public class ControlledGcsBucketResource extends ControlledResource {
       return this;
     }
 
+    public Builder bucketLocation(@Nullable String bucketLocation) {
+      this.bucketLocation = Optional.ofNullable(bucketLocation).orElse(DEFAULT_LOCATION);
+      return this;
+    }
+
     public ControlledGcsBucketResource build() {
       return new ControlledGcsBucketResource(
           workspaceId,
@@ -228,7 +244,8 @@ public class ControlledGcsBucketResource extends ControlledResource {
           accessScope,
           managedBy,
           applicationId,
-          bucketName);
+          bucketName,
+          bucketLocation);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateAzureVmStep.java
@@ -138,7 +138,7 @@ public class CreateAzureVmStep implements Step {
         logger.info(
             "Either the disk, ip, or network passed into this createVm does not exist "
                 + String.format(
-                    "%nResource Group: %s\n\tIp Name: %s\n\tNetwork Name: %s\n\tDisk Name: %s",
+                    "%nResource Group: %s%n\tIp Name: %s%n\tNetwork Name: %s%n\tDisk Name: %s",
                     azureCloudContext.getAzureResourceGroupId(),
                     ipResource.getIpName(),
                     "TODO",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
@@ -78,9 +78,7 @@ public class CreateBigQueryDatasetStep implements Step {
 
     List<Access> accessConfiguration = buildDatasetAccessConfiguration(cloudContext);
     DatasetReference datasetId =
-        new DatasetReference()
-            .setProjectId(projectId)
-            .setDatasetId(resource.getDatasetName());
+        new DatasetReference().setProjectId(projectId).setDatasetId(resource.getDatasetName());
     Dataset datasetToCreate =
         new Dataset()
             .setDatasetReference(datasetId)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateBigQueryDatasetStep.java
@@ -80,12 +80,11 @@ public class CreateBigQueryDatasetStep implements Step {
     DatasetReference datasetId =
         new DatasetReference()
             .setProjectId(projectId)
-            .setDatasetId(
-                resource.getDatasetName() == null ? resource.getName() : resource.getDatasetName());
+            .setDatasetId(resource.getDatasetName());
     Dataset datasetToCreate =
         new Dataset()
             .setDatasetReference(datasetId)
-            .setLocation(creationParameters.getLocation())
+            .setLocation(resource.getDatasetLocation())
             .setDefaultTableExpirationMs(
                 BigQueryApiConversions.toBqExpirationTime(
                     creationParameters.getDefaultTableLifetime()))

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -55,7 +55,7 @@ public class CreateGcsBucketStep implements Step {
     BucketInfo.Builder bucketInfoBuilder =
         BucketInfo.newBuilder(resource.getBucketName())
             .setLocation(resource.getBucketLocation());
-
+    
     // Remaining creation parameters are optional
     Optional.ofNullable(creationParameters.getDefaultStorageClass())
         .map(GcsApiConversions::toGcsApi)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -54,7 +54,7 @@ public class CreateGcsBucketStep implements Step {
 
     BucketInfo.Builder bucketInfoBuilder =
         BucketInfo.newBuilder(resource.getBucketName())
-            .setLocation(creationParameters.getLocation());
+            .setLocation(resource.getBucketLocation());
 
     // Remaining creation parameters are optional
     Optional.ofNullable(creationParameters.getDefaultStorageClass())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateGcsBucketStep.java
@@ -53,9 +53,8 @@ public class CreateGcsBucketStep implements Step {
     String projectId = gcpCloudContextService.getRequiredGcpProject(resource.getWorkspaceId());
 
     BucketInfo.Builder bucketInfoBuilder =
-        BucketInfo.newBuilder(resource.getBucketName())
-            .setLocation(resource.getBucketLocation());
-    
+        BucketInfo.newBuilder(resource.getBucketName()).setLocation(resource.getBucketLocation());
+
     // Remaining creation parameters are optional
     Optional.ofNullable(creationParameters.getDefaultStorageClass())
         .map(GcsApiConversions::toGcsApi)

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -3189,7 +3189,6 @@ components:
         Bucket-specific properties to be set on creation. These are a subset of the
         values accepted by the Gcp Storage API.
       type: object
-      required: [location]
       properties:
         name:
           description: A valid bucket name per https://cloud.google.com/storage/docs/naming-buckets.
@@ -3479,7 +3478,6 @@ components:
         Dataset-specific properties to be set on creation. These are a subset of the
         values accepted by the BigQuery API.
       type: object
-      required: [location]
       properties:
         datasetId:
           description: A valid dataset name per https://cloud.google.com/bigquery/docs/datasets#dataset-naming
@@ -3710,7 +3708,7 @@ components:
         AI Platform Notebook instance specific properties to be set on creation. These are a subset of the
         values accepted by the GCP AI Platforms API. See https://cloud.google.com/ai-platform/notebooks/docs/reference/rest/v1/projects.locations.instances/create
       type: object
-      required: [location, machineType]
+      required: [machineType]
       properties:
         instanceId:
           description: >-

--- a/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
@@ -176,7 +176,8 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
               accessScopeType,
               managedByType,
               null,
-              bucketName);
+              bucketName,
+              "US-CENTRAL1");
 
       ApiResourceDescription resourceDescription =
           resourceController.makeApiResourceDescription(resource, null);
@@ -203,7 +204,8 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
               accessScopeType,
               managedByType,
               null,
-              datasetName);
+              datasetName,
+              "us-central1");
 
       String projectId = "my-project-id";
       ApiResourceDescription resourceDescription =


### PR DESCRIPTION
Currently in CLI, when user does not provide a location when creating a controlled resources, a default location is set. I moved this logic to the WSM side. 