### PR TITLE
[PF-1287] Reroute and pretty up slack messages

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -137,8 +137,15 @@ jobs:
           L4="Res: ${{ steps.resiliency-test.outcome }}"
           text="Link to <https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/$GITHUB_RUN_ID|test run>"
           bold="$L2 | $L3 | $L4"
+          if [ "${{ job.status }}" == "success" ]; then
+            emoji=":white_check_mark:"
+          else
+            emoji=":no_entry:"
+            text="@channel $text"
+          fi
           echo ::set-output name=status-text::$text
           echo ::set-output name=status-bold::$bold
+          echo ::set-output name=status-emoji::$emoji
 
       - name: Notify WSM Slack
         if: always()
@@ -149,8 +156,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          channel: "#terra-workspace-manager"
+          channel: "#terra-wsm-alerts"
           username: "WSM nightly test"
           author_name: ${{ steps.status-message.outputs.status-bold }}
-          icon_emoji: ':vertical_traffic_light:'
+          icon_emoji: ${{ steps.status-message.outputs.status-emoji }}
           text: ${{ steps.status-message.outputs.status-text }}

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -119,7 +119,8 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#terra-workspace-manager"
+        channel: "#terra-wsm-alerts"
         username: "WSM push to main branch"
         author_name: "integrationTest"
+        icon_emoji: ":triangular_ruler:"
         fields: job, commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,7 +180,8 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#terra-workspace-manager"
+        channel: "#terra-wsm-alerts"
         username: "WSM push to main branch"
         author_name: "${{ matrix.gradleTask }}"
+        icon_emoji: ":triangular_ruler:"
         fields: job, commit


### PR DESCRIPTION
This change moves test notifications to the new `#terra-wsm-alerts` channel.
I also changed how the emoji works, so it reflects the status result.
I added `@channel` to the message on failure, but I have not been able to confirm that works.
As usual, it is hard to test push tests without doing a push...
