### PR TITLE
[PF-1034] Expose oldest CLI version property

### DIFF
--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -6,8 +6,10 @@
     <option name="ACTIVE_PROFILES" value="human-readable-logging" />
     <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/service" />
     <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="SHORTEN_COMMAND_LINE" value="NONE" />
     <envs>
       <env name="GOOGLE_APPLICATION_CREDENTIALS" value="../config/wsm-sa.json" />
+      <env name="WORKSPACE_CLI_OLDESTSUPPORTEDVERSION" value="0.149.0" />
     </envs>
     <method v="2">
       <option name="Make" enabled="true" />

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/CliConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/CliConfiguration.java
@@ -1,0 +1,21 @@
+package bio.terra.workspace.app.configuration.external;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix="workspace.cli")
+public class CliConfiguration {
+
+  private String oldestSupportedVersion;
+
+  public String getOldestSupportedVersion() {
+    return oldestSupportedVersion;
+  }
+
+  public void setOldestSupportedVersion(String oldestSupportedVersion) {
+    this.oldestSupportedVersion = oldestSupportedVersion;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/CliConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/CliConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableConfigurationProperties
-@ConfigurationProperties(prefix="workspace.cli")
+@ConfigurationProperties(prefix = "workspace.cli")
 public class CliConfiguration {
 
   private String oldestSupportedVersion;

--- a/service/src/main/java/bio/terra/workspace/app/controller/UnauthenticatedApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/UnauthenticatedApiController.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.app.controller;
 
+import bio.terra.workspace.app.configuration.external.CliConfiguration;
 import bio.terra.workspace.app.configuration.external.VersionConfiguration;
 import bio.terra.workspace.generated.controller.UnauthenticatedApi;
 import bio.terra.workspace.generated.model.ApiSystemVersion;
@@ -17,7 +18,9 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
 
   @Autowired
   public UnauthenticatedApiController(
-      WorkspaceManagerStatusService statusService, VersionConfiguration versionConfiguration) {
+      WorkspaceManagerStatusService statusService,
+      VersionConfiguration versionConfiguration,
+      CliConfiguration cliConfiguration) {
     this.statusService = statusService;
 
     this.currentVersion =
@@ -27,6 +30,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
             .github(
                 "https://github.com/DataBiosphere/terra-workspace-manager/commit/"
                     + versionConfiguration.getGitHash())
+            .oldestSupportedCliVersion(cliConfiguration.getOldestSupportedVersion())
             .build(versionConfiguration.getBuild());
   }
 

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2704,6 +2704,11 @@ components:
         build:
           type: string
           description: Version of the currently deployed app declared in build.gradle. Client and server versions are linked.
+        oldestSupportedCliVersion:
+          type: string
+          description: |
+            For the terra CLI client, the oldest version known to work with the current version of
+            WSM.
 
     CreateWorkspaceRequestBody:
       type: object

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -763,10 +763,9 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
       void bigQueryDataTableReference_deleteWithWrongTypeThenRightType_doesNotDeleteFirstTime() {
         referenceResource = makeBigQueryDataTableResource();
 
-        ReferencedBigQueryDataTableResource resultReferenceResource =
-            referenceResourceService
-                .createReferenceResource(referenceResource, USER_REQUEST)
-                .castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE);
+        referenceResourceService
+            .createReferenceResource(referenceResource, USER_REQUEST)
+            .castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE);
 
         referenceResourceService.deleteReferenceResourceForResourceType(
             workspaceId,


### PR DESCRIPTION
Read `WORKSPACE_CLI_OLDESTSUPPORTEDVERSION` env var and provide value on the `/version` endpoint.