### PR TITLE
Refactor Gradle File

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,12 +1,13 @@
+// Build Script Classpath
 buildscript {
     ext {
         springBootVersion = '2.4.0'
     }
 }
 
+// Project Plugins
 plugins {
     id 'terra-workspace-manager.java-conventions'
-
     id "com.github.ben-manes.versions" version "0.36.0"
     id "com.google.cloud.tools.jib" version "3.0.0"
     id "de.undercouch.download" version "4.1.1"
@@ -19,11 +20,10 @@ plugins {
 // constants visible to all .gradle files in this project
 project.ext {
     artifactGroup = "${group}.workspace"
+    includeDir = "$projectDir/gradle"
     openapiOutputDir = "${buildDir}/openapi"
     resourceDir = "${projectDir}/src/main/resources"
 }
-
-def includeDir = "$projectDir/gradle"
 
 // include order matters, so don't alphabetize
 apply(from: "$includeDir/profiler.gradle")
@@ -35,4 +35,3 @@ apply(from: "$includeDir/taskDependencies.gradle")
 apply(from: "$includeDir/dependencies.gradle")
 apply(from: "$includeDir/testing.gradle")
 
-sourceSets.main.java.srcDir "${openapiOutputDir}/src/main/java"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -16,143 +16,23 @@ plugins {
     id 'ru.vyarus.quality' version '4.5.0'
 }
 
-def artifactGroup = "${group}.workspace"
-def openapiOutputDir = "${buildDir}/openapi"
-def resourceDir = "${projectDir}/src/main/resources"
-
-idea {
-    module {
-        generatedSourceDirs = [file("${openapiOutputDir}/src/main/java")]
-        downloadJavadoc = true
-    }
+// constants visible to all .gradle files in this project
+project.ext {
+    artifactGroup = "${group}.workspace"
+    openapiOutputDir = "${buildDir}/openapi"
+    resourceDir = "${projectDir}/src/main/resources"
 }
 
-dependencies {
-    // Google dependencies
-    constraints {
-        implementation 'com.google.guava:guava:30.1.1-jre' // "-jre" for Java 8 or higher
-    }
-    implementation platform('com.google.cloud:libraries-bom:20.9.0')
-    implementation group: "com.google.auto.value", name: "auto-value-annotations"
-    implementation group: "com.google.guava", name:"guava"
+def includeDir = "$projectDir/gradle"
 
-    // Terra deps
-    implementation group: "bio.terra", name: "datarepo-client", version: "1.41.0-SNAPSHOT"
-    // hk2 is required to use datarepo client, but not correctly exposed by the client
-    implementation group: "org.glassfish.jersey.inject", name: "jersey-hk2", version: "2.32"
-
-    // Get stairway via TCL
-    implementation group: "bio.terra", name: "terra-common-lib", version: "0.0.53-SNAPSHOT"
-    implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.12", version: "0.1-61135c7"
-    implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.4.3-SNAPSHOT"
-
-    // Cloud Resource Library
-    implementation platform('bio.terra.cloud-resource-lib:platform:0.6.0')
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-bigquery'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-billing'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-cloudresourcemanager'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-compute'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-iam'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-notebooks'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-serviceusage'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'google-storage'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-compute'
-    implementation group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-common'
-
-    // Storage transfer service
-    implementation group: 'com.google.apis', name: 'google-api-services-storagetransfer', version: 'v1-rev20210602-1.31.5'
-    implementation group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.25.5"
-
-    // Versioned direct deps
-    implementation group: "org.hashids", name: "hashids", version: "1.0.3"
-    implementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.12.3"
-    implementation group: "org.liquibase", name: "liquibase-core", version: "4.2.1"
-    implementation group: "org.webjars", name: "webjars-locator-core", version: "0.46"
-    runtimeOnly group: "org.postgresql", name: "postgresql", version: "42.2.18"
-
-    // For SpotBugs annotations (still FindBugs annotations)
-    implementation 'com.google.code.findbugs:annotations:3.0.1'
-
-    // Deps whose versions are controlled by Spring
-    implementation group: "javax.validation", name: "validation-api"
-    implementation group: "org.apache.commons", name: "commons-dbcp2"
-    implementation group: "org.apache.commons", name: "commons-lang3"
-    implementation group: "org.apache.commons", name: "commons-pool2"
-    implementation group: "commons-validator", name: "commons-validator", version: "1.7"
-    implementation group: "org.springframework.boot", name: "spring-boot-starter-data-jdbc"
-    implementation group: "org.springframework.boot", name: "spring-boot-starter-web"
-    implementation group: "org.springframework.boot", name: "spring-boot-starter-validation"
-    implementation group: "org.springframework.retry", name: "spring-retry"
-
-    // OpenAPI (swagger) deps
-    implementation gradle.librarySwaggerAnnotations
-    swaggerCodegen gradle.librarySwaggerCli
-    runtimeOnly group: "org.webjars.npm", name: "swagger-ui-dist", version: "3.37.2"
-
-    // Test deps
-    testImplementation group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.22.1"
-    testImplementation group: "io.vavr", name: "vavr", version: "0.10.3"
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude group: 'com.vaadin.external.google', module: 'android-json'
-    }
-    // Allows us to mock final classes
-    testImplementation 'org.mockito:mockito-inline:2.13.0'
-
-    annotationProcessor group: "com.google.auto.value", name: "auto-value", version: "1.7.4"
-    annotationProcessor group: "org.springframework.boot", name: "spring-boot-configuration-processor", version: "2.4.0"
-
-    // Force log4j version to at least 2.17.0 for security concerns.
-    implementation('org.apache.logging.log4j:log4j-api') {
-        version {
-            require "2.17.0"
-        }
-    }
-    implementation('org.apache.logging.log4j:log4j-to-slf4j') {
-        version {
-            require "2.17.0"
-        }
-    }
-}
-
-// Download and extract the Cloud Profiler Java Agent
-ext {
-    // where to place the Cloud Profiler agent in the container
-    cloudProfilerLocation = "/opt/cprof"
-
-    // location for jib extras, including the Java agent
-    jibExtraDirectory = "${buildDir}/jib-agents"
-}
-task downloadProfilerAgent(type: Download) {
-    // where to download the Cloud Profiler agent https://cloud.google.com/profiler/docs/profiling-java
-    src "https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz"
-    dest "${buildDir}/cprof_java_agent_gce.tar.gz"
-}
-task extractProfilerAgent(dependsOn: downloadProfilerAgent, type: Copy) {
-    from tarTree(downloadProfilerAgent.dest)
-    into "${jibExtraDirectory}/${cloudProfilerLocation}"
-}
-
-// OpenAPI/Swagger Server Generation
-swaggerSources {
-    server {
-        inputFile = file("${gradle.openapiSourceFile}")
-        code {
-            language = "spring"
-            library = "spring-boot"
-            outputDir = file(openapiOutputDir)
-            components = ["models", "apis"]
-            rawOptions = [
-                "--api-package", "${artifactGroup}.generated.controller",
-                "--model-package", "${artifactGroup}.generated.model",
-                "--model-name-prefix", "Api",
-                "--additional-properties", "errorOnUnknownEnum=true",
-                "-D", "interfaceOnly=true," +
-                      "useTags=true," +
-                      "dateLibrary=java8"
-            ]
-        }
-    }
-}
+// include order matters, so don't alphabetize
+apply(from: "$includeDir/profiler.gradle")
+apply(from: "$includeDir/deploy.gradle")
+apply(from: "$includeDir/openapi.gradle")
+apply(from: "$includeDir/versionProperties.gradle")
+apply(from: "$rootDir/gradle/quality.gradle")
+apply(from: "$includeDir/taskDependencies.gradle")
+apply(from: "$includeDir/dependencies.gradle")
 
 // Testing config
 
@@ -204,49 +84,4 @@ task azureTest(type: Test) {
     outputs.upToDateWhen { false }
 }
 
-// Generate/clean the version properties file
-// This was being done by a plugin: https://github.com/palantir/gradle-git-version
-// but it does not work with Gradle 7.0. It was also very complicated for a
-// what we need, so easily replaced with a bash script
-def generatedVersionFile = "${resourceDir}/generated/version.properties"
-
-task generateVersionProperties(type: Exec) {
-    commandLine "${projectDir}/writeVersionProperties.sh", "${version}", "${generatedVersionFile}"
-}
-
-task cleanVersionProperties(type: Exec) {
-    commandLine "rm", "-f", "${generatedVersionFile}"
-}
-
-// Deploy config
-jib {
-    from {
-        // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
-        // Google's distroless images are openjdk, this is the simplest with adoptopenjdk
-        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian"
-    }
-    extraDirectories {
-        paths = [file(jibExtraDirectory)]
-    }
-    container {
-        filesModificationTime = java.time.ZonedDateTime.now().toString() // to prevent ui caching
-        jvmFlags = [
-                "-agentpath:" + cloudProfilerLocation + "/profiler_java_agent.so=" +
-                        "-cprof_service=bio.terra.workspace" +
-                        ",-cprof_service_version=" + version +
-                        ",-cprof_enable_heap_sampling=true" +
-                        ",-logtostderr" +
-                        ",-minloglevel=2"
-        ]
-    }
-}
-
 sourceSets.main.java.srcDir "${openapiOutputDir}/src/main/java"
-
-compileJava.dependsOn swaggerSources.server.code, generateVersionProperties
-tasks.jib.dependsOn extractProfilerAgent
-tasks.jibDockerBuild.dependsOn extractProfilerAgent
-tasks.jibBuildTar.dependsOn extractProfilerAgent
-clean.dependsOn cleanVersionProperties
-
-apply from: "$rootDir/gradle/quality.gradle"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -33,55 +33,6 @@ apply(from: "$includeDir/versionProperties.gradle")
 apply(from: "$rootDir/gradle/quality.gradle")
 apply(from: "$includeDir/taskDependencies.gradle")
 apply(from: "$includeDir/dependencies.gradle")
-
-// Testing config
-
-// The path to the default Google service account for the Workspace Manager to run as.
-// Created by scripts/write_config.sh
-def googleCredentialsFile = "${rootDir}/config/wsm-sa.json"
-bootRun {
-    environment.put("GOOGLE_APPLICATION_CREDENTIALS", "${googleCredentialsFile}")
-}
-
-tasks.withType(Test) {
-    environment.put("GOOGLE_APPLICATION_CREDENTIALS", "${googleCredentialsFile}")
-    testLogging {
-        if (System.getenv('PRINT_STANDARD_STREAMS') == null) {
-            events = ["passed", "failed", "skipped", "started"]
-        } else {
-            events = ["passed", "failed", "skipped", "started", "standard_out", "standard_error"]
-        }
-    }
-}
-
-test {
-    useJUnitPlatform {
-        includeTags "unit"
-    }
-    outputs.upToDateWhen { false }
-}
-
-task unitTest(type: Test) {
-    useJUnitPlatform {
-        includeTags "unit"
-    }
-    outputs.upToDateWhen { false }
-    finalizedBy jacocoTestReport
-}
-
-task connectedTest(type: Test) {
-    environment.put('TEST_ENV', System.getenv("TEST_ENV"))
-    useJUnitPlatform {
-        includeTags "connected"
-    }
-    outputs.upToDateWhen { false }
-}
-
-task azureTest(type: Test) {
-    useJUnitPlatform {
-        includeTags "azure"
-    }
-    outputs.upToDateWhen { false }
-}
+apply(from: "$includeDir/testing.gradle")
 
 sourceSets.main.java.srcDir "${openapiOutputDir}/src/main/java"

--- a/service/gradle/dependencies.gradle
+++ b/service/gradle/dependencies.gradle
@@ -1,0 +1,87 @@
+// Manual Task Dependencies
+dependencies {
+  // Google dependencies
+  constraints {
+    implementation 'com.google.guava:guava:30.1.1-jre' // "-jre" for Java 8 or higher
+  }
+  implementation platform('com.google.cloud:libraries-bom:20.9.0')
+  implementation group: "com.google.auto.value", name: "auto-value-annotations"
+  implementation group: "com.google.guava", name:"guava"
+
+  // Terra deps
+  implementation group: "bio.terra", name: "datarepo-client", version: "1.41.0-SNAPSHOT"
+  // hk2 is required to use datarepo client, but not correctly exposed by the client
+  implementation group: "org.glassfish.jersey.inject", name: "jersey-hk2", version: "2.32"
+
+  // Get stairway via TCL
+  implementation group: "bio.terra", name: "terra-common-lib", version: "0.0.53-SNAPSHOT"
+  implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.12", version: "0.1-61135c7"
+  implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.4.3-SNAPSHOT"
+
+  // Cloud Resource Library
+  implementation platform('bio.terra.cloud-resource-lib:platform:0.6.0')
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'google-bigquery'
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'google-billing'
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'google-cloudresourcemanager'
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'google-compute'
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'google-iam'
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'google-notebooks'
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'google-serviceusage'
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'google-storage'
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-compute'
+  implementation group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-common'
+
+  // Storage transfer service
+  implementation group: 'com.google.apis', name: 'google-api-services-storagetransfer', version: 'v1-rev20210602-1.31.5'
+  implementation group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.25.5"
+
+  // Versioned direct deps
+  implementation group: "org.hashids", name: "hashids", version: "1.0.3"
+  implementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.12.3"
+  implementation group: "org.liquibase", name: "liquibase-core", version: "4.2.1"
+  implementation group: "org.webjars", name: "webjars-locator-core", version: "0.46"
+  runtimeOnly group: "org.postgresql", name: "postgresql", version: "42.2.18"
+
+  // For SpotBugs annotations (still FindBugs annotations)
+  implementation 'com.google.code.findbugs:annotations:3.0.1'
+
+  // Deps whose versions are controlled by Spring
+  implementation group: "javax.validation", name: "validation-api"
+  implementation group: "org.apache.commons", name: "commons-dbcp2"
+  implementation group: "org.apache.commons", name: "commons-lang3"
+  implementation group: "org.apache.commons", name: "commons-pool2"
+  implementation group: "commons-validator", name: "commons-validator", version: "1.7"
+  implementation group: "org.springframework.boot", name: "spring-boot-starter-data-jdbc"
+  implementation group: "org.springframework.boot", name: "spring-boot-starter-web"
+  implementation group: "org.springframework.boot", name: "spring-boot-starter-validation"
+  implementation group: "org.springframework.retry", name: "spring-retry"
+
+  // OpenAPI (swagger) deps
+  implementation gradle.librarySwaggerAnnotations
+  swaggerCodegen gradle.librarySwaggerCli
+  runtimeOnly group: "org.webjars.npm", name: "swagger-ui-dist", version: "3.37.2"
+
+  // Test deps
+  testImplementation group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "0.22.1"
+  testImplementation group: "io.vavr", name: "vavr", version: "0.10.3"
+  testImplementation('org.springframework.boot:spring-boot-starter-test') {
+    exclude group: 'com.vaadin.external.google', module: 'android-json'
+  }
+  // Allows us to mock final classes
+  testImplementation 'org.mockito:mockito-inline:2.13.0'
+
+  annotationProcessor group: "com.google.auto.value", name: "auto-value", version: "1.7.4"
+  annotationProcessor group: "org.springframework.boot", name: "spring-boot-configuration-processor", version: "2.4.0"
+
+  // Force log4j version to at least 2.17.0 for security concerns.
+  implementation('org.apache.logging.log4j:log4j-api') {
+    version {
+      require "2.17.0"
+    }
+  }
+  implementation('org.apache.logging.log4j:log4j-to-slf4j') {
+    version {
+      require "2.17.0"
+    }
+  }
+}

--- a/service/gradle/dependencies.gradle
+++ b/service/gradle/dependencies.gradle
@@ -1,4 +1,4 @@
-// Manual Task Dependencies
+// Library Dependencies, Versions, etc.
 dependencies {
   // Google dependencies
   constraints {

--- a/service/gradle/deploy.gradle
+++ b/service/gradle/deploy.gradle
@@ -1,0 +1,24 @@
+import java.time.ZonedDateTime
+
+// Deploy config
+jib {
+  from {
+    // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
+    // Google's distroless images are openjdk, this is the simplest with adoptopenjdk
+    image = "us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian"
+  }
+  extraDirectories {
+    paths = [file(jibExtraDirectory)]
+  }
+  container {
+    filesModificationTime = ZonedDateTime.now().toString() // to prevent ui caching
+    jvmFlags = [
+            "-agentpath:" + cloudProfilerLocation + "/profiler_java_agent.so=" +
+                    "-cprof_service=bio.terra.workspace" +
+                    ",-cprof_service_version=" + version +
+                    ",-cprof_enable_heap_sampling=true" +
+                    ",-logtostderr" +
+                    ",-minloglevel=2"
+    ]
+  }
+}

--- a/service/gradle/ide.gradle
+++ b/service/gradle/ide.gradle
@@ -1,0 +1,7 @@
+// IDE settings and tasks
+idea {
+  module {
+    generatedSourceDirs = [file("${openapiOutputDir}/src/main/java")]
+    downloadJavadoc = true
+  }
+}

--- a/service/gradle/openapi.gradle
+++ b/service/gradle/openapi.gradle
@@ -19,3 +19,5 @@ swaggerSources {
     }
   }
 }
+
+sourceSets.main.java.srcDir "${openapiOutputDir}/src/main/java"

--- a/service/gradle/openapi.gradle
+++ b/service/gradle/openapi.gradle
@@ -1,0 +1,21 @@
+// OpenAPI/Swagger Server Generation
+swaggerSources {
+  server {
+    inputFile = file("${gradle.openapiSourceFile}")
+    code {
+      language = "spring"
+      library = "spring-boot"
+      outputDir = file(openapiOutputDir)
+      components = ["models", "apis"]
+      rawOptions = [
+              "--api-package", "${artifactGroup}.generated.controller",
+              "--model-package", "${artifactGroup}.generated.model",
+              "--model-name-prefix", "Api",
+              "--additional-properties", "errorOnUnknownEnum=true",
+              "-D", "interfaceOnly=true," +
+                      "useTags=true," +
+                      "dateLibrary=java8"
+      ]
+    }
+  }
+}

--- a/service/gradle/profiler.gradle
+++ b/service/gradle/profiler.gradle
@@ -1,0 +1,19 @@
+// Download and extract the Cloud Profiler Java Agent
+ext {
+  // where to place the Cloud Profiler agent in the container
+  cloudProfilerLocation = "/opt/cprof"
+
+  // location for jib extras, including the Java agent
+  jibExtraDirectory = "${buildDir}/jib-agents"
+}
+
+task downloadProfilerAgent(type: Download) {
+  // where to download the Cloud Profiler agent https://cloud.google.com/profiler/docs/profiling-java
+  src "https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz"
+  dest "${buildDir}/cprof_java_agent_gce.tar.gz"
+}
+
+task extractProfilerAgent(dependsOn: downloadProfilerAgent, type: Copy) {
+  from tarTree(downloadProfilerAgent.dest)
+  into "${jibExtraDirectory}/${cloudProfilerLocation}"
+}

--- a/service/gradle/taskDependencies.gradle
+++ b/service/gradle/taskDependencies.gradle
@@ -1,0 +1,5 @@
+tasks.compileJava.dependsOn swaggerSources.server.code, generateVersionProperties
+tasks.jib.dependsOn extractProfilerAgent
+tasks.jibDockerBuild.dependsOn extractProfilerAgent
+tasks.jibBuildTar.dependsOn extractProfilerAgent
+tasks.clean.dependsOn cleanVersionProperties

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -1,0 +1,49 @@
+// Testing config
+
+// The path to the default Google service account for the Workspace Manager to run as.
+// Created by scripts/write_config.sh
+def googleCredentialsFile = "${rootDir}/config/wsm-sa.json"
+bootRun {
+  environment.put("GOOGLE_APPLICATION_CREDENTIALS", "${googleCredentialsFile}")
+}
+
+tasks.withType(Test) {
+  environment.put("GOOGLE_APPLICATION_CREDENTIALS", "${googleCredentialsFile}")
+  testLogging {
+    if (System.getenv('PRINT_STANDARD_STREAMS') == null) {
+      events = ["passed", "failed", "skipped", "started"]
+    } else {
+      events = ["passed", "failed", "skipped", "started", "standard_out", "standard_error"]
+    }
+  }
+}
+
+test {
+  useJUnitPlatform {
+    includeTags "unit"
+  }
+  outputs.upToDateWhen { false }
+}
+
+task unitTest(type: Test) {
+  useJUnitPlatform {
+    includeTags "unit"
+  }
+  outputs.upToDateWhen { false }
+  finalizedBy jacocoTestReport
+}
+
+task connectedTest(type: Test) {
+  environment.put('TEST_ENV', System.getenv("TEST_ENV"))
+  useJUnitPlatform {
+    includeTags "connected"
+  }
+  outputs.upToDateWhen { false }
+}
+
+task azureTest(type: Test) {
+  useJUnitPlatform {
+    includeTags "azure"
+  }
+  outputs.upToDateWhen { false }
+}

--- a/service/gradle/versionProperties.gradle
+++ b/service/gradle/versionProperties.gradle
@@ -1,0 +1,13 @@
+// Generate/clean the version properties file
+// This was being done by a plugin: https://github.com/palantir/gradle-git-version
+// but it does not work with Gradle 7.0. It was also very complicated for a
+// what we need, so easily replaced with a bash script
+def generatedVersionFile = "${resourceDir}/generated/version.properties"
+
+task generateVersionProperties(type: Exec) {
+  commandLine "${projectDir}/writeVersionProperties.sh", "${version}", "${generatedVersionFile}"
+}
+
+task cleanVersionProperties(type: Exec) {
+  commandLine "rm", "-f", "${generatedVersionFile}"
+}


### PR DESCRIPTION
Split `build.gradle` into include files based on purpose. With this change, the build file is only 36 lines long, and the longest (but simplest) included file is 87 lines.

Also tried to add helpful/accurate comments in places.

Based on original PR https://github.com/DataBiosphere/terra-workspace-manager/pull/363/.