### PR TITLE
[PF-1308] Make projectId an attribute of notebooks and controlled buckets.

### DIFF
--- a/integration/src/main/java/scripts/testscripts/DeleteGcpContextWithControlledResource.java
+++ b/integration/src/main/java/scripts/testscripts/DeleteGcpContextWithControlledResource.java
@@ -79,13 +79,12 @@ public class DeleteGcpContextWithControlledResource extends WorkspaceAllocateTes
     // Delete the context, which should delete the controlled resource but not the reference.
     CloudContextMaker.deleteGcpCloudContext(getWorkspaceId(), workspaceApi);
 
-    // Confirm the controlled resource was deleted. This fails with a 400, because WSM won't check
-    // for the existence of a GCP resource without a GCP context.
+    // Confirm the controlled resource was deleted.
     var noGcpContextException =
         assertThrows(
             ApiException.class,
             () -> controlledResourceApi.getBigQueryDataset(getWorkspaceId(), controlledResourceId));
-    assertEquals(HttpStatus.SC_BAD_REQUEST, noGcpContextException.getCode());
+    assertEquals(HttpStatus.SC_NOT_FOUND, noGcpContextException.getCode());
 
     // Confirm the referenced resource was not deleted.
     GcpBigQueryDatasetResource datasetReferenceAfterDelete =

--- a/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
@@ -200,7 +200,7 @@ public class Alpha1ApiController implements Alpha1Api {
             {
               ControlledAiNotebookInstanceResource resource =
                   controlledResource.castToAiNotebookInstanceResource();
-              union.gcpAiNotebookInstance(resource.toApiResource(gcpProjectId));
+              union.gcpAiNotebookInstance(resource.toApiResource());
               break;
             }
           case GCS_BUCKET:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -250,12 +250,11 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
   public ResponseEntity<ApiGcpBigQueryDatasetResource> getBigQueryDataset(
       UUID workspaceId, UUID resourceId) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    String projectId = workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
     return getControlledResourceAsResponseEntity(
         workspaceId,
         resourceId,
         userRequest,
-        r -> r.castToBigQueryDatasetResource().toApiResource(projectId));
+        r -> r.castToBigQueryDatasetResource().toApiResource());
   }
 
   @Override
