### PR TITLE
[PF-1350] Modify test to exercise azure context create service call

### DIFF
--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateAzureContextFlightTest.java
@@ -36,14 +36,21 @@ class CreateAzureContextFlightTest extends BaseAzureTest {
     // There should be no cloud context initially.
     assertTrue(workspaceService.getAuthorizedAzureCloudContext(workspaceId, userRequest).isEmpty());
 
-    // Run the flight.
+    String jobId = UUID.randomUUID().toString();
+    workspaceService.createAzureCloudContext(
+        workspaceId,
+        jobId,
+        userRequest,
+        /* resultPath */ null,
+        azureTestUtils.getAzureCloudContext());
+
+    // Wait for the job to complete
     FlightState flightState =
-        StairwayTestUtils.blockUntilFlightCompletes(
+        StairwayTestUtils.pollUntilComplete(
+            jobId,
             jobService.getStairway(),
-            CreateAzureContextFlight.class,
-            azureTestUtils.createAzureContextInputParameters(workspaceId, userRequest),
-            STAIRWAY_FLIGHT_TIMEOUT,
-            null);
+            Duration.ofSeconds(30),
+            STAIRWAY_FLIGHT_TIMEOUT);
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
 
     // Flight should have created a cloud context.

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateAzureContextFlightTest.java
@@ -47,10 +47,7 @@ class CreateAzureContextFlightTest extends BaseAzureTest {
     // Wait for the job to complete
     FlightState flightState =
         StairwayTestUtils.pollUntilComplete(
-            jobId,
-            jobService.getStairway(),
-            Duration.ofSeconds(30),
-            STAIRWAY_FLIGHT_TIMEOUT);
+            jobId, jobService.getStairway(), Duration.ofSeconds(30), STAIRWAY_FLIGHT_TIMEOUT);
     assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
 
     // Flight should have created a cloud context.


### PR DESCRIPTION
The missing parameter to azure context create was fixed by WOR-122.
There was no test that caught that problem. I modified one of the service tests to exercise that path so this won't regress.