### PR TITLE
[PF-1296] Add handlers and revamp resource type

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
@@ -16,8 +16,8 @@ import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.workspace.Alpha1Service;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.EnumeratedJob;
@@ -89,7 +89,7 @@ public class Alpha1ApiController implements Alpha1Api {
             userRequest,
             limit,
             pageToken,
-            WsmCloudResourceType.fromApiOptional(resource),
+            WsmResourceFamily.fromApiOptional(resource),
             StewardshipType.fromApiOptional(stewardship),
             name,
             JobStateFilter.fromApi(jobState));

--- a/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.app.controller;
 
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
-import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.ControllerValidationUtils;
 import bio.terra.workspace.common.utils.ErrorReportUtils;
 import bio.terra.workspace.generated.controller.Alpha1Api;
@@ -10,32 +9,20 @@ import bio.terra.workspace.generated.model.ApiEnumeratedJob;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.generated.model.ApiJobStateFilter;
 import bio.terra.workspace.generated.model.ApiResourceType;
-import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.ValidationUtils;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
-import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResource;
-import bio.terra.workspace.service.resource.model.WsmResourceType;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable.ReferencedBigQueryDataTableResource;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.datareposnapshot.ReferencedDataRepoSnapshotResource;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.ReferencedGcsBucketResource;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject.ReferencedGcsObjectResource;
 import bio.terra.workspace.service.workspace.Alpha1Service;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.EnumeratedJob;
 import bio.terra.workspace.service.workspace.model.EnumeratedJobs;
 import bio.terra.workspace.service.workspace.model.JobStateFilter;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -87,11 +74,13 @@ public class Alpha1ApiController implements Alpha1Api {
     // Make sure Alpha1 is enabled
     features.alpha1EnabledCheck();
 
+    // Prepare the inputs
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(userRequest, workspaceId, SamWorkspaceAction.READ);
-
     ControllerValidationUtils.validatePaginationParams(0, limit);
     ValidationUtils.validateOptionalResourceName(name);
+
+    // Make sure the caller has read access to the workspace
+    workspaceService.validateWorkspaceAndAction(userRequest, workspaceId, SamWorkspaceAction.READ);
 
     // Do the enumeration
     EnumeratedJobs enumeratedJobs =
@@ -100,7 +89,7 @@ public class Alpha1ApiController implements Alpha1Api {
             userRequest,
             limit,
             pageToken,
-            WsmResourceType.fromApiOptional(resource),
+            WsmCloudResourceType.fromApiOptional(resource),
             StewardshipType.fromApiOptional(stewardship),
             name,
             JobStateFilter.fromApi(jobState));
@@ -124,7 +113,7 @@ public class Alpha1ApiController implements Alpha1Api {
               .jobDescription(enumeratedJob.getJobDescription())
               .operationType(enumeratedJob.getOperationType().toApiModel())
               .resourceType(optResource.map(r -> r.getResourceType().toApiModel()).orElse(null))
-              .resource(optResource.map(this::apiResourceFromWsmResource).orElse(null));
+              .resource(optResource.map(WsmResource::toApiResourceUnion).orElse(null));
       apiJobList.add(apiJob);
     }
 
@@ -135,99 +124,6 @@ public class Alpha1ApiController implements Alpha1Api {
             .results(apiJobList);
 
     return new ResponseEntity<>(result, HttpStatus.OK);
-  }
-
-  // Convert a WsmResource into the API format for enumeration
-  @VisibleForTesting
-  public ApiResourceUnion apiResourceFromWsmResource(WsmResource wsmResource) {
-
-    var union = new ApiResourceUnion();
-    switch (wsmResource.getStewardshipType()) {
-      case REFERENCED:
-        ReferencedResource referencedResource = wsmResource.castToReferencedResource();
-        switch (wsmResource.getResourceType()) {
-          case BIG_QUERY_DATASET:
-            {
-              ReferencedBigQueryDatasetResource resource =
-                  referencedResource.castToBigQueryDatasetResource();
-              union.gcpBqDataset(resource.toApiResource());
-              break;
-            }
-          case BIG_QUERY_DATA_TABLE:
-            {
-              ReferencedBigQueryDataTableResource resource =
-                  referencedResource.castToBigQueryDataTableResource();
-              union.gcpBqDataTable(resource.toApiResource());
-              break;
-            }
-          case DATA_REPO_SNAPSHOT:
-            {
-              ReferencedDataRepoSnapshotResource resource =
-                  referencedResource.castToDataRepoSnapshotResource();
-              union.gcpDataRepoSnapshot(resource.toApiResource());
-              break;
-            }
-
-          case GCS_BUCKET:
-            {
-              ReferencedGcsBucketResource resource = referencedResource.castToGcsBucketResource();
-              union.gcpGcsBucket(resource.toApiModel());
-              break;
-            }
-
-          case GCS_OBJECT:
-            {
-              ReferencedGcsObjectResource resource = referencedResource.castToGcsObjectResource();
-              union.gcpGcsObject(resource.toApiModel());
-              break;
-            }
-
-          default:
-            throw new InternalLogicException(
-                "Unknown referenced resource type: " + wsmResource.getResourceType());
-        }
-        break; // referenced
-
-      case CONTROLLED:
-        ControlledResource controlledResource = wsmResource.castToControlledResource();
-        switch (wsmResource.getResourceType()) {
-          case AI_NOTEBOOK_INSTANCE:
-            {
-              ControlledAiNotebookInstanceResource resource =
-                  controlledResource.castToAiNotebookInstanceResource();
-              union.gcpAiNotebookInstance(resource.toApiResource());
-              break;
-            }
-          case GCS_BUCKET:
-            {
-              ControlledGcsBucketResource resource = controlledResource.castToGcsBucketResource();
-              union.gcpGcsBucket(resource.toApiResource());
-              break;
-            }
-
-          case BIG_QUERY_DATASET:
-            {
-              ControlledBigQueryDatasetResource resource =
-                  controlledResource.castToBigQueryDatasetResource();
-              union.gcpBqDataset(resource.toApiResource());
-              break;
-            }
-          case DATA_REPO_SNAPSHOT: // there is a use case for this, but low priority
-            throw new InternalLogicException(
-                "Unimplemented controlled resource type: " + wsmResource.getResourceType());
-
-          default:
-            throw new InternalLogicException(
-                "Unknown controlled resource type: " + wsmResource.getResourceType());
-        }
-        break; // controlled
-
-      default:
-        throw new InternalLogicException(
-            "Unknown stewardship type: " + wsmResource.getStewardshipType());
-    }
-
-    return union;
   }
 
   private AuthenticatedUserRequest getAuthenticatedInfo() {

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -183,7 +183,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     final ControlledResource resource =
         controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
-    if (resource.getResourceType() != WsmResourceType.GCS_BUCKET) {
+    if (resource.getResourceType() != WsmResourceType.CONTROLLED_GCP_GCS_BUCKET) {
       throw new InvalidControlledResourceException(
           String.format("Resource %s is not a GCS Bucket", resourceId));
     }
@@ -265,7 +265,7 @@ public class ControlledGcpResourceApiController implements ControlledGcpResource
 
     final ControlledResource resource =
         controlledResourceService.getControlledResource(workspaceId, resourceId, userRequest);
-    if (resource.getResourceType() != WsmResourceType.BIG_QUERY_DATASET) {
+    if (resource.getResourceType() != WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET) {
       throw new InvalidControlledResourceException(
           String.format("Resource %s is not a BigQuery Dataset", resourceId));
     }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -33,7 +33,7 @@ import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
-import bio.terra.workspace.service.resource.referenced.cloud.any.ReferencedGitRepoResource;
+import bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo.ReferencedGitRepoResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResourceService;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
@@ -46,6 +46,8 @@ import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -61,6 +63,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   private final ValidationUtils validationUtils;
   private final HttpServletRequest request;
   private final PetSaService petSaService;
+  private final Logger logger = LoggerFactory.getLogger(ReferencedGcpResourceController.class);
 
   @Autowired
   public ReferencedGcpResourceController(
@@ -81,6 +84,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   // -- GCS Bucket object -- //
+
   @Override
   public ResponseEntity<ApiGcpGcsObjectResource> createGcsObjectReference(
       UUID workspaceId, @Valid ApiCreateGcpGcsObjectReferenceRequestBody body) {
@@ -99,7 +103,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
 
     ReferencedResource referenceResource =
         referenceResourceService.createReferenceResource(resource, getAuthenticatedInfo());
-    ApiGcpGcsObjectResource response = referenceResource.castToGcsObjectResource().toApiModel();
+    ApiGcpGcsObjectResource response = referenceResource.castToGcsObjectResource().toApiResource();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -108,7 +112,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResource(id, referenceId, userRequest);
-    ApiGcpGcsObjectResource response = referenceResource.castToGcsObjectResource().toApiModel();
+    ApiGcpGcsObjectResource response = referenceResource.castToGcsObjectResource().toApiResource();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -117,7 +121,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResourceByName(id, name, userRequest);
-    ApiGcpGcsObjectResource response = referenceResource.castToGcsObjectResource().toApiModel();
+    ApiGcpGcsObjectResource response = referenceResource.castToGcsObjectResource().toApiResource();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -166,7 +170,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ResponseEntity<Void> deleteGcsObjectReference(UUID workspaceId, UUID resourceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.deleteReferenceResourceForResourceType(
-        workspaceId, resourceId, userRequest, WsmResourceType.GCS_OBJECT);
+        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_GCP_GCS_OBJECT);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -188,7 +192,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
 
     ReferencedResource referenceResource =
         referenceResourceService.createReferenceResource(resource, getAuthenticatedInfo());
-    ApiGcpGcsBucketResource response = referenceResource.castToGcsBucketResource().toApiModel();
+    ApiGcpGcsBucketResource response = referenceResource.castToGcsBucketResource().toApiResource();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -197,7 +201,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResource(id, referenceId, userRequest);
-    ApiGcpGcsBucketResource response = referenceResource.castToGcsBucketResource().toApiModel();
+    ApiGcpGcsBucketResource response = referenceResource.castToGcsBucketResource().toApiResource();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -206,7 +210,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResourceByName(id, name, userRequest);
-    ApiGcpGcsBucketResource response = referenceResource.castToGcsBucketResource().toApiModel();
+    ApiGcpGcsBucketResource response = referenceResource.castToGcsBucketResource().toApiResource();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -249,7 +253,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ResponseEntity<Void> deleteBucketReference(UUID workspaceId, UUID resourceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.deleteReferenceResourceForResourceType(
-        workspaceId, resourceId, userRequest, WsmResourceType.GCS_BUCKET);
+        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_GCP_GCS_BUCKET);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -349,7 +353,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ResponseEntity<Void> deleteBigQueryDataTableReference(UUID workspaceId, UUID resourceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.deleteReferenceResourceForResourceType(
-        workspaceId, resourceId, userRequest, WsmResourceType.BIG_QUERY_DATA_TABLE);
+        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -447,7 +451,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ResponseEntity<Void> deleteBigQueryDatasetReference(UUID workspaceId, UUID resourceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.deleteReferenceResourceForResourceType(
-        workspaceId, resourceId, userRequest, WsmResourceType.BIG_QUERY_DATASET);
+        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -542,7 +546,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ResponseEntity<Void> deleteDataRepoSnapshotReference(UUID workspaceId, UUID resourceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.deleteReferenceResourceForResourceType(
-        workspaceId, resourceId, userRequest, WsmResourceType.DATA_REPO_SNAPSHOT);
+        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -580,7 +584,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     // Build the correct response type
     final var result =
         new ApiCloneReferencedGcpGcsObjectResourceResult()
-            .resource(clonedReferencedResource.castToGcsObjectResource().toApiModel())
+            .resource(clonedReferencedResource.castToGcsObjectResource().toApiResource())
             .sourceWorkspaceId(sourceReferencedResource.getWorkspaceId())
             .sourceResourceId(sourceReferencedResource.getResourceId())
             .effectiveCloningInstructions(effectiveCloningInstructions.toApiModel());
@@ -591,7 +595,6 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ResponseEntity<ApiCloneReferencedGcpGcsBucketResourceResult> cloneGcpGcsBucketReference(
       UUID workspaceId, UUID resourceId, @Valid ApiCloneReferencedResourceRequestBody body) {
     final AuthenticatedUserRequest petRequest = getCloningCredentials(workspaceId);
-
     final ReferencedResource sourceReferencedResource =
         referenceResourceService.getReferenceResource(workspaceId, resourceId, petRequest);
 
@@ -622,7 +625,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     // Build the correct response type
     final var result =
         new ApiCloneReferencedGcpGcsBucketResourceResult()
-            .resource(clonedReferencedResource.castToGcsBucketResource().toApiModel())
+            .resource(clonedReferencedResource.castToGcsBucketResource().toApiResource())
             .sourceWorkspaceId(sourceReferencedResource.getWorkspaceId())
             .sourceResourceId(sourceReferencedResource.getResourceId())
             .effectiveCloningInstructions(effectiveCloningInstructions.toApiModel());
@@ -676,7 +679,6 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
       cloneGcpBigQueryDatasetReference(
           UUID workspaceId, UUID resourceId, @Valid ApiCloneReferencedResourceRequestBody body) {
     final AuthenticatedUserRequest petRequest = getCloningCredentials(workspaceId);
-
     final ReferencedResource sourceReferencedResource =
         referenceResourceService.getReferenceResource(workspaceId, resourceId, petRequest);
 
@@ -719,6 +721,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
       cloneGcpDataRepoSnapshotReference(
           UUID workspaceId, UUID resourceId, @Valid ApiCloneReferencedResourceRequestBody body) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+
     final ReferencedResource sourceReferencedResource =
         referenceResourceService.getReferenceResource(workspaceId, resourceId, userRequest);
 
@@ -774,7 +777,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
 
     ReferencedResource referenceResource =
         referenceResourceService.createReferenceResource(resource, getAuthenticatedInfo());
-    ApiGitRepoResource response = referenceResource.castToGitRepoResource().toApiModel();
+    ApiGitRepoResource response = referenceResource.castToGitRepoResource().toApiResource();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -783,7 +786,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResource(workspaceId, resourceId, userRequest);
-    ApiGitRepoResource response = referenceResource.castToGitRepoResource().toApiModel();
+    ApiGitRepoResource response = referenceResource.castToGitRepoResource().toApiResource();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -793,7 +796,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResourceByName(workspaceId, resourceName, userRequest);
-    ApiGitRepoResource response = referenceResource.castToGitRepoResource().toApiModel();
+    ApiGitRepoResource response = referenceResource.castToGitRepoResource().toApiResource();
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -829,7 +832,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ResponseEntity<Void> deleteGitRepoReference(UUID workspaceId, UUID resourceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.deleteReferenceResourceForResourceType(
-        workspaceId, resourceId, userRequest, WsmResourceType.GIT_REPO);
+        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_GIT_REPO);
     return new ResponseEntity<>(HttpStatus.OK);
   }
 
@@ -866,7 +869,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     // Build the correct response type
     ApiCloneReferencedGitRepoResourceResult result =
         new ApiCloneReferencedGitRepoResourceResult()
-            .resource(clonedReferencedResource.castToGitRepoResource().toApiModel())
+            .resource(clonedReferencedResource.castToGitRepoResource().toApiResource())
             .sourceWorkspaceId(sourceReferencedResource.getWorkspaceId())
             .sourceResourceId(sourceReferencedResource.getResourceId())
             .effectiveCloningInstructions(effectiveCloningInstructions.toApiModel());

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -546,7 +546,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ResponseEntity<Void> deleteDataRepoSnapshotReference(UUID workspaceId, UUID resourceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.deleteReferenceResourceForResourceType(
-        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
+        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -832,7 +832,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ResponseEntity<Void> deleteGitRepoReference(UUID workspaceId, UUID resourceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     referenceResourceService.deleteReferenceResourceForResourceType(
-        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_GIT_REPO);
+        workspaceId, resourceId, userRequest, WsmResourceType.REFERENCED_ANY_GIT_REPO);
     return new ResponseEntity<>(HttpStatus.OK);
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ResourceController.java
@@ -13,8 +13,8 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.WsmResourceService;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResourceService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.google.common.annotations.VisibleForTesting;
@@ -77,7 +77,7 @@ public class ResourceController implements ResourceApi {
     List<WsmResource> wsmResources =
         resourceService.enumerateResources(
             workspaceId,
-            WsmCloudResourceType.fromApiOptional(resource),
+            WsmResourceFamily.fromApiOptional(resource),
             StewardshipType.fromApiOptional(stewardship),
             offset,
             limit,

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -290,7 +290,7 @@ public class WorkspaceApiController implements WorkspaceApi {
 
     // TODO(PF-404): this endpoint's return type does not support reference types beyond snapshots.
     // Clients should migrate to type-specific endpoints, and this endpoint should be removed.
-    if (referenceResource.getResourceType() != WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT) {
+    if (referenceResource.getResourceType() != WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT) {
       throw new InvalidReferenceException(
           "This endpoint does not support non-snapshot references. Use the newer type-specific endpoints instead.");
     }
@@ -375,7 +375,7 @@ public class WorkspaceApiController implements WorkspaceApi {
     // TODO(PF-404): this is a workaround until clients migrate off this endpoint.
     ApiDataReferenceList responseList = new ApiDataReferenceList();
     for (ReferencedResource resource : enumerateResult) {
-      if (resource.getResourceType() == WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT) {
+      if (resource.getResourceType() == WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT) {
         responseList.addResourcesItem(makeApiDataReferenceDescription(resource));
       }
     }

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -290,7 +290,7 @@ public class WorkspaceApiController implements WorkspaceApi {
 
     // TODO(PF-404): this endpoint's return type does not support reference types beyond snapshots.
     // Clients should migrate to type-specific endpoints, and this endpoint should be removed.
-    if (referenceResource.getResourceType() != WsmResourceType.DATA_REPO_SNAPSHOT) {
+    if (referenceResource.getResourceType() != WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT) {
       throw new InvalidReferenceException(
           "This endpoint does not support non-snapshot references. Use the newer type-specific endpoints instead.");
     }
@@ -375,7 +375,7 @@ public class WorkspaceApiController implements WorkspaceApi {
     // TODO(PF-404): this is a workaround until clients migrate off this endpoint.
     ApiDataReferenceList responseList = new ApiDataReferenceList();
     for (ReferencedResource resource : enumerateResult) {
-      if (resource.getResourceType() == WsmResourceType.DATA_REPO_SNAPSHOT) {
+      if (resource.getResourceType() == WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT) {
         responseList.addResourcesItem(makeApiDataReferenceDescription(resource));
       }
     }

--- a/service/src/main/java/bio/terra/workspace/db/model/DbResource.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/DbResource.java
@@ -5,6 +5,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import java.util.Optional;
@@ -23,6 +24,7 @@ public class DbResource {
   private String name;
   private String description;
   private StewardshipType stewardshipType;
+  private WsmCloudResourceType cloudResourceType;
   private WsmResourceType resourceType;
   private CloningInstructions cloningInstructions;
   private String attributes;
@@ -85,6 +87,15 @@ public class DbResource {
   public DbResource stewardshipType(StewardshipType stewardshipType) {
     this.stewardshipType = stewardshipType;
     return this;
+  }
+
+  public DbResource cloudResourceType(WsmCloudResourceType cloudResourceType) {
+    this.cloudResourceType = cloudResourceType;
+    return this;
+  }
+
+  public WsmCloudResourceType getCloudResourceType() {
+    return cloudResourceType;
   }
 
   public WsmResourceType getResourceType() {

--- a/service/src/main/java/bio/terra/workspace/db/model/DbResource.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/DbResource.java
@@ -5,7 +5,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import java.util.Optional;
@@ -24,7 +24,7 @@ public class DbResource {
   private String name;
   private String description;
   private StewardshipType stewardshipType;
-  private WsmCloudResourceType cloudResourceType;
+  private WsmResourceFamily cloudResourceType;
   private WsmResourceType resourceType;
   private CloningInstructions cloningInstructions;
   private String attributes;
@@ -89,12 +89,12 @@ public class DbResource {
     return this;
   }
 
-  public DbResource cloudResourceType(WsmCloudResourceType cloudResourceType) {
+  public DbResource cloudResourceType(WsmResourceFamily cloudResourceType) {
     this.cloudResourceType = cloudResourceType;
     return this;
   }
 
-  public WsmCloudResourceType getCloudResourceType() {
+  public WsmResourceFamily getCloudResourceType() {
     return cloudResourceType;
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceService.java
@@ -4,8 +4,8 @@ import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import java.util.List;
 import java.util.UUID;
@@ -28,7 +28,7 @@ public class WsmResourceService {
 
   public List<WsmResource> enumerateResources(
       UUID workspaceId,
-      @Nullable WsmCloudResourceType cloudResourceType,
+      @Nullable WsmResourceFamily cloudResourceType,
       @Nullable StewardshipType stewardshipType,
       int offset,
       int limit,

--- a/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceService.java
@@ -4,8 +4,8 @@ import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResource;
-import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import java.util.List;
 import java.util.UUID;
@@ -28,7 +28,7 @@ public class WsmResourceService {
 
   public List<WsmResource> enumerateResources(
       UUID workspaceId,
-      @Nullable WsmResourceType resourceType,
+      @Nullable WsmCloudResourceType cloudResourceType,
       @Nullable StewardshipType stewardshipType,
       int offset,
       int limit,
@@ -40,6 +40,6 @@ public class WsmResourceService {
         userRequest, workspaceId, SamConstants.SamWorkspaceAction.READ);
 
     return resourceDao.enumerateResources(
-        workspaceId, resourceType, stewardshipType, offset, limit);
+        workspaceId, cloudResourceType, stewardshipType, offset, limit);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.disk;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ControlledAzureDiskHandler implements WsmResourceHandler {
   private static ControlledAzureDiskHandler theHandler;
 
   public static ControlledAzureDiskHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ControlledAzureDiskHandler());
+    if (theHandler == null) {
+      theHandler = new ControlledAzureDiskHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.disk;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ControlledAzureDiskHandler implements WsmResourceHandler {
+  private static ControlledAzureDiskHandler theHandler;
+
+  public static ControlledAzureDiskHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ControlledAzureDiskHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ControlledAzureDiskResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
@@ -12,6 +12,7 @@ public class ControlledAzureDiskHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ControlledAzureDiskHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ControlledAzureDiskResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -6,12 +6,16 @@ import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiAzureDiskAttributes;
 import bio.terra.workspace.generated.model.ApiAzureDiskResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -89,7 +93,12 @@ public class ControlledAzureDiskResource extends ControlledResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.AZURE_DISK;
+    return WsmResourceType.CONTROLLED_AZURE_DISK;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.AZURE_DISK;
   }
 
   @Override
@@ -99,10 +108,26 @@ public class ControlledAzureDiskResource extends ControlledResource {
   }
 
   @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.azureDisk(toApiAttributes());
+    return union;
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    ApiResourceUnion union = new ApiResourceUnion();
+    union.azureDisk(toApiResource());
+    return union;
+  }
+
+  @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.AZURE_DISK) {
-      throw new InconsistentFieldsException("Expected AZURE_DISK");
+    if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_DISK
+        || getCloudResourceType() != WsmCloudResourceType.AZURE_DISK
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected controlled AZURE_DISK");
     }
     if (getDiskName() == null) {
       throw new MissingRequiredFieldException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -15,7 +15,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -97,8 +97,8 @@ public class ControlledAzureDiskResource extends ControlledResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.AZURE_DISK;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.AZURE_DISK;
   }
 
   @Override
@@ -125,7 +125,7 @@ public class ControlledAzureDiskResource extends ControlledResource {
   public void validate() {
     super.validate();
     if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_DISK
-        || getCloudResourceType() != WsmCloudResourceType.AZURE_DISK
+        || getResourceFamily() != WsmResourceFamily.AZURE_DISK
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected controlled AZURE_DISK");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.ip;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ControlledAzureIpHandler implements WsmResourceHandler {
+  private static ControlledAzureIpHandler theHandler;
+
+  public static ControlledAzureIpHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ControlledAzureIpHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ControlledAzureIpResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
@@ -12,6 +12,7 @@ public class ControlledAzureIpHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ControlledAzureIpHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ControlledAzureIpResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.ip;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ControlledAzureIpHandler implements WsmResourceHandler {
   private static ControlledAzureIpHandler theHandler;
 
   public static ControlledAzureIpHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ControlledAzureIpHandler());
+    if (theHandler == null) {
+      theHandler = new ControlledAzureIpHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
@@ -6,12 +6,16 @@ import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiAzureIpAttributes;
 import bio.terra.workspace.generated.model.ApiAzureIpResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -81,7 +85,12 @@ public class ControlledAzureIpResource extends ControlledResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.AZURE_IP;
+    return WsmResourceType.CONTROLLED_AZURE_IP;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.AZURE_IP;
   }
 
   @Override
@@ -90,10 +99,26 @@ public class ControlledAzureIpResource extends ControlledResource {
   }
 
   @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.azureIp(toApiAttributes());
+    return union;
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    ApiResourceUnion union = new ApiResourceUnion();
+    union.azureIp(toApiResource());
+    return union;
+  }
+
+  @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.AZURE_IP) {
-      throw new InconsistentFieldsException("Expected AZURE_IP");
+    if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_IP
+        || getCloudResourceType() != WsmCloudResourceType.AZURE_IP
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected controlled AZURE_IP");
     }
     if (getIpName() == null) {
       throw new MissingRequiredFieldException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
@@ -15,7 +15,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -89,8 +89,8 @@ public class ControlledAzureIpResource extends ControlledResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.AZURE_IP;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.AZURE_IP;
   }
 
   @Override
@@ -116,7 +116,7 @@ public class ControlledAzureIpResource extends ControlledResource {
   public void validate() {
     super.validate();
     if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_IP
-        || getCloudResourceType() != WsmCloudResourceType.AZURE_IP
+        || getResourceFamily() != WsmResourceFamily.AZURE_IP
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected controlled AZURE_IP");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.network;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ControlledAzureNetworkHandler implements WsmResourceHandler {
+  private static ControlledAzureNetworkHandler theHandler;
+
+  public static ControlledAzureNetworkHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ControlledAzureNetworkHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ControlledAzureNetworkResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.network;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ControlledAzureNetworkHandler implements WsmResourceHandler {
   private static ControlledAzureNetworkHandler theHandler;
 
   public static ControlledAzureNetworkHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ControlledAzureNetworkHandler());
+    if (theHandler == null) {
+      theHandler = new ControlledAzureNetworkHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
@@ -12,6 +12,7 @@ public class ControlledAzureNetworkHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ControlledAzureNetworkHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ControlledAzureNetworkResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
@@ -15,7 +15,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -120,8 +120,8 @@ public class ControlledAzureNetworkResource extends ControlledResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.AZURE_NETWORK;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.AZURE_NETWORK;
   }
 
   @Override
@@ -153,7 +153,7 @@ public class ControlledAzureNetworkResource extends ControlledResource {
   public void validate() {
     super.validate();
     if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_NETWORK
-        || getCloudResourceType() != WsmCloudResourceType.AZURE_NETWORK
+        || getResourceFamily() != WsmResourceFamily.AZURE_NETWORK
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_NETWORK");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
@@ -6,12 +6,16 @@ import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiAzureNetworkAttributes;
 import bio.terra.workspace.generated.model.ApiAzureNetworkResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -112,7 +116,12 @@ public class ControlledAzureNetworkResource extends ControlledResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.AZURE_NETWORK;
+    return WsmResourceType.CONTROLLED_AZURE_NETWORK;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.AZURE_NETWORK;
   }
 
   @Override
@@ -127,10 +136,26 @@ public class ControlledAzureNetworkResource extends ControlledResource {
   }
 
   @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.azureNetwork(toApiAttributes());
+    return union;
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    ApiResourceUnion union = new ApiResourceUnion();
+    union.azureNetwork(toApiResource());
+    return union;
+  }
+
+  @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.AZURE_NETWORK) {
-      throw new InconsistentFieldsException("Expected AZURE_NETWORK");
+    if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_NETWORK
+        || getCloudResourceType() != WsmCloudResourceType.AZURE_NETWORK
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_NETWORK");
     }
     if (getNetworkName() == null) {
       throw new MissingRequiredFieldException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storage;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ControlledAzureStorageHandler implements WsmResourceHandler {
+  private static ControlledAzureStorageHandler theHandler;
+
+  public static ControlledAzureStorageHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ControlledAzureStorageHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ControlledAzureStorageResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
@@ -12,6 +12,7 @@ public class ControlledAzureStorageHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ControlledAzureStorageHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ControlledAzureStorageResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.storage;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ControlledAzureStorageHandler implements WsmResourceHandler {
   private static ControlledAzureStorageHandler theHandler;
 
   public static ControlledAzureStorageHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ControlledAzureStorageHandler());
+    if (theHandler == null) {
+      theHandler = new ControlledAzureStorageHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
@@ -15,7 +15,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -93,8 +93,8 @@ public class ControlledAzureStorageResource extends ControlledResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.AZURE_STORAGE_ACCOUNT;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.AZURE_STORAGE_ACCOUNT;
   }
 
   @Override
@@ -121,7 +121,7 @@ public class ControlledAzureStorageResource extends ControlledResource {
   public void validate() {
     super.validate();
     if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT
-        || getCloudResourceType() != WsmCloudResourceType.AZURE_STORAGE_ACCOUNT
+        || getResourceFamily() != WsmResourceFamily.AZURE_STORAGE_ACCOUNT
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_STORAGE_ACCOUNT");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
@@ -6,12 +6,16 @@ import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiAzureStorageAttributes;
 import bio.terra.workspace.generated.model.ApiAzureStorageResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -85,7 +89,12 @@ public class ControlledAzureStorageResource extends ControlledResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.AZURE_STORAGE_ACCOUNT;
+    return WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.AZURE_STORAGE_ACCOUNT;
   }
 
   @Override
@@ -95,10 +104,26 @@ public class ControlledAzureStorageResource extends ControlledResource {
   }
 
   @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.azureStorage(toApiAttributes());
+    return union;
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    ApiResourceUnion union = new ApiResourceUnion();
+    union.azureStorageAccount(toApiResource());
+    return union;
+  }
+
+  @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.AZURE_STORAGE_ACCOUNT) {
-      throw new InconsistentFieldsException("Expected AZURE_STORAGE_ACCOUNT");
+    if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT
+        || getCloudResourceType() != WsmCloudResourceType.AZURE_STORAGE_ACCOUNT
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_STORAGE_ACCOUNT");
     }
     if (getStorageAccountName() == null) {
       throw new MissingRequiredFieldException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ControlledAzureVmHandler implements WsmResourceHandler {
+  private static ControlledAzureVmHandler theHandler;
+
+  public static ControlledAzureVmHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ControlledAzureVmHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ControlledAzureVmResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ControlledAzureVmHandler implements WsmResourceHandler {
   private static ControlledAzureVmHandler theHandler;
 
   public static ControlledAzureVmHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ControlledAzureVmHandler());
+    if (theHandler == null) {
+      theHandler = new ControlledAzureVmHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
@@ -12,6 +12,7 @@ public class ControlledAzureVmHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ControlledAzureVmHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ControlledAzureVmResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -6,12 +6,16 @@ import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiAzureVmAttributes;
 import bio.terra.workspace.generated.model.ApiAzureVmResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -128,8 +132,27 @@ public class ControlledAzureVmResource extends ControlledResource {
   }
 
   @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.azureVm(toApiAttributes());
+    return union;
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    ApiResourceUnion union = new ApiResourceUnion();
+    union.azureVm(toApiResource());
+    return union;
+  }
+
+  @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.AZURE_VM;
+    return WsmResourceType.CONTROLLED_AZURE_VM;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.AZURE_VM;
   }
 
   @Override
@@ -148,8 +171,10 @@ public class ControlledAzureVmResource extends ControlledResource {
   @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.AZURE_VM) {
-      throw new InconsistentFieldsException("Expected AZURE_VM");
+    if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_VM
+        || getCloudResourceType() != WsmCloudResourceType.AZURE_VM
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_VM");
     }
     if (getVmName() == null) {
       throw new MissingRequiredFieldException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -15,7 +15,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -151,8 +151,8 @@ public class ControlledAzureVmResource extends ControlledResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.AZURE_VM;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.AZURE_VM;
   }
 
   @Override
@@ -172,7 +172,7 @@ public class ControlledAzureVmResource extends ControlledResource {
   public void validate() {
     super.validate();
     if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_VM
-        || getCloudResourceType() != WsmCloudResourceType.AZURE_VM
+        || getResourceFamily() != WsmResourceFamily.AZURE_VM
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_VM");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRole.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp;
 
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import java.util.List;
 
@@ -39,7 +39,7 @@ public class CustomGcpIamRole {
    * @param includedPermissions The list of GCP permissions this role should grant.
    */
   public static CustomGcpIamRole ofResource(
-      WsmCloudResourceType cloudResourceType,
+      WsmResourceFamily cloudResourceType,
       ControlledResourceIamRole iamRole,
       List<String> includedPermissions) {
     String roleName = cloudResourceType.name().toUpperCase() + "_" + iamRole.name().toUpperCase();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRole.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp;
 
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import java.util.List;
 
@@ -32,15 +33,16 @@ public class CustomGcpIamRole {
    * Create a custom GCP role named by a combination of a resource type and resource-level IAM role.
    * Custom roles applied at the resource level should use this to generate the correct role name.
    *
-   * @param resourceType The type of resource this role is intended for. Used for name generation
+   * @param cloudResourceType The type of cloud resource this role is intended for. Used for name
+   *     generation
    * @param iamRole The IAM role this GCP role is intended for. Used for name generation.
    * @param includedPermissions The list of GCP permissions this role should grant.
    */
   public static CustomGcpIamRole ofResource(
-      WsmResourceType resourceType,
+      WsmCloudResourceType cloudResourceType,
       ControlledResourceIamRole iamRole,
       List<String> includedPermissions) {
-    String roleName = resourceType.name().toUpperCase() + "_" + iamRole.name().toUpperCase();
+    String roleName = cloudResourceType.name().toUpperCase() + "_" + iamRole.name().toUpperCase();
     return new CustomGcpIamRole(roleName, includedPermissions);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp;
 
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableTable;
@@ -98,68 +99,68 @@ public class CustomGcpIamRoleMapping {
           new ImmutableTable.Builder<WsmResourceType, ControlledResourceIamRole, CustomGcpIamRole>()
               // GCS bucket
               .put(
-                  WsmResourceType.GCS_BUCKET,
+                  WsmResourceType.CONTROLLED_GCP_GCS_BUCKET,
                   ControlledResourceIamRole.READER,
                   CustomGcpIamRole.ofResource(
-                      WsmResourceType.GCS_BUCKET,
+                      WsmCloudResourceType.GCS_BUCKET,
                       ControlledResourceIamRole.READER,
                       GCS_BUCKET_READER_PERMISSIONS))
               .put(
-                  WsmResourceType.GCS_BUCKET,
+                  WsmResourceType.CONTROLLED_GCP_GCS_BUCKET,
                   ControlledResourceIamRole.WRITER,
                   CustomGcpIamRole.ofResource(
-                      WsmResourceType.GCS_BUCKET,
+                      WsmCloudResourceType.GCS_BUCKET,
                       ControlledResourceIamRole.WRITER,
                       GCS_BUCKET_WRITER_PERMISSIONS))
               .put(
-                  WsmResourceType.GCS_BUCKET,
+                  WsmResourceType.CONTROLLED_GCP_GCS_BUCKET,
                   ControlledResourceIamRole.EDITOR,
                   CustomGcpIamRole.ofResource(
-                      WsmResourceType.GCS_BUCKET,
+                      WsmCloudResourceType.GCS_BUCKET,
                       ControlledResourceIamRole.EDITOR,
                       GCS_BUCKET_EDITOR_PERMISSIONS))
               // BigQuery dataset
               .put(
-                  WsmResourceType.BIG_QUERY_DATASET,
+                  WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET,
                   ControlledResourceIamRole.READER,
                   CustomGcpIamRole.ofResource(
-                      WsmResourceType.BIG_QUERY_DATASET,
+                      WsmCloudResourceType.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.READER,
                       BIG_QUERY_DATASET_READER_PERMISSIONS))
               .put(
-                  WsmResourceType.BIG_QUERY_DATASET,
+                  WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET,
                   ControlledResourceIamRole.WRITER,
                   CustomGcpIamRole.ofResource(
-                      WsmResourceType.BIG_QUERY_DATASET,
+                      WsmCloudResourceType.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.WRITER,
                       BIG_QUERY_DATASET_WRITER_PERMISSIONS))
               .put(
-                  WsmResourceType.BIG_QUERY_DATASET,
+                  WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET,
                   ControlledResourceIamRole.EDITOR,
                   CustomGcpIamRole.ofResource(
-                      WsmResourceType.BIG_QUERY_DATASET,
+                      WsmCloudResourceType.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.EDITOR,
                       BIG_QUERY_DATASET_EDITOR_PERMISSIONS))
               // AI Notebook instance
               .put(
-                  WsmResourceType.AI_NOTEBOOK_INSTANCE,
+                  WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.READER,
                   CustomGcpIamRole.ofResource(
-                      WsmResourceType.AI_NOTEBOOK_INSTANCE,
+                      WsmCloudResourceType.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.READER,
                       AI_NOTEBOOK_INSTANCE_READER_PERMISSIONS))
               .put(
-                  WsmResourceType.AI_NOTEBOOK_INSTANCE,
+                  WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.WRITER,
                   CustomGcpIamRole.ofResource(
-                      WsmResourceType.AI_NOTEBOOK_INSTANCE,
+                      WsmCloudResourceType.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.WRITER,
                       AI_NOTEBOOK_INSTANCE_WRITER_PERMISSIONS))
               .put(
-                  WsmResourceType.AI_NOTEBOOK_INSTANCE,
+                  WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.EDITOR,
                   CustomGcpIamRole.ofResource(
-                      WsmResourceType.AI_NOTEBOOK_INSTANCE,
+                      WsmCloudResourceType.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.EDITOR,
                       AI_NOTEBOOK_INSTANCE_EDITOR_PERMISSIONS))
               .build();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp;
 
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableTable;
@@ -102,21 +102,21 @@ public class CustomGcpIamRoleMapping {
                   WsmResourceType.CONTROLLED_GCP_GCS_BUCKET,
                   ControlledResourceIamRole.READER,
                   CustomGcpIamRole.ofResource(
-                      WsmCloudResourceType.GCS_BUCKET,
+                      WsmResourceFamily.GCS_BUCKET,
                       ControlledResourceIamRole.READER,
                       GCS_BUCKET_READER_PERMISSIONS))
               .put(
                   WsmResourceType.CONTROLLED_GCP_GCS_BUCKET,
                   ControlledResourceIamRole.WRITER,
                   CustomGcpIamRole.ofResource(
-                      WsmCloudResourceType.GCS_BUCKET,
+                      WsmResourceFamily.GCS_BUCKET,
                       ControlledResourceIamRole.WRITER,
                       GCS_BUCKET_WRITER_PERMISSIONS))
               .put(
                   WsmResourceType.CONTROLLED_GCP_GCS_BUCKET,
                   ControlledResourceIamRole.EDITOR,
                   CustomGcpIamRole.ofResource(
-                      WsmCloudResourceType.GCS_BUCKET,
+                      WsmResourceFamily.GCS_BUCKET,
                       ControlledResourceIamRole.EDITOR,
                       GCS_BUCKET_EDITOR_PERMISSIONS))
               // BigQuery dataset
@@ -124,21 +124,21 @@ public class CustomGcpIamRoleMapping {
                   WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET,
                   ControlledResourceIamRole.READER,
                   CustomGcpIamRole.ofResource(
-                      WsmCloudResourceType.BIG_QUERY_DATASET,
+                      WsmResourceFamily.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.READER,
                       BIG_QUERY_DATASET_READER_PERMISSIONS))
               .put(
                   WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET,
                   ControlledResourceIamRole.WRITER,
                   CustomGcpIamRole.ofResource(
-                      WsmCloudResourceType.BIG_QUERY_DATASET,
+                      WsmResourceFamily.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.WRITER,
                       BIG_QUERY_DATASET_WRITER_PERMISSIONS))
               .put(
                   WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET,
                   ControlledResourceIamRole.EDITOR,
                   CustomGcpIamRole.ofResource(
-                      WsmCloudResourceType.BIG_QUERY_DATASET,
+                      WsmResourceFamily.BIG_QUERY_DATASET,
                       ControlledResourceIamRole.EDITOR,
                       BIG_QUERY_DATASET_EDITOR_PERMISSIONS))
               // AI Notebook instance
@@ -146,21 +146,21 @@ public class CustomGcpIamRoleMapping {
                   WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.READER,
                   CustomGcpIamRole.ofResource(
-                      WsmCloudResourceType.AI_NOTEBOOK_INSTANCE,
+                      WsmResourceFamily.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.READER,
                       AI_NOTEBOOK_INSTANCE_READER_PERMISSIONS))
               .put(
                   WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.WRITER,
                   CustomGcpIamRole.ofResource(
-                      WsmCloudResourceType.AI_NOTEBOOK_INSTANCE,
+                      WsmResourceFamily.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.WRITER,
                       AI_NOTEBOOK_INSTANCE_WRITER_PERMISSIONS))
               .put(
                   WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE,
                   ControlledResourceIamRole.EDITOR,
                   CustomGcpIamRole.ofResource(
-                      WsmCloudResourceType.AI_NOTEBOOK_INSTANCE,
+                      WsmResourceFamily.AI_NOTEBOOK_INSTANCE,
                       ControlledResourceIamRole.EDITOR,
                       AI_NOTEBOOK_INSTANCE_EDITOR_PERMISSIONS))
               .build();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -33,6 +33,7 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
     theHandler = this;
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     // Old version of attributes do not have project id, so in that case we look it up

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -5,11 +5,15 @@ import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Optional;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+@SuppressFBWarnings(
+    value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+    justification = "Enable both injection and static lookup")
 @Component
 public class ControlledAiNotebookHandler implements WsmResourceHandler {
   private static ControlledAiNotebookHandler theHandler;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -18,7 +18,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -134,8 +134,8 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.AI_NOTEBOOK_INSTANCE;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.AI_NOTEBOOK_INSTANCE;
   }
 
   @Override
@@ -162,7 +162,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
   public void validate() {
     super.validate();
     if (getResourceType() != WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE
-        || getCloudResourceType() != WsmCloudResourceType.AI_NOTEBOOK_INSTANCE
+        || getResourceFamily() != WsmResourceFamily.AI_NOTEBOOK_INSTANCE
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected controlled GCP AI_NOTEBOOK_INSTANCE");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -9,12 +9,16 @@ import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceAttributes;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -126,7 +130,12 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.AI_NOTEBOOK_INSTANCE;
+    return WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.AI_NOTEBOOK_INSTANCE;
   }
 
   @Override
@@ -136,10 +145,26 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
   }
 
   @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.gcpAiNotebookInstance(toApiAttributes());
+    return union;
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    ApiResourceUnion union = new ApiResourceUnion();
+    union.gcpAiNotebookInstance(toApiResource());
+    return union;
+  }
+
+  @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.AI_NOTEBOOK_INSTANCE) {
-      throw new InconsistentFieldsException("Expected AI_NOTEBOOK_INSTANCE");
+    if (getResourceType() != WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE
+        || getCloudResourceType() != WsmCloudResourceType.AI_NOTEBOOK_INSTANCE
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected controlled GCP AI_NOTEBOOK_INSTANCE");
     }
     if (!getAccessScope().equals(AccessScopeType.ACCESS_SCOPE_PRIVATE)) {
       throw new BadRequestException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
@@ -5,11 +5,15 @@ import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Optional;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+@SuppressFBWarnings(
+    value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+    justification = "Enable both injection and static lookup")
 @Component
 public class ControlledBigQueryDatasetHandler implements WsmResourceHandler {
   private static ControlledBigQueryDatasetHandler theHandler;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
@@ -33,6 +33,7 @@ public class ControlledBigQueryDatasetHandler implements WsmResourceHandler {
     theHandler = this;
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     // Old version of attributes do not have project id, so in that case we look it up

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -106,8 +106,8 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.BIG_QUERY_DATASET;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.BIG_QUERY_DATASET;
   }
 
   @Override
@@ -130,7 +130,7 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
   public void validate() {
     super.validate();
     if (getResourceType() != WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET
-        || getCloudResourceType() != WsmCloudResourceType.BIG_QUERY_DATASET
+        || getResourceFamily() != WsmResourceFamily.BIG_QUERY_DATASET
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected controlled GCP BIG_QUERY_DATASET");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -5,12 +5,16 @@ import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetAttributes;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -98,7 +102,12 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.BIG_QUERY_DATASET;
+    return WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.BIG_QUERY_DATASET;
   }
 
   @Override
@@ -108,10 +117,22 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
   }
 
   @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    return new ApiResourceAttributesUnion().gcpBqDataset(toApiAttributes());
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    return new ApiResourceUnion().gcpBqDataset(toApiResource());
+  }
+
+  @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.BIG_QUERY_DATASET) {
-      throw new InconsistentFieldsException("Expected BIG_QUERY_DATASET");
+    if (getResourceType() != WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET
+        || getCloudResourceType() != WsmCloudResourceType.BIG_QUERY_DATASET
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected controlled GCP BIG_QUERY_DATASET");
     }
     if (getDatasetName() == null) {
       throw new MissingRequiredFieldException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -12,6 +12,7 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ControlledGcsBucketHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ControlledGcsBucketResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ControlledGcsBucketHandler implements WsmResourceHandler {
   private static ControlledGcsBucketHandler theHandler;
 
   public static ControlledGcsBucketHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ControlledGcsBucketHandler());
+    if (theHandler == null) {
+      theHandler = new ControlledGcsBucketHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ControlledGcsBucketHandler implements WsmResourceHandler {
+  private static ControlledGcsBucketHandler theHandler;
+
+  public static ControlledGcsBucketHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ControlledGcsBucketHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ControlledGcsBucketResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -15,7 +15,7 @@ import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -107,8 +107,8 @@ public class ControlledGcsBucketResource extends ControlledResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.GCS_BUCKET;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.GCS_BUCKET;
   }
 
   @Override
@@ -130,7 +130,7 @@ public class ControlledGcsBucketResource extends ControlledResource {
   public void validate() {
     super.validate();
     if (getResourceType() != WsmResourceType.CONTROLLED_GCP_GCS_BUCKET
-        || getCloudResourceType() != WsmCloudResourceType.GCS_BUCKET
+        || getResourceFamily() != WsmResourceFamily.GCS_BUCKET
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected controlled GCP GCS_BUCKET");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneControlledGcpBigQueryDatasetResourceFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneControlledGcpBigQueryDatasetResourceFlightStep.java
@@ -60,7 +60,7 @@ public class AwaitCloneControlledGcpBigQueryDatasetResourceFlightStep implements
           resultMap.get(
               JobMapKeys.RESPONSE.getKeyName(), ApiClonedControlledGcpBigQueryDataset.class);
       cloneDetails.setStewardshipType(StewardshipType.CONTROLLED);
-      cloneDetails.setResourceType(WsmResourceType.BIG_QUERY_DATASET);
+      cloneDetails.setResourceType(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
       cloneDetails.setCloningInstructions(resource.getCloningInstructions());
       cloneDetails.setSourceResourceId(resource.getResourceId());
       cloneDetails.setDestinationResourceId(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneGcsBucketResourceFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneGcsBucketResourceFlightStep.java
@@ -57,7 +57,7 @@ public class AwaitCloneGcsBucketResourceFlightStep implements Step {
       final var clonedBucket =
           resultMap.get(JobMapKeys.RESPONSE.getKeyName(), ApiClonedControlledGcpGcsBucket.class);
       cloneDetails.setStewardshipType(StewardshipType.CONTROLLED);
-      cloneDetails.setResourceType(WsmResourceType.GCS_BUCKET);
+      cloneDetails.setResourceType(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
       cloneDetails.setCloningInstructions(resource.getCloningInstructions());
       cloneDetails.setSourceResourceId(resource.getResourceId());
       cloneDetails.setDestinationResourceId(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
@@ -49,7 +49,7 @@ public class CloneAllResourcesFlight extends Flight {
         break;
       case CONTROLLED:
         switch (resourceWithFlightId.getResource().getResourceType()) {
-          case GCS_BUCKET:
+          case CONTROLLED_GCP_GCS_BUCKET:
             addStep(
                 new LaunchCloneGcsBucketResourceFlightStep(
                     resourceWithFlightId
@@ -66,7 +66,7 @@ public class CloneAllResourcesFlight extends Flight {
                     resourceWithFlightId.getFlightId()),
                 RetryRules.cloudLongRunning());
             break;
-          case BIG_QUERY_DATASET:
+          case CONTROLLED_GCP_BIG_QUERY_DATASET:
             addStep(
                 new LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep(
                     resourceWithFlightId
@@ -83,8 +83,7 @@ public class CloneAllResourcesFlight extends Flight {
                     resourceWithFlightId.getFlightId()),
                 RetryRules.cloudLongRunning());
             break;
-          case DATA_REPO_SNAPSHOT:
-          case AI_NOTEBOOK_INSTANCE:
+          case CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE:
           default:
             // Can't throw in a flight constructor
             logger.error(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/FindResourcesToCloneStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/FindResourcesToCloneStep.java
@@ -61,7 +61,7 @@ public class FindResourcesToCloneStep implements Step {
   private static boolean isCloneable(WsmResource resource) {
     return StewardshipType.REFERENCED == resource.getStewardshipType()
         || (StewardshipType.CONTROLLED == resource.getStewardshipType()
-            && (WsmResourceType.GCS_BUCKET == resource.getResourceType()
-                || WsmResourceType.BIG_QUERY_DATASET == resource.getResourceType()));
+            && (WsmResourceType.CONTROLLED_GCP_GCS_BUCKET == resource.getResourceType()
+                || WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET == resource.getResourceType()));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
@@ -4,7 +4,7 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.stairway.FlightStatus;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResource;
-import bio.terra.workspace.service.resource.referenced.cloud.any.ReferencedGitRepoResource;
+import bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo.ReferencedGitRepoResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable.ReferencedBigQueryDataTableResource;
@@ -50,7 +50,7 @@ public class WorkspaceCloneUtils {
       String description) {
     final ReferencedResource destinationResource;
     switch (sourceReferencedResource.getResourceType()) {
-      case GCS_BUCKET:
+      case REFERENCED_GCP_GCS_BUCKET:
         destinationResource =
             buildDestinationGcsBucketReference(
                 sourceReferencedResource.castToGcsBucketResource(),
@@ -58,7 +58,7 @@ public class WorkspaceCloneUtils {
                 name,
                 description);
         break;
-      case GCS_OBJECT:
+      case REFERENCED_GCP_GCS_OBJECT:
         destinationResource =
             buildDestinationGcsObjectReference(
                 sourceReferencedResource.castToGcsObjectResource(),
@@ -66,7 +66,7 @@ public class WorkspaceCloneUtils {
                 name,
                 description);
         break;
-      case DATA_REPO_SNAPSHOT:
+      case REFERENCED_DATA_REPO_SNAPSHOT:
         destinationResource =
             buildDestinationDataRepoSnapshotReference(
                 sourceReferencedResource.castToDataRepoSnapshotResource(),
@@ -74,7 +74,7 @@ public class WorkspaceCloneUtils {
                 name,
                 description);
         break;
-      case BIG_QUERY_DATASET:
+      case REFERENCED_GCP_BIG_QUERY_DATASET:
         destinationResource =
             buildDestinationBigQueryDatasetReference(
                 sourceReferencedResource.castToBigQueryDatasetResource(),
@@ -82,7 +82,7 @@ public class WorkspaceCloneUtils {
                 name,
                 description);
         break;
-      case BIG_QUERY_DATA_TABLE:
+      case REFERENCED_GCP_BIG_QUERY_DATA_TABLE:
         destinationResource =
             buildDestinationBigQueryDataTableReference(
                 sourceReferencedResource.castToBigQueryDataTableResource(),
@@ -90,7 +90,7 @@ public class WorkspaceCloneUtils {
                 name,
                 description);
         break;
-      case GIT_REPO:
+      case REFERENCED_GIT_REPO:
         destinationResource =
             buildDestinationGitHubRepoReference(
                 sourceReferencedResource.castToGitRepoResource(),
@@ -98,11 +98,10 @@ public class WorkspaceCloneUtils {
                 name,
                 description);
         break;
-      case AI_NOTEBOOK_INSTANCE:
       default:
         throw new BadRequestException(
             String.format(
-                "Resource type %s not supported",
+                "Resource type %s not supported as a referenced resource",
                 sourceReferencedResource.getResourceType().toString()));
     }
     return destinationResource;
@@ -116,7 +115,7 @@ public class WorkspaceCloneUtils {
    * @param destinationWorkspaceId - workspace ID for new reference
    * @param name - resource name for cloned reference. Will use original name if this is null.
    * @param description - resource description for cloned reference. Uses original if left null.
-   * @return
+   * @return referenced resource
    */
   private static ReferencedResource buildDestinationGcsBucketReference(
       ReferencedGcsBucketResource sourceBucketResource,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
@@ -66,7 +66,7 @@ public class WorkspaceCloneUtils {
                 name,
                 description);
         break;
-      case REFERENCED_DATA_REPO_SNAPSHOT:
+      case REFERENCED_ANY_DATA_REPO_SNAPSHOT:
         destinationResource =
             buildDestinationDataRepoSnapshotReference(
                 sourceReferencedResource.castToDataRepoSnapshotResource(),
@@ -90,7 +90,7 @@ public class WorkspaceCloneUtils {
                 name,
                 description);
         break;
-      case REFERENCED_GIT_REPO:
+      case REFERENCED_ANY_GIT_REPO:
         destinationResource =
             buildDestinationGitHubRepoReference(
                 sourceReferencedResource.castToGitRepoResource(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
@@ -81,6 +81,7 @@ public class CreateControlledResourceFlight extends Flight {
       case ANY:
         // TODO: pull cloud context from flight into step parallel to GCP
         break;
+
       case GCP:
         // This step may need to update the cloud context row in the database to convert
         // context V1 format into V2 format.
@@ -93,7 +94,7 @@ public class CreateControlledResourceFlight extends Flight {
 
     // create the cloud resource and grant IAM roles via CRL
     switch (resource.getResourceType()) {
-      case GCS_BUCKET:
+      case CONTROLLED_GCP_GCS_BUCKET:
         addStep(
             new CreateGcsBucketStep(
                 flightBeanBag.getCrlService(),
@@ -109,13 +110,13 @@ public class CreateControlledResourceFlight extends Flight {
                 userRequest),
             gcpRetryRule);
         break;
-      case AI_NOTEBOOK_INSTANCE:
+      case CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE:
         {
           addNotebookSteps(
               petSaEmail, flightBeanBag, resource.castToAiNotebookInstanceResource(), userRequest);
           break;
         }
-      case BIG_QUERY_DATASET:
+      case CONTROLLED_GCP_BIG_QUERY_DATASET:
         // Unlike other resources, BigQuery datasets set IAM permissions at creation time to avoid
         // unwanted defaults from GCP.
         addStep(
@@ -128,7 +129,7 @@ public class CreateControlledResourceFlight extends Flight {
             gcpRetryRule);
         break;
 
-      case AZURE_DISK:
+      case CONTROLLED_AZURE_DISK:
         addStep(
             new GetAzureDiskStep(
                 flightBeanBag.getAzureConfig(),
@@ -150,7 +151,7 @@ public class CreateControlledResourceFlight extends Flight {
                 resource.castToAzureDiskResource()),
             RetryRules.cloud());
         break;
-      case AZURE_IP:
+      case CONTROLLED_AZURE_IP:
         addStep(
             new GetAzureIpStep(
                 flightBeanBag.getAzureConfig(),
@@ -172,7 +173,7 @@ public class CreateControlledResourceFlight extends Flight {
                 resource.castToAzureIpResource()),
             RetryRules.cloud());
         break;
-      case AZURE_NETWORK:
+      case CONTROLLED_AZURE_NETWORK:
         addStep(
             new GetAzureNetworkStep(
                 flightBeanBag.getAzureConfig(),
@@ -194,7 +195,7 @@ public class CreateControlledResourceFlight extends Flight {
                 resource.castToAzureNetworkResource()),
             RetryRules.cloud());
         break;
-      case AZURE_VM:
+      case CONTROLLED_AZURE_VM:
         addStep(
             new GetAzureVmStep(
                 flightBeanBag.getAzureConfig(),
@@ -217,7 +218,7 @@ public class CreateControlledResourceFlight extends Flight {
                 flightBeanBag.getResourceDao()),
             RetryRules.cloud());
         break;
-      case AZURE_STORAGE_ACCOUNT:
+      case CONTROLLED_AZURE_STORAGE_ACCOUNT:
         addStep(
             new GetAzureStorageStep(
                 flightBeanBag.getAzureConfig(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/SetCreateResponseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/SetCreateResponseStep.java
@@ -29,19 +29,19 @@ public class SetCreateResponseStep implements Step {
     ControlledResource responseResource;
     if (resource.getAccessScope() == AccessScopeType.ACCESS_SCOPE_PRIVATE) {
       switch (resource.getResourceType()) {
-        case GCS_BUCKET:
+        case CONTROLLED_GCP_GCS_BUCKET:
           responseResource =
               resource.castToGcsBucketResource().toBuilder()
                   .privateResourceState(PrivateResourceState.ACTIVE)
                   .build();
           break;
-        case BIG_QUERY_DATASET:
+        case CONTROLLED_GCP_BIG_QUERY_DATASET:
           responseResource =
               resource.castToBigQueryDatasetResource().toBuilder()
                   .privateResourceState(PrivateResourceState.ACTIVE)
                   .build();
           break;
-        case AI_NOTEBOOK_INSTANCE:
+        case CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE:
           responseResource =
               resource.castToAiNotebookInstanceResource().toBuilder()
                   .privateResourceState(PrivateResourceState.ACTIVE)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteControlledResourceFlight.java
@@ -51,7 +51,7 @@ public class DeleteControlledResourceFlight extends Flight {
 
     final RetryRule gcpRetryRule = RetryRules.cloud();
     switch (resource.getResourceType()) {
-      case GCS_BUCKET:
+      case CONTROLLED_GCP_GCS_BUCKET:
         addStep(
             new DeleteGcsBucketStep(
                 flightBeanBag.getCrlService(),
@@ -61,7 +61,7 @@ public class DeleteControlledResourceFlight extends Flight {
                 resourceId),
             gcpRetryRule);
         break;
-      case AZURE_DISK:
+      case CONTROLLED_AZURE_DISK:
         addStep(
             new DeleteAzureDiskStep(
                 flightBeanBag.getAzureConfig(),
@@ -74,7 +74,7 @@ public class DeleteControlledResourceFlight extends Flight {
                 workspaceId,
                 resourceId));
         break;
-      case AZURE_IP:
+      case CONTROLLED_AZURE_IP:
         addStep(
             new DeleteAzureIpStep(
                 flightBeanBag.getAzureConfig(),
@@ -87,7 +87,7 @@ public class DeleteControlledResourceFlight extends Flight {
                 workspaceId,
                 resourceId));
         break;
-      case AZURE_NETWORK:
+      case CONTROLLED_AZURE_NETWORK:
         addStep(
             new DeleteAzureNetworkStep(
                 flightBeanBag.getAzureConfig(),
@@ -100,7 +100,7 @@ public class DeleteControlledResourceFlight extends Flight {
                 workspaceId,
                 resourceId));
         break;
-      case AZURE_VM:
+      case CONTROLLED_AZURE_VM:
         addStep(
             new DeleteAzureVmStep(
                 flightBeanBag.getAzureConfig(),
@@ -113,7 +113,7 @@ public class DeleteControlledResourceFlight extends Flight {
                 workspaceId,
                 resourceId));
         break;
-      case BIG_QUERY_DATASET:
+      case CONTROLLED_GCP_BIG_QUERY_DATASET:
         addStep(
             new DeleteBigQueryDatasetStep(
                 resource.castToBigQueryDatasetResource(),
@@ -121,7 +121,7 @@ public class DeleteControlledResourceFlight extends Flight {
                 flightBeanBag.getGcpCloudContextService()),
             gcpRetryRule);
         break;
-      case AI_NOTEBOOK_INSTANCE:
+      case CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE:
         addStep(
             new DeleteAiNotebookInstanceStep(
                 resource.castToAiNotebookInstanceResource(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
@@ -145,42 +145,42 @@ public abstract class ControlledResource extends WsmResource {
 
   // Double-checked down casts when we need to re-specialize from a ControlledResource
   public ControlledGcsBucketResource castToGcsBucketResource() {
-    validateSubclass(WsmResourceType.GCS_BUCKET);
+    validateSubclass(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
     return (ControlledGcsBucketResource) this;
   }
 
   public ControlledAzureIpResource castToAzureIpResource() {
-    validateSubclass(WsmResourceType.AZURE_IP);
+    validateSubclass(WsmResourceType.CONTROLLED_AZURE_IP);
     return (ControlledAzureIpResource) this;
   }
 
   public ControlledAzureStorageResource castToAzureStorageResource() {
-    validateSubclass(WsmResourceType.AZURE_STORAGE_ACCOUNT);
+    validateSubclass(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
     return (ControlledAzureStorageResource) this;
   }
 
   public ControlledAzureDiskResource castToAzureDiskResource() {
-    validateSubclass(WsmResourceType.AZURE_DISK);
+    validateSubclass(WsmResourceType.CONTROLLED_AZURE_DISK);
     return (ControlledAzureDiskResource) this;
   }
 
   public ControlledAzureNetworkResource castToAzureNetworkResource() {
-    validateSubclass(WsmResourceType.AZURE_NETWORK);
+    validateSubclass(WsmResourceType.CONTROLLED_AZURE_NETWORK);
     return (ControlledAzureNetworkResource) this;
   }
 
   public ControlledAzureVmResource castToAzureVmResource() {
-    validateSubclass(WsmResourceType.AZURE_VM);
+    validateSubclass(WsmResourceType.CONTROLLED_AZURE_VM);
     return (ControlledAzureVmResource) this;
   }
 
   public ControlledAiNotebookInstanceResource castToAiNotebookInstanceResource() {
-    validateSubclass(WsmResourceType.AI_NOTEBOOK_INSTANCE);
+    validateSubclass(WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE);
     return (ControlledAiNotebookInstanceResource) this;
   }
 
   public ControlledBigQueryDatasetResource castToBigQueryDatasetResource() {
-    validateSubclass(WsmResourceType.BIG_QUERY_DATASET);
+    validateSubclass(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
     return (ControlledBigQueryDatasetResource) this;
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmCloudResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmCloudResourceType.java
@@ -1,0 +1,113 @@
+package bio.terra.workspace.service.resource.model;
+
+import bio.terra.common.exception.ValidationException;
+import bio.terra.workspace.generated.model.ApiResourceType;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.SerializationException;
+import org.apache.commons.lang3.StringUtils;
+
+public enum WsmCloudResourceType {
+  AI_NOTEBOOK_INSTANCE(
+      "AI_NOTEBOOK_INSTANCE",
+      ApiResourceType.AI_NOTEBOOK,
+      null, // no reference type for notebooks,
+      WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE),
+  DATA_REPO_SNAPSHOT(
+      "DATA_REPO_SNAPSHOT",
+      ApiResourceType.DATA_REPO_SNAPSHOT,
+      WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT,
+      null), // no controlled type for snapshots
+  GCS_BUCKET(
+      "GCS_BUCKET",
+      ApiResourceType.GCS_BUCKET,
+      WsmResourceType.REFERENCED_GCP_GCS_BUCKET,
+      WsmResourceType.CONTROLLED_GCP_GCS_BUCKET),
+  GCS_OBJECT(
+      "GCS_OBJECT",
+      ApiResourceType.GCS_OBJECT,
+      WsmResourceType.REFERENCED_GCP_GCS_OBJECT,
+      null), // no controlled type for GCS objects
+  BIG_QUERY_DATASET(
+      "BIG_QUERY_DATASET",
+      ApiResourceType.BIG_QUERY_DATASET,
+      WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET,
+      WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET),
+  BIG_QUERY_DATA_TABLE(
+      "BIG_QUERY_DATA_TABLE",
+      ApiResourceType.BIG_QUERY_DATA_TABLE,
+      WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE,
+      null), // no controlled type for BQ data table
+  AZURE_IP("AZURE_IP", ApiResourceType.AZURE_IP, null, WsmResourceType.CONTROLLED_AZURE_IP),
+  AZURE_DISK("AZURE_DISK", ApiResourceType.AZURE_DISK, null, WsmResourceType.CONTROLLED_AZURE_DISK),
+  AZURE_NETWORK(
+      "AZURE_NETWORK",
+      ApiResourceType.AZURE_NETWORK,
+      null,
+      WsmResourceType.CONTROLLED_AZURE_NETWORK),
+  AZURE_VM("AZURE_VM", ApiResourceType.AZURE_VM, null, WsmResourceType.CONTROLLED_AZURE_VM),
+  AZURE_STORAGE_ACCOUNT(
+      "AZURE_STORAGE_ACCOUNT",
+      ApiResourceType.AZURE_STORAGE_ACCOUNT,
+      null,
+      WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT),
+  GIT_REPO("GIT_REPO", ApiResourceType.GIT_REPO, WsmResourceType.REFERENCED_GIT_REPO, null);
+
+  private final String dbString; // serialized form of the resource type
+  private final ApiResourceType apiResourceType;
+  private final WsmResourceType referenceType;
+  private final WsmResourceType controlledType;
+
+  WsmCloudResourceType(
+      String dbString,
+      ApiResourceType apiResourceType,
+      WsmResourceType referenceType,
+      WsmResourceType controlledType) {
+    this.dbString = dbString;
+    this.apiResourceType = apiResourceType;
+    this.referenceType = referenceType;
+    this.controlledType = controlledType;
+  }
+
+  public static WsmCloudResourceType fromSql(String dbString) {
+    for (WsmCloudResourceType value : values()) {
+      if (StringUtils.equals(value.dbString, dbString)) {
+        return value;
+      }
+    }
+    throw new SerializationException(
+        "Deserialization failed: no matching cloud resource type for " + dbString);
+  }
+
+  /**
+   * Convert from an optional api type to WsmResourceType. This method handles the case where the
+   * API input is optional/can be null. If the input is null we return null and leave it to the
+   * caller to raise any error.
+   *
+   * @param apiResourceType incoming resource type or null
+   * @return valid resource type; null if input is null
+   */
+  public static @Nullable WsmCloudResourceType fromApiOptional(
+      @Nullable ApiResourceType apiResourceType) {
+    if (apiResourceType == null) {
+      return null;
+    }
+    for (WsmCloudResourceType value : values()) {
+      if (value.apiResourceType == apiResourceType) {
+        return value;
+      }
+    }
+    throw new ValidationException("Invalid resource type " + apiResourceType);
+  }
+
+  public WsmResourceType getReferenceType() {
+    return referenceType;
+  }
+
+  public WsmResourceType getControlledType() {
+    return controlledType;
+  }
+
+  public String toSql() {
+    return dbString;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
@@ -92,11 +92,11 @@ public abstract class WsmResource {
   public abstract WsmResourceType getResourceType();
 
   /**
-   * Sub-classes must identify their cloud resource type
+   * Sub-classes must identify their resource family
    *
-   * @return cloud resource type
+   * @return resource family
    */
-  public abstract WsmCloudResourceType getCloudResourceType();
+  public abstract WsmResourceFamily getResourceFamily();
 
   /**
    * Attributes string, serialized as JSON. Includes only those attributes of the cloud resource

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
@@ -3,7 +3,9 @@ package bio.terra.workspace.service.resource.model;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceMetadata;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
@@ -90,6 +92,13 @@ public abstract class WsmResource {
   public abstract WsmResourceType getResourceType();
 
   /**
+   * Sub-classes must identify their cloud resource type
+   *
+   * @return cloud resource type
+   */
+  public abstract WsmCloudResourceType getCloudResourceType();
+
+  /**
    * Attributes string, serialized as JSON. Includes only those attributes of the cloud resource
    * that are necessary for identification. The structure of the cloud resource attributes can be
    * whatever is useful for the resource. It need not be a flat POJO.
@@ -99,6 +108,20 @@ public abstract class WsmResource {
   public abstract String attributesToJson();
 
   /**
+   * Each resource is able to create the API union object to return resource attributes
+   *
+   * @return attributes union with the proper attribute filled in
+   */
+  public abstract ApiResourceAttributesUnion toApiAttributesUnion();
+
+  /**
+   * Each resource is able to create the API union object to return resources
+   *
+   * @return resource union with the proper resource filled in
+   */
+  public abstract ApiResourceUnion toApiResourceUnion();
+
+  /**
    * The API metadata object contains the data for both referenced and controlled resources. This
    * class fills in the common part. Referenced resources have no additional data to fill in.
    * Controlled resources overrides this method to fill in the controlled resource specifics.
@@ -106,17 +129,15 @@ public abstract class WsmResource {
    * @return partially constructed Api Model common resource description
    */
   public ApiResourceMetadata toApiMetadata() {
-    ApiResourceMetadata metadata =
-        new ApiResourceMetadata()
-            .workspaceId(workspaceId)
-            .resourceId(resourceId)
-            .name(name)
-            .description(description)
-            .resourceType(getResourceType().toApiModel())
-            .stewardshipType(getStewardshipType().toApiModel())
-            .cloudPlatform(getResourceType().getCloudPlatform().toApiModel())
-            .cloningInstructions(cloningInstructions.toApiModel());
-    return metadata;
+    return new ApiResourceMetadata()
+        .workspaceId(workspaceId)
+        .resourceId(resourceId)
+        .name(name)
+        .description(description)
+        .resourceType(getResourceType().toApiModel())
+        .stewardshipType(getStewardshipType().toApiModel())
+        .cloudPlatform(getResourceType().getCloudPlatform().toApiModel())
+        .cloningInstructions(cloningInstructions.toApiModel());
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
@@ -2,11 +2,12 @@ package bio.terra.workspace.service.resource.model;
 
 import bio.terra.common.exception.ValidationException;
 import bio.terra.workspace.generated.model.ApiResourceType;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.SerializationException;
 import org.apache.commons.lang3.StringUtils;
 
-public enum WsmCloudResourceType {
+public enum WsmResourceFamily {
   AI_NOTEBOOK_INSTANCE(
       "AI_NOTEBOOK_INSTANCE",
       ApiResourceType.AI_NOTEBOOK,
@@ -57,19 +58,19 @@ public enum WsmCloudResourceType {
   private final WsmResourceType referenceType;
   private final WsmResourceType controlledType;
 
-  WsmCloudResourceType(
+  WsmResourceFamily(
       String dbString,
       ApiResourceType apiResourceType,
-      WsmResourceType referenceType,
-      WsmResourceType controlledType) {
+      @Nullable WsmResourceType referenceType,
+      @Nullable WsmResourceType controlledType) {
     this.dbString = dbString;
     this.apiResourceType = apiResourceType;
     this.referenceType = referenceType;
     this.controlledType = controlledType;
   }
 
-  public static WsmCloudResourceType fromSql(String dbString) {
-    for (WsmCloudResourceType value : values()) {
+  public static WsmResourceFamily fromSql(String dbString) {
+    for (WsmResourceFamily value : values()) {
       if (StringUtils.equals(value.dbString, dbString)) {
         return value;
       }
@@ -86,12 +87,12 @@ public enum WsmCloudResourceType {
    * @param apiResourceType incoming resource type or null
    * @return valid resource type; null if input is null
    */
-  public static @Nullable WsmCloudResourceType fromApiOptional(
+  public static @Nullable WsmResourceFamily fromApiOptional(
       @Nullable ApiResourceType apiResourceType) {
     if (apiResourceType == null) {
       return null;
     }
-    for (WsmCloudResourceType value : values()) {
+    for (WsmResourceFamily value : values()) {
       if (value.apiResourceType == apiResourceType) {
         return value;
       }
@@ -99,12 +100,12 @@ public enum WsmCloudResourceType {
     throw new ValidationException("Invalid resource type " + apiResourceType);
   }
 
-  public WsmResourceType getReferenceType() {
-    return referenceType;
+  public Optional<WsmResourceType> getReferenceType() {
+    return Optional.ofNullable(referenceType);
   }
 
-  public WsmResourceType getControlledType() {
-    return controlledType;
+  public Optional<WsmResourceType> getControlledType() {
+    return Optional.ofNullable(controlledType);
   }
 
   public String toSql() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
@@ -16,7 +16,7 @@ public enum WsmResourceFamily {
   DATA_REPO_SNAPSHOT(
       "DATA_REPO_SNAPSHOT",
       ApiResourceType.DATA_REPO_SNAPSHOT,
-      WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT,
+      WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT,
       null), // no controlled type for snapshots
   GCS_BUCKET(
       "GCS_BUCKET",
@@ -51,7 +51,7 @@ public enum WsmResourceFamily {
       ApiResourceType.AZURE_STORAGE_ACCOUNT,
       null,
       WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT),
-  GIT_REPO("GIT_REPO", ApiResourceType.GIT_REPO, WsmResourceType.REFERENCED_GIT_REPO, null);
+  GIT_REPO("GIT_REPO", ApiResourceType.GIT_REPO, WsmResourceType.REFERENCED_ANY_GIT_REPO, null);
 
   private final String dbString; // serialized form of the resource type
   private final ApiResourceType apiResourceType;

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
@@ -1,122 +1,179 @@
 package bio.terra.workspace.service.resource.model;
 
-import bio.terra.common.exception.ValidationException;
+import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.generated.model.ApiResourceType;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
-import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
-import bio.terra.workspace.service.resource.referenced.cloud.any.ReferencedGitRepoResource;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
+import bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo.ReferencedGitRepoHandler;
+import bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo.ReferencedGitRepoResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetHandler;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable.ReferencedBigQueryDataTableHandler;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable.ReferencedBigQueryDataTableResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.datareposnapshot.ReferencedDataRepoSnapshotHandler;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.datareposnapshot.ReferencedDataRepoSnapshotResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.ReferencedGcsBucketHandler;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject.ReferencedGcsObjectHandler;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject.ReferencedGcsObjectResource;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
-import javax.annotation.Nullable;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.SerializationException;
 import org.apache.commons.lang3.StringUtils;
 
+/**
+ * Each resource implementation gets a specific type. This enumeration describes the attributes of
+ * the resource type.
+ */
 public enum WsmResourceType {
-  AI_NOTEBOOK_INSTANCE(
+  CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE(
       CloudPlatform.GCP,
-      "AI_NOTEBOOK_INSTANCE",
+      StewardshipType.CONTROLLED,
+      "GCP_CONTROLLED_AI_NOTEBOOK_INSTANCE",
       ApiResourceType.AI_NOTEBOOK,
-      /*referenceClass=*/ null,
-      ControlledAiNotebookInstanceResource.class),
-  DATA_REPO_SNAPSHOT(
-      CloudPlatform.GCP,
-      "DATA_REPO_SNAPSHOT",
+      ControlledAiNotebookInstanceResource.class,
+      ControlledAiNotebookHandler::getHandler),
+
+  REFERENCED_DATA_REPO_SNAPSHOT(
+      CloudPlatform.GCP, // TODO: switch to ANY when Yu's work goes in
+      StewardshipType.REFERENCED,
+      "REFERENCED_DATA_REPO_SNAPSHOT",
       ApiResourceType.DATA_REPO_SNAPSHOT,
       ReferencedDataRepoSnapshotResource.class,
-      /*controlledClass=*/ null),
-  GCS_BUCKET(
+      ReferencedDataRepoSnapshotHandler::getHandler),
+
+  REFERENCED_GCP_GCS_BUCKET(
       CloudPlatform.GCP,
-      "GCS_BUCKET",
+      StewardshipType.REFERENCED,
+      "REFERENCED_GCS_BUCKET",
       ApiResourceType.GCS_BUCKET,
       ReferencedGcsBucketResource.class,
-      ControlledGcsBucketResource.class),
-  GCS_OBJECT(
+      ReferencedGcsBucketHandler::getHandler),
+
+  CONTROLLED_GCP_GCS_BUCKET(
       CloudPlatform.GCP,
-      "GCS_OBJECT",
+      StewardshipType.CONTROLLED,
+      "CONTROLLED_GCS_BUCKET",
+      ApiResourceType.GCS_BUCKET,
+      ControlledGcsBucketResource.class,
+      ControlledGcsBucketHandler::getHandler),
+
+  REFERENCED_GCP_GCS_OBJECT(
+      CloudPlatform.GCP,
+      StewardshipType.REFERENCED,
+      "REFERENCED_GCS_OBJECT",
       ApiResourceType.GCS_OBJECT,
       ReferencedGcsObjectResource.class,
-      /*controlledClass=*/ null),
-  BIG_QUERY_DATASET(
+      ReferencedGcsObjectHandler::getHandler),
+
+  REFERENCED_GCP_BIG_QUERY_DATASET(
       CloudPlatform.GCP,
-      "BIG_QUERY_DATASET",
+      StewardshipType.REFERENCED,
+      "REFERENCED_BIG_QUERY_DATASET",
       ApiResourceType.BIG_QUERY_DATASET,
       ReferencedBigQueryDatasetResource.class,
-      ControlledBigQueryDatasetResource.class),
-  BIG_QUERY_DATA_TABLE(
+      ReferencedBigQueryDatasetHandler::getHandler),
+
+  CONTROLLED_GCP_BIG_QUERY_DATASET(
       CloudPlatform.GCP,
-      "BIG_QUERY_DATA_TABLE",
+      StewardshipType.CONTROLLED,
+      "CONTROLLED_BIG_QUERY_DATASET",
+      ApiResourceType.BIG_QUERY_DATASET,
+      ControlledBigQueryDatasetResource.class,
+      ControlledBigQueryDatasetHandler::getHandler),
+
+  REFERENCED_GCP_BIG_QUERY_DATA_TABLE(
+      CloudPlatform.GCP,
+      StewardshipType.REFERENCED,
+      "REFERENCED_BIG_QUERY_DATA_TABLE",
       ApiResourceType.BIG_QUERY_DATA_TABLE,
       ReferencedBigQueryDataTableResource.class,
-      null),
-  AZURE_IP(
-      CloudPlatform.AZURE,
-      "AZURE_IP",
-      ApiResourceType.AZURE_IP,
-      null,
-      ControlledAzureIpResource.class),
-  AZURE_DISK(
-      CloudPlatform.AZURE,
-      "AZURE_DISK",
-      ApiResourceType.AZURE_DISK,
-      null,
-      ControlledAzureDiskResource.class),
-  AZURE_NETWORK(
-      CloudPlatform.AZURE,
-      "AZURE_NETWORK",
-      ApiResourceType.AZURE_NETWORK,
-      null,
-      ControlledAzureNetworkResource.class),
-  AZURE_VM(
-      CloudPlatform.AZURE,
-      "AZURE_VM",
-      ApiResourceType.AZURE_VM,
-      null,
-      ControlledAzureVmResource.class),
-  AZURE_STORAGE_ACCOUNT(
-      CloudPlatform.AZURE,
-      "AZURE_STORAGE_ACCOUNT",
-      ApiResourceType.AZURE_STORAGE_ACCOUNT,
-      null,
-      ControlledAzureStorageResource.class),
-  GIT_REPO(
+      ReferencedBigQueryDataTableHandler::getHandler),
+  REFERENCED_GIT_REPO(
       CloudPlatform.ANY,
-      "GIT_REPO",
+      StewardshipType.REFERENCED,
+      "REFERENCED_GIT_REPO",
       ApiResourceType.GIT_REPO,
       ReferencedGitRepoResource.class,
-      /*controlledClass=*/ null);
+      ReferencedGitRepoHandler::getHandler),
+  CONTROLLED_AZURE_IP(
+      CloudPlatform.AZURE,
+      StewardshipType.CONTROLLED,
+      "CONTROLLED_AZURE_IP",
+      ApiResourceType.AZURE_IP,
+      ControlledAzureIpResource.class,
+      ControlledAzureIpHandler::getHandler),
+  CONTROLLED_AZURE_DISK(
+      CloudPlatform.AZURE,
+      StewardshipType.CONTROLLED,
+      "CONTROLLED_AZURE_DISK",
+      ApiResourceType.AZURE_DISK,
+      ControlledAzureDiskResource.class,
+      ControlledAzureDiskHandler::getHandler),
+  CONTROLLED_AZURE_NETWORK(
+      CloudPlatform.AZURE,
+      StewardshipType.CONTROLLED,
+      "CONTROLLED_AZURE_NETWORK",
+      ApiResourceType.AZURE_NETWORK,
+      ControlledAzureNetworkResource.class,
+      ControlledAzureNetworkHandler::getHandler),
+  CONTROLLED_AZURE_VM(
+      CloudPlatform.AZURE,
+      StewardshipType.CONTROLLED,
+      "CONTROLLED_AZURE_VM",
+      ApiResourceType.AZURE_VM,
+      ControlledAzureVmResource.class,
+      ControlledAzureVmHandler::getHandler),
+  CONTROLLED_AZURE_STORAGE_ACCOUNT(
+      CloudPlatform.AZURE,
+      StewardshipType.CONTROLLED,
+      "CONTROLLED_AZURE_STORAGE_ACCOUNT",
+      ApiResourceType.AZURE_STORAGE_ACCOUNT,
+      ControlledAzureStorageResource.class,
+      ControlledAzureStorageHandler::getHandler);
 
   private final CloudPlatform cloudPlatform;
+  private final StewardshipType stewardshipType;
   private final String dbString; // serialized form of the resource type
   private final ApiResourceType apiResourceType;
-  private final Class<? extends ReferencedResource> referenceClass;
-  private final Class<? extends ControlledResource> controlledClass;
+  private final Class<? extends WsmResource> resourceClass;
+  private final Supplier<WsmResourceHandler> resourceHandlerSupplier;
 
   WsmResourceType(
-      // TODO(PF-1290): move cloudPlatform to controlled resource.
       CloudPlatform cloudPlatform,
+      StewardshipType stewardshipType,
       String dbString,
       ApiResourceType apiResourceType,
-      Class<? extends ReferencedResource> referenceClass,
-      Class<? extends ControlledResource> controlledClass) {
+      Class<? extends WsmResource> resourceClass,
+      Supplier<WsmResourceHandler> resourceHandlerSupplier) {
     this.cloudPlatform = cloudPlatform;
+    this.stewardshipType = stewardshipType;
     this.dbString = dbString;
     this.apiResourceType = apiResourceType;
-    this.referenceClass = referenceClass;
-    this.controlledClass = controlledClass;
+    this.resourceClass = resourceClass;
+    this.resourceHandlerSupplier = resourceHandlerSupplier;
   }
 
+  /**
+   * Translate the database resource type string into the resource type
+   *
+   * @param dbString string from the database
+   * @return resource type
+   */
   public static WsmResourceType fromSql(String dbString) {
     for (WsmResourceType value : values()) {
       if (StringUtils.equals(value.dbString, dbString)) {
@@ -127,37 +184,34 @@ public enum WsmResourceType {
         "Deserialization failed: no matching resource type for " + dbString);
   }
 
-  /**
-   * Convert from an optional api type to WsmResourceType. This method handles the case where the
-   * API input is optional/can be null. If the input is null we return null and leave it to the
-   * caller to raise any error.
-   *
-   * @param apiResourceType incoming resource type or null
-   * @return valid resource type; null if input is null
-   */
-  public static @Nullable WsmResourceType fromApiOptional(
-      @Nullable ApiResourceType apiResourceType) {
-    if (apiResourceType == null) {
-      return null;
+  public static WsmResourceType fromSqlParts(
+      WsmCloudResourceType cloudResourceType, StewardshipType stewardshipType) {
+    switch (stewardshipType) {
+      case CONTROLLED:
+        return cloudResourceType.getControlledType();
+      case REFERENCED:
+        return cloudResourceType.getReferenceType();
     }
-    for (WsmResourceType value : values()) {
-      if (value.toApiModel() == apiResourceType) {
-        return value;
-      }
-    }
-    throw new ValidationException("Invalid resource type " + apiResourceType);
+    throw new InvalidMetadataException(
+        String.format(
+            "Invalid combination: cloud resource type %s and stewardship type %s",
+            cloudResourceType, stewardshipType));
   }
 
   public CloudPlatform getCloudPlatform() {
     return cloudPlatform;
   }
 
-  public Class<? extends ReferencedResource> getReferenceClass() {
-    return referenceClass;
+  public StewardshipType getStewardshipType() {
+    return stewardshipType;
   }
 
-  public Class<? extends ControlledResource> getControlledClass() {
-    return controlledClass;
+  public Class<? extends WsmResource> getResourceClass() {
+    return resourceClass;
+  }
+
+  public WsmResourceHandler getResourceHandler() {
+    return resourceHandlerSupplier.get();
   }
 
   public String toSql() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
@@ -185,12 +185,23 @@ public enum WsmResourceType {
   }
 
   public static WsmResourceType fromSqlParts(
-      WsmCloudResourceType cloudResourceType, StewardshipType stewardshipType) {
+      WsmResourceFamily cloudResourceType, StewardshipType stewardshipType) {
     switch (stewardshipType) {
       case CONTROLLED:
-        return cloudResourceType.getControlledType();
+        return cloudResourceType
+            .getControlledType()
+            .orElseThrow(
+                () ->
+                    new InvalidMetadataException(
+                        "Unsupported controlled resource type for " + cloudResourceType));
+
       case REFERENCED:
-        return cloudResourceType.getReferenceType();
+        return cloudResourceType
+            .getReferenceType()
+            .orElseThrow(
+                () ->
+                    new InvalidMetadataException(
+                        "Unsupported referenced resource type for " + cloudResourceType));
     }
     throw new InvalidMetadataException(
         String.format(

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
@@ -43,15 +43,15 @@ public enum WsmResourceType {
   CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE(
       CloudPlatform.GCP,
       StewardshipType.CONTROLLED,
-      "GCP_CONTROLLED_AI_NOTEBOOK_INSTANCE",
+      "CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE",
       ApiResourceType.AI_NOTEBOOK,
       ControlledAiNotebookInstanceResource.class,
       ControlledAiNotebookHandler::getHandler),
 
-  REFERENCED_DATA_REPO_SNAPSHOT(
-      CloudPlatform.GCP, // TODO: switch to ANY when Yu's work goes in
+  REFERENCED_ANY_DATA_REPO_SNAPSHOT(
+      CloudPlatform.ANY,
       StewardshipType.REFERENCED,
-      "REFERENCED_DATA_REPO_SNAPSHOT",
+      "REFERENCED_ANY_DATA_REPO_SNAPSHOT",
       ApiResourceType.DATA_REPO_SNAPSHOT,
       ReferencedDataRepoSnapshotResource.class,
       ReferencedDataRepoSnapshotHandler::getHandler),
@@ -59,7 +59,7 @@ public enum WsmResourceType {
   REFERENCED_GCP_GCS_BUCKET(
       CloudPlatform.GCP,
       StewardshipType.REFERENCED,
-      "REFERENCED_GCS_BUCKET",
+      "REFERENCED_GCP_GCS_BUCKET",
       ApiResourceType.GCS_BUCKET,
       ReferencedGcsBucketResource.class,
       ReferencedGcsBucketHandler::getHandler),
@@ -67,7 +67,7 @@ public enum WsmResourceType {
   CONTROLLED_GCP_GCS_BUCKET(
       CloudPlatform.GCP,
       StewardshipType.CONTROLLED,
-      "CONTROLLED_GCS_BUCKET",
+      "CONTROLLED_GCP_GCS_BUCKET",
       ApiResourceType.GCS_BUCKET,
       ControlledGcsBucketResource.class,
       ControlledGcsBucketHandler::getHandler),
@@ -75,7 +75,7 @@ public enum WsmResourceType {
   REFERENCED_GCP_GCS_OBJECT(
       CloudPlatform.GCP,
       StewardshipType.REFERENCED,
-      "REFERENCED_GCS_OBJECT",
+      "REFERENCED_GCP_GCS_OBJECT",
       ApiResourceType.GCS_OBJECT,
       ReferencedGcsObjectResource.class,
       ReferencedGcsObjectHandler::getHandler),
@@ -83,7 +83,7 @@ public enum WsmResourceType {
   REFERENCED_GCP_BIG_QUERY_DATASET(
       CloudPlatform.GCP,
       StewardshipType.REFERENCED,
-      "REFERENCED_BIG_QUERY_DATASET",
+      "REFERENCED_GCP_BIG_QUERY_DATASET",
       ApiResourceType.BIG_QUERY_DATASET,
       ReferencedBigQueryDatasetResource.class,
       ReferencedBigQueryDatasetHandler::getHandler),
@@ -91,7 +91,7 @@ public enum WsmResourceType {
   CONTROLLED_GCP_BIG_QUERY_DATASET(
       CloudPlatform.GCP,
       StewardshipType.CONTROLLED,
-      "CONTROLLED_BIG_QUERY_DATASET",
+      "CONTROLLED_GCP_BIG_QUERY_DATASET",
       ApiResourceType.BIG_QUERY_DATASET,
       ControlledBigQueryDatasetResource.class,
       ControlledBigQueryDatasetHandler::getHandler),
@@ -99,14 +99,14 @@ public enum WsmResourceType {
   REFERENCED_GCP_BIG_QUERY_DATA_TABLE(
       CloudPlatform.GCP,
       StewardshipType.REFERENCED,
-      "REFERENCED_BIG_QUERY_DATA_TABLE",
+      "REFERENCED_GCP_BIG_QUERY_DATA_TABLE",
       ApiResourceType.BIG_QUERY_DATA_TABLE,
       ReferencedBigQueryDataTableResource.class,
       ReferencedBigQueryDataTableHandler::getHandler),
-  REFERENCED_GIT_REPO(
+  REFERENCED_ANY_GIT_REPO(
       CloudPlatform.ANY,
       StewardshipType.REFERENCED,
-      "REFERENCED_GIT_REPO",
+      "REFERENCED_ANY_GIT_REPO",
       ApiResourceType.GIT_REPO,
       ReferencedGitRepoResource.class,
       ReferencedGitRepoHandler::getHandler),

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoAttributes.java
@@ -1,4 +1,4 @@
-package bio.terra.workspace.service.resource.referenced.cloud.any;
+package bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoHandler.java
@@ -12,6 +12,7 @@ public class ReferencedGitRepoHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElseGet(ReferencedGitRepoHandler::new);
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ReferencedGitRepoResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoHandler.java
@@ -9,7 +9,7 @@ public class ReferencedGitRepoHandler implements WsmResourceHandler {
   private static ReferencedGitRepoHandler theHandler;
 
   public static ReferencedGitRepoHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ReferencedGitRepoHandler());
+    return Optional.ofNullable(theHandler).orElseGet(ReferencedGitRepoHandler::new);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ReferencedGitRepoHandler implements WsmResourceHandler {
   private static ReferencedGitRepoHandler theHandler;
 
   public static ReferencedGitRepoHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElseGet(ReferencedGitRepoHandler::new);
+    if (theHandler == null) {
+      theHandler = new ReferencedGitRepoHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ReferencedGitRepoHandler implements WsmResourceHandler {
+  private static ReferencedGitRepoHandler theHandler;
+
+  public static ReferencedGitRepoHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ReferencedGitRepoHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ReferencedGitRepoResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
@@ -11,7 +11,7 @@ import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -57,8 +57,8 @@ public class ReferencedGitRepoResource extends ReferencedResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.GIT_REPO;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.GIT_REPO;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
@@ -1,4 +1,4 @@
-package bio.terra.workspace.service.resource.referenced.cloud.any;
+package bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo;
 
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
@@ -7,8 +7,11 @@ import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiGitRepoAttributes;
 import bio.terra.workspace.generated.model.ApiGitRepoResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -50,12 +53,27 @@ public class ReferencedGitRepoResource extends ReferencedResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.GIT_REPO;
+    return WsmResourceType.REFERENCED_GIT_REPO;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.GIT_REPO;
   }
 
   @Override
   public String attributesToJson() {
     return DbSerDes.toJson(new ReferencedGitRepoAttributes(gitRepoUrl));
+  }
+
+  @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    return new ApiResourceAttributesUnion().gitRepo(toApiAttributes());
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    return new ApiResourceUnion().gitRepo(toApiResource());
   }
 
   @Override
@@ -70,7 +88,7 @@ public class ReferencedGitRepoResource extends ReferencedResource {
     return new ApiGitRepoAttributes().gitRepoUrl(gitRepoUrl);
   }
 
-  public ApiGitRepoResource toApiModel() {
+  public ApiGitRepoResource toApiResource() {
     return new ApiGitRepoResource().metadata(super.toApiMetadata()).attributes(toApiAttributes());
   }
 
@@ -81,8 +99,8 @@ public class ReferencedGitRepoResource extends ReferencedResource {
   @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.GIT_REPO) {
-      throw new InconsistentFieldsException("Expected GIT_REPO");
+    if (getResourceType() != WsmResourceType.REFERENCED_GIT_REPO) {
+      throw new InconsistentFieldsException("Expected REFERENCED_GIT_REPO");
     }
     if (Strings.isNullOrEmpty(gitRepoUrl)) {
       throw new MissingRequiredFieldException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
@@ -53,7 +53,7 @@ public class ReferencedGitRepoResource extends ReferencedResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.REFERENCED_GIT_REPO;
+    return WsmResourceType.REFERENCED_ANY_GIT_REPO;
   }
 
   @Override
@@ -99,7 +99,7 @@ public class ReferencedGitRepoResource extends ReferencedResource {
   @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.REFERENCED_GIT_REPO) {
+    if (getResourceType() != WsmResourceType.REFERENCED_ANY_GIT_REPO) {
       throw new InconsistentFieldsException("Expected REFERENCED_GIT_REPO");
     }
     if (Strings.isNullOrEmpty(gitRepoUrl)) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResource.java
@@ -8,7 +8,7 @@ import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
-import bio.terra.workspace.service.resource.referenced.cloud.any.ReferencedGitRepoResource;
+import bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo.ReferencedGitRepoResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable.ReferencedBigQueryDataTableResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.datareposnapshot.ReferencedDataRepoSnapshotResource;
@@ -41,32 +41,32 @@ public abstract class ReferencedResource extends WsmResource {
 
   // Double-checked down casts when we need to re-specialize from a ReferenceResource
   public ReferencedBigQueryDatasetResource castToBigQueryDatasetResource() {
-    validateSubclass(WsmResourceType.BIG_QUERY_DATASET);
+    validateSubclass(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET);
     return (ReferencedBigQueryDatasetResource) this;
   }
 
   public ReferencedBigQueryDataTableResource castToBigQueryDataTableResource() {
-    validateSubclass(WsmResourceType.BIG_QUERY_DATA_TABLE);
+    validateSubclass(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE);
     return (ReferencedBigQueryDataTableResource) this;
   }
 
   public ReferencedDataRepoSnapshotResource castToDataRepoSnapshotResource() {
-    validateSubclass(WsmResourceType.DATA_REPO_SNAPSHOT);
+    validateSubclass(WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
     return (ReferencedDataRepoSnapshotResource) this;
   }
 
   public ReferencedGcsBucketResource castToGcsBucketResource() {
-    validateSubclass(WsmResourceType.GCS_BUCKET);
+    validateSubclass(WsmResourceType.REFERENCED_GCP_GCS_BUCKET);
     return (ReferencedGcsBucketResource) this;
   }
 
   public ReferencedGcsObjectResource castToGcsObjectResource() {
-    validateSubclass(WsmResourceType.GCS_OBJECT);
+    validateSubclass(WsmResourceType.REFERENCED_GCP_GCS_OBJECT);
     return (ReferencedGcsObjectResource) this;
   }
 
   public ReferencedGitRepoResource castToGitRepoResource() {
-    validateSubclass(WsmResourceType.GIT_REPO);
+    validateSubclass(WsmResourceType.REFERENCED_GIT_REPO);
     return (ReferencedGitRepoResource) this;
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResource.java
@@ -51,7 +51,7 @@ public abstract class ReferencedResource extends WsmResource {
   }
 
   public ReferencedDataRepoSnapshotResource castToDataRepoSnapshotResource() {
-    validateSubclass(WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
+    validateSubclass(WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT);
     return (ReferencedDataRepoSnapshotResource) this;
   }
 
@@ -66,7 +66,7 @@ public abstract class ReferencedResource extends WsmResource {
   }
 
   public ReferencedGitRepoResource castToGitRepoResource() {
-    validateSubclass(WsmResourceType.REFERENCED_GIT_REPO);
+    validateSubclass(WsmResourceType.REFERENCED_ANY_GIT_REPO);
     return (ReferencedGitRepoResource) this;
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ReferencedBigQueryDatasetHandler implements WsmResourceHandler {
+  private static ReferencedBigQueryDatasetHandler theHandler;
+
+  public static ReferencedBigQueryDatasetHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ReferencedBigQueryDatasetHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ReferencedBigQueryDatasetResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ReferencedBigQueryDatasetHandler implements WsmResourceHandler {
   private static ReferencedBigQueryDatasetHandler theHandler;
 
   public static ReferencedBigQueryDatasetHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ReferencedBigQueryDatasetHandler());
+    if (theHandler == null) {
+      theHandler = new ReferencedBigQueryDatasetHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetHandler.java
@@ -12,6 +12,7 @@ public class ReferencedBigQueryDatasetHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ReferencedBigQueryDatasetHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ReferencedBigQueryDatasetResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
@@ -7,11 +7,14 @@ import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetAttributes;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -57,7 +60,7 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
    */
   public ReferencedBigQueryDatasetResource(DbResource dbResource) {
     super(dbResource);
-    if (dbResource.getResourceType() != WsmResourceType.BIG_QUERY_DATASET) {
+    if (dbResource.getResourceType() != WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET) {
       throw new InvalidMetadataException("Expected BIG_QUERY_DATASET");
     }
 
@@ -94,13 +97,28 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.BIG_QUERY_DATASET;
+    return WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.BIG_QUERY_DATASET;
   }
 
   @Override
   public String attributesToJson() {
     return DbSerDes.toJson(
         new ReferencedBigQueryDatasetAttributes(getProjectId(), getDatasetName()));
+  }
+
+  @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    return new ApiResourceAttributesUnion().gcpBqDataset(toApiAttributes());
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    return new ApiResourceUnion().gcpBqDataset(toApiResource());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -61,7 +61,7 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
   public ReferencedBigQueryDatasetResource(DbResource dbResource) {
     super(dbResource);
     if (dbResource.getResourceType() != WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET) {
-      throw new InvalidMetadataException("Expected BIG_QUERY_DATASET");
+      throw new InvalidMetadataException("Expected REFERENCED_BIG_QUERY_DATASET");
     }
 
     ReferencedBigQueryDatasetAttributes attributes =
@@ -101,8 +101,8 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.BIG_QUERY_DATASET;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.BIG_QUERY_DATASET;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ReferencedBigQueryDataTableHandler implements WsmResourceHandler {
   private static ReferencedBigQueryDataTableHandler theHandler;
 
   public static ReferencedBigQueryDataTableHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ReferencedBigQueryDataTableHandler());
+    if (theHandler == null) {
+      theHandler = new ReferencedBigQueryDataTableHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ReferencedBigQueryDataTableHandler implements WsmResourceHandler {
+  private static ReferencedBigQueryDataTableHandler theHandler;
+
+  public static ReferencedBigQueryDataTableHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ReferencedBigQueryDataTableHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ReferencedBigQueryDataTableResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableHandler.java
@@ -12,6 +12,7 @@ public class ReferencedBigQueryDataTableHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ReferencedBigQueryDataTableHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ReferencedBigQueryDataTableResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
@@ -7,11 +7,14 @@ import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableAttributes;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -63,8 +66,8 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
    */
   public ReferencedBigQueryDataTableResource(DbResource dbResource) {
     super(dbResource);
-    if (dbResource.getResourceType() != WsmResourceType.BIG_QUERY_DATA_TABLE) {
-      throw new InvalidMetadataException("Expected BIG_QUERY_DATA_TABLE");
+    if (dbResource.getResourceType() != WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE) {
+      throw new InvalidMetadataException("Expected referenced GCP BIG_QUERY_DATA_TABLE");
     }
 
     ReferencedBigQueryDataTableAttributes attributes =
@@ -106,7 +109,12 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.BIG_QUERY_DATA_TABLE;
+    return WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.BIG_QUERY_DATA_TABLE;
   }
 
   @Override
@@ -114,6 +122,16 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
     return DbSerDes.toJson(
         new ReferencedBigQueryDataTableAttributes(
             getProjectId(), getDatasetId(), getDataTableId()));
+  }
+
+  @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    return new ApiResourceAttributesUnion().gcpBqDataTable(toApiAttributes());
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    return new ApiResourceUnion().gcpBqDataTable(toApiResource());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -67,7 +67,7 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
   public ReferencedBigQueryDataTableResource(DbResource dbResource) {
     super(dbResource);
     if (dbResource.getResourceType() != WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE) {
-      throw new InvalidMetadataException("Expected referenced GCP BIG_QUERY_DATA_TABLE");
+      throw new InvalidMetadataException("Expected REFERENCED_GCP BIG_QUERY_DATA_TABLE");
     }
 
     ReferencedBigQueryDataTableAttributes attributes =
@@ -113,8 +113,8 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.BIG_QUERY_DATA_TABLE;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.BIG_QUERY_DATA_TABLE;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.referenced.cloud.gcp.datareposnapshot;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ReferencedDataRepoSnapshotHandler implements WsmResourceHandler {
+  private static ReferencedDataRepoSnapshotHandler theHandler;
+
+  public static ReferencedDataRepoSnapshotHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ReferencedDataRepoSnapshotHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ReferencedDataRepoSnapshotResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotHandler.java
@@ -12,6 +12,7 @@ public class ReferencedDataRepoSnapshotHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ReferencedDataRepoSnapshotHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ReferencedDataRepoSnapshotResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.referenced.cloud.gcp.datareposnapsh
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ReferencedDataRepoSnapshotHandler implements WsmResourceHandler {
   private static ReferencedDataRepoSnapshotHandler theHandler;
 
   public static ReferencedDataRepoSnapshotHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ReferencedDataRepoSnapshotHandler());
+    if (theHandler == null) {
+      theHandler = new ReferencedDataRepoSnapshotHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
@@ -12,7 +12,7 @@ import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.datarepo.DataRepoService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -98,8 +98,8 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.DATA_REPO_SNAPSHOT;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.DATA_REPO_SNAPSHOT;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
@@ -7,9 +7,12 @@ import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotAttributes;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.datarepo.DataRepoService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -55,8 +58,8 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
    */
   public ReferencedDataRepoSnapshotResource(DbResource dbResource) {
     super(dbResource);
-    if (dbResource.getResourceType() != WsmResourceType.DATA_REPO_SNAPSHOT) {
-      throw new InvalidMetadataException("Expected DATA_REPO_SNAPSHOT");
+    if (dbResource.getResourceType() != WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT) {
+      throw new InvalidMetadataException("Expected referenced DATA_REPO_SNAPSHOT");
     }
     ReferencedDataRepoSnapshotAttributes attributes =
         DbSerDes.fromJson(dbResource.getAttributes(), ReferencedDataRepoSnapshotAttributes.class);
@@ -91,13 +94,28 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.DATA_REPO_SNAPSHOT;
+    return WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.DATA_REPO_SNAPSHOT;
   }
 
   @Override
   public String attributesToJson() {
     return DbSerDes.toJson(
         new ReferencedDataRepoSnapshotAttributes(getInstanceName(), getSnapshotId()));
+  }
+
+  @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    return new ApiResourceAttributesUnion().gcpDataRepoSnapshot(toApiAttributes());
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    return new ApiResourceUnion().gcpDataRepoSnapshot(toApiResource());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
@@ -58,7 +58,7 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
    */
   public ReferencedDataRepoSnapshotResource(DbResource dbResource) {
     super(dbResource);
-    if (dbResource.getResourceType() != WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT) {
+    if (dbResource.getResourceType() != WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT) {
       throw new InvalidMetadataException("Expected referenced DATA_REPO_SNAPSHOT");
     }
     ReferencedDataRepoSnapshotAttributes attributes =
@@ -94,7 +94,7 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT;
+    return WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ReferencedGcsBucketHandler implements WsmResourceHandler {
   private static ReferencedGcsBucketHandler theHandler;
 
   public static ReferencedGcsBucketHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ReferencedGcsBucketHandler());
+    if (theHandler == null) {
+      theHandler = new ReferencedGcsBucketHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketHandler.java
@@ -12,6 +12,7 @@ public class ReferencedGcsBucketHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ReferencedGcsBucketHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ReferencedGcsBucketResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ReferencedGcsBucketHandler implements WsmResourceHandler {
+  private static ReferencedGcsBucketHandler theHandler;
+
+  public static ReferencedGcsBucketHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ReferencedGcsBucketHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ReferencedGcsBucketResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
@@ -7,11 +7,14 @@ import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketAttributes;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -67,7 +70,7 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
     return new ApiGcpGcsBucketAttributes().bucketName(getBucketName());
   }
 
-  public ApiGcpGcsBucketResource toApiModel() {
+  public ApiGcpGcsBucketResource toApiResource() {
     return new ApiGcpGcsBucketResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());
@@ -75,7 +78,12 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.GCS_BUCKET;
+    return WsmResourceType.REFERENCED_GCP_GCS_BUCKET;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.GCS_BUCKET;
   }
 
   @Override
@@ -84,10 +92,20 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
   }
 
   @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    return new ApiResourceAttributesUnion().gcpGcsBucket(toApiAttributes());
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    return new ApiResourceUnion().gcpGcsBucket(toApiResource());
+  }
+
+  @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.GCS_BUCKET) {
-      throw new InconsistentFieldsException("Expected GCS_BUCKET");
+    if (getResourceType() != WsmResourceType.REFERENCED_GCP_GCS_BUCKET) {
+      throw new InconsistentFieldsException("Expected referenced GCP GCS_BUCKET");
     }
     if (Strings.isNullOrEmpty(getBucketName())) {
       throw new MissingRequiredFieldException("Missing required field for ReferenceGcsBucket.");

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -82,8 +82,8 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.GCS_BUCKET;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.GCS_BUCKET;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectHandler.java
@@ -3,13 +3,15 @@ package bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import java.util.Optional;
 
 public class ReferencedGcsObjectHandler implements WsmResourceHandler {
   private static ReferencedGcsObjectHandler theHandler;
 
   public static ReferencedGcsObjectHandler getHandler() {
-    return Optional.ofNullable(theHandler).orElse(new ReferencedGcsObjectHandler());
+    if (theHandler == null) {
+      theHandler = new ReferencedGcsObjectHandler();
+    }
+    return theHandler;
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectHandler.java
@@ -12,6 +12,7 @@ public class ReferencedGcsObjectHandler implements WsmResourceHandler {
     return Optional.ofNullable(theHandler).orElse(new ReferencedGcsObjectHandler());
   }
 
+  /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
     return new ReferencedGcsObjectResource(dbResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject;
+
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import java.util.Optional;
+
+public class ReferencedGcsObjectHandler implements WsmResourceHandler {
+  private static ReferencedGcsObjectHandler theHandler;
+
+  public static ReferencedGcsObjectHandler getHandler() {
+    return Optional.ofNullable(theHandler).orElse(new ReferencedGcsObjectHandler());
+  }
+
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    return new ReferencedGcsObjectResource(dbResource);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
@@ -7,11 +7,14 @@ import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiGcpGcsObjectAttributes;
 import bio.terra.workspace.generated.model.ApiGcpGcsObjectResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -77,7 +80,7 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
     return new ApiGcpGcsObjectAttributes().bucketName(getBucketName()).fileName(getObjectName());
   }
 
-  public ApiGcpGcsObjectResource toApiModel() {
+  public ApiGcpGcsObjectResource toApiResource() {
     return new ApiGcpGcsObjectResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());
@@ -85,7 +88,12 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
 
   @Override
   public WsmResourceType getResourceType() {
-    return WsmResourceType.GCS_OBJECT;
+    return WsmResourceType.REFERENCED_GCP_GCS_OBJECT;
+  }
+
+  @Override
+  public WsmCloudResourceType getCloudResourceType() {
+    return WsmCloudResourceType.GCS_OBJECT;
   }
 
   @Override
@@ -94,9 +102,19 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
   }
 
   @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    return new ApiResourceAttributesUnion().gcpGcsObject(toApiAttributes());
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    return new ApiResourceUnion().gcpGcsObject(toApiResource());
+  }
+
+  @Override
   public void validate() {
     super.validate();
-    if (getResourceType() != WsmResourceType.GCS_OBJECT) {
+    if (getResourceType() != WsmResourceType.REFERENCED_GCP_GCS_OBJECT) {
       throw new InconsistentFieldsException("Expected GCS_OBJECT");
     }
     if (Strings.isNullOrEmpty(getBucketName()) || Strings.isNullOrEmpty(getObjectName())) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -92,8 +92,8 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
   }
 
   @Override
-  public WsmCloudResourceType getCloudResourceType() {
-    return WsmCloudResourceType.GCS_OBJECT;
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.GCS_OBJECT;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/CreateReferenceMetadataStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/CreateReferenceMetadataStep.java
@@ -7,8 +7,8 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import org.springframework.http.HttpStatus;
 
@@ -24,29 +24,27 @@ public class CreateReferenceMetadataStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws RetryException, InterruptedException {
-    ReferencedResource referenceResource = getReferenceResource(flightContext);
-    resourceDao.createReferenceResource(referenceResource);
-    FlightUtils.setResponse(flightContext, referenceResource.getResourceId(), HttpStatus.OK);
+    WsmResource referencedResource = getReferencedResource(flightContext);
+    resourceDao.createReferencedResource(referencedResource);
+    FlightUtils.setResponse(flightContext, referencedResource.getResourceId(), HttpStatus.OK);
     return StepResult.getStepResultSuccess();
   }
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    ReferencedResource referenceResource = getReferenceResource(flightContext);
-
+    WsmResource referencedResource = getReferencedResource(flightContext);
     // Ignore return value, as we don't care whether a reference was deleted or just not found.
     resourceDao.deleteResource(
-        referenceResource.getWorkspaceId(), referenceResource.getResourceId());
+        referencedResource.getWorkspaceId(), referencedResource.getResourceId());
 
     return StepResult.getStepResultSuccess();
   }
 
-  private ReferencedResource getReferenceResource(FlightContext flightContext) {
+  private WsmResource getReferencedResource(FlightContext flightContext) {
     FlightMap inputMap = flightContext.getInputParameters();
     WsmResourceType resourceType =
         WsmResourceType.valueOf(inputMap.get(ResourceKeys.RESOURCE_TYPE, String.class));
-
     // Use the resource type to deserialize the right class
-    return inputMap.get(ResourceKeys.RESOURCE, resourceType.getReferenceClass());
+    return inputMap.get(ResourceKeys.RESOURCE, resourceType.getResourceClass());
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/Alpha1Service.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/Alpha1Service.java
@@ -13,8 +13,8 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.job.exception.InternalStairwayException;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.model.EnumeratedJob;
@@ -70,7 +70,7 @@ public class Alpha1Service {
       AuthenticatedUserRequest userRequest,
       int limit,
       @Nullable String pageToken,
-      @Nullable WsmCloudResourceType cloudResourceType,
+      @Nullable WsmResourceFamily cloudResourceType,
       @Nullable StewardshipType stewardshipType,
       @Nullable String resourceName,
       @Nullable JobStateFilter jobStateFilter) {
@@ -125,7 +125,7 @@ public class Alpha1Service {
 
   private FlightFilter buildFlightFilter(
       UUID workspaceId,
-      @Nullable WsmCloudResourceType cloudResourceType,
+      @Nullable WsmResourceFamily cloudResourceType,
       @Nullable StewardshipType stewardshipType,
       @Nullable String resourceName,
       @Nullable JobStateFilter jobStateFilter) {

--- a/service/src/main/java/bio/terra/workspace/service/workspace/Alpha1Service.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/Alpha1Service.java
@@ -13,8 +13,8 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.job.exception.InternalStairwayException;
 import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmCloudResourceType;
 import bio.terra.workspace.service.resource.model.WsmResource;
-import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.model.EnumeratedJob;
@@ -59,7 +59,7 @@ public class Alpha1Service {
    * @param userRequest authenticated user
    * @param limit max number of jobs to return
    * @param pageToken optional starting place in the result set; start at beginning if missing
-   * @param resourceType optional filter by resource type
+   * @param cloudResourceType optional filter by cloud resource type
    * @param stewardshipType optional filter by stewardship type
    * @param resourceName optional filter by resource name
    * @param jobStateFilter optional filter by job state
@@ -70,7 +70,7 @@ public class Alpha1Service {
       AuthenticatedUserRequest userRequest,
       int limit,
       @Nullable String pageToken,
-      @Nullable WsmResourceType resourceType,
+      @Nullable WsmCloudResourceType cloudResourceType,
       @Nullable StewardshipType stewardshipType,
       @Nullable String resourceName,
       @Nullable JobStateFilter jobStateFilter) {
@@ -84,7 +84,7 @@ public class Alpha1Service {
     try {
       FlightFilter filter =
           buildFlightFilter(
-              workspaceId, resourceType, stewardshipType, resourceName, jobStateFilter);
+              workspaceId, cloudResourceType, stewardshipType, resourceName, jobStateFilter);
       flightEnumeration = stairwayComponent.get().getFlights(pageToken, limit, filter);
     } catch (StairwayException | InterruptedException stairwayEx) {
       throw new InternalStairwayException(stairwayEx);
@@ -125,7 +125,7 @@ public class Alpha1Service {
 
   private FlightFilter buildFlightFilter(
       UUID workspaceId,
-      @Nullable WsmResourceType resourceType,
+      @Nullable WsmCloudResourceType cloudResourceType,
       @Nullable StewardshipType stewardshipType,
       @Nullable String resourceName,
       @Nullable JobStateFilter jobStateFilter) {
@@ -135,7 +135,7 @@ public class Alpha1Service {
     filter.addFilterInputParameter(
         WorkspaceFlightMapKeys.WORKSPACE_ID, FlightFilterOp.EQUAL, workspaceId.toString());
     // Add optional filters
-    Optional.ofNullable(resourceType)
+    Optional.ofNullable(cloudResourceType)
         .map(
             t ->
                 filter.addFilterInputParameter(

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -4543,11 +4543,13 @@ components:
         azureDisk:
           $ref: '#/components/schemas/AzureDiskResource'
         azureNetwork:
-          $ref: '#/components/schemas/AzureDiskResource'
+          $ref: '#/components/schemas/AzureNetworkResource'
         azureVm:
           $ref: '#/components/schemas/AzureVmResource'
         azureStorageAccount:
           $ref: '#/components/schemas/AzureStorageResource'
+        gitRepo:
+          $ref: '#/components/schemas/GitRepoResource'
 
     OperationType:
       type: string

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -126,7 +126,7 @@ terra.common:
 # Feature flags can be overridden like any other Spring property. In particular, for local
 # execution, you can set an environment variable, such as:
 #
-#  FEATURE_AZURE_ENABLED=true
+#  FEATURE_AZUREENABLED=true
 #
 # The WSM helm chart will take all values under the "env" and make them environment variables
 # in the container, so you can get the equivalent setting by adding:

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -5,4 +5,5 @@
     <include file="changesets/20211006_application_columns.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20211130_private_resource_state.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20211201_cronjob_table.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220131_resource_type.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20220131_resource_type.yaml
+++ b/service/src/main/resources/db/changesets/20220131_resource_type.yaml
@@ -1,23 +1,26 @@
 databaseChangeLog:
 - changeSet:
-    id: resource type fixup
+    id: add exact resource type
     author: ddietterich
     changes:
-    - renameColumn:
-        tableName: resource
-        newColumnName: resource_family
-        oldColumnName: resource_type
-        remarks: The general type of resource, for example, GCS_BUCKET/
     - addColumn:
         tableName: resource
         columns:
         - column:
             name: exact_resource_type
             type: text
-            defaultValue: "notset"
-            constraints:
-              nullable: false
             remarks: |
-              The specific resource type in the form {stewardship}_{cloud}_{cloud_resource_type}
-              For example, CONTROLLED_GCP_GCS_BUCKET and REFERENCED_ANY_GIT_REPO.
-
+                The specific resource type in the form {stewardship}_{cloud}_{resource_type}
+                For example, CONTROLLED_GCP_GCS_BUCKET and REFERENCED_ANY_GIT_REPO.
+    - sql:
+        # Fix the cloud platform for any existing data repo snapshots. There were previously
+        # created with cloud_platform of GCP
+        sql: update resource set cloud_platform = 'ANY' where resource_type = 'DATA_REPO_SNAPSHOT';
+    - sql:
+        # Fill in the exact_resource_type column by concatenation
+        sql: update resource set exact_resource_type = (stewardship_type || '_' || cloud_platform || '_' || resource_type);
+    - addNotNullConstraint:
+        tableName: resource
+        columnName: exact_resource_type
+        constraintName: exact_resource_type_notnull
+        validate: true

--- a/service/src/main/resources/db/changesets/20220131_resource_type.yaml
+++ b/service/src/main/resources/db/changesets/20220131_resource_type.yaml
@@ -5,18 +5,19 @@ databaseChangeLog:
     changes:
     - renameColumn:
         tableName: resource
-        newColumnName: cloud_resource_type
+        newColumnName: resource_family
         oldColumnName: resource_type
-        remarks: The type of cloud resource, for example, GCS_BUCKET.
+        remarks: The general type of resource, for example, GCS_BUCKET/
     - addColumn:
         tableName: resource
         columns:
         - column:
-            name: resource_type
+            name: exact_resource_type
             type: text
             defaultValue: "notset"
             constraints:
               nullable: false
             remarks: |
               The specific resource type in the form {stewardship}_{cloud}_{cloud_resource_type}
+              For example, CONTROLLED_GCP_GCS_BUCKET and REFERENCED_ANY_GIT_REPO.
 

--- a/service/src/main/resources/db/changesets/20220131_resource_type.yaml
+++ b/service/src/main/resources/db/changesets/20220131_resource_type.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+- changeSet:
+    id: resource type fixup
+    author: ddietterich
+    changes:
+    - renameColumn:
+        tableName: resource
+        newColumnName: cloud_resource_type
+        oldColumnName: resource_type
+        remarks: The type of cloud resource, for example, GCS_BUCKET.
+    - addColumn:
+        tableName: resource
+        columns:
+        - column:
+            name: resource_type
+            type: text
+            defaultValue: "notset"
+            constraints:
+              nullable: false
+            remarks: |
+              The specific resource type in the form {stewardship}_{cloud}_{cloud_resource_type}
+

--- a/service/src/test/java/bio/terra/workspace/db/RawDaoTestFixture.java
+++ b/service/src/test/java/bio/terra/workspace/db/RawDaoTestFixture.java
@@ -41,10 +41,10 @@ public class RawDaoTestFixture {
       String privateResourceState) {
     final String sql =
         "INSERT INTO resource (workspace_id, cloud_platform, resource_id, name, description, stewardship_type,"
-            + " exact_resource_type, resource_family, cloning_instructions, attributes,"
+            + " exact_resource_type, resource_type, cloning_instructions, attributes,"
             + " access_scope, managed_by, associated_app, assigned_user, private_resource_state)"
             + " VALUES (:workspace_id, :cloud_platform, :resource_id, :name, :description, :stewardship_type,"
-            + " :exact_resource_type, :resource_family, :cloning_instructions, cast(:attributes AS jsonb),"
+            + " :exact_resource_type, :resource_type, :cloning_instructions, cast(:attributes AS jsonb),"
             + " :access_scope, :managed_by, :associated_app, :assigned_user, :private_resource_state)";
 
     final var params =
@@ -56,7 +56,7 @@ public class RawDaoTestFixture {
             .addValue("description", description)
             .addValue("stewardship_type", stewardshipType)
             .addValue("exact_resource_type", resourceType)
-            .addValue("resource_family", resourceFamily)
+            .addValue("resource_type", resourceFamily)
             .addValue("cloning_instructions", cloningInstructions)
             .addValue("attributes", attributes)
             .addValue("access_scope", accessScope)

--- a/service/src/test/java/bio/terra/workspace/db/RawDaoTestFixture.java
+++ b/service/src/test/java/bio/terra/workspace/db/RawDaoTestFixture.java
@@ -12,12 +12,12 @@ import org.springframework.stereotype.Component;
 
 /** DAO in the test to contain direct access to the database */
 @Component
-public class TestDao {
-  private static final Logger logger = LoggerFactory.getLogger(TestDao.class);
+public class RawDaoTestFixture {
+  private static final Logger logger = LoggerFactory.getLogger(RawDaoTestFixture.class);
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   @Autowired
-  public TestDao(NamedParameterJdbcTemplate jdbcTemplate) {
+  public RawDaoTestFixture(NamedParameterJdbcTemplate jdbcTemplate) {
     this.jdbcTemplate = jdbcTemplate;
   }
 
@@ -31,7 +31,7 @@ public class TestDao {
       String description,
       String stewardshipType,
       String resourceType,
-      String cloudResourceType,
+      String resourceFamily,
       String cloningInstructions,
       String attributes,
       String accessScope,
@@ -41,10 +41,10 @@ public class TestDao {
       String privateResourceState) {
     final String sql =
         "INSERT INTO resource (workspace_id, cloud_platform, resource_id, name, description, stewardship_type,"
-            + " resource_type, cloud_resource_type, cloning_instructions, attributes,"
+            + " exact_resource_type, resource_family, cloning_instructions, attributes,"
             + " access_scope, managed_by, associated_app, assigned_user, private_resource_state)"
             + " VALUES (:workspace_id, :cloud_platform, :resource_id, :name, :description, :stewardship_type,"
-            + " :resource_type, :cloud_resource_type, :cloning_instructions, cast(:attributes AS jsonb),"
+            + " :exact_resource_type, :resource_family, :cloning_instructions, cast(:attributes AS jsonb),"
             + " :access_scope, :managed_by, :associated_app, :assigned_user, :private_resource_state)";
 
     final var params =
@@ -55,8 +55,8 @@ public class TestDao {
             .addValue("name", name)
             .addValue("description", description)
             .addValue("stewardship_type", stewardshipType)
-            .addValue("resource_type", resourceType)
-            .addValue("cloud_resource_type", cloudResourceType)
+            .addValue("exact_resource_type", resourceType)
+            .addValue("resource_family", resourceFamily)
             .addValue("cloning_instructions", cloningInstructions)
             .addValue("attributes", attributes)
             .addValue("access_scope", accessScope)

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -31,7 +31,7 @@ public class ResourceDaoTest extends BaseUnitTest {
   @Autowired ResourceDao resourceDao;
   @Autowired WorkspaceDao workspaceDao;
   @Autowired GcpCloudContextService gcpCloudContextService;
-  @Autowired TestDao testDao;
+  @Autowired RawDaoTestFixture testDao;
 
   /**
    * Creates a workspaces with a GCP cloud context and stores it in the database. Returns the

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -15,8 +15,6 @@ import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.Contr
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
-import bio.terra.workspace.service.resource.model.WsmResource;
-import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
@@ -277,32 +275,5 @@ public class ResourceDaoTest extends BaseUnitTest {
     resourceDao.deleteResource(uniqueResource.getWorkspaceId(), uniqueResource.getResourceId());
     resourceDao.deleteResource(
         duplicatingResource.getWorkspaceId(), duplicatingResource.getResourceId());
-  }
-
-  @Test
-  public void testResourceTypeCompatibility() {
-    UUID workspaceId = createGcpWorkspace();
-    UUID resourceId = UUID.randomUUID();
-    // Store a resource in the upgraded form
-    testDao.storeResource(
-        workspaceId.toString(),
-        "GCP",
-        resourceId.toString(),
-        "testgcs-fc5ab877-e14d-44b6-a6ba-34b29fd3fd11",
-        "A bucket that had beer in it, briefly. 🍻",
-        "CONTROLLED",
-        "notset", // the state after the liquibase upgrade
-        "GCS_BUCKET",
-        "COPY_REFERENCE",
-        "{\"bucketName\": \"my-bucket-611975c8-c54c-4f1f-8a11-268f003b904c\"}",
-        "ACCESS_SHARED",
-        "USER",
-        null,
-        null,
-        "NOT_APPLICABLE");
-
-    // Retrieve using the resourceDao and make sure the resource type gets filled in right
-    WsmResource resource = resourceDao.getResource(workspaceId, resourceId);
-    assertEquals(resource.getResourceType(), WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/db/TestDao.java
+++ b/service/src/test/java/bio/terra/workspace/db/TestDao.java
@@ -1,0 +1,78 @@
+package bio.terra.workspace.db;
+
+import bio.terra.common.db.WriteTransaction;
+import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/** DAO in the test to contain direct access to the database */
+@Component
+public class TestDao {
+  private static final Logger logger = LoggerFactory.getLogger(TestDao.class);
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired
+  public TestDao(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  // Write a resource into the database from bare parts
+  @WriteTransaction
+  public void storeResource(
+      String workspaceId,
+      String cloudPlatform,
+      String resourceId,
+      String name,
+      String description,
+      String stewardshipType,
+      String resourceType,
+      String cloudResourceType,
+      String cloningInstructions,
+      String attributes,
+      String accessScope,
+      String managedBy,
+      String associatedApp,
+      String assignedUser,
+      String privateResourceState) {
+    final String sql =
+        "INSERT INTO resource (workspace_id, cloud_platform, resource_id, name, description, stewardship_type,"
+            + " resource_type, cloud_resource_type, cloning_instructions, attributes,"
+            + " access_scope, managed_by, associated_app, assigned_user, private_resource_state)"
+            + " VALUES (:workspace_id, :cloud_platform, :resource_id, :name, :description, :stewardship_type,"
+            + " :resource_type, :cloud_resource_type, :cloning_instructions, cast(:attributes AS jsonb),"
+            + " :access_scope, :managed_by, :associated_app, :assigned_user, :private_resource_state)";
+
+    final var params =
+        new MapSqlParameterSource()
+            .addValue("workspace_id", workspaceId)
+            .addValue("cloud_platform", cloudPlatform)
+            .addValue("resource_id", resourceId)
+            .addValue("name", name)
+            .addValue("description", description)
+            .addValue("stewardship_type", stewardshipType)
+            .addValue("resource_type", resourceType)
+            .addValue("cloud_resource_type", cloudResourceType)
+            .addValue("cloning_instructions", cloningInstructions)
+            .addValue("attributes", attributes)
+            .addValue("access_scope", accessScope)
+            .addValue("managed_by", managedBy)
+            .addValue("associated_app", associatedApp)
+            .addValue("assigned_user", assignedUser)
+            .addValue("private_resource_state", privateResourceState);
+
+    try {
+      jdbcTemplate.update(sql, params);
+      logger.info("Inserted record for resource {} for workspace {}", resourceId, workspaceId);
+    } catch (DuplicateKeyException e) {
+      throw new DuplicateResourceException(
+          String.format(
+              "A resource already exists in the workspace that has the same name (%s) or the same id (%s)",
+              name, resourceId));
+    }
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleTest.java
@@ -19,32 +19,32 @@ public class CustomGcpIamRoleTest extends BaseUnitTest {
     assertEquals(
         "GCS_BUCKET_READER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
-            .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.READER)
+            .get(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET, ControlledResourceIamRole.READER)
             .getRoleName());
     assertEquals(
         "GCS_BUCKET_WRITER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
-            .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.WRITER)
+            .get(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET, ControlledResourceIamRole.WRITER)
             .getRoleName());
     assertEquals(
         "GCS_BUCKET_EDITOR",
         CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
-            .get(WsmResourceType.GCS_BUCKET, ControlledResourceIamRole.EDITOR)
+            .get(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET, ControlledResourceIamRole.EDITOR)
             .getRoleName());
     assertEquals(
         "BIG_QUERY_DATASET_READER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
-            .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.READER)
+            .get(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET, ControlledResourceIamRole.READER)
             .getRoleName());
     assertEquals(
         "BIG_QUERY_DATASET_WRITER",
         CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
-            .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.WRITER)
+            .get(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET, ControlledResourceIamRole.WRITER)
             .getRoleName());
     assertEquals(
         "BIG_QUERY_DATASET_EDITOR",
         CustomGcpIamRoleMapping.CUSTOM_GCP_RESOURCE_IAM_ROLES
-            .get(WsmResourceType.BIG_QUERY_DATASET, ControlledResourceIamRole.EDITOR)
+            .get(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET, ControlledResourceIamRole.EDITOR)
             .getRoleName());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
@@ -66,7 +66,7 @@ public class StoreControlledResourceMetadataStepTest extends BaseUnitTest {
 
     WsmResource daoResource =
         resourceDao.getResource(bucketResource.getWorkspaceId(), bucketResource.getResourceId());
-    assertThat(daoResource.getResourceType(), equalTo(WsmResourceType.GCS_BUCKET));
+    assertThat(daoResource.getResourceType(), equalTo(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET));
 
     ControlledGcsBucketResource daoBucket = (ControlledGcsBucketResource) daoResource;
     assertThat(bucketResource, equalTo(daoBucket));

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -365,7 +365,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
 
       ReferencedDataRepoSnapshotResource resource =
           referenceResource.castToDataRepoSnapshotResource();
-      assertEquals(resource.getResourceType(), WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
+      assertEquals(resource.getResourceType(), WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT);
 
       ReferencedResource resultReferenceResource =
           referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST);
@@ -389,7 +389,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
           workspaceId,
           referenceResource.getResourceId(),
           USER_REQUEST,
-          WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
+          WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT);
     }
 
     @Test
@@ -918,7 +918,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
 
         ReferencedDataRepoSnapshotResource resource =
             referenceResource.castToDataRepoSnapshotResource();
-        assertEquals(resource.getResourceType(), WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
+        assertEquals(resource.getResourceType(), WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT);
         referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST);
 
         UUID resourceId = UUID.randomUUID();

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -365,7 +365,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
 
       ReferencedDataRepoSnapshotResource resource =
           referenceResource.castToDataRepoSnapshotResource();
-      assertEquals(resource.getResourceType(), WsmResourceType.DATA_REPO_SNAPSHOT);
+      assertEquals(resource.getResourceType(), WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
 
       ReferencedResource resultReferenceResource =
           referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST);
@@ -389,7 +389,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
           workspaceId,
           referenceResource.getResourceId(),
           USER_REQUEST,
-          WsmResourceType.DATA_REPO_SNAPSHOT);
+          WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
     }
 
     @Test
@@ -494,7 +494,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         assertEquals(referenceResource.getStewardshipType(), StewardshipType.REFERENCED);
 
         ReferencedGcsObjectResource resource = referenceResource.castToGcsObjectResource();
-        assertEquals(resource.getResourceType(), WsmResourceType.GCS_OBJECT);
+        assertEquals(resource.getResourceType(), WsmResourceType.REFERENCED_GCP_GCS_OBJECT);
 
         ReferencedResource resultReferenceResource =
             referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST);
@@ -519,7 +519,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
             workspaceId,
             referenceResource.getResourceId(),
             USER_REQUEST,
-            WsmResourceType.GCS_OBJECT);
+            WsmResourceType.REFERENCED_GCP_GCS_OBJECT);
       }
 
       private ReferencedGcsBucketResource makeGcsBucketResource() {
@@ -541,7 +541,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
         assertEquals(referenceResource.getStewardshipType(), StewardshipType.REFERENCED);
 
         ReferencedGcsBucketResource resource = referenceResource.castToGcsBucketResource();
-        assertEquals(resource.getResourceType(), WsmResourceType.GCS_BUCKET);
+        assertEquals(resource.getResourceType(), WsmResourceType.REFERENCED_GCP_GCS_BUCKET);
 
         ReferencedResource resultReferenceResource =
             referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST);
@@ -567,7 +567,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
             workspaceId,
             referenceResource.getResourceId(),
             USER_REQUEST,
-            WsmResourceType.GCS_BUCKET);
+            WsmResourceType.REFERENCED_GCP_GCS_BUCKET);
       }
 
       @Test
@@ -680,7 +680,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
 
         ReferencedBigQueryDatasetResource resource =
             referenceResource.castToBigQueryDatasetResource();
-        assertEquals(resource.getResourceType(), WsmResourceType.BIG_QUERY_DATASET);
+        assertEquals(resource.getResourceType(), WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET);
 
         ReferencedResource resultReferenceResource =
             referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST);
@@ -706,7 +706,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
             workspaceId,
             referenceResource.getResourceId(),
             USER_REQUEST,
-            WsmResourceType.BIG_QUERY_DATASET);
+            WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET);
       }
 
       @Test
@@ -716,7 +716,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
 
         ReferencedBigQueryDataTableResource resource =
             referenceResource.castToBigQueryDataTableResource();
-        assertEquals(resource.getResourceType(), WsmResourceType.BIG_QUERY_DATA_TABLE);
+        assertEquals(
+            resource.getResourceType(), WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE);
         assertEquals(resource.getDataTableId(), DATA_TABLE_NAME);
         assertEquals(resource.getDatasetId(), DATASET_NAME);
 
@@ -742,7 +743,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
             workspaceId,
             referenceResource.getResourceId(),
             USER_REQUEST,
-            WsmResourceType.BIG_QUERY_DATA_TABLE);
+            WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE);
       }
 
       @Test
@@ -757,7 +758,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
             workspaceId,
             referenceResource.getResourceId(),
             USER_REQUEST,
-            WsmResourceType.BIG_QUERY_DATASET);
+            WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET);
 
         // Fail to delete the resource the first time with the wrong resource type.
         ReferencedResource resource =
@@ -771,7 +772,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
             workspaceId,
             referenceResource.getResourceId(),
             USER_REQUEST,
-            WsmResourceType.BIG_QUERY_DATA_TABLE);
+            WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE);
         // BQ data table is successfully deleted.
         assertThrows(
             ResourceNotFoundException.class,
@@ -917,7 +918,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
 
         ReferencedDataRepoSnapshotResource resource =
             referenceResource.castToDataRepoSnapshotResource();
-        assertEquals(resource.getResourceType(), WsmResourceType.DATA_REPO_SNAPSHOT);
+        assertEquals(resource.getResourceType(), WsmResourceType.REFERENCED_DATA_REPO_SNAPSHOT);
         referenceResourceService.createReferenceResource(referenceResource, USER_REQUEST);
 
         UUID resourceId = UUID.randomUUID();


### PR DESCRIPTION
This PR completes the initial layout of resource handlers. They are only used for creating resources from `ResourceDao`.

I revised the resource type scheme and captured in a new section of the design doc: [Implementation Notes](https://docs.google.com/document/d/1NE0NO0sojGJMU-AK7dNTboEExX6bMRUVOLzonZ8Nujw/edit#heading=h.aie3oryzkkjx)

Summarizing here:
- `WsmResourceType` is renamed to `WsmCloudResourceType` and is mainly used for API and DAO
- new `WsmResourceType` is specific to resource, stewardship, and cloud; e.g., `CONTROLLED_GCP_GCS_BUCKET`.
- renamed `resource_type` column to `cloud_resource_type`; added a new `resource_type` column

I added several new methods to all resources:
- `toApiAttributesUnion` - removes a switch from the `ResourceController`
- `toApiResourceUnion` - removes a switch from `Alpha1Controller`
- `getCloudResourceType`

Other smaller changes:
- normalized naming to `toApiResource` in all resources. It has a typed return, so can't be abstract.

There are a lot of files, but the changes are almost all renaming of WsmResourceType.