### PR TITLE
[PF-1371] Fix flaky createAiNotebookInstanceUndo test

### DIFF
--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -361,14 +361,6 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .undoStepFailures(retrySteps)
             .build());
 
-    String jobId =
-        controlledResourceService.createAiNotebookInstance(
-            resource,
-            creationParameters,
-            DEFAULT_ROLE,
-            new ApiJobControl().id(UUID.randomUUID().toString()),
-            "fakeResultPath",
-            user.getAuthenticatedRequest());
     // Revoke user's Pet SA access, if they have it. Because these tests re-use a common workspace,
     // the user may have pet SA access enabled prior to this test.
     String serviceAccountEmail =
@@ -383,6 +375,15 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
         canImpersonateSa(
             ServiceAccountName.builder().projectId(projectId).email(serviceAccountEmail).build(),
             userIamCow));
+
+    String jobId =
+        controlledResourceService.createAiNotebookInstance(
+            resource,
+            creationParameters,
+            DEFAULT_ROLE,
+            new ApiJobControl().id(UUID.randomUUID().toString()),
+            "fakeResultPath",
+            user.getAuthenticatedRequest());
     jobService.waitForJob(jobId);
     assertEquals(
         FlightStatus.ERROR, stairwayComponent.get().getFlightState(jobId).getFlightStatus());


### PR DESCRIPTION
This fixes an error in the `createAiNotebookInstanceUndo` connectedTest where we checked a pre-flight assertion during a flight instead of before it. This led to flaky failures depending on how far along the flight was when the assertion ran.