@@ -263,6 +262,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
       UUID workspaceId, UUID resourceId, ApiUpdateControlledGcpBigQueryDatasetRequestBody body) {
     logger.info("Updating dataset resourceId {} workspaceId {}", resourceId, workspaceId);
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+
     final ControlledResource resource =
         controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
     if (resource.getResourceType() != WsmResourceType.BIG_QUERY_DATASET) {
@@ -279,12 +279,11 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
         body.getDescription());
 
     // Retrieve and cast response to UpdateControlledGcpBigQueryDatasetResponse
-    String projectId = workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
     return getControlledResourceAsResponseEntity(
         workspaceId,
         resourceId,
         userRequest,
-        r -> r.castToBigQueryDatasetResource().toApiResource(projectId));
+        r -> r.castToBigQueryDatasetResource().toApiResource());
   }
 
   /**
@@ -321,8 +320,6 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
       UUID workspaceId, ApiCreateControlledGcpBigQueryDatasetRequestBody body) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
 
-    String projectId = workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
-
     PrivateUserRole privateUserRole =
         ControllerUtils.computePrivateUserRole(
             workspaceId, body.getCommon(), userRequest, samService);
@@ -355,7 +352,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     var response =
         new ApiCreatedControlledGcpBigQueryDataset()
             .resourceId(createdDataset.getResourceId())
-            .bigQueryDataset(createdDataset.toApiResource(projectId));
+            .bigQueryDataset(createdDataset.toApiResource());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -439,7 +439,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
       ControlledAiNotebookInstanceResource resource = jobResult.getResult();
       String workspaceProjectId =
           workspaceService.getAuthorizedRequiredGcpProject(resource.getWorkspaceId(), userRequest);
-      apiResource = resource.toApiResource(workspaceProjectId);
+      apiResource = resource.toApiResource();
     }
     return new ApiCreatedControlledGcpAiNotebookInstanceResult()
         .jobReport(jobResult.getJobReport())
@@ -498,10 +498,9 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
         controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
     try {
       ApiGcpAiNotebookInstanceResource response =
-          controlledResource
-              .castToAiNotebookInstanceResource()
-              .toApiResource(
-                  workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest));
+          controlledResource.castToAiNotebookInstanceResource().toApiResource();
+      // TODO: security check for: workspaceService.getAuthorizedRequiredGcpProject(workspaceId,
+      // userRequest));
       return new ResponseEntity<>(response, HttpStatus.OK);
     } catch (InvalidMetadataException ex) {
       throw new BadRequestException(

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -328,8 +328,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     AccessScopeType accessScopeType = AccessScopeType.fromApi(body.getCommon().getAccessScope());
 
     // We need to retrieve the project id so it can be used in the BQ dataset attributes.
-    String projectId =
-        workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
+    String projectId = workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
 
     ControlledBigQueryDatasetResource resource =
         ControlledBigQueryDatasetResource.builder()
@@ -376,8 +375,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
   public ResponseEntity<ApiCreatedControlledGcpAiNotebookInstanceResult> createAiNotebookInstance(
       UUID workspaceId, @Valid ApiCreateControlledGcpAiNotebookInstanceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    String projectId =
-        workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
+    String projectId = workspaceService.getAuthorizedRequiredGcpProject(workspaceId, userRequest);
 
     PrivateUserRole privateUserRole =
         ControllerUtils.computePrivateUserRole(

--- a/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
@@ -36,7 +36,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.slf4j.Logger;
@@ -102,9 +101,7 @@ public class ResourceController implements ResourceApi {
         workspaceService.getAuthorizedGcpProject(workspaceId, userRequest).orElse(null);
 
     List<ApiResourceDescription> apiResourceDescriptionList =
-        wsmResources.stream()
-            .map(r -> makeApiResourceDescription(r, gcpProjectId))
-            .collect(Collectors.toList());
+        wsmResources.stream().map(r -> makeApiResourceDescription(r)).collect(Collectors.toList());
 
     var apiResourceList = new ApiResourceList().resources(apiResourceDescriptionList);
     return new ResponseEntity<>(apiResourceList, HttpStatus.OK);
@@ -119,8 +116,7 @@ public class ResourceController implements ResourceApi {
 
   // Convert a WsmResource into the API format for enumeration
   @VisibleForTesting
-  public ApiResourceDescription makeApiResourceDescription(
-      WsmResource wsmResource, @Nullable String gcpProjectId) {
+  public ApiResourceDescription makeApiResourceDescription(WsmResource wsmResource) {
 
     ApiResourceMetadata common = wsmResource.toApiMetadata();
     var union = new ApiResourceAttributesUnion();
@@ -186,7 +182,7 @@ public class ResourceController implements ResourceApi {
             {
               ControlledAiNotebookInstanceResource resource =
                   controlledResource.castToAiNotebookInstanceResource();
-              union.gcpAiNotebookInstance(resource.toApiResource(gcpProjectId).getAttributes());
+              union.gcpAiNotebookInstance(resource.toApiResource().getAttributes());
               break;
             }
           case GCS_BUCKET:
@@ -200,7 +196,7 @@ public class ResourceController implements ResourceApi {
             {
               ControlledBigQueryDatasetResource resource =
                   controlledResource.castToBigQueryDatasetResource();
-              union.gcpBqDataset(resource.toApiAttributes(gcpProjectId));
+              union.gcpBqDataset(resource.toApiAttributes());
               break;
             }
 

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -17,7 +17,9 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.Controlled
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -873,9 +875,18 @@ public class ResourceDao {
           case GCS_BUCKET:
             return new ControlledGcsBucketResource(dbResource);
           case AI_NOTEBOOK_INSTANCE:
-            return new ControlledAiNotebookInstanceResource(dbResource);
+            {
+              // TODO: (PF-1296) handler dispatch instead of this switch statement
+              ControlledAiNotebookHandler handler = ControlledAiNotebookHandler.getHandler();
+              return handler.makeResourceFromDb(dbResource);
+            }
           case BIG_QUERY_DATASET:
-            return new ControlledBigQueryDatasetResource(dbResource);
+            {
+              // TODO: (PF-1296) handler dispatch instead of this switch statement
+              ControlledBigQueryDatasetHandler handler =
+                  ControlledBigQueryDatasetHandler.getHandler();
+              return handler.makeResourceFromDb(dbResource);
+            }
           case AZURE_IP:
             return new ControlledAzureIpResource(dbResource);
           case AZURE_DISK:

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -321,6 +321,7 @@ public class ControlledResourceService {
       ApiGcpBigQueryDatasetCreationParameters creationParameters,
       ControlledResourceIamRole privateResourceIamRole,
       AuthenticatedUserRequest userRequest) {
+
     JobBuilder jobBuilder =
         commonCreationJobBuilder(resource, privateResourceIamRole, userRequest)
             .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -1,0 +1,60 @@
+package bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook;
+
+import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import java.util.Optional;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ControlledAiNotebookHandler implements WsmResourceHandler {
+  private static ControlledAiNotebookHandler theHandler;
+  private final GcpCloudContextService gcpCloudContextService;
+
+  @Autowired
+  public ControlledAiNotebookHandler(GcpCloudContextService gcpCloudContextService) {
+    this.gcpCloudContextService = gcpCloudContextService;
+  }
+
+  public static ControlledAiNotebookHandler getHandler() {
+    return theHandler;
+  }
+
+  @PostConstruct
+  public void init() {
+    theHandler = this;
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    // Old version of attributes do not have project id, so in that case we look it up
+    ControlledAiNotebookInstanceAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAiNotebookInstanceAttributes.class);
+    String projectId =
+        Optional.ofNullable(attributes.getProjectId())
+            .orElse(gcpCloudContextService.getRequiredGcpProject(dbResource.getWorkspaceId()));
+
+    var resource =
+        ControlledAiNotebookInstanceResource.builder()
+            .workspaceId(dbResource.getWorkspaceId())
+            .resourceId(dbResource.getResourceId())
+            .name(dbResource.getName().orElse(null))
+            .description(dbResource.getDescription().orElse(null))
+            .cloningInstructions(dbResource.getCloningInstructions())
+            .assignedUser(dbResource.getAssignedUser().orElse(null))
+            .privateResourceState(dbResource.getPrivateResourceState().orElse(null))
+            .accessScope(dbResource.getAccessScope().orElse(null))
+            .managedBy(dbResource.getManagedBy().orElse(null))
+            .applicationId(dbResource.getApplicationId().orElse(null))
+            .instanceId(attributes.getInstanceId())
+            .location(attributes.getLocation())
+            .projectId(projectId)
+            .build();
+    resource.validate();
+    return resource;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceAttributes.java
@@ -7,12 +7,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ControlledAiNotebookInstanceAttributes {
   private final String instanceId;
   private final String location;
+  private final String projectId;
 
   @JsonCreator
   public ControlledAiNotebookInstanceAttributes(
-      @JsonProperty("instanceId") String instanceName, @JsonProperty("location") String location) {
+      @JsonProperty("instanceId") String instanceName,
+      @JsonProperty("location") String location,
+      @JsonProperty("projectId") String projectId) {
     this.instanceId = instanceName;
     this.location = location;
+    this.projectId = projectId;
   }
 
   public String getInstanceId() {
@@ -21,5 +25,9 @@ public class ControlledAiNotebookInstanceAttributes {
 
   public String getLocation() {
     return location;
+  }
+
+  public String getProjectId() {
+    return projectId;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetAttributes.java
@@ -5,13 +5,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ControlledBigQueryDatasetAttributes {
   private final String datasetName;
+  private final String projectId;
 
   @JsonCreator
-  public ControlledBigQueryDatasetAttributes(@JsonProperty("datasetName") String datasetName) {
+  public ControlledBigQueryDatasetAttributes(
+      @JsonProperty("datasetName") String datasetName,
+      @JsonProperty("projectId") String projectId) {
     this.datasetName = datasetName;
+    this.projectId = projectId;
   }
 
   public String getDatasetName() {
     return datasetName;
+  }
+
+  public String getProjectId() {
+    return projectId;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
@@ -1,0 +1,59 @@
+package bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset;
+
+import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import java.util.Optional;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ControlledBigQueryDatasetHandler implements WsmResourceHandler {
+  private static ControlledBigQueryDatasetHandler theHandler;
+  private final GcpCloudContextService gcpCloudContextService;
+
+  @Autowired
+  public ControlledBigQueryDatasetHandler(GcpCloudContextService gcpCloudContextService) {
+    this.gcpCloudContextService = gcpCloudContextService;
+  }
+
+  public static ControlledBigQueryDatasetHandler getHandler() {
+    return theHandler;
+  }
+
+  @PostConstruct
+  public void init() {
+    theHandler = this;
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    // Old version of attributes do not have project id, so in that case we look it up
+    ControlledBigQueryDatasetAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledBigQueryDatasetAttributes.class);
+    String projectId =
+        Optional.ofNullable(attributes.getProjectId())
+            .orElse(gcpCloudContextService.getRequiredGcpProject(dbResource.getWorkspaceId()));
+
+    var resource =
+        ControlledBigQueryDatasetResource.builder()
+            .workspaceId(dbResource.getWorkspaceId())
+            .resourceId(dbResource.getResourceId())
+            .name(dbResource.getName().orElse(null))
+            .description(dbResource.getDescription().orElse(null))
+            .cloningInstructions(dbResource.getCloningInstructions())
+            .assignedUser(dbResource.getAssignedUser().orElse(null))
+            .privateResourceState(dbResource.getPrivateResourceState().orElse(null))
+            .accessScope(dbResource.getAccessScope().orElse(null))
+            .managedBy(dbResource.getManagedBy().orElse(null))
+            .applicationId(dbResource.getApplicationId().orElse(null))
+            .datasetName(attributes.getDatasetName())
+            .projectId(projectId)
+            .build();
+    resource.validate();
+    return resource;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -90,7 +90,7 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
         .datasetId(getDatasetName());
   }
 
-  public ApiGcpBigQueryDatasetResource toApiResource(String projectId) {
+  public ApiGcpBigQueryDatasetResource toApiResource() {
     return new ApiGcpBigQueryDatasetResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
@@ -85,6 +85,8 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
             ControlledResourceKeys.LOCATION,
             ControlledResourceKeys.LOCATION,
             String.class);
+    final String destinationProjectId =
+        gcpCloudContextService.getRequiredGcpProject(destinationWorkspaceId);
     final ControlledBigQueryDatasetResource destinationResource =
         ControlledBigQueryDatasetResource.builder()
             .accessScope(sourceDataset.getAccessScope())
@@ -96,6 +98,7 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
             .name(resourceName)
             .resourceId(UUID.randomUUID())
             .workspaceId(destinationWorkspaceId)
+            .projectId(destinationProjectId)
             .build();
 
     final ApiGcpBigQueryDatasetCreationParameters creationParameters =
@@ -108,11 +111,9 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
             destinationResource, creationParameters, iamRole, userRequest);
 
     workingMap.put(ControlledResourceKeys.CLONED_RESOURCE_DEFINITION, clonedResource);
-    final String destinationProjectId =
-        gcpCloudContextService.getRequiredGcpProject(destinationWorkspaceId);
     final ApiClonedControlledGcpBigQueryDataset apiResult =
         new ApiClonedControlledGcpBigQueryDataset()
-            .dataset(clonedResource.toApiResource(destinationProjectId))
+            .dataset(clonedResource.toApiResource())
             .effectiveCloningInstructions(effectiveCloningInstructions.toApiModel())
             .sourceWorkspaceId(sourceDataset.getWorkspaceId())
             .sourceResourceId(sourceDataset.getResourceId());

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceHandler.java
@@ -1,0 +1,20 @@
+package bio.terra.workspace.service.resource.model;
+
+import bio.terra.workspace.db.model.DbResource;
+
+/**
+ * Interface defining the common methods for processing per-resource handlers. Each resource type
+ * gets a singleton handler that implements this interface. The idea is to allow code like
+ * ResourceDao to locate a resource type's handler by lookup in the type enum and call it to, for
+ * example, create the resource object from the DbResource object.
+ */
+public interface WsmResourceHandler {
+
+  /**
+   * Build a specific resource object from data out of the database.
+   *
+   * @param dbResource resource data from the database
+   * @return resource object
+   */
+  WsmResource makeResourceFromDb(DbResource dbResource);
+}

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -331,7 +331,8 @@ public class ControlledResourceFixtures {
         .assignedUser(null)
         .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
         .managedBy(ManagedByType.MANAGED_BY_USER)
-        .datasetName("test_dataset");
+        .datasetName("test_dataset")
+        .projectId("my-project-id");
   }
 
   public static final ApiGcpBigQueryDatasetUpdateParameters BQ_DATASET_UPDATE_PARAMETERS_NEW =
