### PR TITLE
[PF-1363] Create caller's pet SA on GCP context create

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
@@ -72,6 +72,7 @@ public class CreateGcpContextFlightV2 extends Flight {
     addStep(
         new SyncSamGroupsStep(appContext.getSamService(), workspaceId, userRequest), shortRetry);
     addStep(new GcpCloudSyncStep(crl.getCloudResourceManagerCow()), cloudRetry);
+    addStep(new CreatePetSaStep(appContext.getSamService(), userRequest), shortRetry);
 
     // Store the cloud context data and unlock the database row
     // This must be the last step, since it clears the lock. So this step also

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreatePetSaStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreatePetSaStep.java
@@ -1,0 +1,40 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.GCP_PROJECT_ID;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+
+/**
+ * Step to create the caller's pet service account in a newly-created GCP context. There can be a
+ * brief delay between SA creation and propagation of proxy-group permissions within GCP, so we
+ * pre-emptively create the caller's pet SA during GCP context creation instead of creating it the
+ * first time it's needed.
+ */
+public class CreatePetSaStep implements Step {
+
+  private final SamService samService;
+  private final AuthenticatedUserRequest userRequest;
+
+  public CreatePetSaStep(SamService samService, AuthenticatedUserRequest userRequest) {
+    this.samService = samService;
+    this.userRequest = userRequest;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    String projectId = context.getWorkingMap().get(GCP_PROJECT_ID, String.class);
+    samService.getOrCreatePetSaEmail(projectId, userRequest.getRequiredToken());
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Sam does not support deleting pet SAs, so nothing to undo here.
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
@@ -259,6 +259,7 @@ class CreateGcpContextFlightV2Test extends BaseConnectedTest {
     retrySteps.put(StoreGcpContextStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(SyncSamGroupsStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(GcpCloudSyncStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    retrySteps.put(CreatePetSaStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     return retrySteps;
   }
 


### PR DESCRIPTION
This change adds a new step to the "create GCP context" flight to create a pet service account in the newly-created GCP project for the caller. Previously, pet SAs would only be created the first time they were explicitly requested from Sam. This is a small optimization to prevent the following failure case which has appeared a few times:

1. Sam immediately adds new pet SAs to the appropriate proxy group on creation. However, there can be a small delay (generally a few seconds) before GCP permissions granted to the proxy group apply to the new group member.
2. A common use of pet SAs in Workspace Manager is checking access to referenced cloud resources, which happens on referenced resource creation. If this is the first time a user's pet is needed in the workspace, WSM will request Sam create the pet SA and then immediately try to use the pet credentials.
3. WSM attempts to check permissions on a cloud resource using the pet SA. However, the SA was just created and GCP permissions have not propagated, leading to a false negative IAM check.

This is especially common while cloning workspaces, where WSM may attempt to read referenced resources from the source workspace immediately after creating the destination workspace.