### PR TITLE
[PF-1330] Return empty application map from config instead of null

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/WsmApplicationConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/WsmApplicationConfiguration.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.app.configuration.external;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/WsmApplicationConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/WsmApplicationConfiguration.java
@@ -1,6 +1,9 @@
 package bio.terra.workspace.app.configuration.external;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -59,7 +62,7 @@ public class WsmApplicationConfiguration {
   Map<String, App> configurations;
 
   public Map<String, App> getConfigurations() {
-    return configurations;
+    return Optional.ofNullable(configurations).orElse(Collections.emptyMap());
   }
 
   public void setConfigurations(Map<String, App> configurations) {


### PR DESCRIPTION
This changes the application configuration reader to return an empty `Map` instead of null when no applications are configured. This is similar to the previous `List` behavior prior to #580.

Without this change, WSM will always [throw a NPE](https://github.com/DataBiosphere/terra-workspace-manager/blob/main/service/src/main/java/bio/terra/workspace/service/workspace/WsmApplicationService.java#L261) on startup if no applications are configured. This was hidden in this repo because one application is present in the default configuration values, but the Verily default configuration did not have this.