@@ -369,7 +370,8 @@ public class ControlledResourceFixtures {
         .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
         .managedBy(ManagedByType.MANAGED_BY_USER)
         .instanceId("my-instance-id")
-        .location("us-east1-b");
+        .location("us-east1-b")
+        .projectId("my-project-id");
   }
 
   public static final OffsetDateTime OFFSET_DATE_TIME_1 =

--- a/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
@@ -24,7 +24,6 @@ import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable.ReferencedBigQueryDataTableResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.datareposnapshot.ReferencedDataRepoSnapshotResource;
@@ -64,7 +63,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
             workspaceId, resourceId, resourceName, description, cloning, projectId, datasetName);
 
     ApiResourceDescription resourceDescription =
-        resourceController.makeApiResourceDescription((WsmResource) resource, null);
+        resourceController.makeApiResourceDescription(resource);
     validateWsmResource(resourceDescription);
     ApiResourceAttributesUnion union = resourceDescription.getResourceAttributes();
     ApiGcpBigQueryDatasetAttributes attributes = union.getGcpBqDataset();
@@ -91,7 +90,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
             datatableName);
 
     ApiResourceDescription resourceDescription =
-        resourceController.makeApiResourceDescription((WsmResource) resource, null);
+        resourceController.makeApiResourceDescription(resource);
     validateWsmResource(resourceDescription);
     ApiResourceAttributesUnion union = resourceDescription.getResourceAttributes();
     ApiGcpBigQueryDataTableAttributes attributes = union.getGcpBqDataTable();
