### PR TITLE
[No Ticket] Fix the release workflow to have the right file path

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -155,4 +155,4 @@ jobs:
       id: create_release
       with:
         tag: ${{ steps.tag.outputs.tag }}
-        artifacts: "service/build/main/resources/api/service_openapi.yaml"
+        artifacts: "service/build/resources/main/api/service_openapi.yaml"

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -142,8 +142,15 @@ jobs:
         event-type: update-service
         client-payload: '{"service": "workspacemanager", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
     - name: Build the OpenAPI interface
+      if: steps.skiptest.outputs.is-bump == 'no'
       run: ./gradlew :service:generateSwaggerCodeServer
+    - name: Where is the file
+      if: steps.skiptest.outputs.is-bump == 'no'
+      run: |
+        pwd
+        find . -name "service_openapi.yaml"
     - name: Make release
+      if: steps.skiptest.outputs.is-bump == 'no'
       uses: ncipollo/release-action@v1
       id: create_release
       with:


### PR DESCRIPTION
Not sure how I messed it up, but here is a fix. I am leaving the logging step in because
- it is cheap
- when we add other things to the release it will help the next dev know what the right path is