### PR TITLE
[No ticket] Fix outdated client library documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ repositories {
 
 Add a dependency like
 ```gradle
-implementation(group: 'bio.terra', name: 'terra-workspace-manager-client', version: 'x.x.x')
+implementation(group: 'bio.terra', name: 'workspace-manager-client', version: 'x.x.x')
 ```
 See [settings.gradle](settings.gradle) for the latest version information.
 


### PR DESCRIPTION
The WSM client has been published as `workspace-manager-client` instead of `terra-workspace-manager-client` for the past > year, but we never updated the README.