### PR TITLE
[PF-1347] Use BQ result tables instead of temporary tables in tests

### DIFF
--- a/integration/src/main/java/scripts/utils/BqDataTableUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDataTableUtils.java
@@ -11,7 +11,9 @@ import bio.terra.workspace.model.GcpBigQueryDataTableAttributes;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
 import bio.terra.workspace.model.UpdateBigQueryDataTableReferenceRequestBody;
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.JobInfo.WriteDisposition;
 import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import java.io.IOException;
 import java.util.UUID;
@@ -65,6 +67,9 @@ public class BqDataTableUtils {
       throws IOException, InterruptedException {
 
     final BigQuery bigQueryClient = ClientTestUtils.getGcpBigQueryClient(user, projectId);
+    final TableId resultTableId =
+        TableId.of(
+            projectId, dataset.getAttributes().getDatasetId(), BqDatasetUtils.BQ_RESULT_TABLE_NAME);
     final TableResult employeeTableResult =
         bigQueryClient.query(
             QueryJobConfiguration.newBuilder(
@@ -73,6 +78,8 @@ public class BqDataTableUtils {
                         + "."
                         + dataset.getAttributes().getDatasetId()
                         + ".employee`;")
+                .setDestinationTable(resultTableId)
+                .setWriteDisposition(WriteDisposition.WRITE_TRUNCATE)
                 .build());
     final long numRows =
         StreamSupport.stream(employeeTableResult.getValues().spliterator(), false).count();


### PR DESCRIPTION
This change removes the places in integration tests where we currently implicitly use BigQuery temporary tables to hold query results. Instead, all queries which return results now have the destination table explicitly specified. This allows us to run these tests in cloud environments where Domain Restricted Sharing is enforced - otherwise, BigQuery will attempt to grant IAM policies on temporary tables directly to end-users, which causes errors.