### PR TITLE
[PF-1090] Mark bucket and bigquery response properties as required

### DIFF
--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -3203,9 +3203,10 @@ components:
     CreatedControlledGcpGcsBucket:
       description: Response Payload for requesting a new controlled GCS bucket.
       type: object
+      required: [resourceId, gcpBucket]
       properties:
         resourceId:
-          description: UUID of a newly-created resource. Null if not created yet.
+          description: UUID of a newly-created resource.
           type: string
           format: uuid
         gcpBucket:
@@ -3213,9 +3214,10 @@ components:
     CreatedControlledGcpBigQueryDataset:
       description: Response Payload for requesting a new controlled BigQuery dataset.
       type: object
+      required: [resourceId, bigQueryDataset]
       properties:
         resourceId:
-          description: UUID of a newly-created resource. Null if not created yet.
+          description: UUID of a newly-created resource.
           type: string
           format: uuid
         bigQueryDataset:


### PR DESCRIPTION
They are listed as optional, but will be present on success.