### PR TITLE
[PF-1327] DRY the create controlled resource path

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
@@ -77,7 +77,7 @@ public class Alpha1ApiController implements Alpha1Api {
     // Prepare the inputs
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ControllerValidationUtils.validatePaginationParams(0, limit);
-    ValidationUtils.validateOptionalResourceName(name);
+    ResourceValidationUtils.validateOptionalResourceName(name);
 
     // Make sure the caller has read access to the workspace
     workspaceService.validateWorkspaceAndAction(userRequest, workspaceId, SamWorkspaceAction.READ);

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.app.controller;
 
 import bio.terra.common.exception.ApiException;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
-import bio.terra.workspace.common.utils.ControllerUtils;
 import bio.terra.workspace.generated.controller.ControlledAzureResourceApi;
 import bio.terra.workspace.generated.model.ApiAzureDiskResource;
 import bio.terra.workspace.generated.model.ApiAzureIpResource;
@@ -48,13 +47,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
-public class ControlledAzureResourceApiController implements ControlledAzureResourceApi {
+public class ControlledAzureResourceApiController extends ControlledResourceControllerCommon
+    implements ControlledAzureResourceApi {
   private final Logger logger = LoggerFactory.getLogger(ControlledGcpResourceApiController.class);
 
-  private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final ControlledResourceService controlledResourceService;
-  private final SamService samService;
-  private final HttpServletRequest request;
   private final JobService jobService;
   private final FeatureConfiguration features;
 
@@ -66,10 +63,8 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
       JobService jobService,
       HttpServletRequest request,
       FeatureConfiguration features) {
-    this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
+    super(authenticatedUserRequestFactory, request, controlledResourceService, samService);
     this.controlledResourceService = controlledResourceService;
-    this.samService = samService;
-    this.request = request;
     this.jobService = jobService;
     this.features = features;
   }
@@ -81,8 +76,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     final PrivateUserRole privateUserRole =
-        ControllerUtils.computePrivateUserRole(
-            workspaceId, body.getCommon(), userRequest, samService);
+        computePrivateUserRole(workspaceId, body.getCommon(), userRequest);
 
     ControlledAzureDiskResource resource =
         ControlledAzureDiskResource.builder()
@@ -118,8 +112,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     final PrivateUserRole privateUserRole =
-        ControllerUtils.computePrivateUserRole(
-            workspaceId, body.getCommon(), userRequest, samService);
+        computePrivateUserRole(workspaceId, body.getCommon(), userRequest);
 
     ControlledAzureIpResource resource =
         ControlledAzureIpResource.builder()
@@ -153,8 +146,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     final PrivateUserRole privateUserRole =
-        ControllerUtils.computePrivateUserRole(
-            workspaceId, body.getCommon(), userRequest, samService);
+        computePrivateUserRole(workspaceId, body.getCommon(), userRequest);
 
     ControlledAzureStorageResource resource =
         ControlledAzureStorageResource.builder()
@@ -188,8 +180,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     final PrivateUserRole privateUserRole =
-        ControllerUtils.computePrivateUserRole(
-            workspaceId, body.getCommon(), userRequest, samService);
+        computePrivateUserRole(workspaceId, body.getCommon(), userRequest);
 
     ControlledAzureVmResource resource =
         ControlledAzureVmResource.builder()
@@ -217,8 +208,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
             body.getAzureVm(),
             privateUserRole.getRole(),
             body.getJobControl(),
-            ControllerUtils.getAsyncResultEndpoint(
-                request, body.getJobControl().getId(), "create-result"),
+            getAsyncResultEndpoint(body.getJobControl().getId(), "create-result"),
             userRequest);
 
     final ApiCreatedControlledAzureVmResult result =
@@ -235,8 +225,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     ApiCreatedControlledAzureVmResult result =
         fetchCreateControlledAzureVmResult(jobId, userRequest);
-    return new ResponseEntity<>(
-        result, ControllerUtils.getAsyncResponseCode(result.getJobReport()));
+    return new ResponseEntity<>(result, getAsyncResponseCode(result.getJobReport()));
   }
 
   private ApiCreatedControlledAzureVmResult fetchCreateControlledAzureVmResult(
@@ -256,8 +245,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     final PrivateUserRole privateUserRole =
-        ControllerUtils.computePrivateUserRole(
-            workspaceId, body.getCommon(), userRequest, samService);
+        computePrivateUserRole(workspaceId, body.getCommon(), userRequest);
 
     ControlledAzureNetworkResource resource =
         ControlledAzureNetworkResource.builder()
@@ -300,7 +288,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
             jobControl,
             workspaceId,
             resourceId,
-            ControllerUtils.getAsyncResultEndpoint(request, jobControl.getId(), "delete-result"),
+            getAsyncResultEndpoint(jobControl.getId(), "delete-result"),
             userRequest);
     return getJobDeleteResult(jobId, userRequest);
   }
@@ -319,7 +307,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
             jobControl,
             workspaceId,
             resourceId,
-            ControllerUtils.getAsyncResultEndpoint(request, jobControl.getId(), "delete-result"),
+            getAsyncResultEndpoint(jobControl.getId(), "delete-result"),
             userRequest);
     return getJobDeleteResult(jobId, userRequest);
   }
@@ -338,7 +326,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
             jobControl,
             workspaceId,
             resourceId,
-            ControllerUtils.getAsyncResultEndpoint(request, jobControl.getId(), "delete-result"),
+            getAsyncResultEndpoint(jobControl.getId(), "delete-result"),
             userRequest);
     return getJobDeleteResult(jobId, userRequest);
   }
@@ -357,7 +345,7 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
             jobControl,
             workspaceId,
             resourceId,
-            ControllerUtils.getAsyncResultEndpoint(request, jobControl.getId(), "delete-result"),
+            getAsyncResultEndpoint(jobControl.getId(), "delete-result"),
             userRequest);
     return getJobDeleteResult(jobId, userRequest);
   }
@@ -448,11 +436,6 @@ public class ControlledAzureResourceApiController implements ControlledAzureReso
         new ApiDeleteControlledAzureResourceResult()
             .jobReport(jobResult.getJobReport())
             .errorReport(jobResult.getApiErrorReport());
