### PR TITLE
make dependencies explicit

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -6,3 +6,4 @@ plugins {
 def includeDir = "$projectDir/gradle"
 apply(from: "$includeDir/dependencies.gradle")
 apply(from: "$includeDir/openapi.gradle")
+tasks.spotlessJava.dependsOn(generateSwaggerCodeClient)

--- a/service/gradle/taskDependencies.gradle
+++ b/service/gradle/taskDependencies.gradle
@@ -1,5 +1,6 @@
-tasks.compileJava.dependsOn swaggerSources.server.code, generateVersionProperties
-tasks.jib.dependsOn extractProfilerAgent
-tasks.jibDockerBuild.dependsOn extractProfilerAgent
-tasks.jibBuildTar.dependsOn extractProfilerAgent
-tasks.clean.dependsOn cleanVersionProperties
+tasks.compileJava.dependsOn(swaggerSources.server.code, generateVersionProperties)
+tasks.jib.dependsOn(extractProfilerAgent)
+tasks.jibDockerBuild.dependsOn(extractProfilerAgent)
+tasks.jibBuildTar.dependsOn(extractProfilerAgent)
+tasks.clean.dependsOn(cleanVersionProperties)
+tasks.spotlessJava.dependsOn(generateSwaggerCodeServer)


### PR DESCRIPTION
Fix a bunch of warnings of the form 
```
- Gradle detected a problem with the following location: '/Users/jaycarlton/repos/terra-workspace-manager/service/build/openapi/src/main/java/bio/terra/workspace/generated/controller/Alpha1Api.java'. Reason: Task ':service:spotlessJava' uses this output of task ':service:generateSwaggerCodeServer' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

Updated task trees are attached.
[service_build_tasks.txt](https://github.com/DataBiosphere/terra-workspace-manager/files/8179535/service_build_tasks.txt)
[client_build_tasks.txt](https://github.com/DataBiosphere/terra-workspace-manager/files/8179565/client_build_tasks.txt)
