### PR TITLE
[PF-1298] Retrieve all cloud contexts in a step

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStep.java
@@ -9,6 +9,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
@@ -24,21 +25,20 @@ public class CreateAzureDiskStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureDiskResource resource;
-  private final AzureCloudContext azureCloudContext;
 
   public CreateAzureDiskStep(
-      AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
-      CrlService crlService,
-      ControlledAzureDiskResource resource) {
+      AzureConfiguration azureConfig, CrlService crlService, ControlledAzureDiskResource resource) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
 
     try {
@@ -81,6 +81,10 @@ public class CreateAzureDiskStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
 
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStep.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
@@ -21,21 +22,20 @@ public class GetAzureDiskStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureDiskResource resource;
-  private final AzureCloudContext azureCloudContext;
 
   public GetAzureDiskStep(
-      AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
-      CrlService crlService,
-      ControlledAzureDiskResource resource) {
+      AzureConfiguration azureConfig, CrlService crlService, ControlledAzureDiskResource resource) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
     try {
       computeManager

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStep.java
@@ -9,6 +9,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
@@ -25,21 +26,20 @@ public class CreateAzureIpStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureIpResource resource;
-  private final AzureCloudContext azureCloudContext;
 
   public CreateAzureIpStep(
-      AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
-      CrlService crlService,
-      ControlledAzureIpResource resource) {
+      AzureConfiguration azureConfig, CrlService crlService, ControlledAzureIpResource resource) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
 
     try {
@@ -82,6 +82,10 @@ public class CreateAzureIpStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
 
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStep.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
@@ -25,21 +26,20 @@ public class GetAzureIpStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureIpResource resource;
-  private final AzureCloudContext azureCloudContext;
 
   public GetAzureIpStep(
-      AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
-      CrlService crlService,
-      ControlledAzureIpResource resource) {
+      AzureConfiguration azureConfig, CrlService crlService, ControlledAzureIpResource resource) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
     try {
       computeManager

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStep.java
@@ -10,6 +10,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
@@ -28,21 +29,22 @@ public class CreateAzureNetworkStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureNetworkResource resource;
-  private final AzureCloudContext azureCloudContext;
 
   public CreateAzureNetworkStep(
       AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
       CrlService crlService,
       ControlledAzureNetworkResource resource) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
 
     try {
@@ -128,6 +130,10 @@ public class CreateAzureNetworkStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
 
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStep.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
@@ -25,21 +26,22 @@ public class GetAzureNetworkStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureNetworkResource resource;
-  private final AzureCloudContext azureCloudContext;
 
   public GetAzureNetworkStep(
       AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
       CrlService crlService,
       ControlledAzureNetworkResource resource) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
     try {
       computeManager

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
@@ -9,6 +9,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resourcemanager.data.CreateStorageAccountRequestData;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
@@ -21,21 +22,22 @@ public class CreateAzureStorageStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureStorageResource resource;
-  private final AzureCloudContext azureCloudContext;
 
   public CreateAzureStorageStep(
       AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
       CrlService crlService,
       ControlledAzureStorageResource resource) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
 
     try {
@@ -78,6 +80,10 @@ public class CreateAzureStorageStep implements Step {
    */
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
 
     // If the storage account does not exist (isAvailable == true)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStep.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.resourcemanager.storage.StorageManager;
 import org.slf4j.Logger;
@@ -23,21 +24,22 @@ public class GetAzureStorageStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureStorageResource resource;
-  private final AzureCloudContext azureCloudContext;
 
   public GetAzureStorageStep(
       AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
       CrlService crlService,
       ControlledAzureStorageResource resource) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
 
     if (storageManager

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
@@ -14,6 +14,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.Controll
 import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.CreateAzureIpStep;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
@@ -32,17 +33,14 @@ public class CreateAzureVmStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureVmResource resource;
-  private final AzureCloudContext azureCloudContext;
   private final ResourceDao resourceDao;
 
   public CreateAzureVmStep(
       AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
       CrlService crlService,
       ControlledAzureVmResource resource,
       ResourceDao resourceDao) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
     this.resourceDao = resourceDao;
@@ -50,6 +48,10 @@ public class CreateAzureVmStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
 
     final ControlledAzureIpResource ipResource =
@@ -153,6 +155,10 @@ public class CreateAzureVmStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
 
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/GetAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/GetAzureVmStep.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
@@ -17,21 +18,20 @@ public class GetAzureVmStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureVmResource resource;
-  private final AzureCloudContext azureCloudContext;
 
   public GetAzureVmStep(
-      AzureConfiguration azureConfig,
-      AzureCloudContext azureCloudContext,
-      CrlService crlService,
-      ControlledAzureVmResource resource) {
+      AzureConfiguration azureConfig, CrlService crlService, ControlledAzureVmResource resource) {
     this.azureConfig = azureConfig;
-    this.azureCloudContext = azureCloudContext;
     this.crlService = crlService;
     this.resource = resource;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
     try {
       computeManager

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/CreateControlledResourceFlight.java
@@ -76,21 +76,14 @@ public class CreateControlledResourceFlight extends Flight {
             userRequest));
 
     // Get the cloud context and store it in the working map
-    switch (resource.getResourceType().getCloudPlatform()) {
-      case AZURE:
-      case ANY:
-        // TODO: pull cloud context from flight into step parallel to GCP
-        break;
-
-      case GCP:
-        // This step may need to update the cloud context row in the database to convert
-        // context V1 format into V2 format.
-        addStep(
-            new GetGcpCloudContextStep(
-                resource.getWorkspaceId(), flightBeanBag.getGcpCloudContextService(), userRequest),
-            dbRetryRule);
-        break;
-    }
+    addStep(
+        new GetCloudContextStep(
+            resource.getWorkspaceId(),
+            resource.getResourceType().getCloudPlatform(),
+            flightBeanBag.getGcpCloudContextService(),
+            flightBeanBag.getAzureCloudContextService(),
+            userRequest),
+        dbRetryRule);
 
     // create the cloud resource and grant IAM roles via CRL
     switch (resource.getResourceType()) {
@@ -133,20 +126,12 @@ public class CreateControlledResourceFlight extends Flight {
         addStep(
             new GetAzureDiskStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureDiskResource()),
             RetryRules.cloud());
         addStep(
             new CreateAzureDiskStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureDiskResource()),
             RetryRules.cloud());
@@ -155,20 +140,12 @@ public class CreateControlledResourceFlight extends Flight {
         addStep(
             new GetAzureIpStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureIpResource()),
             RetryRules.cloud());
         addStep(
             new CreateAzureIpStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureIpResource()),
             RetryRules.cloud());
@@ -177,20 +154,12 @@ public class CreateControlledResourceFlight extends Flight {
         addStep(
             new GetAzureNetworkStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureNetworkResource()),
             RetryRules.cloud());
         addStep(
             new CreateAzureNetworkStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureNetworkResource()),
             RetryRules.cloud());
@@ -199,20 +168,12 @@ public class CreateControlledResourceFlight extends Flight {
         addStep(
             new GetAzureVmStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureVmResource()),
             RetryRules.cloud());
         addStep(
             new CreateAzureVmStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureVmResource(),
                 flightBeanBag.getResourceDao()),
@@ -222,20 +183,12 @@ public class CreateControlledResourceFlight extends Flight {
         addStep(
             new GetAzureStorageStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureStorageResource()),
             RetryRules.cloud());
         addStep(
             new CreateAzureStorageStep(
                 flightBeanBag.getAzureConfig(),
-                flightBeanBag
-                    .getAzureCloudContextService()
-                    .getAzureCloudContext(resource.getWorkspaceId())
-                    .get(),
                 flightBeanBag.getCrlService(),
                 resource.castToAzureStorageResource()),
             RetryRules.cloud());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GetCloudContextStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GetCloudContextStep.java
@@ -1,0 +1,81 @@
+package bio.terra.workspace.service.resource.controlled.flight.create;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.exception.InternalLogicException;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.workspace.AzureCloudContextService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Retrieve the cloud context, if applicable, and store it in the working map. Since this step only
+ * reads data, it is idempotent
+ */
+public class GetCloudContextStep implements Step {
+
+  private static final Logger logger = LoggerFactory.getLogger(GetCloudContextStep.class);
+  private final UUID workspaceId;
+  private final CloudPlatform cloudPlatform;
+  private final GcpCloudContextService gcpCloudContextService;
+  private final AzureCloudContextService azureCloudContextService;
+  private final AuthenticatedUserRequest userRequest;
+
+  public GetCloudContextStep(
+      UUID workspaceId,
+      CloudPlatform cloudPlatform,
+      GcpCloudContextService gcpCloudContextService,
+      AzureCloudContextService azureCloudContextService,
+      AuthenticatedUserRequest userRequest) {
+    this.workspaceId = workspaceId;
+    this.cloudPlatform = cloudPlatform;
+    this.gcpCloudContextService = gcpCloudContextService;
+    this.azureCloudContextService = azureCloudContextService;
+    this.userRequest = userRequest;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+
+    // Get the cloud context and store it in the working map
+    switch (cloudPlatform) {
+      case AZURE:
+        AzureCloudContext azureCloudContext =
+            azureCloudContextService.getRequiredAzureCloudContext(workspaceId);
+        flightContext
+            .getWorkingMap()
+            .put(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, azureCloudContext);
+        break;
+
+      case GCP:
+        GcpCloudContext gcpCloudContext =
+            gcpCloudContextService.getRequiredGcpCloudContext(workspaceId, userRequest);
+        flightContext
+            .getWorkingMap()
+            .put(ControlledResourceKeys.GCP_CLOUD_CONTEXT, gcpCloudContext);
+        break;
+
+      case ANY:
+      default:
+        // There cannot be an ANY resource that is also a controlled resource.
+        throw new InternalLogicException(
+            "Invalid cloud platform for controlled resource: " + cloudPlatform);
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/AzureCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/AzureCloudContextService.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
 import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import java.util.Optional;
@@ -82,5 +83,11 @@ public class AzureCloudContextService {
     return workspaceDao
         .getCloudContext(workspaceId, CloudPlatform.AZURE)
         .map(AzureCloudContext::deserialize);
+  }
+
+  public AzureCloudContext getRequiredAzureCloudContext(UUID workspaceId) {
+    return getAzureCloudContext(workspaceId)
+        .orElseThrow(
+            () -> new CloudContextRequiredException("Operation requires Azure cloud context"));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -25,6 +25,7 @@ public final class WorkspaceFlightMapKeys {
     public static final String CREATION_PARAMETERS = "creationParameters";
     public static final String PRIVATE_RESOURCE_IAM_ROLE = "privateResourceIamRole";
     public static final String GCP_CLOUD_CONTEXT = "gcpCloudContext";
+    public static final String AZURE_CLOUD_CONTEXT = "azureCloudContext";
     public static final String UPDATE_PARAMETERS = "updateParameters";
     public static final String PREVIOUS_UPDATE_PARAMETERS = "previousUpdateParameters";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
@@ -57,7 +57,6 @@ public class CreateAzureDiskStepTest extends BaseAzureTest {
 
   private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
 
-
   @BeforeEach
   public void setup() {
     // PublicIpAddresses mocks
@@ -85,7 +84,8 @@ public class CreateAzureDiskStepTest extends BaseAzureTest {
         .thenReturn(new ManagementError("Conflict", "Resource already exists."));
 
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
@@ -10,12 +10,14 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.cloudres.azure.resourcemanager.compute.data.CreateDiskRequestData;
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementError;
@@ -51,8 +53,10 @@ public class CreateAzureDiskStepTest extends BaseAzureTest {
   @Mock private Disk.DefinitionStages.WithCreate mockDiskStage6;
   @Mock private Disk.DefinitionStages.WithCreate mockDiskStage7;
   @Mock private ManagementException mockException;
+  @Mock private FlightMap mockWorkingMap;
 
   private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+
 
   @BeforeEach
   public void setup() {
@@ -79,6 +83,9 @@ public class CreateAzureDiskStepTest extends BaseAzureTest {
     // Exception mock
     when(mockException.getValue())
         .thenReturn(new ManagementError("Conflict", "Resource already exists."));
+
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
   }
 
   @Test
@@ -89,7 +96,6 @@ public class CreateAzureDiskStepTest extends BaseAzureTest {
     var createAzureDiskStep =
         new CreateAzureDiskStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureDisk(
                 creationParameters.getName(),
@@ -132,7 +138,6 @@ public class CreateAzureDiskStepTest extends BaseAzureTest {
     CreateAzureDiskStep createAzureDiskStep =
         new CreateAzureDiskStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureDisk(
                 creationParameters.getName(),
@@ -156,7 +161,6 @@ public class CreateAzureDiskStepTest extends BaseAzureTest {
     CreateAzureDiskStep createAzureDiskStep =
         new CreateAzureDiskStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureDisk(
                 creationParameters.getName(),

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
@@ -53,7 +53,8 @@ public class GetAzureDiskStepTest extends BaseAzureTest {
         .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
 
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
@@ -14,6 +15,7 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
@@ -38,6 +40,7 @@ public class GetAzureDiskStepTest extends BaseAzureTest {
   @Mock private Disks mockDisks;
   @Mock private Disk mockDisk;
   @Mock private ManagementException mockException;
+  @Mock private FlightMap mockWorkingMap;
 
   @BeforeEach
   public void setup() {
@@ -48,6 +51,9 @@ public class GetAzureDiskStepTest extends BaseAzureTest {
     when(mockComputeManager.disks()).thenReturn(mockDisks);
     when(mockException.getValue())
         .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
+
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
   }
 
   @Test
@@ -58,7 +64,6 @@ public class GetAzureDiskStepTest extends BaseAzureTest {
     GetAzureDiskStep step =
         new GetAzureDiskStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureDisk(
                 creationParameters.getName(),
@@ -83,7 +88,6 @@ public class GetAzureDiskStepTest extends BaseAzureTest {
     GetAzureDiskStep step =
         new GetAzureDiskStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureDisk(
                 creationParameters.getName(),

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
@@ -83,7 +83,8 @@ public class CreateAzureIpStepTest extends BaseAzureTest {
         .thenReturn(new ManagementError("Conflict", "Resource already exists."));
 
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
@@ -10,12 +10,14 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.cloudres.azure.resourcemanager.compute.data.CreatePublicIpRequestData;
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementError;
@@ -50,6 +52,7 @@ public class CreateAzureIpStepTest extends BaseAzureTest {
   @Mock private PublicIpAddress.DefinitionStages.WithGroup mockIpStage2;
   @Mock private PublicIpAddress.DefinitionStages.WithCreate mockIpStage3;
   @Mock private ManagementException mockException;
+  @Mock private FlightMap mockWorkingMap;
 
   private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
 
@@ -78,6 +81,9 @@ public class CreateAzureIpStepTest extends BaseAzureTest {
     // Exception mock
     when(mockException.getValue())
         .thenReturn(new ManagementError("Conflict", "Resource already exists."));
+
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
   }
 
   @Test
@@ -88,7 +94,6 @@ public class CreateAzureIpStepTest extends BaseAzureTest {
     CreateAzureIpStep createAzureIpStep =
         new CreateAzureIpStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureIp(
                 creationParameters.getName(), creationParameters.getRegion()));
@@ -129,7 +134,6 @@ public class CreateAzureIpStepTest extends BaseAzureTest {
     CreateAzureIpStep createAzureIpStep =
         new CreateAzureIpStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureIp(
                 creationParameters.getName(), creationParameters.getRegion()));
@@ -151,7 +155,6 @@ public class CreateAzureIpStepTest extends BaseAzureTest {
     CreateAzureIpStep createAzureIpStep =
         new CreateAzureIpStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureIp(
                 creationParameters.getName(), creationParameters.getRegion()));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
@@ -56,7 +56,8 @@ public class GetAzureIpStepTest extends BaseAzureTest {
         .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
 
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
@@ -14,6 +15,7 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
@@ -40,6 +42,7 @@ public class GetAzureIpStepTest extends BaseAzureTest {
   @Mock private PublicIpAddresses mockPublicIpAddresses;
   @Mock private PublicIpAddress mockPublicIpAddress;
   @Mock private ManagementException mockException;
+  @Mock private FlightMap mockWorkingMap;
 
   @BeforeEach
   public void setup() {
@@ -51,6 +54,9 @@ public class GetAzureIpStepTest extends BaseAzureTest {
     when(mockNetworkManager.publicIpAddresses()).thenReturn(mockPublicIpAddresses);
     when(mockException.getValue())
         .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
+
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
   }
 
   @Test
@@ -61,7 +67,6 @@ public class GetAzureIpStepTest extends BaseAzureTest {
     GetAzureIpStep getAzureIpStep =
         new GetAzureIpStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureIp(
                 creationParameters.getName(), creationParameters.getRegion()));
@@ -84,7 +89,6 @@ public class GetAzureIpStepTest extends BaseAzureTest {
     GetAzureIpStep getAzureIpStep =
         new GetAzureIpStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureIp(
                 creationParameters.getName(), creationParameters.getRegion()));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
@@ -10,12 +10,14 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.cloudres.azure.resourcemanager.compute.data.CreateNetworkRequestData;
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementError;
@@ -106,6 +108,7 @@ public class CreateAzureNetworkStepTest extends BaseAzureTest {
       mockNetworkStage15;
 
   @Mock private ManagementException mockException;
+  @Mock private FlightMap mockWorkingMap;
 
   private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
 
@@ -162,6 +165,9 @@ public class CreateAzureNetworkStepTest extends BaseAzureTest {
     // Exception mock
     when(mockException.getValue())
         .thenReturn(new ManagementError("Conflict", "Resource already exists."));
+
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
   }
 
   @Test
@@ -172,7 +178,6 @@ public class CreateAzureNetworkStepTest extends BaseAzureTest {
     var createAzureNetworkStep =
         new CreateAzureNetworkStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureNetwork(creationParameters));
 
@@ -215,7 +220,6 @@ public class CreateAzureNetworkStepTest extends BaseAzureTest {
     CreateAzureNetworkStep createAzureNetworkStep =
         new CreateAzureNetworkStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureNetwork(creationParameters));
 
@@ -236,7 +240,6 @@ public class CreateAzureNetworkStepTest extends BaseAzureTest {
     CreateAzureNetworkStep createAzureNetworkStep =
         new CreateAzureNetworkStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureNetwork(creationParameters));
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
@@ -167,7 +167,8 @@ public class CreateAzureNetworkStepTest extends BaseAzureTest {
         .thenReturn(new ManagementError("Conflict", "Resource already exists."));
 
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
@@ -54,7 +54,8 @@ public class GetAzureNetworkStepTest extends BaseAzureTest {
         .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
 
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
@@ -14,6 +15,7 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
@@ -39,6 +41,7 @@ public class GetAzureNetworkStepTest extends BaseAzureTest {
   @Mock private Networks mockNetworks;
   @Mock private ComputeManager mockComputeManager;
   @Mock private ManagementException mockException;
+  @Mock private FlightMap mockWorkingMap;
 
   @BeforeEach
   public void setup() {
@@ -49,6 +52,9 @@ public class GetAzureNetworkStepTest extends BaseAzureTest {
     when(mockNetworkManager.networks()).thenReturn(mockNetworks);
     when(mockException.getValue())
         .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
+
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
   }
 
   @Test
@@ -59,7 +65,6 @@ public class GetAzureNetworkStepTest extends BaseAzureTest {
     GetAzureNetworkStep step =
         new GetAzureNetworkStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureNetwork(creationParams));
 
@@ -81,7 +86,6 @@ public class GetAzureNetworkStepTest extends BaseAzureTest {
     GetAzureNetworkStep step =
         new GetAzureNetworkStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureNetwork(creationParams));
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -83,7 +83,8 @@ public class CreateAzureStorageStepTest extends BaseAzureTest {
     when(mockException.getValue())
         .thenReturn(new ManagementError("Conflict", "Invalid resource state."));
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
@@ -54,7 +54,8 @@ public class GetAzureStorageStepTest extends BaseAzureTest {
         .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
 
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
@@ -14,6 +15,7 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
@@ -38,6 +40,7 @@ public class GetAzureStorageStepTest extends BaseAzureTest {
   @Mock private ManagementException mockException;
   @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
   @Mock private StorageAccounts mockStorageAccounts;
+  @Mock private FlightMap mockWorkingMap;
 
   @BeforeEach
   public void setup() {
@@ -49,6 +52,9 @@ public class GetAzureStorageStepTest extends BaseAzureTest {
 
     when(mockException.getValue())
         .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
+
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
   }
 
   @Test
@@ -59,7 +65,6 @@ public class GetAzureStorageStepTest extends BaseAzureTest {
     GetAzureStorageStep getAzureStorageStep =
         new GetAzureStorageStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureStorage(
                 creationParameters.getName(), creationParameters.getRegion()));
@@ -82,7 +87,6 @@ public class GetAzureStorageStepTest extends BaseAzureTest {
     GetAzureStorageStep getAzureStorageStep =
         new GetAzureStorageStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureStorage(
                 creationParameters.getName(), creationParameters.getRegion()));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -251,7 +251,8 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
         .thenReturn(new ManagementError("Conflict", "Resource already exists."));
 
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.cloudres.azure.resourcemanager.compute.data.CreateVirtualMachineRequestData;
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureTest;
@@ -22,6 +23,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.Controlled
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementError;
@@ -151,6 +153,7 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
   @Mock private ControlledAzureIpResource mockAzureIpResource;
   @Mock private ControlledAzureDiskResource mockAzureDiskResource;
   @Mock private ControlledAzureNetworkResource mockAzureNetworkResource;
+  @Mock private FlightMap mockWorkingMap;
 
   private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
 
@@ -246,6 +249,9 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
     // Exception mock
     when(mockException.getValue())
         .thenReturn(new ManagementError("Conflict", "Resource already exists."));
+
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class)).thenReturn(mockAzureCloudContext);
   }
 
   @Test
@@ -256,7 +262,6 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
     var createAzureVmStep =
         new CreateAzureVmStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureVm(creationParameters),
             mockResourceDao);
@@ -301,7 +306,6 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
     var createAzureVmStep =
         new CreateAzureVmStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureVm(creationParameters),
             mockResourceDao);
@@ -323,7 +327,6 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
     var createAzureVmStep =
         new CreateAzureVmStep(
             mockAzureConfig,
-            mockAzureCloudContext,
             mockCrlService,
             ControlledResourceFixtures.getAzureVm(creationParameters),
             mockResourceDao);


### PR DESCRIPTION
For GCP, we have a step that retrieves the cloud context and puts it in the working map. For Azure, we were retrieving the context in the Flight constructor and passing it as a parameter. This consolidates the cloud context retrieval in a new step calls `GetCloudContextStep`.

In general, avoid doing any interesting code in the flight constructor. The error handling from exceptions thrown in the constructor are not handled as well as from a step. Also, there is efficiency gained if the flight is paused and restarted.

This is part 1 of 2 that will extract resource steps into the resource object and remove the big switch statements. All part of making it simpler and more localized to add resources.