@@ -111,7 +110,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
             workspaceId, resourceId, resourceName, description, cloning, instanceName, snapshotId);
 
     ApiResourceDescription resourceDescription =
-        resourceController.makeApiResourceDescription((WsmResource) resource, null);
+        resourceController.makeApiResourceDescription(resource);
     validateWsmResource(resourceDescription);
     ApiResourceAttributesUnion union = resourceDescription.getResourceAttributes();
     ApiDataRepoSnapshotAttributes attributes = union.getGcpDataRepoSnapshot();
@@ -129,7 +128,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
             workspaceId, resourceId, resourceName, description, cloning, bucketName);
 
     ApiResourceDescription resourceDescription =
-        resourceController.makeApiResourceDescription((WsmResource) resource, null);
+        resourceController.makeApiResourceDescription(resource);
     validateWsmResource(resourceDescription);
     ApiResourceAttributesUnion union = resourceDescription.getResourceAttributes();
     ApiGcpGcsBucketAttributes attributes = union.getGcpGcsBucket();
@@ -180,7 +179,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
               bucketName);
 
       ApiResourceDescription resourceDescription =
-          resourceController.makeApiResourceDescription(resource, null);
+          resourceController.makeApiResourceDescription(resource);
       validateControlledResource(resourceDescription);
       ApiResourceAttributesUnion union = resourceDescription.getResourceAttributes();
       ApiGcpGcsBucketAttributes attributes = union.getGcpGcsBucket();
