### PR TITLE
[IA-3196] update credential path

### DIFF
--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -255,7 +255,7 @@ vaultgetdb "secret/dsde/terra/kernel/${k8senv}/${namespace}/workspace/postgres/s
 # Write the test application configuration into the local-properties.yml file
 if [ "$target" == "local" ]; then
   tmpfile=$(mktemp)
-  vaultget "secret/dsde/terra/azure/common/managed-app-publisher" "${tmpfile}"
+  vaultget "secret/dsde/terra/azure/dev/workspacemanager/managed-app-publisher" "${tmpfile}"
   clientid=$(jq -r '."client-id"' "${tmpfile}" )
   clientsecret=$(jq -r '."client-secret"' "${tmpfile}" )
   tenantid=$(jq -r '."tenant-id"' "${tmpfile}" )

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -132,7 +132,7 @@ terra.common:
 # in the container, so you can get the equivalent setting by adding:
 #
 #  env:
-#    FEATURE_AZURE_ENABLED: true
+#    FEATURE_AZUREENABLED: true
 #
 # into the appropriate values file. That includes the values file in local_dev.
 feature:


### PR DESCRIPTION
A better terraformed credential is created via https://github.com/broadinstitute/terraform-ap-deployments/pull/502

Update WSM to use that