### PR TITLE
Fix flaky test PrivateControlledAiNotebookInstanceLifecycle

### DIFF
--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -113,6 +113,15 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
         resource.getAttributes().getLocation(),
         "The notebook uses the default location because location is not specified.");
 
+    // Any workspace user should be able to enumerate notebooks, even though they can't
+    // read or write them.
+    ResourceApi otherUserApi = ClientTestUtils.getResourceClient(otherWorkspaceUser, server);
+    ResourceList notebookList =
+        otherUserApi.enumerateResources(
+            getWorkspaceId(), 0, 5, ResourceType.AI_NOTEBOOK, StewardshipType.CONTROLLED);
+    assertEquals(3, notebookList.getResources().size());
+    MultiResourcesUtils.assertResourceType(ResourceType.AI_NOTEBOOK, notebookList);
+
     createAControlledAiNotebookInstanceWithoutSpecifiedInstanceId_validInstanceIdIsGenerated(
         resourceUserApi);
 
@@ -147,15 +156,6 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
         HttpStatus.SC_FORBIDDEN,
         directDeleteForbidden.getStatusCode(),
         "User may not delete notebook directly on GCP");
-
-    // Any workspace user should be able to enumerate all created notebooks, even though they can't
-    // read or write them.
-    ResourceApi otherUserApi = ClientTestUtils.getResourceClient(otherWorkspaceUser, server);
-    ResourceList notebookList =
-        otherUserApi.enumerateResources(
-            getWorkspaceId(), 0, 5, ResourceType.AI_NOTEBOOK, StewardshipType.CONTROLLED);
-    assertEquals(3, notebookList.getResources().size());
-    MultiResourcesUtils.assertResourceType(ResourceType.AI_NOTEBOOK, notebookList);
 
     // Delete the AI Notebook through WSM.
     DeleteControlledGcpAiNotebookInstanceResult deleteResult =

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -119,7 +119,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
     ResourceList notebookList =
         otherUserApi.enumerateResources(
             getWorkspaceId(), 0, 5, ResourceType.AI_NOTEBOOK, StewardshipType.CONTROLLED);
-    assertEquals(3, notebookList.getResources().size());
+    assertEquals(1, notebookList.getResources().size());
     MultiResourcesUtils.assertResourceType(ResourceType.AI_NOTEBOOK, notebookList);
 
     createAControlledAiNotebookInstanceWithoutSpecifiedInstanceId_validInstanceIdIsGenerated(


### PR DESCRIPTION
Before PR:
1. Line 87: Create first notebook
2. In `createAControlledAiNotebookInstanceWithoutSpecifiedInstanceId_validInstanceIdIsGenerated()`
    - Create second notebook
    - Delete second notebook
3. In `createAControlledAiNotebookInstanceWithoutSpecifiedInstanceId_specifyLocation()`
    - Create third notebook
    - Delete third notebook
4. Line 157: List notebooks and assert there are 3 notebooks

4 was sometimes failing because second notebook was deleted, so there were 2 notebooks instead of 3.

I moved 4 to before 2. Instead of 3 notebooks, I assert there is 1 notebook.