@@ -191,6 +190,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
     @Test
     public void mapControlledBigQueryDatasetTest() throws Exception {
       String datasetName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
+      String projectId = "my-project-id";
 
       var resource =
           new ControlledBigQueryDatasetResource(
@@ -204,11 +204,11 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
               accessScopeType,
               managedByType,
               null,
-              datasetName);
+              datasetName,
+              projectId);
 
-      String projectId = "my-project-id";
       ApiResourceDescription resourceDescription =
-          resourceController.makeApiResourceDescription(resource, projectId);
+          resourceController.makeApiResourceDescription(resource);
       validateControlledResource(resourceDescription);
       ApiResourceAttributesUnion union = resourceDescription.getResourceAttributes();
       ApiGcpBigQueryDatasetAttributes attributes = union.getGcpBqDataset();
@@ -233,11 +233,12 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
               .managedBy(managedByType)
               .location("us-east1-b")
               .instanceId(instanceId)
+              .projectId("my-project-id")
               .build();
 
       String projectId = "my-project-id";
       ApiResourceDescription resourceDescription =
-          resourceController.makeApiResourceDescription(resource, projectId);
+          resourceController.makeApiResourceDescription(resource);
       validateControlledResource(resourceDescription);
       ApiResourceAttributesUnion union = resourceDescription.getResourceAttributes();
       ApiGcpAiNotebookInstanceAttributes attributes = union.getGcpAiNotebookInstance();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResourceTest.java
