### PR TITLE
[PF-1297] Refactor DAO uniqueness check

### DIFF
--- a/service/src/main/java/bio/terra/workspace/db/model/UniquenessCheckAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/UniquenessCheckAttributes.java
@@ -9,21 +9,25 @@ import org.apache.commons.lang3.tuple.Pair;
  * check that the ResourceDao should do. At this time, only string compares are supported, since
  * those are all that are in use. We can make this more complex if we need other datatypes.
  */
-public class UniquenessCheckParameters {
+public class UniquenessCheckAttributes {
   /** The scope of the uniqueness check */
   public enum UniquenessScope {
     /** search all resources of this type in the WSM database */
-    WSM,
+    GLOBAL,
     /** search resources of this type within the workspace */
     WORKSPACE;
   }
 
-  private final UniquenessScope uniquenessScope;
+  private UniquenessScope uniquenessScope;
   private final List<Pair<String, String>> parameters;
 
-  public UniquenessCheckParameters(UniquenessScope uniquenessScope) {
-    this.uniquenessScope = uniquenessScope;
+  public UniquenessCheckAttributes() {
     this.parameters = new ArrayList<>();
+  }
+
+  public UniquenessCheckAttributes uniquenessScope(UniquenessScope uniquenessScope) {
+    this.uniquenessScope = uniquenessScope;
+    return this;
   }
 
   public UniquenessScope getUniquenessScope() {
@@ -42,7 +46,7 @@ public class UniquenessCheckParameters {
    * @param value value of the attribute to check
    * @return this - for fluent style
    */
-  public UniquenessCheckParameters addParameter(String name, String value) {
+  public UniquenessCheckAttributes addParameter(String name, String value) {
     parameters.add(Pair.of(name, value));
     return this;
   }

--- a/service/src/main/java/bio/terra/workspace/db/model/UniquenessCheckParameters.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/UniquenessCheckParameters.java
@@ -1,0 +1,50 @@
+package bio.terra.workspace.db.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * This class is returned from resource handlers to the ResourceDao. It describes
+ * the uniqueness check that the ResourceDao should do. At this time, only
+ * string compares are supported, since those are all that are in use. We can
+ * make this more complex if we need other datatypes.
+ */
+public class UniquenessCheckParameters {
+  /** The scope of the uniqueness check */
+  public enum UniquenessScope {
+    /** search all resources of this type in the WSM database */
+    WSM,
+    /** search resources of this type within the workspace */
+    WORKSPACE;
+  }
+
+  private final UniquenessScope uniquenessScope;
+  private final List<Pair<String, String>> parameters;
+
+  public UniquenessCheckParameters(UniquenessScope uniquenessScope) {
+    this.uniquenessScope = uniquenessScope;
+    this.parameters = new ArrayList<>();
+  }
+
+  public UniquenessScope getUniquenessScope() {
+    return uniquenessScope;
+  }
+
+  public List<Pair<String, String>> getParameters() {
+    return parameters;
+  }
+
+  /**
+   * Add a parameter to be filtered. The filters are JSONB references of the
+   * form:  attributes->>'name' = value
+   *
+   * @param name name of the attribute to check
+   * @param value value of the attribute to check
+   * @return this - for fluent style
+   */
+  public UniquenessCheckParameters addParameter(String name, String value) {
+    parameters.add(Pair.of(name, value));
+    return this;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/db/model/UniquenessCheckParameters.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/UniquenessCheckParameters.java
@@ -5,10 +5,9 @@ import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
- * This class is returned from resource handlers to the ResourceDao. It describes
- * the uniqueness check that the ResourceDao should do. At this time, only
- * string compares are supported, since those are all that are in use. We can
- * make this more complex if we need other datatypes.
+ * This class is returned from resource handlers to the ResourceDao. It describes the uniqueness
+ * check that the ResourceDao should do. At this time, only string compares are supported, since
+ * those are all that are in use. We can make this more complex if we need other datatypes.
  */
 public class UniquenessCheckParameters {
   /** The scope of the uniqueness check */
@@ -36,8 +35,8 @@ public class UniquenessCheckParameters {
   }
 
   /**
-   * Add a parameter to be filtered. The filters are JSONB references of the
-   * form:  attributes->>'name' = value
+   * Add a parameter to be filtered. The filters are JSONB references of the form:
+   * attributes->>'name' = value
    *
    * @param name name of the attribute to check
    * @param value value of the attribute to check

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -4,8 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.db.model.UniquenessCheckParameters;
-import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureDiskAttributes;
 import bio.terra.workspace.generated.model.ApiAzureDiskResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -75,9 +75,10 @@ public class ControlledAzureDiskResource extends ControlledResource {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckParameters() {
     return Optional.of(
-        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.WORKSPACE)
             .addParameter("diskName", getDiskName()));
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -4,6 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.db.model.UniquenessCheckParameters;
+import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureDiskAttributes;
 import bio.terra.workspace.generated.model.ApiAzureDiskResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -71,6 +73,14 @@ public class ControlledAzureDiskResource extends ControlledResource {
     validate();
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+    return Optional.of(new UniquenessCheckParameters(
+        UniquenessScope.WORKSPACE)
+        .addParameter("diskName", getDiskName()));
+  }
+
   public String getDiskName() {
     return diskName;
   }
@@ -83,12 +93,12 @@ public class ControlledAzureDiskResource extends ControlledResource {
     return size;
   }
 
-  public ApiAzureDiskAttributes toApiAttributes() {
-    return new ApiAzureDiskAttributes().diskName(getDiskName()).region(region.toString());
-  }
-
   public ApiAzureDiskResource toApiResource() {
     return new ApiAzureDiskResource().metadata(super.toApiMetadata()).attributes(toApiAttributes());
+  }
+
+  private ApiAzureDiskAttributes toApiAttributes() {
+    return new ApiAzureDiskAttributes().diskName(getDiskName()).region(region);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -76,9 +76,9 @@ public class ControlledAzureDiskResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
-    return Optional.of(new UniquenessCheckParameters(
-        UniquenessScope.WORKSPACE)
-        .addParameter("diskName", getDiskName()));
+    return Optional.of(
+        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+            .addParameter("diskName", getDiskName()));
   }
 
   public String getDiskName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
@@ -4,8 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.db.model.UniquenessCheckParameters;
-import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureIpAttributes;
 import bio.terra.workspace.generated.model.ApiAzureIpResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -71,9 +71,10 @@ public class ControlledAzureIpResource extends ControlledResource {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckParameters() {
     return Optional.of(
-        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.WORKSPACE)
             .addParameter("ipName", getIpName()));
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
@@ -72,9 +72,9 @@ public class ControlledAzureIpResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
-    return Optional.of(new UniquenessCheckParameters(
-        UniquenessScope.WORKSPACE)
-        .addParameter("ipName", getIpName()));
+    return Optional.of(
+        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+            .addParameter("ipName", getIpName()));
   }
 
   public String getIpName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
@@ -4,6 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.db.model.UniquenessCheckParameters;
+import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureIpAttributes;
 import bio.terra.workspace.generated.model.ApiAzureIpResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -65,6 +67,14 @@ public class ControlledAzureIpResource extends ControlledResource {
     this.ipName = attributes.getIpName();
     this.region = attributes.getRegion();
     validate();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+    return Optional.of(new UniquenessCheckParameters(
+        UniquenessScope.WORKSPACE)
+        .addParameter("ipName", getIpName()));
   }
 
   public String getIpName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
@@ -4,6 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.db.model.UniquenessCheckParameters;
+import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureNetworkAttributes;
 import bio.terra.workspace.generated.model.ApiAzureNetworkResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -77,6 +79,14 @@ public class ControlledAzureNetworkResource extends ControlledResource {
     this.subnetAddressCidr = attributes.getSubnetAddressCidr();
     this.region = attributes.getRegion();
     validate();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+    return Optional.of(new UniquenessCheckParameters(
+        UniquenessScope.WORKSPACE)
+        .addParameter("networkName", getNetworkName()));
   }
 
   public String getNetworkName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
@@ -84,9 +84,9 @@ public class ControlledAzureNetworkResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
-    return Optional.of(new UniquenessCheckParameters(
-        UniquenessScope.WORKSPACE)
-        .addParameter("networkName", getNetworkName()));
+    return Optional.of(
+        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+            .addParameter("networkName", getNetworkName()));
   }
 
   public String getNetworkName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
@@ -4,8 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.db.model.UniquenessCheckParameters;
-import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureNetworkAttributes;
 import bio.terra.workspace.generated.model.ApiAzureNetworkResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -83,9 +83,10 @@ public class ControlledAzureNetworkResource extends ControlledResource {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckParameters() {
     return Optional.of(
-        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.WORKSPACE)
             .addParameter("networkName", getNetworkName()));
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
@@ -4,6 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.db.model.UniquenessCheckParameters;
+import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureStorageAttributes;
 import bio.terra.workspace.generated.model.ApiAzureStorageResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -65,6 +67,14 @@ public class ControlledAzureStorageResource extends ControlledResource {
     this.storageAccountName = attributes.getStorageAccountName();
     this.region = attributes.getRegion();
     validate();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+    return Optional.of(new UniquenessCheckParameters(
+        UniquenessScope.WORKSPACE)
+        .addParameter("storageAccountName", getStorageAccountName()));
   }
 
   public String getStorageAccountName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
@@ -72,9 +72,9 @@ public class ControlledAzureStorageResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
-    return Optional.of(new UniquenessCheckParameters(
-        UniquenessScope.WORKSPACE)
-        .addParameter("storageAccountName", getStorageAccountName()));
+    return Optional.of(
+        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+            .addParameter("storageAccountName", getStorageAccountName()));
   }
 
   public String getStorageAccountName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
@@ -4,8 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.db.model.UniquenessCheckParameters;
-import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureStorageAttributes;
 import bio.terra.workspace.generated.model.ApiAzureStorageResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -71,9 +71,10 @@ public class ControlledAzureStorageResource extends ControlledResource {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckParameters() {
     return Optional.of(
-        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.WORKSPACE)
             .addParameter("storageAccountName", getStorageAccountName()));
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -93,9 +93,9 @@ public class ControlledAzureVmResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
-    return Optional.of(new UniquenessCheckParameters(
-        UniquenessScope.WORKSPACE)
-        .addParameter("vmName", getVmName()));
+    return Optional.of(
+        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+            .addParameter("vmName", getVmName()));
   }
 
   public String getVmName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -4,6 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.db.model.UniquenessCheckParameters;
+import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureVmAttributes;
 import bio.terra.workspace.generated.model.ApiAzureVmResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -86,6 +88,14 @@ public class ControlledAzureVmResource extends ControlledResource {
     this.networkId = attributes.getNetworkId();
     this.diskId = attributes.getDiskId();
     validate();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+    return Optional.of(new UniquenessCheckParameters(
+        UniquenessScope.WORKSPACE)
+        .addParameter("vmName", getVmName()));
   }
 
   public String getVmName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -4,8 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.db.model.UniquenessCheckParameters;
-import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureVmAttributes;
 import bio.terra.workspace.generated.model.ApiAzureVmResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -92,9 +92,10 @@ public class ControlledAzureVmResource extends ControlledResource {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckParameters() {
     return Optional.of(
-        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.WORKSPACE)
             .addParameter("vmName", getVmName()));
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -97,10 +97,10 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
-    return Optional.of(new UniquenessCheckParameters(
-        UniquenessScope.WORKSPACE)
-        .addParameter("instanceId", getInstanceId())
-        .addParameter("location", getLocation()));
+    return Optional.of(
+        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+            .addParameter("instanceId", getInstanceId())
+            .addParameter("location", getLocation()));
   }
 
   /** The user specified id of the notebook instance. */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -7,8 +7,8 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
-import bio.terra.workspace.db.model.UniquenessCheckParameters;
-import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceAttributes;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -96,9 +96,10 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckParameters() {
     return Optional.of(
-        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.WORKSPACE)
             .addParameter("instanceId", getInstanceId())
             .addParameter("location", getLocation()));
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -7,6 +7,8 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.model.UniquenessCheckParameters;
+import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceAttributes;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -90,6 +92,15 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
         .instanceId(getInstanceId())
         .location(getLocation())
         .projectId(getProjectId());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+    return Optional.of(new UniquenessCheckParameters(
+        UniquenessScope.WORKSPACE)
+        .addParameter("instanceId", getInstanceId())
+        .addParameter("location", getLocation()));
   }
 
   /** The user specified id of the notebook instance. */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -3,8 +3,8 @@ package bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
-import bio.terra.workspace.db.model.UniquenessCheckParameters;
-import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetAttributes;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -84,9 +84,10 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckParameters() {
     return Optional.of(
-        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.WORKSPACE)
             .addParameter("datasetName", getDatasetName()));
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -85,9 +85,9 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
-    return Optional.of(new UniquenessCheckParameters(
-        UniquenessScope.WORKSPACE)
-        .addParameter("datasetName", getDatasetName()));
+    return Optional.of(
+        new UniquenessCheckParameters(UniquenessScope.WORKSPACE)
+            .addParameter("datasetName", getDatasetName()));
   }
 
   public String getDatasetName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -3,6 +3,8 @@ package bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.model.UniquenessCheckParameters;
+import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetAttributes;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -78,6 +80,14 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
         .applicationId(getApplicationId())
         .datasetName(getDatasetName())
         .projectId(projectId);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+    return Optional.of(new UniquenessCheckParameters(
+        UniquenessScope.WORKSPACE)
+        .addParameter("datasetName", getDatasetName()));
   }
 
   public String getDatasetName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -69,9 +69,9 @@ public class ControlledGcsBucketResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
-    return Optional.of(new UniquenessCheckParameters(
-        UniquenessScope.WSM)
-        .addParameter("bucketName", getBucketName()));
+    return Optional.of(
+        new UniquenessCheckParameters(UniquenessScope.WSM)
+            .addParameter("bucketName", getBucketName()));
   }
 
   public static ControlledGcsBucketResource.Builder builder() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -4,6 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.db.model.UniquenessCheckParameters;
+import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketAttributes;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -62,6 +64,14 @@ public class ControlledGcsBucketResource extends ControlledResource {
         DbSerDes.fromJson(dbResource.getAttributes(), ControlledGcsBucketAttributes.class);
     this.bucketName = attributes.getBucketName();
     validate();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+    return Optional.of(new UniquenessCheckParameters(
+        UniquenessScope.WSM)
+        .addParameter("bucketName", getBucketName()));
   }
 
   public static ControlledGcsBucketResource.Builder builder() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -4,8 +4,8 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.db.model.UniquenessCheckParameters;
-import bio.terra.workspace.db.model.UniquenessCheckParameters.UniquenessScope;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketAttributes;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
@@ -68,9 +68,10 @@ public class ControlledGcsBucketResource extends ControlledResource {
 
   /** {@inheritDoc} */
   @Override
-  public Optional<UniquenessCheckParameters> getUniquenessCheckParameters() {
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckParameters() {
     return Optional.of(
-        new UniquenessCheckParameters(UniquenessScope.WSM)
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.GLOBAL)
             .addParameter("bucketName", getBucketName()));
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
@@ -4,7 +4,7 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.db.model.UniquenessCheckParameters;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
 import bio.terra.workspace.generated.model.ApiControlledResourceMetadata;
 import bio.terra.workspace.generated.model.ApiPrivateResourceUser;
 import bio.terra.workspace.generated.model.ApiResourceMetadata;
@@ -74,7 +74,7 @@ public abstract class ControlledResource extends WsmResource {
    *
    * @return optional uniqueness description
    */
-  public abstract Optional<UniquenessCheckParameters> getUniquenessCheckParameters();
+  public abstract Optional<UniquenessCheckAttributes> getUniquenessCheckParameters();
 
   /**
    * If specified, the assigned user must be equal to the user making the request.

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
@@ -4,6 +4,7 @@ import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.db.model.UniquenessCheckParameters;
 import bio.terra.workspace.generated.model.ApiControlledResourceMetadata;
 import bio.terra.workspace.generated.model.ApiPrivateResourceUser;
 import bio.terra.workspace.generated.model.ApiResourceMetadata;
@@ -66,10 +67,14 @@ public abstract class ControlledResource extends WsmResource {
     this.privateResourceState = dbResource.getPrivateResourceState().orElse(null);
   }
 
-  @Override
-  public StewardshipType getStewardshipType() {
-    return StewardshipType.CONTROLLED;
-  }
+  /**
+   * The ResourceDao calls this method for controlled parameters. The return value
+   * describes filtering the DAO should do to verify the uniqueness of the resource.
+   * If the return is not present, then no validation check will be performed.
+   *
+   * @return optional uniqueness description
+   */
+  public abstract Optional<UniquenessCheckParameters> getUniquenessCheckParameters();
 
   /**
    * If specified, the assigned user must be equal to the user making the request.
@@ -98,6 +103,11 @@ public abstract class ControlledResource extends WsmResource {
 
   public ControlledResourceCategory getCategory() {
     return ControlledResourceCategory.get(accessScope, managedBy);
+  }
+
+  @Override
+  public StewardshipType getStewardshipType() {
+    return StewardshipType.CONTROLLED;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
@@ -68,9 +68,9 @@ public abstract class ControlledResource extends WsmResource {
   }
 
   /**
-   * The ResourceDao calls this method for controlled parameters. The return value
-   * describes filtering the DAO should do to verify the uniqueness of the resource.
-   * If the return is not present, then no validation check will be performed.
+   * The ResourceDao calls this method for controlled parameters. The return value describes
+   * filtering the DAO should do to verify the uniqueness of the resource. If the return is not
+   * present, then no validation check will be performed.
    *
    * @return optional uniqueness description
    */

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.model;
 
-import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
@@ -182,31 +181,6 @@ public enum WsmResourceType {
     }
     throw new SerializationException(
         "Deserialization failed: no matching resource type for " + dbString);
-  }
-
-  public static WsmResourceType fromSqlParts(
-      WsmResourceFamily cloudResourceType, StewardshipType stewardshipType) {
-    switch (stewardshipType) {
-      case CONTROLLED:
-        return cloudResourceType
-            .getControlledType()
-            .orElseThrow(
-                () ->
-                    new InvalidMetadataException(
-                        "Unsupported controlled resource type for " + cloudResourceType));
-
-      case REFERENCED:
-        return cloudResourceType
-            .getReferenceType()
-            .orElseThrow(
-                () ->
-                    new InvalidMetadataException(
-                        "Unsupported referenced resource type for " + cloudResourceType));
-    }
-    throw new InvalidMetadataException(
-        String.format(
-            "Invalid combination: cloud resource type %s and stewardship type %s",
-            cloudResourceType, stewardshipType));
   }
 
   public CloudPlatform getCloudPlatform() {

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -29,7 +29,6 @@ public class ResourceDaoTest extends BaseUnitTest {
   @Autowired ResourceDao resourceDao;
   @Autowired WorkspaceDao workspaceDao;
   @Autowired GcpCloudContextService gcpCloudContextService;
-  @Autowired RawDaoTestFixture testDao;
 
   /**
    * Creates a workspaces with a GCP cloud context and stores it in the database. Returns the


### PR DESCRIPTION
Add the method `getUniquenessCheckParameters` to all controlled resource classes. The method is called from ResourceDao to get the parameters to check. The DAO then generates a SQL statement and executes the check.

This moves per-resource code out of ReesourceDao. Making the POJO to describe the check seemed better than letting the resources pass in SQL to execute. See what you think.