-    return new ResponseEntity<>(
-        response, ControllerUtils.getAsyncResponseCode(response.getJobReport()));
-  }
-
-  private AuthenticatedUserRequest getAuthenticatedInfo() {
-    return authenticatedUserRequestFactory.from(request);
+    return new ResponseEntity<>(response, getAsyncResponseCode(response.getJobReport()));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -44,7 +44,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
-public class ControlledAzureResourceApiController extends ControlledResourceControllerCommon
+public class ControlledAzureResourceApiController extends ControlledResourceControllerBase
     implements ControlledAzureResourceApi {
   private final Logger logger = LoggerFactory.getLogger(ControlledGcpResourceApiController.class);
 
@@ -176,7 +176,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             .build();
 
     final String jobId =
-        controlledResourceService.createVm(
+        controlledResourceService.createAzureVm(
             resource,
             body.getAzureVm(),
             commonFields.getIamRole(),

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -52,7 +52,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
-public class ControlledGcpResourceApiController extends ControlledResourceControllerCommon
+public class ControlledGcpResourceApiController extends ControlledResourceControllerBase
     implements ControlledGcpResourceApi {
   private final Logger logger = LoggerFactory.getLogger(ControlledGcpResourceApiController.class);
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledResourceControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledResourceControllerBase.java
@@ -17,10 +17,10 @@ import javax.servlet.http.HttpServletRequest;
  * Super class for controllers containing common code. The code in here requires the @Autowired
  * beans from the @Controller classes, so it is better as a superclass rather than static methods.
  */
-public class ControlledResourceControllerCommon extends ControllerCommon {
+public class ControlledResourceControllerBase extends ControllerBase {
   private final ControlledResourceService controlledResourceService;
 
-  public ControlledResourceControllerCommon(
+  public ControlledResourceControllerBase(
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
       HttpServletRequest request,
       ControlledResourceService controlledResourceService,

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledResourceControllerCommon.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledResourceControllerCommon.java
@@ -1,0 +1,56 @@
+package bio.terra.workspace.app.controller;
+
+import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
+import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
+import bio.terra.workspace.service.resource.controlled.model.PrivateUserRole;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
+import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Super class for controllers containing common code. The code in here requires the @Autowired
+ * beans from the @Controller classes, so it is better as a superclass rather than static methods.
+ */
+public class ControlledResourceControllerCommon extends ControllerCommon {
+  private final ControlledResourceService controlledResourceService;
+
+  public ControlledResourceControllerCommon(
+      AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
+      HttpServletRequest request,
+      ControlledResourceService controlledResourceService,
+      SamService samService) {
+    super(authenticatedUserRequestFactory, request, samService);
+    this.controlledResourceService = controlledResourceService;
+  }
+
+  public ControlledResourceFields toCommonFields(
+      UUID workspaceId,
+      ApiControlledResourceCommonFields apiCommonFields,
+      AuthenticatedUserRequest userRequest) {
+
+    ManagedByType managedBy = ManagedByType.fromApi(apiCommonFields.getManagedBy());
+    AccessScopeType accessScopeType = AccessScopeType.fromApi(apiCommonFields.getAccessScope());
+    PrivateUserRole privateUserRole =
+        computePrivateUserRole(workspaceId, apiCommonFields, userRequest);
+
+    return ControlledResourceFields.builder()
+        .workspaceId(workspaceId)
+        .resourceId(UUID.randomUUID())
+        .name(apiCommonFields.getName())
+        .description(apiCommonFields.getDescription())
+        .cloningInstructions(
+            CloningInstructions.fromApiModel(apiCommonFields.getCloningInstructions()))
+        .iamRole(privateUserRole.getRole())
+        .assignedUser(privateUserRole.getUserEmail())
+        .accessScope(accessScopeType)
+        .managedBy(managedBy)
+        .applicationId(controlledResourceService.getAssociatedApp(managedBy, userRequest))
+        .build();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
@@ -29,12 +29,12 @@ import org.springframework.http.HttpStatus;
  * Super class for controllers containing common code. The code in here requires the @Autowired
  * beans from the @Controller classes, so it is better as a superclass rather than static methods.
  */
-public class ControllerCommon {
+public class ControllerBase {
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final HttpServletRequest request;
   private final SamService samService;
 
-  public ControllerCommon(
+  public ControllerBase(
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
       HttpServletRequest request,
       SamService samService) {

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -30,7 +30,7 @@ import bio.terra.workspace.generated.model.ApiUpdateGitRepoReferenceRequestBody;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo.ReferencedGitRepoResource;
@@ -60,7 +60,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
 
   private final ReferencedResourceService referenceResourceService;
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
-  private final ValidationUtils validationUtils;
+  private final ResourceValidationUtils validationUtils;
   private final HttpServletRequest request;
   private final PetSaService petSaService;
   private final Logger logger = LoggerFactory.getLogger(ReferencedGcpResourceController.class);
@@ -69,7 +69,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   public ReferencedGcpResourceController(
       ReferencedResourceService referenceResourceService,
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
-      ValidationUtils validationUtils,
+      ResourceValidationUtils validationUtils,
       HttpServletRequest request,
       PetSaService petSaService) {
     this.referenceResourceService = referenceResourceService;

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -39,7 +39,7 @@ import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.JobService.AsyncJobResult;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
@@ -75,7 +75,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
-public class WorkspaceApiController extends ControllerCommon implements WorkspaceApi {
+public class WorkspaceApiController extends ControllerBase implements WorkspaceApi {
   private static final Logger logger = LoggerFactory.getLogger(WorkspaceApiController.class);
   private final WorkspaceService workspaceService;
   private final JobService jobService;
@@ -245,7 +245,7 @@ public class WorkspaceApiController extends ControllerCommon implements Workspac
         body);
 
     ControllerValidationUtils.validate(body);
-    ValidationUtils.validateResourceName(body.getName());
+    ResourceValidationUtils.validateResourceName(body.getName());
 
     var resource =
         new ReferencedDataRepoSnapshotResource(
@@ -300,7 +300,7 @@ public class WorkspaceApiController extends ControllerCommon implements Workspac
       throw new InvalidReferenceException(
           "This endpoint does not support non-snapshot references. Use the newer type-specific endpoints instead.");
     }
-    ValidationUtils.validateResourceName(name);
+    ResourceValidationUtils.validateResourceName(name);
 
     ReferencedResource referenceResource =
         referenceResourceService.getReferenceResourceByName(workspaceId, name, userRequest);
@@ -320,7 +320,7 @@ public class WorkspaceApiController extends ControllerCommon implements Workspac
     }
 
     if (body.getName() != null) {
-      ValidationUtils.validateResourceName(body.getName());
+      ResourceValidationUtils.validateResourceName(body.getName());
     }
 
     referenceResourceService.updateReferenceResource(

--- a/service/src/main/java/bio/terra/workspace/db/model/DbResource.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/DbResource.java
@@ -7,9 +7,11 @@ import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
+import bio.terra.workspace.service.workspace.exceptions.MissingRequiredFieldsException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -34,6 +36,9 @@ public class DbResource {
   @Nullable private UUID applicationId;
   @Nullable private String assignedUser;
   @Nullable private PrivateResourceState privateResourceState;
+
+  private static final Supplier<RuntimeException> MISSING_REQUIRED_FIELD =
+      () -> new MissingRequiredFieldsException("Missing required field");
 
   public UUID getWorkspaceId() {
     return workspaceId;
@@ -62,8 +67,8 @@ public class DbResource {
     return this;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public DbResource name(String name) {
@@ -71,8 +76,8 @@ public class DbResource {
     return this;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public DbResource description(String description) {
@@ -125,8 +130,8 @@ public class DbResource {
     return this;
   }
 
-  public Optional<AccessScopeType> getAccessScope() {
-    return Optional.ofNullable(accessScope);
+  public AccessScopeType getAccessScope() {
+    return Optional.ofNullable(accessScope).orElseThrow(MISSING_REQUIRED_FIELD);
   }
 
   public DbResource accessScope(@Nullable AccessScopeType accessScope) {
@@ -134,8 +139,8 @@ public class DbResource {
     return this;
   }
 
-  public Optional<ManagedByType> getManagedBy() {
-    return Optional.ofNullable(managedBy);
+  public ManagedByType getManagedBy() {
+    return Optional.ofNullable(managedBy).orElseThrow(MISSING_REQUIRED_FIELD);
   }
 
   public DbResource managedBy(@Nullable ManagedByType managedBy) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -25,9 +25,9 @@ import org.springframework.stereotype.Component;
 
 /** A collection of static validation functions */
 @Component
-public class ValidationUtils {
+public class ResourceValidationUtils {
 
-  private static final Logger logger = LoggerFactory.getLogger(ValidationUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(ResourceValidationUtils.class);
 
   /**
    * GCS bucket name validation is somewhat complex due to rules about usage of "." and restricted
@@ -91,7 +91,7 @@ public class ValidationUtils {
   private final GitRepoReferencedResourceConfiguration gitRepoReferencedResourceConfiguration;
 
   @Autowired
-  public ValidationUtils(
+  public ResourceValidationUtils(
       GitRepoReferencedResourceConfiguration gitRepoReferencedResourceConfiguration) {
     this.gitRepoReferencedResourceConfiguration = gitRepoReferencedResourceConfiguration;
   }
@@ -347,7 +347,7 @@ public class ValidationUtils {
   public static <T> void checkFieldNonNull(@Nullable T fieldValue, String fieldName) {
     if (fieldValue == null) {
       throw new MissingRequiredFieldException(
-          String.format("Missing required field '%s' for ControlledNotebookInstance.", fieldName));
+          String.format("Missing required field '%s' for resource", fieldName));
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ValidationUtils.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.resource;
 
 import bio.terra.common.exception.InconsistentFieldsException;
+import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.app.configuration.external.GitRepoReferencedResourceConfiguration;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
@@ -340,6 +341,13 @@ public class ValidationUtils {
       logger.warn("Invalid Azure region {}", region);
       throw new InvalidReferenceException(
           "Invalid Azure Region specified. See the class `com.azure.core.management.Region`");
+    }
+  }
+
+  public static <T> void checkFieldNonNull(@Nullable T fieldValue, String fieldName) {
+    if (fieldValue == null) {
+      throw new MissingRequiredFieldException(
+          String.format("Missing required field '%s' for ControlledNotebookInstance.", fieldName));
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
@@ -5,7 +5,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceActions;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.stage.StageService;
@@ -51,10 +51,10 @@ public class ControlledResourceMetadataManager {
         userRequest, workspaceId, resourceId, SamControlledResourceActions.EDIT_ACTION);
     // Name may be null if the user is not updating it in this request.
     if (name != null) {
-      ValidationUtils.validateResourceName(name);
+      ResourceValidationUtils.validateResourceName(name);
     }
     // Description may also be null, but this validator accepts null descriptions.
-    ValidationUtils.validateResourceDescriptionName(description);
+    ResourceValidationUtils.validateResourceDescriptionName(description);
     resourceDao.updateResource(workspaceId, resourceId, name, description);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -99,7 +99,7 @@ public class ControlledResourceService {
     this.features = features;
   }
 
-  public String createVm(
+  public String createAzureVm(
       ControlledAzureVmResource resource,
       ApiAzureVmCreationParameters creationParameters,
       ControlledResourceIamRole privateResourceIamRole,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -14,9 +14,7 @@ import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
-import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetUpdateParameters;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketUpdateParameters;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -199,18 +197,6 @@ public class ControlledResourceService {
     return jobId;
   }
 
-  /** Starts a create controlled bucket resource, blocking until its job is finished. */
-  public ControlledGcsBucketResource createBucket(
-      ControlledGcsBucketResource resource,
-      ApiGcpGcsBucketCreationParameters creationParameters,
-      ControlledResourceIamRole privateResourceIamRole,
-      AuthenticatedUserRequest userRequest) {
-    JobBuilder jobBuilder =
-        commonCreationJobBuilder(resource, privateResourceIamRole, userRequest)
-            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
-    return jobBuilder.submitAndWait(ControlledGcsBucketResource.class);
-  }
-
   public ControlledGcsBucketResource updateGcsBucket(
       ControlledGcsBucketResource resource,
       @Nullable ApiGcpGcsBucketUpdateParameters updateParameters,
@@ -324,22 +310,6 @@ public class ControlledResourceService {
         commonCreationJobBuilder(resource, privateResourceIamRole, userRequest)
             .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
     return jobBuilder.submitAndWait(ControlledResource.class);
-  }
-
-  /**
-   * Starts a job to create controlled BigQuery dataset resource, blocking until its job is
-   * finished.
-   */
-  public ControlledBigQueryDatasetResource createBigQueryDataset(
-      ControlledBigQueryDatasetResource resource,
-      ApiGcpBigQueryDatasetCreationParameters creationParameters,
-      ControlledResourceIamRole privateResourceIamRole,
-      AuthenticatedUserRequest userRequest) {
-
-    JobBuilder jobBuilder =
-        commonCreationJobBuilder(resource, privateResourceIamRole, userRequest)
-            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
-    return jobBuilder.submitAndWait(ControlledBigQueryDatasetResource.class);
   }
 
   /** Starts an update controlled BigQuery dataset resource, blocking until its job is finished. */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -314,6 +314,18 @@ public class ControlledResourceService {
     return jobBuilder.submit();
   }
 
+  public <T> ControlledResource createControlledResourceSync(
+      ControlledResource resource,
+      ControlledResourceIamRole privateResourceIamRole,
+      AuthenticatedUserRequest userRequest,
+      T creationParameters) {
+
+    JobBuilder jobBuilder =
+        commonCreationJobBuilder(resource, privateResourceIamRole, userRequest)
+            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
+    return jobBuilder.submitAndWait(ControlledResource.class);
+  }
+
   /**
    * Starts a job to create controlled BigQuery dataset resource, blocking until its job is
    * finished.

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -42,6 +42,7 @@ import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import bio.terra.workspace.service.workspace.model.WsmApplication;
@@ -225,6 +226,10 @@ public class ControlledResourceService {
       ControlledResourceIamRole privateResourceIamRole,
       AuthenticatedUserRequest userRequest,
       T creationParameters) {
+
+    if (resource.getResourceType().getCloudPlatform() == CloudPlatform.AZURE) {
+      features.azureEnabledCheck();
+    }
 
     JobBuilder jobBuilder =
         commonCreationJobBuilder(resource, privateResourceIamRole, userRequest)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -7,10 +7,6 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.db.ApplicationDao;
 import bio.terra.workspace.db.ResourceDao;
-import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
@@ -26,10 +22,6 @@ import bio.terra.workspace.service.job.JobBuilder;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceSyncMapping.SyncMapping;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpResource;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpPolicyBuilder;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
@@ -104,78 +96,6 @@ public class ControlledResourceService {
     this.gcpCloudContextService = gcpCloudContextService;
     this.controlledResourceMetadataManager = controlledResourceMetadataManager;
     this.features = features;
-  }
-
-  public ControlledAzureIpResource createIp(
-      ControlledAzureIpResource resource,
-      ApiAzureIpCreationParameters creationParameters,
-      ControlledResourceIamRole privateResourceIamRole,
-      AuthenticatedUserRequest userRequest) {
-    features.azureEnabledCheck();
-
-    JobBuilder jobBuilder =
-        commonCreationJobBuilder(
-                resource,
-                privateResourceIamRole,
-                new ApiJobControl().id(UUID.randomUUID().toString()),
-                null,
-                userRequest)
-            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
-    return jobBuilder.submitAndWait(ControlledAzureIpResource.class);
-  }
-
-  public ControlledAzureStorageResource createStorage(
-      ControlledAzureStorageResource resource,
-      ApiAzureStorageCreationParameters creationParameters,
-      ControlledResourceIamRole privateResourceIamRole,
-      AuthenticatedUserRequest userRequest) {
-    features.azureEnabledCheck();
-
-    JobBuilder jobBuilder =
-        commonCreationJobBuilder(
-                resource,
-                privateResourceIamRole,
-                new ApiJobControl().id(UUID.randomUUID().toString()),
-                null,
-                userRequest)
-            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
-    return jobBuilder.submitAndWait(ControlledAzureStorageResource.class);
-  }
-
-  public ControlledAzureDiskResource createDisk(
-      ControlledAzureDiskResource resource,
-      ApiAzureDiskCreationParameters creationParameters,
-      ControlledResourceIamRole privateResourceIamRole,
-      AuthenticatedUserRequest userRequest) {
-    features.azureEnabledCheck();
-
-    JobBuilder jobBuilder =
-        commonCreationJobBuilder(
-                resource,
-                privateResourceIamRole,
-                new ApiJobControl().id(UUID.randomUUID().toString()),
-                null,
-                userRequest)
-            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
-    return jobBuilder.submitAndWait(ControlledAzureDiskResource.class);
-  }
-
-  public ControlledAzureNetworkResource createNetwork(
-      ControlledAzureNetworkResource resource,
-      ApiAzureNetworkCreationParameters creationParameters,
-      ControlledResourceIamRole privateResourceIamRole,
-      AuthenticatedUserRequest userRequest) {
-    features.azureEnabledCheck();
-
-    JobBuilder jobBuilder =
-        commonCreationJobBuilder(
-                resource,
-                privateResourceIamRole,
-                new ApiJobControl().id(UUID.randomUUID().toString()),
-                null,
-                userRequest)
-            .addParameter(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
-    return jobBuilder.submitAndWait(ControlledAzureNetworkResource.class);
   }
 
   public String createVm(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskAttributes.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ControlledAzureDiskAttributes {
   private final String diskName;
   private final String region;
+  /** size is in GB */
   private final int size;
 
   @JsonCreator

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
@@ -29,7 +29,6 @@ public class ControlledAzureDiskHandler implements WsmResourceHandler {
             .size(attributes.getSize())
             .common(new ControlledResourceFields(dbResource))
             .build();
-    resource.validate();
     return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskHandler.java
@@ -1,6 +1,8 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.disk;
 
+import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 
@@ -17,6 +19,17 @@ public class ControlledAzureDiskHandler implements WsmResourceHandler {
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
-    return new ControlledAzureDiskResource(dbResource);
+    ControlledAzureDiskAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureDiskAttributes.class);
+
+    var resource =
+        ControlledAzureDiskResource.builder()
+            .diskName(attributes.getDiskName())
+            .region(attributes.getRegion())
+            .size(attributes.getSize())
+            .common(new ControlledResourceFields(dbResource))
+            .build();
+    resource.validate();
+    return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -7,7 +7,6 @@ import bio.terra.stairway.RetryRule;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.db.DbSerDes;
-import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureDiskAttributes;
@@ -20,6 +19,7 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import java.util.UUID;
-import javax.annotation.Nullable;
 
 public class ControlledAzureDiskResource extends ControlledResource {
   private final String diskName;
@@ -70,13 +69,13 @@ public class ControlledAzureDiskResource extends ControlledResource {
     validate();
   }
 
-  public ControlledAzureDiskResource(DbResource dbResource) {
-    super(dbResource);
-    ControlledAzureDiskAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureDiskAttributes.class);
-    this.diskName = attributes.getDiskName();
-    this.region = attributes.getRegion();
-    this.size = attributes.getSize();
+  // Constructor for the builder
+  private ControlledAzureDiskResource(
+      ControlledResourceFields common, String diskName, String region, int size) {
+    super(common);
+    this.diskName = diskName;
+    this.region = region;
+    this.size = size;
     validate();
   }
 
@@ -218,44 +217,13 @@ public class ControlledAzureDiskResource extends ControlledResource {
   }
 
   public static class Builder {
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
-    private CloningInstructions cloningInstructions;
-    private String assignedUser;
-    // Default value is NOT_APPLICABLE for shared resources and INITIALIZING for private resources.
-    @Nullable private PrivateResourceState privateResourceState;
-    private AccessScopeType accessScope;
-    private ManagedByType managedBy;
-    private UUID applicationId;
+    private ControlledResourceFields common;
     private String diskName;
     private String region;
     private int size;
 
-    public ControlledAzureDiskResource.Builder workspaceId(UUID workspaceId) {
-      this.workspaceId = workspaceId;
-      return this;
-    }
-
-    public ControlledAzureDiskResource.Builder resourceId(UUID resourceId) {
-      this.resourceId = resourceId;
-      return this;
-    }
-
-    public ControlledAzureDiskResource.Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public ControlledAzureDiskResource.Builder description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public ControlledAzureDiskResource.Builder cloningInstructions(
-        CloningInstructions cloningInstructions) {
-      this.cloningInstructions = cloningInstructions;
+    public Builder common(ControlledResourceFields common) {
+      this.common = common;
       return this;
     }
 
@@ -274,53 +242,8 @@ public class ControlledAzureDiskResource extends ControlledResource {
       return this;
     }
 
-    public ControlledAzureDiskResource.Builder assignedUser(String assignedUser) {
-      this.assignedUser = assignedUser;
-      return this;
-    }
-
-    public ControlledAzureDiskResource.Builder privateResourceState(
-        PrivateResourceState privateResourceState) {
-      this.privateResourceState = privateResourceState;
-      return this;
-    }
-
-    private PrivateResourceState defaultPrivateResourceState() {
-      return this.accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
-          ? PrivateResourceState.INITIALIZING
-          : PrivateResourceState.NOT_APPLICABLE;
-    }
-
-    public ControlledAzureDiskResource.Builder accessScope(AccessScopeType accessScope) {
-      this.accessScope = accessScope;
-      return this;
-    }
-
-    public ControlledAzureDiskResource.Builder managedBy(ManagedByType managedBy) {
-      this.managedBy = managedBy;
-      return this;
-    }
-
-    public ControlledAzureDiskResource.Builder applicationId(UUID applicationId) {
-      this.applicationId = applicationId;
-      return this;
-    }
-
     public ControlledAzureDiskResource build() {
-      return new ControlledAzureDiskResource(
-          workspaceId,
-          resourceId,
-          name,
-          description,
-          cloningInstructions,
-          assignedUser,
-          Optional.ofNullable(privateResourceState).orElse(defaultPrivateResourceState()),
-          accessScope,
-          managedBy,
-          applicationId,
-          diskName,
-          region,
-          size);
+      return new ControlledAzureDiskResource(common, diskName, region, size);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.generated.model.ApiAzureDiskResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -34,6 +34,7 @@ import java.util.UUID;
 public class ControlledAzureDiskResource extends ControlledResource {
   private final String diskName;
   private final String region;
+  /** size is in GB */
   private final int size;
 
   @JsonCreator
@@ -194,8 +195,8 @@ public class ControlledAzureDiskResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureDisk.");
     }
-    ValidationUtils.validateRegion(getRegion());
-    ValidationUtils.validateAzureDiskName(getDiskName());
+    ResourceValidationUtils.validateRegion(getRegion());
+    ResourceValidationUtils.validateAzureDiskName(getDiskName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
@@ -1,6 +1,8 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.ip;
 
+import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 
@@ -17,6 +19,16 @@ public class ControlledAzureIpHandler implements WsmResourceHandler {
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
-    return new ControlledAzureIpResource(dbResource);
+    ControlledAzureIpAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureIpAttributes.class);
+
+    var resource =
+        ControlledAzureIpResource.builder()
+            .ipName(attributes.getIpName())
+            .region(attributes.getRegion())
+            .common(new ControlledResourceFields(dbResource))
+            .build();
+    resource.validate();
+    return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpHandler.java
@@ -28,7 +28,6 @@ public class ControlledAzureIpHandler implements WsmResourceHandler {
             .region(attributes.getRegion())
             .common(new ControlledResourceFields(dbResource))
             .build();
-    resource.validate();
     return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.generated.model.ApiAzureIpResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -182,8 +182,8 @@ public class ControlledAzureIpResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureIP.");
     }
-    ValidationUtils.validateRegion(getRegion());
-    ValidationUtils.validateAzureIPorSubnetName(getIpName());
+    ResourceValidationUtils.validateRegion(getRegion());
+    ResourceValidationUtils.validateAzureIPorSubnetName(getIpName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
@@ -7,7 +7,6 @@ import bio.terra.stairway.RetryRule;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.db.DbSerDes;
-import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureIpAttributes;
@@ -20,6 +19,7 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import java.util.UUID;
-import javax.annotation.Nullable;
 
 public class ControlledAzureIpResource extends ControlledResource {
   private final String ipName;
@@ -67,12 +66,11 @@ public class ControlledAzureIpResource extends ControlledResource {
     validate();
   }
 
-  public ControlledAzureIpResource(DbResource dbResource) {
-    super(dbResource);
-    ControlledAzureIpAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureIpAttributes.class);
-    this.ipName = attributes.getIpName();
-    this.region = attributes.getRegion();
+  // Constructor for the builder
+  private ControlledAzureIpResource(ControlledResourceFields common, String ipName, String region) {
+    super(common);
+    this.ipName = ipName;
+    this.region = region;
     validate();
   }
 
@@ -207,43 +205,12 @@ public class ControlledAzureIpResource extends ControlledResource {
   }
 
   public static class Builder {
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
-    private CloningInstructions cloningInstructions;
-    // Default value is NOT_APPLICABLE for shared resources and INITIALIZING for private resources.
-    @Nullable private PrivateResourceState privateResourceState;
-    private String assignedUser;
-    private AccessScopeType accessScope;
-    private ManagedByType managedBy;
-    private UUID applicationId;
+    private ControlledResourceFields common;
     private String ipName;
     private String region;
 
-    public ControlledAzureIpResource.Builder workspaceId(UUID workspaceId) {
-      this.workspaceId = workspaceId;
-      return this;
-    }
-
-    public ControlledAzureIpResource.Builder resourceId(UUID resourceId) {
-      this.resourceId = resourceId;
-      return this;
-    }
-
-    public ControlledAzureIpResource.Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public ControlledAzureIpResource.Builder description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public ControlledAzureIpResource.Builder cloningInstructions(
-        CloningInstructions cloningInstructions) {
-      this.cloningInstructions = cloningInstructions;
+    public Builder common(ControlledResourceFields common) {
+      this.common = common;
       return this;
     }
 
@@ -257,52 +224,8 @@ public class ControlledAzureIpResource extends ControlledResource {
       return this;
     }
 
-    public ControlledAzureIpResource.Builder assignedUser(String assignedUser) {
-      this.assignedUser = assignedUser;
-      return this;
-    }
-
-    public ControlledAzureIpResource.Builder privateResourceState(
-        PrivateResourceState privateResourceState) {
-      this.privateResourceState = privateResourceState;
-      return this;
-    }
-
-    private PrivateResourceState defaultPrivateResourceState() {
-      return this.accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
-          ? PrivateResourceState.INITIALIZING
-          : PrivateResourceState.NOT_APPLICABLE;
-    }
-
-    public ControlledAzureIpResource.Builder accessScope(AccessScopeType accessScope) {
-      this.accessScope = accessScope;
-      return this;
-    }
-
-    public ControlledAzureIpResource.Builder managedBy(ManagedByType managedBy) {
-      this.managedBy = managedBy;
-      return this;
-    }
-
-    public ControlledAzureIpResource.Builder applicationId(UUID applicationId) {
-      this.applicationId = applicationId;
-      return this;
-    }
-
     public ControlledAzureIpResource build() {
-      return new ControlledAzureIpResource(
-          workspaceId,
-          resourceId,
-          name,
-          description,
-          cloningInstructions,
-          assignedUser,
-          Optional.ofNullable(privateResourceState).orElse(defaultPrivateResourceState()),
-          accessScope,
-          managedBy,
-          applicationId,
-          ipName,
-          region);
+      return new ControlledAzureIpResource(common, ipName, region);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
@@ -1,6 +1,8 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.network;
 
+import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 
@@ -17,6 +19,19 @@ public class ControlledAzureNetworkHandler implements WsmResourceHandler {
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
-    return new ControlledAzureNetworkResource(dbResource);
+    ControlledAzureNetworkAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureNetworkAttributes.class);
+
+    var resource =
+        ControlledAzureNetworkResource.builder()
+            .common(new ControlledResourceFields(dbResource))
+            .networkName(attributes.getNetworkName())
+            .subnetName(attributes.getSubnetName())
+            .addressSpaceCidr(attributes.getAddressSpaceCidr())
+            .subnetAddressCidr(attributes.getSubnetAddressCidr())
+            .region(attributes.getRegion())
+            .build();
+    resource.validate();
+    return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkHandler.java
@@ -31,7 +31,6 @@ public class ControlledAzureNetworkHandler implements WsmResourceHandler {
             .subnetAddressCidr(attributes.getSubnetAddressCidr())
             .region(attributes.getRegion())
             .build();
-    resource.validate();
     return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
@@ -7,7 +7,6 @@ import bio.terra.stairway.RetryRule;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.db.DbSerDes;
-import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureNetworkAttributes;
@@ -20,6 +19,7 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import java.util.UUID;
-import javax.annotation.Nullable;
 
 public class ControlledAzureNetworkResource extends ControlledResource {
   private final String networkName;
@@ -76,15 +75,20 @@ public class ControlledAzureNetworkResource extends ControlledResource {
     validate();
   }
 
-  public ControlledAzureNetworkResource(DbResource dbResource) {
-    super(dbResource);
-    ControlledAzureNetworkAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureNetworkAttributes.class);
-    this.networkName = attributes.getNetworkName();
-    this.subnetName = attributes.getSubnetName();
-    this.addressSpaceCidr = attributes.getAddressSpaceCidr();
-    this.subnetAddressCidr = attributes.getSubnetAddressCidr();
-    this.region = attributes.getRegion();
+  // Constructor for the builder
+  private ControlledAzureNetworkResource(
+      ControlledResourceFields common,
+      String networkName,
+      String subnetName,
+      String addressSpaceCidr,
+      String subnetAddressCidr,
+      String region) {
+    super(common);
+    this.networkName = networkName;
+    this.subnetName = subnetName;
+    this.addressSpaceCidr = addressSpaceCidr;
+    this.subnetAddressCidr = subnetAddressCidr;
+    this.region = region;
     validate();
   }
 
@@ -262,46 +266,15 @@ public class ControlledAzureNetworkResource extends ControlledResource {
   }
 
   public static class Builder {
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
-    private CloningInstructions cloningInstructions;
-    private String assignedUser;
-    // Default value is NOT_APPLICABLE for shared resources and INITIALIZING for private resources.
-    @Nullable private PrivateResourceState privateResourceState;
-    private AccessScopeType accessScope;
-    private ManagedByType managedBy;
-    private UUID applicationId;
+    private ControlledResourceFields common;
     private String networkName;
     private String subnetName;
     private String addressSpaceCidr;
     private String subnetAddressCidr;
     private String region;
 
-    public ControlledAzureNetworkResource.Builder workspaceId(UUID workspaceId) {
-      this.workspaceId = workspaceId;
-      return this;
-    }
-
-    public ControlledAzureNetworkResource.Builder resourceId(UUID resourceId) {
-      this.resourceId = resourceId;
-      return this;
-    }
-
-    public ControlledAzureNetworkResource.Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public ControlledAzureNetworkResource.Builder description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public ControlledAzureNetworkResource.Builder cloningInstructions(
-        CloningInstructions cloningInstructions) {
-      this.cloningInstructions = cloningInstructions;
+    public Builder common(ControlledResourceFields common) {
+      this.common = common;
       return this;
     }
 
@@ -330,55 +303,9 @@ public class ControlledAzureNetworkResource extends ControlledResource {
       return this;
     }
 
-    public ControlledAzureNetworkResource.Builder assignedUser(String assignedUser) {
-      this.assignedUser = assignedUser;
-      return this;
-    }
-
-    public ControlledAzureNetworkResource.Builder privateResourceState(
-        PrivateResourceState privateResourceState) {
-      this.privateResourceState = privateResourceState;
-      return this;
-    }
-
-    private PrivateResourceState defaultPrivateResourceState() {
-      return this.accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
-          ? PrivateResourceState.INITIALIZING
-          : PrivateResourceState.NOT_APPLICABLE;
-    }
-
-    public ControlledAzureNetworkResource.Builder accessScope(AccessScopeType accessScope) {
-      this.accessScope = accessScope;
-      return this;
-    }
-
-    public ControlledAzureNetworkResource.Builder managedBy(ManagedByType managedBy) {
-      this.managedBy = managedBy;
-      return this;
-    }
-
-    public ControlledAzureNetworkResource.Builder applicationId(UUID applicationId) {
-      this.applicationId = applicationId;
-      return this;
-    }
-
     public ControlledAzureNetworkResource build() {
       return new ControlledAzureNetworkResource(
-          workspaceId,
-          resourceId,
-          name,
-          description,
-          cloningInstructions,
-          assignedUser,
-          Optional.ofNullable(privateResourceState).orElse(defaultPrivateResourceState()),
-          accessScope,
-          managedBy,
-          applicationId,
-          networkName,
-          subnetName,
-          addressSpaceCidr,
-          subnetAddressCidr,
-          region);
+          common, networkName, subnetName, addressSpaceCidr, subnetAddressCidr, region);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.generated.model.ApiAzureNetworkResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -240,11 +240,11 @@ public class ControlledAzureNetworkResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureNetwork.");
     }
-    ValidationUtils.validateRegion(getRegion());
-    ValidationUtils.validateAzureNetworkName(getNetworkName());
-    ValidationUtils.validateAzureIPorSubnetName(getSubnetName());
-    ValidationUtils.validateAzureCidrBlock(getAddressSpaceCidr());
-    ValidationUtils.validateAzureCidrBlock(getSubnetAddressCidr());
+    ResourceValidationUtils.validateRegion(getRegion());
+    ResourceValidationUtils.validateAzureNetworkName(getNetworkName());
+    ResourceValidationUtils.validateAzureIPorSubnetName(getSubnetName());
+    ResourceValidationUtils.validateAzureCidrBlock(getAddressSpaceCidr());
+    ResourceValidationUtils.validateAzureCidrBlock(getSubnetAddressCidr());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
@@ -1,6 +1,8 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.storage;
 
+import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 
@@ -17,6 +19,16 @@ public class ControlledAzureStorageHandler implements WsmResourceHandler {
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
-    return new ControlledAzureStorageResource(dbResource);
+    ControlledAzureStorageResource attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureStorageResource.class);
+
+    var resource =
+        ControlledAzureStorageResource.builder()
+            .storageAccountName(attributes.getStorageAccountName())
+            .region(attributes.getRegion())
+            .common(new ControlledResourceFields(dbResource))
+            .build();
+    resource.validate();
+    return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageHandler.java
@@ -28,7 +28,6 @@ public class ControlledAzureStorageHandler implements WsmResourceHandler {
             .region(attributes.getRegion())
             .common(new ControlledResourceFields(dbResource))
             .build();
-    resource.validate();
     return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
@@ -15,7 +15,7 @@ import bio.terra.workspace.generated.model.ApiAzureStorageResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -188,7 +188,7 @@ public class ControlledAzureStorageResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureStorage.");
     }
-    ValidationUtils.validateStorageAccountName(getStorageAccountName());
+    ResourceValidationUtils.validateStorageAccountName(getStorageAccountName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
@@ -8,7 +8,6 @@ import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.db.DbSerDes;
-import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureStorageAttributes;
@@ -21,6 +20,7 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import java.util.UUID;
-import javax.annotation.Nullable;
 
 public class ControlledAzureStorageResource extends ControlledResource {
   private final String storageAccountName;
@@ -68,12 +67,11 @@ public class ControlledAzureStorageResource extends ControlledResource {
     validate();
   }
 
-  public ControlledAzureStorageResource(DbResource dbResource) {
-    super(dbResource);
-    ControlledAzureStorageAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureStorageAttributes.class);
-    this.storageAccountName = attributes.getStorageAccountName();
-    this.region = attributes.getRegion();
+  private ControlledAzureStorageResource(
+      ControlledResourceFields common, String storageAccountName, String region) {
+    super(common);
+    this.storageAccountName = storageAccountName;
+    this.region = region;
     validate();
   }
 
@@ -212,43 +210,12 @@ public class ControlledAzureStorageResource extends ControlledResource {
   }
 
   public static class Builder {
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
-    private CloningInstructions cloningInstructions;
-    private String assignedUser;
-    // Default value is NOT_APPLICABLE for shared resources and INITIALIZING for private resources.
-    @Nullable private PrivateResourceState privateResourceState;
-    private AccessScopeType accessScope;
-    private ManagedByType managedBy;
-    private UUID applicationId;
+    private ControlledResourceFields common;
     private String storageAccountName;
     private String region;
 
-    public ControlledAzureStorageResource.Builder workspaceId(UUID workspaceId) {
-      this.workspaceId = workspaceId;
-      return this;
-    }
-
-    public ControlledAzureStorageResource.Builder resourceId(UUID resourceId) {
-      this.resourceId = resourceId;
-      return this;
-    }
-
-    public ControlledAzureStorageResource.Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public ControlledAzureStorageResource.Builder description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public ControlledAzureStorageResource.Builder cloningInstructions(
-        CloningInstructions cloningInstructions) {
-      this.cloningInstructions = cloningInstructions;
+    public Builder common(ControlledResourceFields common) {
+      this.common = common;
       return this;
     }
 
@@ -262,52 +229,8 @@ public class ControlledAzureStorageResource extends ControlledResource {
       return this;
     }
 
-    public ControlledAzureStorageResource.Builder assignedUser(String assignedUser) {
-      this.assignedUser = assignedUser;
-      return this;
-    }
-
-    public ControlledAzureStorageResource.Builder privateResourceState(
-        PrivateResourceState privateResourceState) {
-      this.privateResourceState = privateResourceState;
-      return this;
-    }
-
-    private PrivateResourceState defaultPrivateResourceState() {
-      return this.accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
-          ? PrivateResourceState.INITIALIZING
-          : PrivateResourceState.NOT_APPLICABLE;
-    }
-
-    public ControlledAzureStorageResource.Builder accessScope(AccessScopeType accessScope) {
-      this.accessScope = accessScope;
-      return this;
-    }
-
-    public ControlledAzureStorageResource.Builder managedBy(ManagedByType managedBy) {
-      this.managedBy = managedBy;
-      return this;
-    }
-
-    public ControlledAzureStorageResource.Builder applicationId(UUID applicationId) {
-      this.applicationId = applicationId;
-      return this;
-    }
-
     public ControlledAzureStorageResource build() {
-      return new ControlledAzureStorageResource(
-          workspaceId,
-          resourceId,
-          name,
-          description,
-          cloningInstructions,
-          assignedUser,
-          Optional.ofNullable(privateResourceState).orElse(defaultPrivateResourceState()),
-          accessScope,
-          managedBy,
-          applicationId,
-          storageAccountName,
-          region);
+      return new ControlledAzureStorageResource(common, storageAccountName, region);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
@@ -1,6 +1,8 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
 
+import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 
@@ -17,6 +19,21 @@ public class ControlledAzureVmHandler implements WsmResourceHandler {
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
-    return new ControlledAzureVmResource(dbResource);
+    ControlledAzureVmAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureVmAttributes.class);
+
+    var resource =
+        ControlledAzureVmResource.builder()
+            .vmName(attributes.getVmName())
+            .region(attributes.getRegion())
+            .vmSize(attributes.getVmSize())
+            .vmImageUri(attributes.getVmImageUri())
+            .ipId(attributes.getIpId())
+            .networkId(attributes.getNetworkId())
+            .diskId(attributes.getDiskId())
+            .common(new ControlledResourceFields(dbResource))
+            .build();
+    resource.validate();
+    return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
@@ -33,7 +33,6 @@ public class ControlledAzureVmHandler implements WsmResourceHandler {
             .diskId(attributes.getDiskId())
             .common(new ControlledResourceFields(dbResource))
             .build();
-    resource.validate();
     return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.generated.model.ApiAzureVmResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -264,9 +264,9 @@ public class ControlledAzureVmResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required diskId field for ControlledAzureVm.");
     }
-    ValidationUtils.validateAzureIPorSubnetName(getVmName());
-    ValidationUtils.validateAzureVmSize(getVmSize());
-    ValidationUtils.validateRegion(getRegion());
+    ResourceValidationUtils.validateAzureIPorSubnetName(getVmName());
+    ResourceValidationUtils.validateAzureVmSize(getVmSize());
+    ResourceValidationUtils.validateRegion(getRegion());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -7,7 +7,6 @@ import bio.terra.stairway.RetryRule;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.db.DbSerDes;
-import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiAzureVmAttributes;
@@ -20,6 +19,7 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import java.util.UUID;
-import javax.annotation.Nullable;
 
 public class ControlledAzureVmResource extends ControlledResource {
   private final String vmName;
@@ -83,17 +82,23 @@ public class ControlledAzureVmResource extends ControlledResource {
     validate();
   }
 
-  public ControlledAzureVmResource(DbResource dbResource) {
-    super(dbResource);
-    ControlledAzureVmAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureVmAttributes.class);
-    this.vmName = attributes.getVmName();
-    this.region = attributes.getRegion();
-    this.vmImageUri = attributes.getVmImageUri();
-    this.vmSize = attributes.getVmSize();
-    this.ipId = attributes.getIpId();
-    this.networkId = attributes.getNetworkId();
-    this.diskId = attributes.getDiskId();
+  private ControlledAzureVmResource(
+      ControlledResourceFields common,
+      String vmName,
+      String region,
+      String vmSize,
+      String vmImageUri,
+      UUID ipId,
+      UUID networkId,
+      UUID diskId) {
+    super(common);
+    this.vmName = vmName;
+    this.region = region;
+    this.vmImageUri = vmImageUri;
+    this.vmSize = vmSize;
+    this.ipId = ipId;
+    this.networkId = networkId;
+    this.diskId = diskId;
     validate();
   }
 
@@ -287,17 +292,7 @@ public class ControlledAzureVmResource extends ControlledResource {
   }
 
   public static class Builder {
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
-    private CloningInstructions cloningInstructions;
-    private String assignedUser;
-    // Default value is NOT_APPLICABLE for shared resources and INITIALIZING for private resources.
-    @Nullable private PrivateResourceState privateResourceState;
-    private AccessScopeType accessScope;
-    private ManagedByType managedBy;
-    private UUID applicationId;
+    private ControlledResourceFields common;
     private String vmName;
     private String region;
     private String vmSize;
@@ -306,29 +301,8 @@ public class ControlledAzureVmResource extends ControlledResource {
     private UUID networkId;
     private UUID diskId;
 
-    public ControlledAzureVmResource.Builder workspaceId(UUID workspaceId) {
-      this.workspaceId = workspaceId;
-      return this;
-    }
-
-    public ControlledAzureVmResource.Builder resourceId(UUID resourceId) {
-      this.resourceId = resourceId;
-      return this;
-    }
-
-    public ControlledAzureVmResource.Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public ControlledAzureVmResource.Builder description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public ControlledAzureVmResource.Builder cloningInstructions(
-        CloningInstructions cloningInstructions) {
-      this.cloningInstructions = cloningInstructions;
+    public Builder common(ControlledResourceFields common) {
+      this.common = common;
       return this;
     }
 
@@ -367,57 +341,9 @@ public class ControlledAzureVmResource extends ControlledResource {
       return this;
     }
 
-    public ControlledAzureVmResource.Builder assignedUser(String assignedUser) {
-      this.assignedUser = assignedUser;
-      return this;
-    }
-
-    public ControlledAzureVmResource.Builder privateResourceState(
-        PrivateResourceState privateResourceState) {
-      this.privateResourceState = privateResourceState;
-      return this;
-    }
-
-    private PrivateResourceState defaultPrivateResourceState() {
-      return this.accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
-          ? PrivateResourceState.INITIALIZING
-          : PrivateResourceState.NOT_APPLICABLE;
-    }
-
-    public ControlledAzureVmResource.Builder accessScope(AccessScopeType accessScope) {
-      this.accessScope = accessScope;
-      return this;
-    }
-
-    public ControlledAzureVmResource.Builder managedBy(ManagedByType managedBy) {
-      this.managedBy = managedBy;
-      return this;
-    }
-
-    public ControlledAzureVmResource.Builder applicationId(UUID applicationId) {
-      this.applicationId = applicationId;
-      return this;
-    }
-
     public ControlledAzureVmResource build() {
       return new ControlledAzureVmResource(
-          workspaceId,
-          resourceId,
-          name,
-          description,
-          cloningInstructions,
-          assignedUser,
-          Optional.ofNullable(privateResourceState).orElse(defaultPrivateResourceState()),
-          accessScope,
-          managedBy,
-          applicationId,
-          vmName,
-          region,
-          vmSize,
-          vmImageUri,
-          ipId,
-          networkId,
-          diskId);
+          common, vmName, region, vmSize, vmImageUri, ipId, networkId, diskId);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook;
 
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
@@ -45,16 +46,7 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
 
     var resource =
         ControlledAiNotebookInstanceResource.builder()
-            .workspaceId(dbResource.getWorkspaceId())
-            .resourceId(dbResource.getResourceId())
-            .name(dbResource.getName().orElse(null))
-            .description(dbResource.getDescription().orElse(null))
-            .cloningInstructions(dbResource.getCloningInstructions())
-            .assignedUser(dbResource.getAssignedUser().orElse(null))
-            .privateResourceState(dbResource.getPrivateResourceState().orElse(null))
-            .accessScope(dbResource.getAccessScope().orElse(null))
-            .managedBy(dbResource.getManagedBy().orElse(null))
-            .applicationId(dbResource.getApplicationId().orElse(null))
+            .common(new ControlledResourceFields(dbResource))
             .instanceId(attributes.getInstanceId())
             .location(attributes.getLocation())
             .projectId(projectId)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -51,7 +51,6 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
             .location(attributes.getLocation())
             .projectId(projectId)
             .build();
-    resource.validate();
     return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -17,7 +17,7 @@ import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -233,7 +233,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
     checkFieldNonNull(getInstanceId(), "instanceId");
     checkFieldNonNull(getLocation(), "location");
     checkFieldNonNull(getProjectId(), "projectId");
-    ValidationUtils.validateAiNotebookInstanceId(getInstanceId());
+    ResourceValidationUtils.validateAiNotebookInstanceId(getInstanceId());
   }
 
   /** Returns an auto generated instance name with the username and date time. */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -79,25 +80,18 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
     validate();
   }
 
-  public static Builder builder() {
-    return new Builder();
+  // Constructor for the builder
+  private ControlledAiNotebookInstanceResource(
+      ControlledResourceFields common, String instanceId, String location, String projectId) {
+    super(common);
+    this.instanceId = instanceId;
+    this.location = location;
+    this.projectId = projectId;
+    validate();
   }
 
-  public Builder toBuilder() {
-    return new Builder()
-        .workspaceId(getWorkspaceId())
-        .resourceId(getResourceId())
-        .name(getName())
-        .description(getDescription())
-        .cloningInstructions(getCloningInstructions())
-        .assignedUser(getAssignedUser().orElse(null))
-        .privateResourceState(getPrivateResourceState().orElse(null))
-        .accessScope(getAccessScope())
-        .managedBy(getManagedBy())
-        .applicationId(getApplicationId())
-        .instanceId(getInstanceId())
-        .location(getLocation())
-        .projectId(getProjectId());
+  public static Builder builder() {
+    return new Builder();
   }
 
   /** {@inheritDoc} */
@@ -308,43 +302,13 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
 
   /** Builder for {@link ControlledAiNotebookInstanceResource}. */
   public static class Builder {
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
-    private CloningInstructions cloningInstructions;
-    private String assignedUser;
-    // Default value is NOT_APPLICABLE for shared resources and INITIALIZING for private resources.
-    @Nullable private PrivateResourceState privateResourceState;
-    private AccessScopeType accessScope;
-    private ManagedByType managedBy;
-    private UUID applicationId;
+    private ControlledResourceFields common;
     private String instanceId;
     private String location;
     private String projectId;
 
-    public Builder workspaceId(UUID workspaceId) {
-      this.workspaceId = workspaceId;
-      return this;
-    }
-
-    public Builder resourceId(UUID resourceId) {
-      this.resourceId = resourceId;
-      return this;
-    }
-
-    public Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public Builder description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public Builder cloningInstructions(CloningInstructions cloningInstructions) {
-      this.cloningInstructions = cloningInstructions;
+    public Builder common(ControlledResourceFields common) {
+      this.common = common;
       return this;
     }
 
@@ -363,52 +327,8 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
       return this;
     }
 
-    public Builder assignedUser(String assignedUser) {
-      this.assignedUser = assignedUser;
-      return this;
-    }
-
-    public Builder privateResourceState(PrivateResourceState privateResourceState) {
-      this.privateResourceState = privateResourceState;
-      return this;
-    }
-
-    private PrivateResourceState defaultPrivateResourceState() {
-      return this.accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
-          ? PrivateResourceState.INITIALIZING
-          : PrivateResourceState.NOT_APPLICABLE;
-    }
-
-    public Builder accessScope(AccessScopeType accessScope) {
-      this.accessScope = accessScope;
-      return this;
-    }
-
-    public Builder managedBy(ManagedByType managedBy) {
-      this.managedBy = managedBy;
-      return this;
-    }
-
-    public Builder applicationId(UUID applicationId) {
-      this.applicationId = applicationId;
-      return this;
-    }
-
     public ControlledAiNotebookInstanceResource build() {
-      return new ControlledAiNotebookInstanceResource(
-          workspaceId,
-          resourceId,
-          name,
-          description,
-          cloningInstructions,
-          assignedUser,
-          Optional.ofNullable(privateResourceState).orElse(defaultPrivateResourceState()),
-          accessScope,
-          managedBy,
-          applicationId,
-          instanceId,
-          location,
-          projectId);
+      return new ControlledAiNotebookInstanceResource(common, instanceId, location, projectId);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
@@ -48,18 +48,7 @@ public class ControlledBigQueryDatasetHandler implements WsmResourceHandler {
         ControlledBigQueryDatasetResource.builder()
             .datasetName(attributes.getDatasetName())
             .projectId(projectId)
-            .common(
-                new ControlledResourceFields()
-                    .workspaceId(dbResource.getWorkspaceId())
-                    .resourceId(dbResource.getResourceId())
-                    .name(dbResource.getName().orElse(null))
-                    .description(dbResource.getDescription().orElse(null))
-                    .cloningInstructions(dbResource.getCloningInstructions())
-                    .assignedUser(dbResource.getAssignedUser().orElse(null))
-                    .privateResourceState(dbResource.getPrivateResourceState().orElse(null))
-                    .accessScope(dbResource.getAccessScope().orElse(null))
-                    .managedBy(dbResource.getManagedBy().orElse(null))
-                    .applicationId(dbResource.getApplicationId().orElse(null)))
+            .common(new ControlledResourceFields(dbResource))
             .build();
     resource.validate();
     return resource;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
@@ -50,7 +50,6 @@ public class ControlledBigQueryDatasetHandler implements WsmResourceHandler {
             .projectId(projectId)
             .common(new ControlledResourceFields(dbResource))
             .build();
-    resource.validate();
     return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset;
 
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
@@ -45,18 +46,20 @@ public class ControlledBigQueryDatasetHandler implements WsmResourceHandler {
 
     var resource =
         ControlledBigQueryDatasetResource.builder()
-            .workspaceId(dbResource.getWorkspaceId())
-            .resourceId(dbResource.getResourceId())
-            .name(dbResource.getName().orElse(null))
-            .description(dbResource.getDescription().orElse(null))
-            .cloningInstructions(dbResource.getCloningInstructions())
-            .assignedUser(dbResource.getAssignedUser().orElse(null))
-            .privateResourceState(dbResource.getPrivateResourceState().orElse(null))
-            .accessScope(dbResource.getAccessScope().orElse(null))
-            .managedBy(dbResource.getManagedBy().orElse(null))
-            .applicationId(dbResource.getApplicationId().orElse(null))
             .datasetName(attributes.getDatasetName())
             .projectId(projectId)
+            .common(
+                new ControlledResourceFields()
+                    .workspaceId(dbResource.getWorkspaceId())
+                    .resourceId(dbResource.getResourceId())
+                    .name(dbResource.getName().orElse(null))
+                    .description(dbResource.getDescription().orElse(null))
+                    .cloningInstructions(dbResource.getCloningInstructions())
+                    .assignedUser(dbResource.getAssignedUser().orElse(null))
+                    .privateResourceState(dbResource.getPrivateResourceState().orElse(null))
+                    .accessScope(dbResource.getAccessScope().orElse(null))
+                    .managedBy(dbResource.getManagedBy().orElse(null))
+                    .applicationId(dbResource.getApplicationId().orElse(null)))
             .build();
     resource.validate();
     return resource;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -19,6 +19,7 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -30,7 +31,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import java.util.UUID;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -69,24 +69,35 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
     validate();
   }
 
+  public ControlledBigQueryDatasetResource(
+      ControlledResourceFields common, String datasetName, String projectId) {
+    super(common);
+    this.datasetName = datasetName;
+    this.projectId = projectId;
+    validate();
+  }
+
   public static ControlledBigQueryDatasetResource.Builder builder() {
     return new ControlledBigQueryDatasetResource.Builder();
   }
 
   public Builder toBuilder() {
-    return new Builder()
-        .workspaceId(getWorkspaceId())
-        .resourceId(getResourceId())
-        .name(getName())
-        .description(getDescription())
-        .cloningInstructions(getCloningInstructions())
-        .assignedUser(getAssignedUser().orElse(null))
-        .privateResourceState(getPrivateResourceState().orElse(null))
-        .accessScope(getAccessScope())
-        .managedBy(getManagedBy())
-        .applicationId(getApplicationId())
-        .datasetName(getDatasetName())
-        .projectId(projectId);
+    ControlledResourceFields common =
+        new ControlledResourceFields()
+            .workspaceId(getWorkspaceId())
+            .resourceId(getResourceId())
+            .name(getName())
+            .description(getDescription())
+            .cloningInstructions(getCloningInstructions())
+            .assignedUser(getAssignedUser().orElse(null))
+            .accessScope(getAccessScope())
+            .privateResourceState(getPrivateResourceState().orElse(null))
+            .managedBy(getManagedBy())
+            .applicationId(getApplicationId());
+
+    Builder builder = new Builder();
+    builder.datasetName(getDatasetName()).projectId(projectId).common(common);
+    return builder;
   }
 
   /** {@inheritDoc} */
@@ -233,44 +244,17 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
   }
 
   public static class Builder {
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
-    private CloningInstructions cloningInstructions;
-    private String assignedUser;
-    // Default value is NOT_APPLICABLE for shared resources and INITIALIZING for private resources.
-    @Nullable private PrivateResourceState privateResourceState;
-    private AccessScopeType accessScope;
-    private ManagedByType managedBy;
-    private UUID applicationId;
+    private ControlledResourceFields common;
     private String datasetName;
     private String projectId;
 
-    public ControlledBigQueryDatasetResource.Builder workspaceId(UUID workspaceId) {
-      this.workspaceId = workspaceId;
+    public ControlledBigQueryDatasetResource.Builder common(ControlledResourceFields common) {
+      this.common = common;
       return this;
     }
 
-    public ControlledBigQueryDatasetResource.Builder resourceId(UUID resourceId) {
-      this.resourceId = resourceId;
-      return this;
-    }
-
-    public ControlledBigQueryDatasetResource.Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public ControlledBigQueryDatasetResource.Builder description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public ControlledBigQueryDatasetResource.Builder cloningInstructions(
-        CloningInstructions cloningInstructions) {
-      this.cloningInstructions = cloningInstructions;
-      return this;
+    public ControlledResourceFields getCommon() {
+      return common;
     }
 
     public ControlledBigQueryDatasetResource.Builder datasetName(String datasetName) {
@@ -291,51 +275,8 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
       return this;
     }
 
-    public Builder assignedUser(String assignedUser) {
-      this.assignedUser = assignedUser;
-      return this;
-    }
-
-    public Builder privateResourceState(PrivateResourceState privateResourceState) {
-      this.privateResourceState = privateResourceState;
-      return this;
-    }
-
-    private PrivateResourceState defaultPrivateResourceState() {
-      return this.accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
-          ? PrivateResourceState.INITIALIZING
-          : PrivateResourceState.NOT_APPLICABLE;
-    }
-
-    public Builder accessScope(AccessScopeType accessScope) {
-      this.accessScope = accessScope;
-      return this;
-    }
-
-    public Builder managedBy(ManagedByType managedBy) {
-      this.managedBy = managedBy;
-      return this;
-    }
-
-    public Builder applicationId(UUID applicationId) {
-      this.applicationId = applicationId;
-      return this;
-    }
-
     public ControlledBigQueryDatasetResource build() {
-      return new ControlledBigQueryDatasetResource(
-          workspaceId,
-          resourceId,
-          name,
-          description,
-          cloningInstructions,
-          assignedUser,
-          Optional.ofNullable(privateResourceState).orElse(defaultPrivateResourceState()),
-          accessScope,
-          managedBy,
-          applicationId,
-          datasetName,
-          projectId);
+      return new ControlledBigQueryDatasetResource(common, datasetName, projectId);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -69,7 +69,8 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
     validate();
   }
 
-  public ControlledBigQueryDatasetResource(
+  // Constructor for the builder
+  private ControlledBigQueryDatasetResource(
       ControlledResourceFields common, String datasetName, String projectId) {
     super(common);
     this.datasetName = datasetName;
@@ -79,25 +80,6 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
 
   public static ControlledBigQueryDatasetResource.Builder builder() {
     return new ControlledBigQueryDatasetResource.Builder();
-  }
-
-  public Builder toBuilder() {
-    ControlledResourceFields common =
-        new ControlledResourceFields()
-            .workspaceId(getWorkspaceId())
-            .resourceId(getResourceId())
-            .name(getName())
-            .description(getDescription())
-            .cloningInstructions(getCloningInstructions())
-            .assignedUser(getAssignedUser().orElse(null))
-            .accessScope(getAccessScope())
-            .privateResourceState(getPrivateResourceState().orElse(null))
-            .managedBy(getManagedBy())
-            .applicationId(getApplicationId());
-
-    Builder builder = new Builder();
-    builder.datasetName(getDatasetName()).projectId(projectId).common(common);
-    return builder;
   }
 
   /** {@inheritDoc} */
@@ -251,10 +233,6 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
     public ControlledBigQueryDatasetResource.Builder common(ControlledResourceFields common) {
       this.common = common;
       return this;
-    }
-
-    public ControlledResourceFields getCommon() {
-      return common;
     }
 
     public ControlledBigQueryDatasetResource.Builder datasetName(String datasetName) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -190,7 +190,7 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required field projectId for BigQuery dataset");
     }
-    ValidationUtils.validateBqDatasetName(getDatasetName());
+    ResourceValidationUtils.validateBqDatasetName(getDatasetName());
   }
 
   @Override
@@ -240,7 +240,7 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
         // If the user doesn't specify a dataset name, we will use the resource name by default.
         // But if the resource name is not a valid dataset name, we will need to generate a unique
         // dataset id.
-        ValidationUtils.validateBqDatasetName(datasetName);
+        ResourceValidationUtils.validateBqDatasetName(datasetName);
         this.datasetName = datasetName;
       } catch (InvalidReferenceException e) {
         this.datasetName = generateUniqueDatasetId();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -26,7 +26,6 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
             .bucketName(attributes.getBucketName())
             .common(new ControlledResourceFields(dbResource))
             .build();
-    resource.validate();
     return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -1,6 +1,8 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 
+import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 
@@ -17,6 +19,14 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
-    return new ControlledGcsBucketResource(dbResource);
+    ControlledGcsBucketAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledGcsBucketAttributes.class);
+    var resource =
+        ControlledGcsBucketResource.builder()
+            .bucketName(attributes.getBucketName())
+            .common(new ControlledResourceFields(dbResource))
+            .build();
+    resource.validate();
+    return resource;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -7,7 +7,6 @@ import bio.terra.stairway.RetryRule;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.db.DbSerDes;
-import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketAttributes;
@@ -20,6 +19,7 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -65,12 +65,15 @@ public class ControlledGcsBucketResource extends ControlledResource {
     validate();
   }
 
-  public ControlledGcsBucketResource(DbResource dbResource) {
-    super(dbResource);
-    ControlledGcsBucketAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ControlledGcsBucketAttributes.class);
-    this.bucketName = attributes.getBucketName();
+  // Constructor for the builder
+  private ControlledGcsBucketResource(ControlledResourceFields common, String bucketName) {
+    super(common);
+    this.bucketName = bucketName;
     validate();
+  }
+
+  public static ControlledGcsBucketResource.Builder builder() {
+    return new ControlledGcsBucketResource.Builder();
   }
 
   /** {@inheritDoc} */
@@ -121,27 +124,8 @@ public class ControlledGcsBucketResource extends ControlledResource {
         new DeleteGcsBucketStep(this, flightBeanBag.getCrlService()), RetryRules.cloud());
   }
 
-  public static ControlledGcsBucketResource.Builder builder() {
-    return new ControlledGcsBucketResource.Builder();
-  }
-
   private static String generateBucketName() {
     return String.format("terra_%s_bucket", UUID.randomUUID()).replace("-", "_");
-  }
-
-  public Builder toBuilder() {
-    return new Builder()
-        .workspaceId(getWorkspaceId())
-        .resourceId(getResourceId())
-        .name(getName())
-        .description(getDescription())
-        .cloningInstructions(getCloningInstructions())
-        .assignedUser(getAssignedUser().orElse(null))
-        .privateResourceState(getPrivateResourceState().orElse(null))
-        .accessScope(getAccessScope())
-        .managedBy(getManagedBy())
-        .applicationId(getApplicationId())
-        .bucketName(getBucketName());
   }
 
   public String getBucketName() {
@@ -222,43 +206,11 @@ public class ControlledGcsBucketResource extends ControlledResource {
   }
 
   public static class Builder {
-
-    private UUID workspaceId;
-    private UUID resourceId;
-    private String name;
-    private String description;
-    private CloningInstructions cloningInstructions;
-    private String assignedUser;
-    // Default value is NOT_APPLICABLE for shared resources and INITIALIZING for private resources.
-    @Nullable private PrivateResourceState privateResourceState;
-    private AccessScopeType accessScope;
-    private ManagedByType managedBy;
-    private UUID applicationId;
+    private ControlledResourceFields common;
     private String bucketName;
 
-    public ControlledGcsBucketResource.Builder workspaceId(UUID workspaceId) {
-      this.workspaceId = workspaceId;
-      return this;
-    }
-
-    public ControlledGcsBucketResource.Builder resourceId(UUID resourceId) {
-      this.resourceId = resourceId;
-      return this;
-    }
-
-    public ControlledGcsBucketResource.Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public ControlledGcsBucketResource.Builder description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public ControlledGcsBucketResource.Builder cloningInstructions(
-        CloningInstructions cloningInstructions) {
-      this.cloningInstructions = cloningInstructions;
+    public ControlledGcsBucketResource.Builder common(ControlledResourceFields common) {
+      this.common = common;
       return this;
     }
 
@@ -267,50 +219,8 @@ public class ControlledGcsBucketResource extends ControlledResource {
       return this;
     }
 
-    public Builder assignedUser(String assignedUser) {
-      this.assignedUser = assignedUser;
-      return this;
-    }
-
-    public Builder privateResourceState(PrivateResourceState privateResourceState) {
-      this.privateResourceState = privateResourceState;
-      return this;
-    }
-
-    private PrivateResourceState defaultPrivateResourceState() {
-      return this.accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
-          ? PrivateResourceState.INITIALIZING
-          : PrivateResourceState.NOT_APPLICABLE;
-    }
-
-    public Builder accessScope(AccessScopeType accessScope) {
-      this.accessScope = accessScope;
-      return this;
-    }
-
-    public Builder managedBy(ManagedByType managedBy) {
-      this.managedBy = managedBy;
-      return this;
-    }
-
-    public Builder applicationId(UUID applicationId) {
-      this.applicationId = applicationId;
-      return this;
-    }
-
     public ControlledGcsBucketResource build() {
-      return new ControlledGcsBucketResource(
-          workspaceId,
-          resourceId,
-          name,
-          description,
-          cloningInstructions,
-          assignedUser,
-          Optional.ofNullable(privateResourceState).orElse(defaultPrivateResourceState()),
-          accessScope,
-          managedBy,
-          applicationId,
-          bucketName);
+      return new ControlledGcsBucketResource(common, bucketName);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -178,7 +178,7 @@ public class ControlledGcsBucketResource extends ControlledResource {
     if (getBucketName() == null) {
       throw new MissingRequiredFieldException("Missing required field for ControlledGcsBucket.");
     }
-    ValidationUtils.validateBucketName(getBucketName());
+    ResourceValidationUtils.validateBucketName(getBucketName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
@@ -15,8 +15,10 @@ import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import java.util.Optional;
@@ -86,8 +88,8 @@ public class CopyGcsBucketDefinitionStep implements Step {
         inputParameters.get(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, UUID.class);
 
     // bucket resource for create flight
-    ControlledGcsBucketResource destinationBucketResource =
-        ControlledGcsBucketResource.builder()
+    ControlledResourceFields commonFields =
+        ControlledResourceFields.builder()
             .workspaceId(destinationWorkspaceId)
             .resourceId(UUID.randomUUID()) // random ID for new resource
             .name(resourceName)
@@ -97,9 +99,11 @@ public class CopyGcsBucketDefinitionStep implements Step {
             .accessScope(sourceBucket.getAccessScope())
             .managedBy(sourceBucket.getManagedBy())
             .applicationId(sourceBucket.getApplicationId())
-            .bucketName(bucketName)
             .privateResourceState(privateResourceState)
             .build();
+
+    ControlledGcsBucketResource destinationBucketResource =
+        ControlledGcsBucketResource.builder().bucketName(bucketName).common(commonFields).build();
 
     final ApiGcpGcsBucketCreationParameters destinationCreationParameters =
         getDestinationCreationParameters(inputParameters, workingMap);
@@ -109,8 +113,10 @@ public class CopyGcsBucketDefinitionStep implements Step {
 
     // Launch a CreateControlledResourcesFlight to make the destination bucket
     final ControlledGcsBucketResource clonedBucket =
-        controlledResourceService.createBucket(
-            destinationBucketResource, destinationCreationParameters, iamRole, userRequest);
+        controlledResourceService
+            .createControlledResourceSync(
+                destinationBucketResource, iamRole, userRequest, destinationCreationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
     workingMap.put(ControlledResourceKeys.CLONED_RESOURCE_DEFINITION, clonedBucket);
     // TODO: create new type & use it here
     final ApiCreatedControlledGcpGcsBucket apiCreatedBucket =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
@@ -118,12 +118,12 @@ public class CopyGcsBucketDefinitionStep implements Step {
                 destinationBucketResource, iamRole, userRequest, destinationCreationParameters)
             .castByEnum(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
     workingMap.put(ControlledResourceKeys.CLONED_RESOURCE_DEFINITION, clonedBucket);
-    // TODO: create new type & use it here
+
     final ApiCreatedControlledGcpGcsBucket apiCreatedBucket =
         new ApiCreatedControlledGcpGcsBucket()
             .gcpBucket(clonedBucket.toApiResource())
             .resourceId(destinationBucketResource.getResourceId());
-    // todo: bundle everything so it doesn't use API types here.
+
     final ApiClonedControlledGcpGcsBucket apiBucketResult =
         new ApiClonedControlledGcpGcsBucket()
             .effectiveCloningInstructions(cloningInstructions.toApiModel())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
@@ -15,6 +15,7 @@ import bio.terra.workspace.service.resource.controlled.ControlledResourceService
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
@@ -88,20 +89,22 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
             String.class);
     final String destinationProjectId =
         gcpCloudContextService.getRequiredGcpProject(destinationWorkspaceId);
+    final ControlledResourceFields commonFields =
+        ControlledResourceFields.builder()
+            .accessScope(sourceDataset.getAccessScope())
+            .assignedUser(sourceDataset.getAssignedUser().orElse(null))
+            .cloningInstructions(sourceDataset.getCloningInstructions())
+            .description(description)
+            .managedBy(sourceDataset.getManagedBy())
+            .name(resourceName)
+            .resourceId(UUID.randomUUID())
+            .workspaceId(destinationWorkspaceId)
+            .build();
     final ControlledBigQueryDatasetResource destinationResource =
         ControlledBigQueryDatasetResource.builder()
             .projectId(destinationProjectId)
             .datasetName(datasetName)
-            .common(
-                new ControlledResourceFields()
-                    .accessScope(sourceDataset.getAccessScope())
-                    .assignedUser(sourceDataset.getAssignedUser().orElse(null))
-                    .cloningInstructions(sourceDataset.getCloningInstructions())
-                    .description(description)
-                    .managedBy(sourceDataset.getManagedBy())
-                    .name(resourceName)
-                    .resourceId(UUID.randomUUID())
-                    .workspaceId(destinationWorkspaceId))
+            .common(commonFields)
             .build();
 
     final ApiGcpBigQueryDatasetCreationParameters creationParameters =
@@ -110,8 +113,10 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
         IamRoleUtils.getIamRoleForAccessScope(destinationResource.getAccessScope());
 
     final ControlledBigQueryDatasetResource clonedResource =
-        controlledResourceService.createBigQueryDataset(
-            destinationResource, creationParameters, iamRole, userRequest);
+        controlledResourceService
+            .createControlledResourceSync(
+                destinationResource, iamRole, userRequest, creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
 
     workingMap.put(ControlledResourceKeys.CLONED_RESOURCE_DEFINITION, clonedResource);
     final ApiClonedControlledGcpBigQueryDataset apiResult =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
@@ -89,16 +90,18 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
         gcpCloudContextService.getRequiredGcpProject(destinationWorkspaceId);
     final ControlledBigQueryDatasetResource destinationResource =
         ControlledBigQueryDatasetResource.builder()
-            .accessScope(sourceDataset.getAccessScope())
-            .assignedUser(sourceDataset.getAssignedUser().orElse(null))
-            .cloningInstructions(sourceDataset.getCloningInstructions())
-            .datasetName(datasetName)
-            .description(description)
-            .managedBy(sourceDataset.getManagedBy())
-            .name(resourceName)
-            .resourceId(UUID.randomUUID())
-            .workspaceId(destinationWorkspaceId)
             .projectId(destinationProjectId)
+            .datasetName(datasetName)
+            .common(
+                new ControlledResourceFields()
+                    .accessScope(sourceDataset.getAccessScope())
+                    .assignedUser(sourceDataset.getAssignedUser().orElse(null))
+                    .cloningInstructions(sourceDataset.getCloningInstructions())
+                    .description(description)
+                    .managedBy(sourceDataset.getManagedBy())
+                    .name(resourceName)
+                    .resourceId(UUID.randomUUID())
+                    .workspaceId(destinationWorkspaceId))
             .build();
 
     final ApiGcpBigQueryDatasetCreationParameters creationParameters =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
@@ -62,6 +62,20 @@ public abstract class ControlledResource extends WsmResource {
     this.privateResourceState = dbResource.getPrivateResourceState().orElse(null);
   }
 
+  public ControlledResource(ControlledResourceFields builder) {
+    super(
+        builder.getWorkspaceId(),
+        builder.getResourceId(),
+        builder.getName(),
+        builder.getDescription(),
+        builder.getCloningInstructions());
+    this.assignedUser = builder.getAssignedUser();
+    this.accessScope = builder.getAccessScope();
+    this.managedBy = builder.getManagedBy();
+    this.applicationId = builder.getApplicationId();
+    this.privateResourceState = builder.getPrivateResourceState();
+  }
+
   /**
    * The ResourceDao calls this method for controlled parameters. The return value describes
    * filtering the DAO should do to verify the uniqueness of the resource. If the return is not

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
@@ -56,8 +56,8 @@ public abstract class ControlledResource extends WsmResource {
       throw new InvalidMetadataException("Expected CONTROLLED");
     }
     this.assignedUser = dbResource.getAssignedUser().orElse(null);
-    this.accessScope = dbResource.getAccessScope().orElse(null);
-    this.managedBy = dbResource.getManagedBy().orElse(null);
+    this.accessScope = dbResource.getAccessScope();
+    this.managedBy = dbResource.getManagedBy();
     this.applicationId = dbResource.getApplicationId().orElse(null);
     this.privateResourceState = dbResource.getPrivateResourceState().orElse(null);
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceCategory.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceCategory.java
@@ -26,13 +26,13 @@ public enum ControlledResourceCategory {
       AccessScopeType.ACCESS_SCOPE_SHARED,
       ManagedByType.MANAGED_BY_APPLICATION,
       SamConstants.SamResource.CONTROLLED_APPLICATION_SHARED,
-      SamConstants.SamWorkspaceAction.CREATE_CONTROLLED_USER_SHARED,
+      SamConstants.SamWorkspaceAction.CREATE_CONTROLLED_APPLICATION_SHARED,
       ControlledResourceSyncMapping.APPLICATION_SHARED_MAPPING),
   APPLICATION_PRIVATE(
       AccessScopeType.ACCESS_SCOPE_PRIVATE,
       ManagedByType.MANAGED_BY_APPLICATION,
       SamConstants.SamResource.CONTROLLED_APPLICATION_PRIVATE,
-      SamConstants.SamWorkspaceAction.CREATE_CONTROLLED_USER_PRIVATE,
+      SamConstants.SamWorkspaceAction.CREATE_CONTROLLED_APPLICATION_PRIVATE,
       ControlledResourceSyncMapping.APPLICATION_PRIVATE_MAPPING);
 
   private final AccessScopeType accessScopeType;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceFields.java
@@ -1,0 +1,141 @@
+package bio.terra.workspace.service.resource.controlled.model;
+
+import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
+import java.util.Optional;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+/**
+ * ControlledResourceFields is used as a way to collect common resources for a controlled resource.
+ * That way, we can more easily add common resource parameters to all resources without visiting
+ * each implementation. Although for safe serialization, we still have to visit each @JsonCreator
+ * resource constructor and add the parameters.
+ *
+ * <p>This allows us to make controller code that processes the common parts of the API input and
+ * uses the methods in this class to populate the builder.
+ */
+public class ControlledResourceFields {
+  private UUID workspaceId;
+  private UUID resourceId;
+  private String name;
+  private String description;
+  private CloningInstructions cloningInstructions;
+  @Nullable private String assignedUser;
+  // We hold the iamRole to simplify the controller flow. It is not retained in the
+  // controlled object.
+  @Nullable private ControlledResourceIamRole iamRole;
+  // Default value is NOT_APPLICABLE for shared resources and INITIALIZING for private resources.
+  @Nullable private PrivateResourceState privateResourceState;
+  private AccessScopeType accessScope;
+  private ManagedByType managedBy;
+  private UUID applicationId;
+
+  public UUID getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public ControlledResourceFields workspaceId(UUID workspaceId) {
+    this.workspaceId = workspaceId;
+    return this;
+  }
+
+  public UUID getResourceId() {
+    return resourceId;
+  }
+
+  public ControlledResourceFields resourceId(UUID resourceId) {
+    this.resourceId = resourceId;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ControlledResourceFields name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public ControlledResourceFields description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  public CloningInstructions getCloningInstructions() {
+    return cloningInstructions;
+  }
+
+  public ControlledResourceFields cloningInstructions(CloningInstructions cloningInstructions) {
+    this.cloningInstructions = cloningInstructions;
+    return this;
+  }
+
+  @Nullable
+  public ControlledResourceIamRole getIamRole() {
+    return iamRole;
+  }
+
+  public ControlledResourceFields iamRole(@Nullable ControlledResourceIamRole iamRole) {
+    this.iamRole = iamRole;
+    return this;
+  }
+
+  @Nullable
+  public String getAssignedUser() {
+    return assignedUser;
+  }
+
+  public ControlledResourceFields assignedUser(@Nullable String assignedUser) {
+    this.assignedUser = assignedUser;
+    return this;
+  }
+
+  @Nullable
+  public PrivateResourceState getPrivateResourceState() {
+    return Optional.ofNullable(privateResourceState)
+        .orElseGet(
+            () ->
+                this.accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
+                    ? PrivateResourceState.INITIALIZING
+                    : PrivateResourceState.NOT_APPLICABLE);
+  }
+
+  public ControlledResourceFields privateResourceState(
+      @Nullable PrivateResourceState privateResourceState) {
+    this.privateResourceState = privateResourceState;
+    return this;
+  }
+
+  public AccessScopeType getAccessScope() {
+    return accessScope;
+  }
+
+  public ControlledResourceFields accessScope(AccessScopeType accessScope) {
+    this.accessScope = accessScope;
+    return this;
+  }
+
+  public ManagedByType getManagedBy() {
+    return managedBy;
+  }
+
+  public ControlledResourceFields managedBy(ManagedByType managedBy) {
+    this.managedBy = managedBy;
+    return this;
+  }
+
+  public UUID getApplicationId() {
+    return applicationId;
+  }
+
+  public ControlledResourceFields applicationId(UUID applicationId) {
+    this.applicationId = applicationId;
+    return this;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceFields.java
@@ -2,7 +2,7 @@ package bio.terra.workspace.service.resource.controlled.model;
 
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import java.util.Optional;
 import java.util.UUID;
@@ -16,6 +16,8 @@ import javax.annotation.Nullable;
  *
  * <p>This allows us to make controller code that processes the common parts of the API input and
  * uses the methods in this class to populate the builder.
+ *
+ * <p>See {@link ControlledResource} for details on the meaning of the fields
  */
 public class ControlledResourceFields {
   private final UUID workspaceId;
@@ -37,15 +39,15 @@ public class ControlledResourceFields {
   public ControlledResourceFields(DbResource dbResource) {
     workspaceId = dbResource.getWorkspaceId();
     resourceId = dbResource.getResourceId();
-    name = dbResource.getName().orElse(null);
-    description = dbResource.getDescription().orElse(null);
+    name = dbResource.getName();
+    description = dbResource.getDescription();
     cloningInstructions = dbResource.getCloningInstructions();
     assignedUser = dbResource.getAssignedUser().orElse(null);
     // This field is used on create, but not stored in the database.
     iamRole = null;
     privateResourceState = dbResource.getPrivateResourceState().orElse(null);
-    accessScope = dbResource.getAccessScope().orElse(null);
-    managedBy = dbResource.getManagedBy().orElse(null);
+    accessScope = dbResource.getAccessScope();
+    managedBy = dbResource.getManagedBy();
     applicationId = dbResource.getApplicationId().orElse(null);
   }
 
@@ -150,12 +152,12 @@ public class ControlledResourceFields {
     @Nullable private UUID applicationId;
 
     public ControlledResourceFields build() {
-      ValidationUtils.checkFieldNonNull(workspaceId, "workspaceId");
-      ValidationUtils.checkFieldNonNull(resourceId, "resourceId");
-      ValidationUtils.checkFieldNonNull(name, "name");
-      ValidationUtils.checkFieldNonNull(cloningInstructions, "cloningInstructions");
-      ValidationUtils.checkFieldNonNull(accessScope, "accessScope");
-      ValidationUtils.checkFieldNonNull(managedBy, "managedBy");
+      ResourceValidationUtils.checkFieldNonNull(workspaceId, "workspaceId");
+      ResourceValidationUtils.checkFieldNonNull(resourceId, "resourceId");
+      ResourceValidationUtils.checkFieldNonNull(name, "name");
+      ResourceValidationUtils.checkFieldNonNull(cloningInstructions, "cloningInstructions");
+      ResourceValidationUtils.checkFieldNonNull(accessScope, "accessScope");
+      ResourceValidationUtils.checkFieldNonNull(managedBy, "managedBy");
 
       return new ControlledResourceFields(
           workspaceId,

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
@@ -6,7 +6,7 @@ import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceMetadata;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.google.common.base.Strings;
@@ -52,8 +52,8 @@ public abstract class WsmResource {
     this(
         dbResource.getWorkspaceId(),
         dbResource.getResourceId(),
-        dbResource.getName().orElse(null),
-        dbResource.getDescription().orElse(null),
+        dbResource.getName(),
+        dbResource.getDescription(),
         dbResource.getCloningInstructions());
   }
 
@@ -174,9 +174,9 @@ public abstract class WsmResource {
         || getResourceId() == null) {
       throw new MissingRequiredFieldException("Missing required field for WsmResource.");
     }
-    ValidationUtils.validateResourceName(getName());
+    ResourceValidationUtils.validateResourceName(getName());
     if (getDescription() != null) {
-      ValidationUtils.validateResourceDescriptionName(getDescription());
+      ResourceValidationUtils.validateResourceDescriptionName(getDescription());
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResourceService.java
@@ -8,7 +8,7 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.job.JobBuilder;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.WorkspaceCloneUtils;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
@@ -121,10 +121,10 @@ public class ReferencedResourceService {
         userRequest, workspaceId, SamConstants.SamWorkspaceAction.UPDATE_REFERENCE);
     // Name may be null if the user is not updating it in this request.
     if (name != null) {
-      ValidationUtils.validateResourceName(name);
+      ResourceValidationUtils.validateResourceName(name);
     }
     // Description may also be null, but this validator accepts null descriptions.
-    ValidationUtils.validateResourceDescriptionName(description);
+    ResourceValidationUtils.validateResourceDescriptionName(description);
     boolean updated;
     if (resource != null) {
       JobBuilder updateJob =

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
@@ -139,7 +139,7 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
       throw new MissingRequiredFieldException(
           "Missing required field for ReferenceBigQueryDatasetAttributes.");
     }
-    ValidationUtils.validateBqDatasetName(getDatasetName());
+    ResourceValidationUtils.validateBqDatasetName(getDatasetName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
@@ -154,8 +154,8 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
       throw new MissingRequiredFieldException(
           "Missing required field for ReferenceBigQueryDataTableAttributes");
     }
-    ValidationUtils.validateBqDatasetName(getDatasetId());
-    ValidationUtils.validateBqDataTableName(getDataTableId());
+    ResourceValidationUtils.validateBqDatasetName(getDatasetId());
+    ResourceValidationUtils.validateBqDataTableName(getDataTableId());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
@@ -121,7 +121,7 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
     if (Strings.isNullOrEmpty(getBucketName())) {
       throw new MissingRequiredFieldException("Missing required field for ReferenceGcsBucket.");
     }
-    ValidationUtils.validateBucketName(getBucketName());
+    ResourceValidationUtils.validateBucketName(getBucketName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
@@ -132,8 +132,8 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
       throw new MissingRequiredFieldException(
           "Missing required field for ReferenceGcsObjectResource.");
     }
-    ValidationUtils.validateBucketName(getBucketName());
-    ValidationUtils.validateGcsObjectName(getObjectName());
+    ResourceValidationUtils.validateBucketName(getBucketName());
+    ResourceValidationUtils.validateGcsObjectName(getObjectName());
   }
 
   @Override

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -4971,3 +4971,4 @@ components:
 security:
   - bearerAuth: []
   - authorization: [openid, email, profile]
+

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -376,8 +376,8 @@ public class ControlledResourceFixtures {
    * <p>Tests should not rely on any particular value for the fields returned by this function and
    * instead override the values that they care about.
    */
-  public static ControlledAiNotebookInstanceResource.Builder makeDefaultAiNotebookInstance() {
-    return ControlledAiNotebookInstanceResource.builder()
+  public static ControlledResourceFields.Builder makeNotebookCommonFieldsBuilder() {
+    return ControlledResourceFields.builder()
         .workspaceId(UUID.randomUUID())
         .resourceId(UUID.randomUUID())
         .name("my-notebook")
@@ -385,7 +385,12 @@ public class ControlledResourceFixtures {
         .cloningInstructions(CloningInstructions.COPY_NOTHING)
         .assignedUser("myusername@mydomain.mine")
         .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
-        .managedBy(ManagedByType.MANAGED_BY_USER)
+        .managedBy(ManagedByType.MANAGED_BY_USER);
+  }
+
+  public static ControlledAiNotebookInstanceResource.Builder makeDefaultAiNotebookInstance() {
+    return ControlledAiNotebookInstanceResource.builder()
+        .common(makeNotebookCommonFieldsBuilder().build())
         .instanceId("my-instance-id")
         .location("us-east1-b")
         .projectId("my-project-id");

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -45,7 +45,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
@@ -297,35 +296,10 @@ public class ControlledResourceFixtures {
 
   private ControlledResourceFixtures() {}
 
-  /**
-   * Returns a {@link ControlledGcsBucketResource.Builder} that is ready to be built.
-   *
-   * <p>Tests should not rely on any particular value for the fields returned by this function and
-   * instead override the values that they care about.
-   */
-  public static ControlledGcsBucketResource.Builder makeDefaultControlledGcsBucketResource() {
-    UUID resourceId = UUID.randomUUID();
-    return new ControlledGcsBucketResource.Builder()
+  /** Returns a {@link ControlledResourceFields.Builder} with the fields filled in */
+  public static ControlledResourceFields.Builder makeDefaultControlledResourceFieldsBuilder() {
+    return ControlledResourceFields.builder()
         .workspaceId(UUID.randomUUID())
-        .resourceId(resourceId)
-        .name("testgcs-" + resourceId)
-        .description(RESOURCE_DESCRIPTION)
-        .cloningInstructions(CLONING_INSTRUCTIONS)
-        .assignedUser(null)
-        .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-        .managedBy(ManagedByType.MANAGED_BY_USER)
-        .bucketName(uniqueBucketName());
-  }
-
-  /**
-   * Returns a {@link ControlledResourceFields} that is ready to be includeded in a controlled
-   * resource builder.
-   */
-  public static ControlledResourceFields makeDefaultControlledResourceFields(
-      @Nullable UUID inWorkspaceId) {
-    UUID workspaceId = Optional.ofNullable(inWorkspaceId).orElse(UUID.randomUUID());
-    return new ControlledResourceFields()
-        .workspaceId(workspaceId)
         .resourceId(UUID.randomUUID())
         .name(uniqueName("test_dataset").replace("-", "_"))
         .description("how much data could a dataset set if a dataset could set data?")
@@ -333,6 +307,32 @@ public class ControlledResourceFixtures {
         .assignedUser(null)
         .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
         .managedBy(ManagedByType.MANAGED_BY_USER);
+  }
+
+  /**
+   * Returns a {@link ControlledResourceFields} that is ready to be included in a controlled
+   * resource builder.
+   */
+  public static ControlledResourceFields makeDefaultControlledResourceFields(
+      @Nullable UUID inWorkspaceId) {
+    ControlledResourceFields.Builder builder = makeDefaultControlledResourceFieldsBuilder();
+    if (inWorkspaceId != null) {
+      builder.workspaceId(inWorkspaceId);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Returns a {@link ControlledGcsBucketResource.Builder} that is ready to be built.
+   *
+   * <p>Tests should not rely on any particular value for the fields returned by this function and
+   * instead override the values that they care about.
+   */
+  public static ControlledGcsBucketResource.Builder makeDefaultControlledGcsBucketBuilder(
+      @Nullable UUID workspaceId) {
+    return new ControlledGcsBucketResource.Builder()
+        .common(makeDefaultControlledResourceFields(workspaceId))
+        .bucketName(uniqueBucketName());
   }
 
   /**
@@ -345,7 +345,7 @@ public class ControlledResourceFixtures {
     return new Builder()
         .common(makeDefaultControlledResourceFields(workspaceId))
         .projectId("my_project")
-        .datasetName("my_dataset");
+        .datasetName(uniqueDatasetId());
   }
 
   public static final ApiGcpBigQueryDatasetUpdateParameters BQ_DATASET_UPDATE_PARAMETERS_NEW =
@@ -364,6 +364,10 @@ public class ControlledResourceFixtures {
 
   public static String uniqueName(String prefix) {
     return prefix + "-" + UUID.randomUUID().toString();
+  }
+
+  public static String uniqueDatasetId() {
+    return "my_test_dataset_" + (int) (Math.floor(Math.random() * 10000));
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -1,9 +1,9 @@
 package bio.terra.workspace.common.fixtures;
 
-import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
+import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
@@ -24,8 +24,10 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.Contr
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource.Builder;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -43,7 +45,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 /** A series of static objects useful for testing controlled resources. */
 public class ControlledResourceFixtures {
@@ -314,25 +318,34 @@ public class ControlledResourceFixtures {
   }
 
   /**
-   * Returns a {@link ControlledBigQueryDatasetResource.Builder} that is ready to be built.
-   *
-   * <p>Tests should not rely on any particular value for the fields returned by this function and
-   * instead override the values that they care about.
+   * Returns a {@link ControlledResourceFields} that is ready to be includeded in a controlled
+   * resource builder.
    */
-  public static ControlledBigQueryDatasetResource.Builder
-      makeDefaultControlledBigQueryDatasetResource() {
-    UUID resourceId = UUID.randomUUID();
-    return new ControlledBigQueryDatasetResource.Builder()
-        .workspaceId(UUID.randomUUID())
-        .resourceId(resourceId)
+  public static ControlledResourceFields makeDefaultControlledResourceFields(
+      @Nullable UUID inWorkspaceId) {
+    UUID workspaceId = Optional.ofNullable(inWorkspaceId).orElse(UUID.randomUUID());
+    return new ControlledResourceFields()
+        .workspaceId(workspaceId)
+        .resourceId(UUID.randomUUID())
         .name(uniqueName("test_dataset").replace("-", "_"))
         .description("how much data could a dataset set if a dataset could set data?")
         .cloningInstructions(CLONING_INSTRUCTIONS)
         .assignedUser(null)
         .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-        .managedBy(ManagedByType.MANAGED_BY_USER)
-        .datasetName("test_dataset")
-        .projectId("my-project-id");
+        .managedBy(ManagedByType.MANAGED_BY_USER);
+  }
+
+  /**
+   * Make a bigquery builder with defaults filled in
+   *
+   * @return resource builder
+   */
+  public static ControlledBigQueryDatasetResource.Builder makeDefaultControlledBigQueryBuilder(
+      @Nullable UUID workspaceId) {
+    return new Builder()
+        .common(makeDefaultControlledResourceFields(workspaceId))
+        .projectId("my_project")
+        .datasetName("my_dataset");
   }
 
   public static final ApiGcpBigQueryDatasetUpdateParameters BQ_DATASET_UPDATE_PARAMETERS_NEW =

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -301,7 +301,7 @@ public class ControlledResourceFixtures {
     return ControlledResourceFields.builder()
         .workspaceId(UUID.randomUUID())
         .resourceId(UUID.randomUUID())
-        .name(uniqueName("test_dataset").replace("-", "_"))
+        .name(uniqueName("test_resource").replace("-", "_"))
         .description("how much data could a dataset set if a dataset could set data?")
         .cloningInstructions(CLONING_INSTRUCTIONS)
         .assignedUser(null)
@@ -322,12 +322,7 @@ public class ControlledResourceFixtures {
     return builder.build();
   }
 
-  /**
-   * Returns a {@link ControlledGcsBucketResource.Builder} that is ready to be built.
-   *
-   * <p>Tests should not rely on any particular value for the fields returned by this function and
-   * instead override the values that they care about.
-   */
+  /** Returns a {@link ControlledGcsBucketResource.Builder} that is ready to be built. */
   public static ControlledGcsBucketResource.Builder makeDefaultControlledGcsBucketBuilder(
       @Nullable UUID workspaceId) {
     return new ControlledGcsBucketResource.Builder()

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -1,0 +1,17 @@
+package bio.terra.workspace.common.fixtures;
+
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import java.util.UUID;
+
+public class WorkspaceFixtures {
+
+  public static void createGcpCloudContext(
+      WorkspaceDao workspaceDao, UUID workspaceId, String projectId) {
+    String flightId = UUID.randomUUID().toString();
+    workspaceDao.createCloudContextStart(workspaceId, CloudPlatform.GCP, flightId);
+    workspaceDao.createCloudContextFinish(
+        workspaceId, CloudPlatform.GCP, new GcpCloudContext(projectId).serialize(), flightId);
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -7,7 +7,15 @@ import java.util.UUID;
 
 public class WorkspaceFixtures {
 
-  public static void createGcpCloudContext(
+  /**
+   * This method creates the database artifact for a cloud context without actually creating
+   * anything beyond the database row.
+   *
+   * @param workspaceDao workspace DAO for the creation
+   * @param workspaceId fake workspaceId to connect the context to
+   * @param projectId fake projectId to for the context
+   */
+  public static void createGcpCloudContextInDatabase(
       WorkspaceDao workspaceDao, UUID workspaceId, String projectId) {
     String flightId = UUID.randomUUID().toString();
     workspaceDao.createCloudContextStart(workspaceId, CloudPlatform.GCP, flightId);

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -45,7 +45,7 @@ public class ResourceDaoTest extends BaseUnitTest {
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     workspaceDao.createWorkspace(workspace);
-    WorkspaceFixtures.createGcpCloudContext(
+    WorkspaceFixtures.createGcpCloudContextInDatabase(
         workspaceDao, workspace.getWorkspaceId(), "my-project-id");
     return workspace.getWorkspaceId();
   }

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -69,9 +69,7 @@ public class ResourceDaoTest extends BaseUnitTest {
   public void createGetDeleteControlledBigQueryDataset() {
     UUID workspaceId = createGcpWorkspace();
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspaceId)
-            .build();
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceId).build();
     resourceDao.createControlledResource(resource);
 
     assertEquals(
@@ -100,9 +98,7 @@ public class ResourceDaoTest extends BaseUnitTest {
             .workspaceId(workspaceId)
             .build();
     ControlledBigQueryDatasetResource dataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspaceId)
-            .build();
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceId).build();
     resourceDao.createControlledResource(bucket);
     resourceDao.createControlledResource(dataset);
 
@@ -240,29 +236,30 @@ public class ResourceDaoTest extends BaseUnitTest {
     String datasetName1 = "dataset1";
     final UUID workspaceId1 = createGcpWorkspace();
     final ControlledBigQueryDatasetResource initialResource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspaceId1)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceId1)
+            .common(ControlledResourceFixtures.makeDefaultControlledResourceFields(workspaceId1))
             .datasetName(datasetName1)
             .build();
-
     resourceDao.createControlledResource(initialResource);
 
     final UUID workspaceId2 = createGcpWorkspace();
     // This is in a different workspace (and so a different cloud context), so it is not a conflict
     // even with the same Dataset ID.
     final ControlledBigQueryDatasetResource uniqueResource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspaceId2)
-            .name("uniqueResourceName")
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceId1)
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFields(workspaceId2)
+                    .name("uniqueResourcename"))
             .datasetName(datasetName1)
             .build();
     resourceDao.createControlledResource(uniqueResource);
 
     // This is in the same workspace as initialResource, so it should be a conflict.
     final ControlledBigQueryDatasetResource duplicatingResource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspaceId1)
-            .name("differentResourceName")
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceId1)
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFields(workspaceId1)
+                    .name("differentResourceName"))
             .datasetName(datasetName1)
             .build();
 

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -15,6 +15,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.Cont
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
@@ -76,8 +77,12 @@ public class ResourceDaoTest extends BaseUnitTest {
   @Test
   public void createGetControlledAiNotebookInstance() {
     UUID workspaceId = createGcpWorkspace();
+    ControlledResourceFields commonFields =
+        ControlledResourceFixtures.makeNotebookCommonFieldsBuilder()
+            .workspaceId(workspaceId)
+            .build();
     ControlledAiNotebookInstanceResource resource =
-        ControlledResourceFixtures.makeDefaultAiNotebookInstance().workspaceId(workspaceId).build();
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance().common(commonFields).build();
     resourceDao.createControlledResource(resource);
 
     assertEquals(
@@ -146,29 +151,35 @@ public class ResourceDaoTest extends BaseUnitTest {
   @Test
   public void duplicateNotebookIsRejected() {
     final UUID workspaceId1 = createGcpWorkspace();
-    final ControlledResource initialResource =
-        ControlledResourceFixtures.makeDefaultAiNotebookInstance()
+    ControlledResourceFields commonFields1 =
+        ControlledResourceFixtures.makeNotebookCommonFieldsBuilder()
             .workspaceId(workspaceId1)
             .build();
+    ControlledAiNotebookInstanceResource initialResource =
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance().common(commonFields1).build();
     resourceDao.createControlledResource(initialResource);
     assertEquals(
         initialResource,
         resourceDao.getResource(initialResource.getWorkspaceId(), initialResource.getResourceId()));
 
-    final ControlledResource duplicatingResource =
-        ControlledResourceFixtures.makeDefaultAiNotebookInstance()
+    ControlledResourceFields commonFields2 =
+        ControlledResourceFixtures.makeNotebookCommonFieldsBuilder()
             .workspaceId(workspaceId1)
             .name("resource-2")
             .build();
+    final ControlledResource duplicatingResource =
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance().common(commonFields2).build();
     assertThrows(
         DuplicateResourceException.class,
         () -> resourceDao.createControlledResource(duplicatingResource));
 
-    final ControlledResource resourceWithDifferentWorkspaceId =
-        ControlledResourceFixtures.makeDefaultAiNotebookInstance()
+    ControlledResourceFields commonFields3 =
+        ControlledResourceFixtures.makeNotebookCommonFieldsBuilder()
             .workspaceId(createGcpWorkspace())
             .name("resource-3")
             .build();
+    final ControlledResource resourceWithDifferentWorkspaceId =
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance().common(commonFields3).build();
 
     // should be fine: separate workspaces implies separate gcp projects
     resourceDao.createControlledResource(resourceWithDifferentWorkspaceId);
@@ -179,10 +190,14 @@ public class ResourceDaoTest extends BaseUnitTest {
             resourceWithDifferentWorkspaceId.getWorkspaceId(),
             resourceWithDifferentWorkspaceId.getResourceId()));
 
-    final ControlledResource resourceWithDifferentLocation =
-        ControlledResourceFixtures.makeDefaultAiNotebookInstance()
+    ControlledResourceFields commonFields4 =
+        ControlledResourceFixtures.makeNotebookCommonFieldsBuilder()
             .workspaceId(workspaceId1)
             .name("resource-4")
+            .build();
+    final ControlledResource resourceWithDifferentLocation =
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance()
+            .common(commonFields4)
             .location("somewhere-else")
             .build();
 
@@ -194,12 +209,17 @@ public class ResourceDaoTest extends BaseUnitTest {
             resourceWithDifferentLocation.getWorkspaceId(),
             resourceWithDifferentLocation.getResourceId()));
 
-    final ControlledAiNotebookInstanceResource resourceWithDefaultLocation =
-        ControlledResourceFixtures.makeDefaultAiNotebookInstance()
+    ControlledResourceFields commonFields5 =
+        ControlledResourceFixtures.makeNotebookCommonFieldsBuilder()
             .workspaceId(workspaceId1)
             .name("resource-5")
+            .build();
+    final ControlledAiNotebookInstanceResource resourceWithDefaultLocation =
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance()
+            .common(commonFields5)
             .location(null)
             .build();
+
     resourceDao.createControlledResource(resourceWithDefaultLocation);
     assertEquals(
         resourceWithDefaultLocation,

--- a/service/src/test/java/bio/terra/workspace/serdes/ControlledGcsBucketResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/serdes/ControlledGcsBucketResourceTest.java
@@ -21,15 +21,19 @@ public class ControlledGcsBucketResourceTest extends BaseUnitTest {
     assertThrows(
         MissingRequiredFieldException.class,
         () ->
-            ControlledResourceFixtures.makeDefaultControlledGcsBucketResource()
-                .workspaceId(null)
+            ControlledGcsBucketResource.builder()
+                .bucketName(ControlledResourceFixtures.uniqueBucketName())
+                .common(
+                    ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
+                        .workspaceId(null)
+                        .build())
                 .build());
   }
 
   @Test
   public void testSerialization() throws JsonProcessingException {
     ControlledGcsBucketResource gcsBucketResource =
-        ControlledResourceFixtures.makeDefaultControlledGcsBucketResource().build();
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(null).build();
 
     final ObjectMapper objectMapper = StairwayMapper.getObjectMapper();
     final String serialized = objectMapper.writeValueAsString(gcsBucketResource);

--- a/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
@@ -21,6 +21,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.Cont
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
@@ -223,14 +224,17 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
 
       var resource =
           ControlledAiNotebookInstanceResource.builder()
-              .workspaceId(workspaceId)
-              .resourceId(resourceId)
-              .name(resourceName)
-              .description(description)
-              .cloningInstructions(cloning)
-              .assignedUser(assignedUser)
-              .accessScope(accessScopeType)
-              .managedBy(managedByType)
+              .common(
+                  ControlledResourceFields.builder()
+                      .workspaceId(workspaceId)
+                      .resourceId(resourceId)
+                      .name(resourceName)
+                      .description(description)
+                      .cloningInstructions(cloning)
+                      .assignedUser(assignedUser)
+                      .accessScope(accessScopeType)
+                      .managedBy(managedByType)
+                      .build())
               .location("us-east1-b")
               .instanceId(instanceId)
               .projectId("my-project-id")

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -30,75 +30,75 @@ public class ValidationUtilsTest extends BaseUnitTest {
           + "."
           + "012345678901234567890123456789";
 
-  ValidationUtils validationUtils;
+  ResourceValidationUtils validationUtils;
   @Autowired GitRepoReferencedResourceConfiguration gitRepoReferencedResourceConfiguration;
 
   @BeforeEach
   public void setup() {
     gitRepoReferencedResourceConfiguration.setAllowListedGitRepoHostNames(
         List.of("github.com", "gitlab.com"));
-    validationUtils = new ValidationUtils(gitRepoReferencedResourceConfiguration);
+    validationUtils = new ResourceValidationUtils(gitRepoReferencedResourceConfiguration);
   }
 
   @Test
   public void aiNotebookInstanceName() {
-    ValidationUtils.validateAiNotebookInstanceId("valid-instance-id-0");
+    ResourceValidationUtils.validateAiNotebookInstanceId("valid-instance-id-0");
     assertThrows(
         InvalidReferenceException.class,
-        () -> ValidationUtils.validateAiNotebookInstanceId("1number-first"));
+        () -> ResourceValidationUtils.validateAiNotebookInstanceId("1number-first"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ValidationUtils.validateAiNotebookInstanceId("-dash-first"));
+        () -> ResourceValidationUtils.validateAiNotebookInstanceId("-dash-first"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ValidationUtils.validateAiNotebookInstanceId("dash-last-"));
+        () -> ResourceValidationUtils.validateAiNotebookInstanceId("dash-last-"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ValidationUtils.validateAiNotebookInstanceId("white space"));
+        () -> ResourceValidationUtils.validateAiNotebookInstanceId("white space"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ValidationUtils.validateAiNotebookInstanceId("other-symbols^&)"));
+        () -> ResourceValidationUtils.validateAiNotebookInstanceId("other-symbols^&)"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ValidationUtils.validateAiNotebookInstanceId("unicode-\\u00C6"));
+        () -> ResourceValidationUtils.validateAiNotebookInstanceId("unicode-\\u00C6"));
     assertThrows(
         InvalidReferenceException.class,
         () ->
-            ValidationUtils.validateAiNotebookInstanceId(
+            ResourceValidationUtils.validateAiNotebookInstanceId(
                 "more-than-63-chars111111111111111111111111111111111111111111111111111"));
   }
 
   @Test
   public void notebookCreationParametersExactlyOneOfVmImageOrContainerImage() {
     // Nothing throws on successful validation.
-    ValidationUtils.validate(defaultNotebookCreationParameters());
+    ResourceValidationUtils.validate(defaultNotebookCreationParameters());
 
     // Neither vmImage nor containerImage.
     assertThrows(
         InconsistentFieldsException.class,
         () ->
-            ValidationUtils.validate(
+            ResourceValidationUtils.validate(
                 defaultNotebookCreationParameters().containerImage(null).vmImage(null)));
     // Both vmImage and containerImage.
     assertThrows(
         InconsistentFieldsException.class,
         () ->
-            ValidationUtils.validate(
+            ResourceValidationUtils.validate(
                 defaultNotebookCreationParameters()
                     .containerImage(new ApiGcpAiNotebookInstanceContainerImage())
                     .vmImage(new ApiGcpAiNotebookInstanceVmImage())));
     // Valid containerImage.
-    ValidationUtils.validate(
+    ResourceValidationUtils.validate(
         defaultNotebookCreationParameters()
             .vmImage(null)
             .containerImage(
                 new ApiGcpAiNotebookInstanceContainerImage().repository("my-repository")));
     // Valid vmImage.
-    ValidationUtils.validate(
+    ResourceValidationUtils.validate(
         defaultNotebookCreationParameters()
             .vmImage(new ApiGcpAiNotebookInstanceVmImage().imageName("image-name"))
             .containerImage(null));
-    ValidationUtils.validate(
+    ResourceValidationUtils.validate(
         defaultNotebookCreationParameters()
             .vmImage(new ApiGcpAiNotebookInstanceVmImage().imageFamily("image-family"))
             .containerImage(null));
@@ -106,7 +106,7 @@ public class ValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InconsistentFieldsException.class,
         () ->
-            ValidationUtils.validate(
+            ResourceValidationUtils.validate(
                 defaultNotebookCreationParameters()
                     .vmImage(new ApiGcpAiNotebookInstanceVmImage())
                     .containerImage(null)));
@@ -114,7 +114,7 @@ public class ValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InconsistentFieldsException.class,
         () ->
-            ValidationUtils.validate(
+            ResourceValidationUtils.validate(
                 defaultNotebookCreationParameters()
                     .vmImage(
                         new ApiGcpAiNotebookInstanceVmImage()
@@ -126,63 +126,69 @@ public class ValidationUtilsTest extends BaseUnitTest {
   @Test
   public void validateBucketName_nameHas64Character_throwsException() {
     assertThrows(
-        InvalidNameException.class, () -> ValidationUtils.validateBucketName(INVALID_STRING));
+        InvalidNameException.class,
+        () -> ResourceValidationUtils.validateBucketName(INVALID_STRING));
   }
 
   @Test
   public void validateBucketName_nameHas63Character_OK() {
-    ValidationUtils.validateBucketName(MAX_VALID_STRING);
+    ResourceValidationUtils.validateBucketName(MAX_VALID_STRING);
   }
 
   @Test
   public void validateBucketName_nameHas2Character_throwsException() {
-    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateBucketName("aa"));
+    assertThrows(
+        InvalidNameException.class, () -> ResourceValidationUtils.validateBucketName("aa"));
   }
 
   @Test
   public void validateBucketName_nameHas3Character_OK() {
-    ValidationUtils.validateBucketName("123");
+    ResourceValidationUtils.validateBucketName("123");
   }
 
   @Test
   public void validateBucketName_nameHas222CharacterWithDotSeparator_OK() {
-    ValidationUtils.validateBucketName(MAX_VALID_STRING_WITH_DOTS);
+    ResourceValidationUtils.validateBucketName(MAX_VALID_STRING_WITH_DOTS);
   }
 
   @Test
   public void validateBucketName_nameWithDotSeparatorButOneSubstringExceedsLimit_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ValidationUtils.validateBucketName(INVALID_STRING + "." + MAX_VALID_STRING));
+        () -> ResourceValidationUtils.validateBucketName(INVALID_STRING + "." + MAX_VALID_STRING));
   }
 
   @Test
   public void validateBucketName_nameStartAndEndWithNumber_OK() {
-    ValidationUtils.validateBucketName("1-bucket-1");
+    ResourceValidationUtils.validateBucketName("1-bucket-1");
   }
 
   @Test
   public void validateBucketName_nameStartAndEndWithDot_throwsException() {
     assertThrows(
-        InvalidNameException.class, () -> ValidationUtils.validateBucketName(".bucket-name."));
+        InvalidNameException.class,
+        () -> ResourceValidationUtils.validateBucketName(".bucket-name."));
   }
 
   @Test
   public void validateBucketName_nameWithGoogPrefix_throwsException() {
     assertThrows(
-        InvalidNameException.class, () -> ValidationUtils.validateBucketName("goog-bucket-name1"));
+        InvalidNameException.class,
+        () -> ResourceValidationUtils.validateBucketName("goog-bucket-name1"));
   }
 
   @Test
   public void validateBucketName_nameContainsGoogle_throwsException() {
     assertThrows(
-        InvalidNameException.class, () -> ValidationUtils.validateBucketName("bucket-google-name"));
+        InvalidNameException.class,
+        () -> ResourceValidationUtils.validateBucketName("bucket-google-name"));
   }
 
   @Test
   public void validateBucketName_nameContainsG00gle_throwsException() {
     assertThrows(
-        InvalidNameException.class, () -> ValidationUtils.validateBucketName("bucket-g00gle-name"));
+        InvalidNameException.class,
+        () -> ResourceValidationUtils.validateBucketName("bucket-g00gle-name"));
   }
 
   @Test
@@ -193,7 +199,7 @@ public class ValidationUtilsTest extends BaseUnitTest {
     }
     assertThrows(
         InvalidNameException.class,
-        () -> ValidationUtils.validateResourceDescriptionName(sb.toString()));
+        () -> ResourceValidationUtils.validateResourceDescriptionName(sb.toString()));
   }
 
   @Test
@@ -202,24 +208,27 @@ public class ValidationUtilsTest extends BaseUnitTest {
     for (int i = 0; i < 2048; i++) {
       sb.append("a");
     }
-    ValidationUtils.validateResourceDescriptionName(sb.toString());
+    ResourceValidationUtils.validateResourceDescriptionName(sb.toString());
   }
 
   @Test
   public void validateBucketFileName_disallowName_throwException() {
-    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateGcsObjectName("."));
+    assertThrows(
+        InvalidNameException.class, () -> ResourceValidationUtils.validateGcsObjectName("."));
   }
 
   @Test
   public void validateBucketFileName_emptyOrNullString_throwsException() {
-    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateGcsObjectName(""));
+    assertThrows(
+        InvalidNameException.class, () -> ResourceValidationUtils.validateGcsObjectName(""));
   }
 
   @Test
   public void validateBucketFileName_startsWithAcmeChallengePrefix_throwsException() {
     String file = ".well-known/acme-challenge/hello.txt";
 
-    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateGcsObjectName(file));
+    assertThrows(
+        InvalidNameException.class, () -> ResourceValidationUtils.validateGcsObjectName(file));
   }
 
   @Test
@@ -227,31 +236,33 @@ public class ValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InvalidNameException.class,
         () ->
-            ValidationUtils.validateGcsObjectName(
+            ResourceValidationUtils.validateGcsObjectName(
                 RandomStringUtils.random(1025, /*letters=*/ true, /*numbers=*/ true)));
   }
 
   @Test
   public void validateBucketFileName_legalFileName_validate() {
-    ValidationUtils.validateGcsObjectName("hello.txt");
-    ValidationUtils.validateGcsObjectName(
+    ResourceValidationUtils.validateGcsObjectName("hello.txt");
+    ResourceValidationUtils.validateGcsObjectName(
         RandomStringUtils.random(1024, /*letters=*/ true, /*numbers=*/ true));
-    ValidationUtils.validateGcsObjectName("你好.png");
+    ResourceValidationUtils.validateGcsObjectName("你好.png");
   }
 
   @Test
   public void validateBqDataTableName() {
-    ValidationUtils.validateBqDataTableName("00_お客様");
-    ValidationUtils.validateBqDataTableName("table 01");
-    ValidationUtils.validateBqDataTableName("ग्राहक");
-    ValidationUtils.validateBqDataTableName("étudiant-01");
+    ResourceValidationUtils.validateBqDataTableName("00_お客様");
+    ResourceValidationUtils.validateBqDataTableName("table 01");
+    ResourceValidationUtils.validateBqDataTableName("ग्राहक");
+    ResourceValidationUtils.validateBqDataTableName("étudiant-01");
   }
 
   @Test
   public void validateBqDataTableName_invalidName_throwsException() {
     assertThrows(
-        InvalidNameException.class, () -> ValidationUtils.validateBqDataTableName("00_お客様*"));
-    assertThrows(InvalidNameException.class, () -> ValidationUtils.validateBqDataTableName(""));
+        InvalidNameException.class,
+        () -> ResourceValidationUtils.validateBqDataTableName("00_お客様*"));
+    assertThrows(
+        InvalidNameException.class, () -> ResourceValidationUtils.validateBqDataTableName(""));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -548,8 +548,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .build();
 
     ControlledBigQueryDatasetResource createdDataset =
-        controlledResourceService.createBigQueryDataset(
-            resource, creationParameters, null, user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                resource, null, user.getAuthenticatedRequest(), creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
     assertEquals(resource, createdDataset);
 
     ControlledBigQueryDatasetResource fetchedDataset =
@@ -609,7 +611,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createBqDatasetDo() throws Exception {
-    String datasetId = uniqueDatasetId();
+    String datasetId = ControlledResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
     Integer defaultTableLifetimeSec = 5900;
     Integer defaultPartitionLifetimeSec = 5901;
@@ -630,8 +632,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     jobService.setFlightDebugInfoForTest(
         FlightDebugInfo.newBuilder().doStepFailures(retrySteps).build());
     ControlledBigQueryDatasetResource createdDataset =
-        controlledResourceService.createBigQueryDataset(
-            resource, creationParameters, null, user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                resource, null, user.getAuthenticatedRequest(), creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
     assertEquals(resource, createdDataset);
 
     BigQueryCow bqCow = crlService.createWsmSaBigQueryCow();
@@ -656,7 +660,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createBqDatasetUndo() throws Exception {
-    String datasetId = uniqueDatasetId();
+    String datasetId = ControlledResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
 
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
@@ -682,8 +686,8 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     assertThrows(
         InvalidResultStateException.class,
         () ->
-            controlledResourceService.createBigQueryDataset(
-                resource, creationParameters, null, user.getAuthenticatedRequest()));
+            controlledResourceService.createControlledResourceSync(
+                resource, null, user.getAuthenticatedRequest(), creationParameters));
 
     BigQueryCow bqCow = crlService.createWsmSaBigQueryCow();
     GoogleJsonResponseException getException =
@@ -704,7 +708,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void deleteBqDatasetDo() throws Exception {
-    String datasetId = uniqueDatasetId();
+    String datasetId = ControlledResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
 
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
@@ -715,8 +719,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .build();
 
     ControlledBigQueryDatasetResource createdDataset =
-        controlledResourceService.createBigQueryDataset(
-            resource, creationParameters, null, user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                resource, null, user.getAuthenticatedRequest(), creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
     assertEquals(resource, createdDataset);
 
     // Test idempotency of delete by retrying steps once.
@@ -749,7 +755,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void deleteBqDatasetUndo() throws Exception {
-    String datasetId = uniqueDatasetId();
+    String datasetId = ControlledResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
 
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
@@ -760,8 +766,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .build();
 
     ControlledBigQueryDatasetResource createdDataset =
-        controlledResourceService.createBigQueryDataset(
-            resource, creationParameters, null, user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                resource, null, user.getAuthenticatedRequest(), creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
     assertEquals(resource, createdDataset);
 
     // None of the steps on this flight are undoable, so even with lastStepFailure set to true we
@@ -797,7 +805,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void updateBqDatasetDo() throws Exception {
     // create the dataset
-    String datasetId = uniqueDatasetId();
+    String datasetId = ControlledResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
         new ApiGcpBigQueryDatasetCreationParameters().datasetId(datasetId).location(location);
@@ -807,8 +815,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .build();
 
     ControlledBigQueryDatasetResource createdDataset =
-        controlledResourceService.createBigQueryDataset(
-            resource, creationParameters, null, user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                resource, null, user.getAuthenticatedRequest(), creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
     assertEquals(resource, createdDataset);
 
     // Test idempotency of dataset-specific steps by retrying them once.
@@ -856,7 +866,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void updateBqDatasetUndo() throws Exception {
     // create the dataset
-    String datasetId = uniqueDatasetId();
+    String datasetId = ControlledResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
     Integer initialDefaultTableLifetime = 4800;
     Integer initialDefaultPartitionLifetime = 4801;
@@ -871,8 +881,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .datasetName(datasetId)
             .build();
     ControlledBigQueryDatasetResource createdDataset =
-        controlledResourceService.createBigQueryDataset(
-            resource, creationParameters, null, user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                resource, null, user.getAuthenticatedRequest(), creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
     assertEquals(resource, createdDataset);
 
     // Test idempotency of dataset-specific steps by retrying them once.
@@ -931,7 +943,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void updateBqDatasetWithUndefinedExpirationTimes() throws Exception {
     // create the dataset, with expiration times initially defined
-    String datasetId = uniqueDatasetId();
+    String datasetId = ControlledResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
     Integer initialDefaultTableLifetime = 4800;
     Integer initialDefaultPartitionLifetime = 4801;
@@ -946,8 +958,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .datasetName(datasetId)
             .build();
     ControlledBigQueryDatasetResource createdDataset =
-        controlledResourceService.createBigQueryDataset(
-            resource, creationParameters, null, user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                resource, null, user.getAuthenticatedRequest(), creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
 
     // check the expiration times stored on the cloud are defined
     validateBigQueryDatasetCloudMetadata(
@@ -1001,7 +1015,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void updateBqDatasetWithInvalidExpirationTimes() throws Exception {
     // create the dataset, with expiration times initially undefined
-    String datasetId = uniqueDatasetId();
+    String datasetId = ControlledResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
         new ApiGcpBigQueryDatasetCreationParameters().datasetId(datasetId).location(location);
@@ -1011,8 +1025,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .build();
 
     ControlledBigQueryDatasetResource createdDataset =
-        controlledResourceService.createBigQueryDataset(
-            resource, creationParameters, null, user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                resource, null, user.getAuthenticatedRequest(), creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
 
     // make an update request to set the table expiration time to an invalid value (<3600)
     final ApiGcpBigQueryDatasetUpdateParameters updateParameters =
@@ -1051,10 +1067,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createGcsBucketDo() throws Exception {
     ControlledGcsBucketResource resource =
-        ControlledResourceFixtures.makeDefaultControlledGcsBucketResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspace.getWorkspaceId())
             .build();
 
     // Test idempotency of bucket-specific steps by retrying them once.
@@ -1064,11 +1077,13 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     jobService.setFlightDebugInfoForTest(
         FlightDebugInfo.newBuilder().doStepFailures(retrySteps).build());
     ControlledGcsBucketResource createdBucket =
-        controlledResourceService.createBucket(
-            resource,
-            ControlledResourceFixtures.getGoogleBucketCreationParameters(),
-            null,
-            user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                resource,
+                null,
+                user.getAuthenticatedRequest(),
+                ControlledResourceFixtures.getGoogleBucketCreationParameters())
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
     assertEquals(resource, createdBucket);
 
     StorageCow storageCow = crlService.createStorageCow(projectId);
@@ -1084,31 +1099,25 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createGcsBucketDo_invalidBucketName_throwsBadRequestException() throws Exception {
     ControlledGcsBucketResource resource =
-        ControlledResourceFixtures.makeDefaultControlledGcsBucketResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspace.getWorkspaceId())
             .bucketName("192.168.5.4")
             .build();
 
     assertThrows(
         BadRequestException.class,
         () ->
-            controlledResourceService.createBucket(
+            controlledResourceService.createControlledResourceSync(
                 resource,
-                ControlledResourceFixtures.getGoogleBucketCreationParameters(),
                 null,
-                user.getAuthenticatedRequest()));
+                user.getAuthenticatedRequest(),
+                ControlledResourceFixtures.getGoogleBucketCreationParameters()));
   }
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createGcsBucketUndo() throws Exception {
     ControlledGcsBucketResource resource =
-        ControlledResourceFixtures.makeDefaultControlledGcsBucketResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspace.getWorkspaceId())
             .build();
 
     // Test idempotency of bucket-specific undo steps by retrying them once. Fail at the end of
@@ -1124,11 +1133,11 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     assertThrows(
         InvalidResultStateException.class,
         () ->
-            controlledResourceService.createBucket(
+            controlledResourceService.createControlledResourceSync(
                 resource,
-                ControlledResourceFixtures.getGoogleBucketCreationParameters(),
                 null,
-                user.getAuthenticatedRequest()));
+                user.getAuthenticatedRequest(),
+                ControlledResourceFixtures.getGoogleBucketCreationParameters()));
 
     // Validate the bucket does not exist.
     StorageCow storageCow = crlService.createStorageCow(projectId);
@@ -1278,18 +1287,17 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   private ControlledGcsBucketResource createDefaultSharedGcsBucket(
       Workspace workspace, UserAccessUtils.TestUser user) {
     ControlledGcsBucketResource originalResource =
-        ControlledResourceFixtures.makeDefaultControlledGcsBucketResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspace.getWorkspaceId())
             .build();
 
     ControlledGcsBucketResource createdBucket =
-        controlledResourceService.createBucket(
-            originalResource,
-            ControlledResourceFixtures.getGoogleBucketCreationParameters(),
-            null,
-            user.getAuthenticatedRequest());
+        controlledResourceService
+            .createControlledResourceSync(
+                originalResource,
+                null,
+                user.getAuthenticatedRequest(),
+                ControlledResourceFixtures.getGoogleBucketCreationParameters())
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
     assertEquals(originalResource, createdBucket);
     return createdBucket;
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -339,13 +339,14 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createAiNotebookInstanceUndo() throws Exception {
     String instanceId = "create-ai-notebook-instance-undo";
+    String name = "create-ai-notebook-instance-undo-name";
 
     ApiGcpAiNotebookInstanceCreationParameters creationParameters =
         ControlledResourceFixtures.defaultNotebookCreationParameters()
             .instanceId(instanceId)
             .location(DEFAULT_NOTEBOOK_LOCATION);
     ControlledAiNotebookInstanceResource resource =
-        makeNotebookTestResource(workspace.getWorkspaceId(), instanceId, instanceId);
+        makeNotebookTestResource(workspace.getWorkspaceId(), name, instanceId);
 
     // Test idempotency of undo steps by retrying them once.
     Map<String, StepStatus> retrySteps = new HashMap<>();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -543,12 +543,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
         new ApiGcpBigQueryDatasetCreationParameters().datasetId(datasetId).location(location);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
             .datasetName(datasetId)
             .build();
+
     ControlledBigQueryDatasetResource createdDataset =
         controlledResourceService.createBigQueryDataset(
             resource, creationParameters, null, user.getAuthenticatedRequest());
@@ -622,10 +620,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .defaultTableLifetime(defaultTableLifetimeSec)
             .defaultPartitionLifetime(defaultPartitionLifetimeSec);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
             .datasetName(datasetId)
             .build();
 
@@ -667,10 +662,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
         new ApiGcpBigQueryDatasetCreationParameters().datasetId(datasetId).location(location);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
             .datasetName(datasetId)
             .build();
 
@@ -718,10 +710,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
         new ApiGcpBigQueryDatasetCreationParameters().datasetId(datasetId).location(location);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
             .datasetName(datasetId)
             .build();
 
@@ -766,10 +755,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
         new ApiGcpBigQueryDatasetCreationParameters().datasetId(datasetId).location(location);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
             .datasetName(datasetId)
             .build();
 
@@ -816,12 +802,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
         new ApiGcpBigQueryDatasetCreationParameters().datasetId(datasetId).location(location);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
             .datasetName(datasetId)
             .build();
+
     ControlledBigQueryDatasetResource createdDataset =
         controlledResourceService.createBigQueryDataset(
             resource, creationParameters, null, user.getAuthenticatedRequest());
@@ -883,10 +867,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .defaultTableLifetime(initialDefaultTableLifetime)
             .defaultPartitionLifetime(initialDefaultPartitionLifetime);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
             .datasetName(datasetId)
             .build();
     ControlledBigQueryDatasetResource createdDataset =
@@ -961,10 +942,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .defaultTableLifetime(initialDefaultTableLifetime)
             .defaultPartitionLifetime(initialDefaultPartitionLifetime);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
             .datasetName(datasetId)
             .build();
     ControlledBigQueryDatasetResource createdDataset =
@@ -1028,12 +1006,10 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     ApiGcpBigQueryDatasetCreationParameters creationParameters =
         new ApiGcpBigQueryDatasetCreationParameters().datasetId(datasetId).location(location);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
             .datasetName(datasetId)
             .build();
+
     ControlledBigQueryDatasetResource createdDataset =
         controlledResourceService.createBigQueryDataset(
             resource, creationParameters, null, user.getAuthenticatedRequest());

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -133,7 +133,7 @@ public class AzureDisabledTest extends BaseConnectedTest {
     assertThrows(
         FeatureNotSupportedException.class,
         () ->
-            controlledResourceService.createVm(
+            controlledResourceService.createAzureVm(
                 vmResource, vmCreationParameters, null, null, null, userRequest));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -6,12 +6,10 @@ import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.exception.FeatureNotSupportedException;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
-import bio.terra.workspace.generated.model.ApiAccessScope;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
-import bio.terra.workspace.generated.model.ApiManagedBy;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
@@ -19,9 +17,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.Controll
 import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
-import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
-import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
-import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
@@ -67,15 +63,12 @@ public class AzureDisabledTest extends BaseConnectedTest {
     final ApiAzureIpCreationParameters ipCreationParameters =
         ControlledResourceFixtures.getAzureIpCreationParameters();
 
+    ControlledResourceFields commonFields =
+        ControlledResourceFixtures.makeDefaultControlledResourceFields(workspaceId);
+
     ControlledAzureIpResource ipResource =
         ControlledAzureIpResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(uuid)
-            .name(getAzureName("ip"))
-            .description(getAzureName("ip-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(commonFields)
             .ipName(ipCreationParameters.getName())
             .region(ipCreationParameters.getRegion())
             .build();
@@ -83,21 +76,15 @@ public class AzureDisabledTest extends BaseConnectedTest {
     assertThrows(
         FeatureNotSupportedException.class,
         () ->
-            controlledResourceService.createIp(
-                ipResource, ipCreationParameters, null, userRequest));
+            controlledResourceService.createControlledResourceSync(
+                ipResource, null, userRequest, ipCreationParameters));
 
     final ApiAzureDiskCreationParameters diskCreationParameters =
         ControlledResourceFixtures.getAzureDiskCreationParameters();
 
     ControlledAzureDiskResource diskResource =
         ControlledAzureDiskResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(uuid)
-            .name(getAzureName("disk"))
-            .description(getAzureName("disk-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(commonFields)
             .diskName(diskCreationParameters.getName())
             .region(diskCreationParameters.getRegion())
             .size(diskCreationParameters.getSize())
@@ -106,21 +93,15 @@ public class AzureDisabledTest extends BaseConnectedTest {
     assertThrows(
         FeatureNotSupportedException.class,
         () ->
-            controlledResourceService.createDisk(
-                diskResource, diskCreationParameters, null, userRequest));
+            controlledResourceService.createControlledResourceSync(
+                diskResource, null, userRequest, diskCreationParameters));
 
     final ApiAzureNetworkCreationParameters networkCreationParameters =
         ControlledResourceFixtures.getAzureNetworkCreationParameters();
 
     ControlledAzureNetworkResource networkResource =
         ControlledAzureNetworkResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(uuid)
-            .name(getAzureName("network"))
-            .description(getAzureName("network-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(commonFields)
             .networkName(networkCreationParameters.getName())
             .region(networkCreationParameters.getRegion())
             .subnetName(networkCreationParameters.getSubnetName())
@@ -131,21 +112,15 @@ public class AzureDisabledTest extends BaseConnectedTest {
     assertThrows(
         FeatureNotSupportedException.class,
         () ->
-            controlledResourceService.createNetwork(
-                networkResource, networkCreationParameters, null, userRequest));
+            controlledResourceService.createControlledResourceSync(
+                networkResource, null, userRequest, networkCreationParameters));
 
     final ApiAzureVmCreationParameters vmCreationParameters =
         ControlledResourceFixtures.getAzureVmCreationParameters();
 
     ControlledAzureVmResource vmResource =
         ControlledAzureVmResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(uuid)
-            .name(getAzureName("vm"))
-            .description(getAzureName("vm-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(commonFields)
             .vmName(vmCreationParameters.getName())
             .vmSize(vmCreationParameters.getVmSize())
             .vmImageUri(vmCreationParameters.getVmImageUri())

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -30,6 +30,7 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResource;
@@ -79,13 +80,16 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureIpResource resource =
         ControlledAzureIpResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(resourceId)
-            .name(getAzureName("ip"))
-            .description(getAzureName("ip-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name(getAzureName("ip"))
+                    .description(getAzureName("ip-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
             .ipName(creationParameters.getName())
             .region(creationParameters.getRegion())
             .build();
@@ -139,13 +143,16 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureDiskResource resource =
         ControlledAzureDiskResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(resourceId)
-            .name(getAzureName("disk"))
-            .description(getAzureName("disk-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name(getAzureName("disk"))
+                    .description(getAzureName("disk-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
             .diskName(creationParameters.getName())
             .region(creationParameters.getRegion())
             .size(creationParameters.getSize())
@@ -211,13 +218,16 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureVmResource resource =
         ControlledAzureVmResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(resourceId)
-            .name(getAzureName("vm"))
-            .description(getAzureName("vm-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name(getAzureName("vm"))
+                    .description(getAzureName("vm-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
             .vmName(creationParameters.getName())
             .vmSize(creationParameters.getVmSize())
             .vmImageUri(creationParameters.getVmImageUri())
@@ -330,13 +340,16 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureDiskResource resource =
         ControlledAzureDiskResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(resourceId)
-            .name(getAzureName("disk"))
-            .description(getAzureName("disk-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name(getAzureName("disk"))
+                    .description(getAzureName("disk-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
             .diskName(creationParameters.getName())
             .region(creationParameters.getRegion())
             .size(creationParameters.getSize())
@@ -365,13 +378,16 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureIpResource resource =
         ControlledAzureIpResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(resourceId)
-            .name(getAzureName("ip"))
-            .description(getAzureName("ip-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name(getAzureName("ip"))
+                    .description(getAzureName("ip-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
             .ipName(ipCreationParameters.getName())
             .region(ipCreationParameters.getRegion())
             .build();
@@ -400,13 +416,16 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureNetworkResource resource =
         ControlledAzureNetworkResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(resourceId)
-            .name(getAzureName("network"))
-            .description(getAzureName("network-desc"))
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name(getAzureName("network"))
+                    .description(getAzureName("network-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
             .networkName(creationParameters.getName())
             .region(creationParameters.getRegion())
             .subnetName(creationParameters.getSubnetName())
@@ -458,13 +477,16 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
     final UUID resourceId = UUID.randomUUID();
     ControlledAzureNetworkResource resource =
         ControlledAzureNetworkResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(resourceId)
-            .name("testNetwork")
-            .description("testDesc")
-            .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-            .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-            .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceId(workspaceId)
+                    .resourceId(resourceId)
+                    .name("testNetwork")
+                    .description("testDesc")
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
             .networkName(creationParams.getName())
             .region(creationParams.getRegion())
             .subnetName(creationParams.getSubnetName())

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResourceTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import org.junit.jupiter.api.Test;
 
 public class ControlledAiNotebookInstanceResourceTest extends BaseUnitTest {
@@ -33,11 +34,19 @@ public class ControlledAiNotebookInstanceResourceTest extends BaseUnitTest {
 
   @Test
   public void validateSharedAccessThrows() {
+    ControlledResourceFields commonFields =
+        ControlledResourceFixtures.makeNotebookCommonFieldsBuilder()
+            .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
+            .build();
+
     assertThrows(
         BadRequestException.class,
         () ->
-            ControlledResourceFixtures.makeDefaultAiNotebookInstance()
-                .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
+            ControlledAiNotebookInstanceResource.builder()
+                .common(commonFields)
+                .instanceId("an-instance")
+                .location("us-east1-b")
+                .projectId("a-projecct-id")
                 .build());
   }
 
@@ -108,14 +117,12 @@ public class ControlledAiNotebookInstanceResourceTest extends BaseUnitTest {
   public void toApiResource() {
     ControlledAiNotebookInstanceResource resource =
         ControlledResourceFixtures.makeDefaultAiNotebookInstance()
-            .name("my-notebook")
             .instanceId("my-instance-id")
             .location("us-east1-b")
             .projectId("my-project-id")
             .build();
 
     ApiGcpAiNotebookInstanceResource apiResource = resource.toApiResource();
-    assertEquals("my-notebook", apiResource.getMetadata().getName());
     assertEquals("my-project-id", apiResource.getAttributes().getProjectId());
     assertEquals("us-east1-b", apiResource.getAttributes().getLocation());
     assertEquals("my-instance-id", apiResource.getAttributes().getInstanceId());

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/UpdateBigQueryDatasetStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/UpdateBigQueryDatasetStepTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.BQ_DATASET_UPDATE_PARAMETERS_NEW;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.BQ_DATASET_UPDATE_PARAMETERS_PREV;
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,6 +16,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetUpdateParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
@@ -70,7 +70,8 @@ public class UpdateBigQueryDatasetStepTest extends BaseUnitTest {
             eq(mockBigQueryCow), eq(PROJECT_ID), any(String.class), datasetCaptor.capture());
 
     final ControlledBigQueryDatasetResource datasetResource =
-        makeDefaultControlledBigQueryDatasetResource().build();
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(null).build();
+
     doReturn(PROJECT_ID)
         .when(mockGcpCloudContextService)
         .getRequiredGcpProject(datasetResource.getWorkspaceId());

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/UpdateGcsBucketStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/UpdateGcsBucketStepTest.java
@@ -4,7 +4,6 @@ import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.BUC
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.BUCKET_UPDATE_PARAMETERS_2;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.OFFSET_DATE_TIME_1;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.OFFSET_DATE_TIME_2;
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledGcsBucketResource;
 import static bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.GcsApiConversions.toGoogleDateTime;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -22,6 +21,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
@@ -81,7 +81,7 @@ public class UpdateGcsBucketStepTest extends BaseUnitTest {
     doReturn(mockBuiltBucketCow).when(mockBuiltBucketCow).update();
     doReturn(mockBucketCowBuilder).when(mockBuiltBucketCow).toBuilder();
     final ControlledGcsBucketResource bucketResource =
-        makeDefaultControlledGcsBucketResource().build();
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(null).build();
     doReturn(PROJECT_ID)
         .when(mockGcpCloudContextService)
         .getRequiredGcpProject(bucketResource.getWorkspaceId());

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
@@ -51,9 +51,7 @@ public class StoreControlledResourceMetadataStepTest extends BaseUnitTest {
 
     // Stub the flight map as of this step
     ControlledGcsBucketResource bucketResource =
-        ControlledResourceFixtures.makeDefaultControlledGcsBucketResource()
-            .workspaceId(workspaceId)
-            .build();
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceId).build();
 
     final FlightMap inputFlightMap = new FlightMap();
     inputFlightMap.put(ResourceKeys.RESOURCE, bucketResource);

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferenceValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferenceValidationUtilsTest.java
@@ -3,7 +3,7 @@ package bio.terra.workspace.service.resource.referenced;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.workspace.common.BaseUnitTest;
-import bio.terra.workspace.service.resource.ValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.exception.InvalidNameException;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import org.junit.jupiter.api.Test;
@@ -13,23 +13,24 @@ public class ReferenceValidationUtilsTest extends BaseUnitTest {
   @Test
   public void testInvalidCharInBucketName() {
     assertThrows(
-        InvalidNameException.class, () -> ValidationUtils.validateBucketName("INVALIDBUCKETNAME"));
+        InvalidNameException.class,
+        () -> ResourceValidationUtils.validateBucketName("INVALIDBUCKETNAME"));
   }
 
   @Test
   public void validBucketNameOk() {
-    ValidationUtils.validateBucketName("valid-bucket_name.1");
+    ResourceValidationUtils.validateBucketName("valid-bucket_name.1");
   }
 
   @Test
   public void testInvalidCharInBqDatasetName() {
     assertThrows(
         InvalidReferenceException.class,
-        () -> ValidationUtils.validateBqDatasetName("invalid-name-for-dataset"));
+        () -> ResourceValidationUtils.validateBqDatasetName("invalid-name-for-dataset"));
   }
 
   @Test
   public void validBqDatasetNameOk() {
-    ValidationUtils.validateBqDatasetName("valid_bigquery_name_1");
+    ResourceValidationUtils.validateBqDatasetName("valid_bigquery_name_1");
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -27,6 +27,7 @@ import bio.terra.workspace.service.job.JobService.AsyncJobResult;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
@@ -190,13 +191,15 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
       UUID workspaceId, String datasetName, String projectId) {
     ControlledBigQueryDatasetResource datasetToCreate =
         ControlledBigQueryDatasetResource.builder()
-            .workspaceId(workspaceId)
-            .resourceId(UUID.randomUUID())
-            .name(datasetName)
-            .cloningInstructions(CloningInstructions.COPY_NOTHING)
-            .assignedUser(userAccessUtils.getSecondUserEmail())
-            .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
-            .managedBy(ManagedByType.MANAGED_BY_USER)
+            .common(
+                new ControlledResourceFields()
+                    .workspaceId(workspaceId)
+                    .resourceId(UUID.randomUUID())
+                    .name(datasetName)
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .assignedUser(userAccessUtils.getSecondUserEmail())
+                    .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
+                    .managedBy(ManagedByType.MANAGED_BY_USER))
             .datasetName(datasetName)
             .projectId(projectId)
             .build();

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
@@ -49,9 +49,8 @@ public class WorkspaceDeleteFlightTest extends BaseConnectedTest {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     Workspace workspace = connectedTestUtils.createWorkspaceWithGcpContext(userRequest);
     ControlledBigQueryDatasetResource dataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .build();
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(null).build();
+
     var creationParameters =
         ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters()
             .datasetId(dataset.getDatasetName());
@@ -106,9 +105,7 @@ public class WorkspaceDeleteFlightTest extends BaseConnectedTest {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     Workspace workspace = connectedTestUtils.createWorkspaceWithGcpContext(userRequest);
     ControlledBigQueryDatasetResource dataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryDatasetResource()
-            .workspaceId(workspace.getWorkspaceId())
-            .build();
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(null).build();
     var creationParameters =
         ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters()
             .datasetId(dataset.getDatasetName());

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
@@ -49,12 +49,15 @@ public class WorkspaceDeleteFlightTest extends BaseConnectedTest {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     Workspace workspace = connectedTestUtils.createWorkspaceWithGcpContext(userRequest);
     ControlledBigQueryDatasetResource dataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(null).build();
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
+            .build();
 
     var creationParameters =
         ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters()
             .datasetId(dataset.getDatasetName());
-    controlledResourceService.createBigQueryDataset(dataset, creationParameters, null, userRequest);
+    controlledResourceService
+        .createControlledResourceSync(dataset, null, userRequest, creationParameters)
+        .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
 
     ControlledBigQueryDatasetResource gotResource =
         controlledResourceService
@@ -105,11 +108,14 @@ public class WorkspaceDeleteFlightTest extends BaseConnectedTest {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     Workspace workspace = connectedTestUtils.createWorkspaceWithGcpContext(userRequest);
     ControlledBigQueryDatasetResource dataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(null).build();
+        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
+            .build();
     var creationParameters =
         ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters()
             .datasetId(dataset.getDatasetName());
-    controlledResourceService.createBigQueryDataset(dataset, creationParameters, null, userRequest);
+    controlledResourceService
+        .createControlledResourceSync(dataset, null, userRequest, creationParameters)
+        .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
 
     ControlledBigQueryDatasetResource gotResource =
         controlledResourceService


### PR DESCRIPTION
This PR includes two refactors; one small and one large.

The small refactor is putting controllers in an object hierarchy to make it easier to share code. At the top is `ControllerCommon` that includes code useful for most all controllers. Then the more specific `ControlledResourceControllerCommon` that includes code shared by `ControlledGcpResourceApiController` and `ControlledAzureResourceController`.  These replace the, now deleted, utility class `ControllerUtils`. I think they offer easier sharing. These can probably be expanded in the future, but this is plenty for now.

The large refactor is removing redundant code in the create controlled resource path. There was redundancy in the controllers and even more in the ControlledResourceService. I was able to remove most resource-type-sepcific methods and replace them with the single `CreateControlledResourceSync` generic method.

The bulk of the change relates to the handling of fields common to all controlled resources. Today, these are separately computed and provided to every resource's builder class. I replaced that with:
- `ControlledResourceFields` class that has a builder for all of those shared fields.
- All controlled resource classes now have a builder that just takes their specific attributes (e.g., datasetName, bucketName) and the common fields class.
- The `ControlledResourceControllerCommon` super class has a method `toCommonFields` that convers the API common fields into a `ControlledResourceFields` class.

Now if we add a new common field, we do not have to visit every resource.