@@ -111,9 +111,10 @@ public class ControlledAiNotebookInstanceResourceTest extends BaseUnitTest {
             .name("my-notebook")
             .instanceId("my-instance-id")
             .location("us-east1-b")
+            .projectId("my-project-id")
             .build();
 
-    ApiGcpAiNotebookInstanceResource apiResource = resource.toApiResource("my-project-id");
+    ApiGcpAiNotebookInstanceResource apiResource = resource.toApiResource();
     assertEquals("my-notebook", apiResource.getMetadata().getName());
     assertEquals("my-project-id", apiResource.getAttributes().getProjectId());
     assertEquals("us-east1-b", apiResource.getAttributes().getLocation());

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -87,10 +87,12 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
         jobService.retrieveAsyncJobResult(
             makeContextJobId, GcpCloudContext.class, userAccessUtils.defaultUserAuthRequest());
     assertEquals(StatusEnum.SUCCEEDED, createContextJobResult.getJobReport().getStatus());
+    GcpCloudContext cloudContext = createContextJobResult.getResult();
 
     // Create a private dataset for secondary user
     String datasetId = RandomStringUtils.randomAlphabetic(8);
-    ControlledBigQueryDatasetResource privateDataset = buildPrivateDataset(workspaceId, datasetId);
+    ControlledBigQueryDatasetResource privateDataset =
+        buildPrivateDataset(workspaceId, datasetId, cloudContext.getGcpProjectId());
     assertNotNull(privateDataset);
 
     // Validate with Sam that secondary user can read their private resource
@@ -184,7 +186,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
   }
 
   private ControlledBigQueryDatasetResource buildPrivateDataset(
-      UUID workspaceId, String datasetName) {
+      UUID workspaceId, String datasetName, String projectId) {
     ControlledBigQueryDatasetResource datasetToCreate =
         ControlledBigQueryDatasetResource.builder()
             .workspaceId(workspaceId)
@@ -195,6 +197,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
             .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
             .managedBy(ManagedByType.MANAGED_BY_USER)
             .datasetName(datasetName)
+            .projectId(projectId)
             .build();
     ApiGcpBigQueryDatasetCreationParameters datasetCreationParameters =
         new ApiGcpBigQueryDatasetCreationParameters()


### PR DESCRIPTION
In working on the larger resource handler implementation I ran into a problem. Notebooks and controlled buckets returned their GCP projectId in the resource return, but did not save the projectId in their attributes. That meant that we had to do a cloud context lookup in the database in those specific cases.

This change stores projectId as part of the attributes for those objects. The projectId is immutable, so it is safe to store with the resource. This is upward compatible, but not backward compatible. The new version of attributes can deserialize the old version of attributes, but not vice versa. This is only an issue during a rolling upgrade, so not something I think we need to worry about right now.

To implement the upward compatibility, I needed to call the GcpCloudContextService and get the projectId. I cannot do that from the resource object, so I put in the initial resource handler hierarchy. I just implemented the minimum of the two handlers for these objects.

I put you three on the reviewer list to keep you in the loop on these structural changes. Let me know if you'd prefer I spread it around.