### PR TITLE
IA-3211 Explicitly create nic instead of relying on Azure to implicitly creating nic

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
@@ -17,22 +17,13 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.network.Contr
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
-import com.azure.core.credential.TokenCredential;
-import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
-import com.azure.core.management.profile.AzureProfile;
-import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.compute.models.Disk;
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.azure.resourcemanager.network.models.Network;
-import com.azure.resourcemanager.network.models.NetworkInterface;
 import com.azure.resourcemanager.network.models.PublicIpAddress;
-import com.azure.resourcemanager.resources.ResourceManager;
-import com.azure.resourcemanager.resources.fluentcore.arm.models.GroupableResource;
-import com.azure.resourcemanager.resources.fluentcore.arm.models.Resource;
-import com.azure.resourcemanager.resources.fluentcore.model.Creatable;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,15 +91,19 @@ public class CreateAzureVmStep implements Step {
               .getByResourceGroup(
                   azureCloudContext.getAzureResourceGroupId(), networkResource.getNetworkName());
 
-
-      var createNic = computeManager.networkManager().networkInterfaces()
+      var createNic =
+          computeManager
+              .networkManager()
+              .networkInterfaces()
               .define(String.format("nic-%s", resource.getVmName()))
               .withRegion(resource.getRegion())
               .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
               .withExistingPrimaryNetwork(existingNetwork)
               .withSubnet(networkResource.getSubnetName())
               .withPrimaryPrivateIPAddressDynamic()
-              .withExistingPrimaryPublicIPAddress(existingAzureIp) //TODO this needs to be updated to support not exposing public IP
+              .withExistingPrimaryPublicIPAddress(
+                  existingAzureIp) // TODO this needs to be updated to support not exposing public
+              // IP
               .create();
 
       computeManager

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
@@ -17,13 +17,22 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.network.Contr
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
+import com.azure.core.management.profile.AzureProfile;
+import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.compute.models.Disk;
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.azure.resourcemanager.network.models.Network;
+import com.azure.resourcemanager.network.models.NetworkInterface;
 import com.azure.resourcemanager.network.models.PublicIpAddress;
+import com.azure.resourcemanager.resources.ResourceManager;
+import com.azure.resourcemanager.resources.fluentcore.arm.models.GroupableResource;
+import com.azure.resourcemanager.resources.fluentcore.arm.models.Resource;
+import com.azure.resourcemanager.resources.fluentcore.model.Creatable;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,15 +100,23 @@ public class CreateAzureVmStep implements Step {
               .getByResourceGroup(
                   azureCloudContext.getAzureResourceGroupId(), networkResource.getNetworkName());
 
+
+      var createNic = computeManager.networkManager().networkInterfaces()
+              .define(String.format("nic-%s", resource.getVmName()))
+              .withRegion(resource.getRegion())
+              .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
+              .withExistingPrimaryNetwork(existingNetwork)
+              .withSubnet(networkResource.getSubnetName())
+              .withPrimaryPrivateIPAddressDynamic()
+              .withExistingPrimaryPublicIPAddress(existingAzureIp) //TODO this needs to be updated to support not exposing public IP
+              .create();
+
       computeManager
           .virtualMachines()
           .define(resource.getVmName())
           .withRegion(resource.getRegion())
           .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
-          .withExistingPrimaryNetwork(existingNetwork)
-          .withSubnet(networkResource.getSubnetName())
-          .withPrimaryPrivateIPAddressDynamic()
-          .withExistingPrimaryPublicIPAddress(existingAzureIp)
+          .withExistingPrimaryNetworkInterface(createNic)
           // See here for difference between 'specialized' and 'general' LinuxCustomImage, the
           // managed disk storage option being the key factor
           // https://docs.microsoft.com/en-us/azure/virtual-machines/linux/imaging#generalized-and-specialized

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -37,6 +37,8 @@ import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.azure.resourcemanager.compute.models.VirtualMachines;
 import com.azure.resourcemanager.network.NetworkManager;
 import com.azure.resourcemanager.network.models.Network;
+import com.azure.resourcemanager.network.models.NetworkInterface;
+import com.azure.resourcemanager.network.models.NetworkInterfaces;
 import com.azure.resourcemanager.network.models.NetworkSecurityGroup;
 import com.azure.resourcemanager.network.models.NetworkSecurityGroups;
 import com.azure.resourcemanager.network.models.NetworkSecurityRule;
@@ -74,9 +76,6 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
   @Mock private VirtualMachine.DefinitionStages.Blank mockVmStage1;
   @Mock private VirtualMachine.DefinitionStages.WithGroup mockVmStage2;
   @Mock private VirtualMachine.DefinitionStages.WithNetwork mockVmStage3;
-  @Mock private VirtualMachine.DefinitionStages.WithSubnet mockVmStage4;
-  @Mock private VirtualMachine.DefinitionStages.WithPrivateIP mockVmStage5;
-  @Mock private VirtualMachine.DefinitionStages.WithPublicIPAddress mockVmStage6;
   @Mock private VirtualMachine.DefinitionStages.WithProximityPlacementGroup mockVmStage7;
 
   @Mock private VirtualMachine.DefinitionStages.WithLinuxCreateManaged mockVmStage10;
@@ -96,6 +95,15 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
 
   @Mock private NetworkSecurityGroup mockNsg;
   @Mock private NetworkSecurityGroups mockNsgs;
+  @Mock private NetworkInterfaces mockNis;
+  @Mock private NetworkInterface.DefinitionStages.Blank mockNicDefine;
+  @Mock private NetworkInterface.DefinitionStages.WithGroup mockNicWithRegion;
+  @Mock private NetworkInterface.DefinitionStages.WithPrimaryNetwork mockNicWithExistingRg;
+  @Mock private NetworkInterface.DefinitionStages.WithPrimaryNetworkSubnet mockNicWithExistingPrimaryNetwork;
+  @Mock private NetworkInterface.DefinitionStages.WithPrimaryPrivateIP mockNicWithPrivateIp;
+  @Mock private NetworkInterface.DefinitionStages.WithCreate mockNicWithCreate;
+  @Mock private NetworkInterface mockNi;
+
   @Mock private NetworkSecurityGroup.DefinitionStages.Blank mockNetworkStage1;
   @Mock private NetworkSecurityGroup.DefinitionStages.WithGroup mockNetworkStage1a;
   @Mock private NetworkSecurityGroup.DefinitionStages.WithCreate mockNetworkStage2;
@@ -180,6 +188,15 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
     // get network mocks
     when(mockNetworkManager.networks()).thenReturn(mockNetworks);
     when(mockNetworks.getByResourceGroup(anyString(), anyString())).thenReturn(mockNetwork);
+    when(mockNetworkManager.networkInterfaces()).thenReturn(mockNis);
+    when(mockNis.define(anyString())).thenReturn(mockNicDefine);
+    when(mockNicDefine.withRegion(anyString())).thenReturn(mockNicWithRegion);
+    when(mockNicWithRegion.withExistingResourceGroup(anyString())).thenReturn(mockNicWithExistingRg);
+    when(mockNicWithExistingRg.withExistingPrimaryNetwork(mockNetwork)).thenReturn(mockNicWithExistingPrimaryNetwork);
+    when(mockNicWithExistingPrimaryNetwork.withSubnet(anyString())).thenReturn(mockNicWithPrivateIp);
+    when(mockNicWithPrivateIp.withPrimaryPrivateIPAddressDynamic()).thenReturn(mockNicWithCreate);
+    when(mockNicWithCreate.withExistingPrimaryPublicIPAddress(mockPublicIpAddress)).thenReturn(mockNicWithCreate);
+    when(mockNicWithCreate.create()).thenReturn(mockNi);
 
     // create network security group mocks
     when(mockNetworkManager.networkSecurityGroups()).thenReturn(mockNsgs);
@@ -220,11 +237,7 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
     when(mockVms.define(anyString())).thenReturn(mockVmStage1);
     when(mockVmStage1.withRegion(anyString())).thenReturn(mockVmStage2);
     when(mockVmStage2.withExistingResourceGroup(anyString())).thenReturn(mockVmStage3);
-    when(mockVmStage3.withExistingPrimaryNetwork(any(Network.class))).thenReturn(mockVmStage4);
-    when(mockVmStage4.withSubnet(anyString())).thenReturn(mockVmStage5);
-    when(mockVmStage5.withPrimaryPrivateIPAddressDynamic()).thenReturn(mockVmStage6);
-    when(mockVmStage6.withExistingPrimaryPublicIPAddress(any(PublicIpAddress.class)))
-        .thenReturn(mockVmStage7);
+    when(mockVmStage3.withExistingPrimaryNetworkInterface(mockNi)).thenReturn(mockVmStage7);
     when(mockVmStage7.withSpecializedLinuxCustomImage(anyString())).thenReturn(mockVmStage10);
     when(mockVmStage10.withExistingDataDisk(any(Disk.class))).thenReturn(mockVmStage11);
     when(mockVmStage11.withTag(anyString(), anyString())).thenReturn(mockVmStage11a);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -99,7 +99,11 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
   @Mock private NetworkInterface.DefinitionStages.Blank mockNicDefine;
   @Mock private NetworkInterface.DefinitionStages.WithGroup mockNicWithRegion;
   @Mock private NetworkInterface.DefinitionStages.WithPrimaryNetwork mockNicWithExistingRg;
-  @Mock private NetworkInterface.DefinitionStages.WithPrimaryNetworkSubnet mockNicWithExistingPrimaryNetwork;
+
+  @Mock
+  private NetworkInterface.DefinitionStages.WithPrimaryNetworkSubnet
+      mockNicWithExistingPrimaryNetwork;
+
   @Mock private NetworkInterface.DefinitionStages.WithPrimaryPrivateIP mockNicWithPrivateIp;
   @Mock private NetworkInterface.DefinitionStages.WithCreate mockNicWithCreate;
   @Mock private NetworkInterface mockNi;
@@ -191,11 +195,15 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
     when(mockNetworkManager.networkInterfaces()).thenReturn(mockNis);
     when(mockNis.define(anyString())).thenReturn(mockNicDefine);
     when(mockNicDefine.withRegion(anyString())).thenReturn(mockNicWithRegion);
-    when(mockNicWithRegion.withExistingResourceGroup(anyString())).thenReturn(mockNicWithExistingRg);
-    when(mockNicWithExistingRg.withExistingPrimaryNetwork(mockNetwork)).thenReturn(mockNicWithExistingPrimaryNetwork);
-    when(mockNicWithExistingPrimaryNetwork.withSubnet(anyString())).thenReturn(mockNicWithPrivateIp);
+    when(mockNicWithRegion.withExistingResourceGroup(anyString()))
+        .thenReturn(mockNicWithExistingRg);
+    when(mockNicWithExistingRg.withExistingPrimaryNetwork(mockNetwork))
+        .thenReturn(mockNicWithExistingPrimaryNetwork);
+    when(mockNicWithExistingPrimaryNetwork.withSubnet(anyString()))
+        .thenReturn(mockNicWithPrivateIp);
     when(mockNicWithPrivateIp.withPrimaryPrivateIPAddressDynamic()).thenReturn(mockNicWithCreate);
-    when(mockNicWithCreate.withExistingPrimaryPublicIPAddress(mockPublicIpAddress)).thenReturn(mockNicWithCreate);
+    when(mockNicWithCreate.withExistingPrimaryPublicIPAddress(mockPublicIpAddress))
+        .thenReturn(mockNicWithCreate);
     when(mockNicWithCreate.create()).thenReturn(mockNi);
 
     // create network security group mocks


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3211

Previously nic is created implicitly, and when we're using an image size that's not supported in a location, Azure will somehow try to implicitly create 2 nics, and VM creation will fail with a very non helpful message
```
Resource /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-terra-integration-test-20211118/providers/Microsoft.Network/networkInterfaces/nic63118f8d27a/ipConfigurations/primary is referencing public IP address /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-terra-integration-test-20211118/providers/Microsoft.Network/publicIPAddresses/ip-1647876356741 that is already allocated to resource /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-terra-integration-test-20211118/providers/Microsoft.Network/networkInterfaces/nic652111b7ae7/ipConfigurations/primary
```

With this change, the VM creation will fail with a much more helpful message that tells you the exact thing you need to fix

```
    "message": "Failed to construct exception: com.azure.core.management.exception.ManagementException; Exception message: Status code 409, &quot;{&quot;error&quot;:{&quot;code&quot;:&quot;SkuNotAvailable&quot;,&quot;message&quot;:&quot;The requested size for resource &#39;/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-jc-test/providers/Microsoft.Compute/virtualMachines/vm-16478872963N&#39; is currently not available in location &#39;westcentralus&#39; zones &#39;&#39; for subscription &#39;3efc5bdf-be0e-44e7-b1d7-c08931e3c16c&#39;. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details.&quot;}}&quot;",
```