### PR TITLE
[WOR-137] Point at new snapshots for ITs

### DIFF
--- a/integration/src/main/resources/configs/integration/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/DataReferenceLifecycle.json
@@ -14,7 +14,7 @@
       "parameters": {
         "spend-profile-id": "wm-default-spend-profile",
         "data-repo-instance": "terra",
-        "snapshot-id": "97b5559a-2f8f-4df3-89ae-5a249173ee0c"
+        "snapshot-id": "220a2d18-56f7-492a-b7b3-2bc7d79e54b2"
       }
     }
   ],

--- a/integration/src/main/resources/configs/integration/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/integration/EnumerateDataReferences.json
@@ -14,7 +14,7 @@
       "parameters": {
         "spend-profile-id": "wm-default-spend-profile",
         "data-repo-instance": "terra",
-        "snapshot-id": "97b5559a-2f8f-4df3-89ae-5a249173ee0c"
+        "snapshot-id": "220a2d18-56f7-492a-b7b3-2bc7d79e54b2"
       }
     }
   ],

--- a/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
@@ -14,8 +14,8 @@
       "parameters": {
         "spend-profile-id": "wm-default-spend-profile",
         "data-repo-instance": "terra",
-        "snapshot-id": "97b5559a-2f8f-4df3-89ae-5a249173ee0c",
-        "snapshot-id-2": "de189c9b-ef96-4ade-9970-5829056083e3"
+        "snapshot-id":"220a2d18-56f7-492a-b7b3-2bc7d79e54b2",
+        "snapshot-id-2":"3d3d6fde-0a66-4807-b03e-f30e67eb0fe9"
       }
     }
   ],

--- a/integration/src/main/resources/configs/perf/DataReferenceLifecycle.json
+++ b/integration/src/main/resources/configs/perf/DataReferenceLifecycle.json
@@ -14,7 +14,7 @@
       "parameters": {
         "spend-profile-id": "wm-default-spend-profile",
         "data-repo-instance": "terra",
-        "snapshot-id": "97b5559a-2f8f-4df3-89ae-5a249173ee0c"
+        "snapshot-id": "220a2d18-56f7-492a-b7b3-2bc7d79e54b2"
       }
     }
   ],

--- a/integration/src/main/resources/configs/perf/EnumerateDataReferences.json
+++ b/integration/src/main/resources/configs/perf/EnumerateDataReferences.json
@@ -14,7 +14,7 @@
       "parameters": {
         "spend-profile-id": "wm-default-spend-profile",
         "data-repo-instance": "terra",
-        "snapshot-id": "97b5559a-2f8f-4df3-89ae-5a249173ee0c"
+        "snapshot-id": "220a2d18-56f7-492a-b7b3-2bc7d79e54b2"
       }
     }
   ],


### PR DESCRIPTION
## Context
The [`ReferencedDataRepoSnapshotLifecycle`](https://github.com/DataBiosphere/terra-workspace-manager/blob/main/integration/src/main/java/scripts/testscripts/ReferencedDataRepoSnapshotLifecycle.java) IT is failing because the snapshots it was consuming were deleted. 

## This PR
* Points at 2 newly created snapshots that were created and explicitly named for this test
   * I need to look into creating a dev group that can own these snapshots, for now they are under my dev acct and readable by the IT SAs.