### PR TITLE
[PF-1256] Unicode-escape certain characters in WSM JSON responses

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
@@ -3,6 +3,8 @@ package bio.terra.workspace.app.configuration.spring;
 import bio.terra.workspace.app.StartupInitializer;
 import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfiguration;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -22,13 +24,49 @@ public class BeanConfig {
     return new NamedParameterJdbcTemplate(config.getDataSource());
   }
 
+  public static class HTMLCharacterEscapes extends CharacterEscapes {
+    private final int[] asciiEscapes;
+
+    public HTMLCharacterEscapes() {
+      // Start with a copy of the default set of escaped characters, then modify.
+      int[] esc = CharacterEscapes.standardAsciiEscapesForJSON();
+      // Escape HTML metacharacters for security reasons. For JSON, CharacterEscapes.ESCAPE_STANDARD
+      // means unicode-escaping.
+      esc['<'] = CharacterEscapes.ESCAPE_STANDARD;
+      esc['>'] = CharacterEscapes.ESCAPE_STANDARD;
+      esc['&'] = CharacterEscapes.ESCAPE_STANDARD;
+      asciiEscapes = esc;
+    }
+
+    /** Return the escape codes used for ASCII characters. */
+    @Override
+    public int[] getEscapeCodesForAscii() {
+      return asciiEscapes;
+    }
+
+    /**
+     * Return the escape codes used for non-ASCII characters, or ASCII characters with escape code
+     * set to ESCAPE_CUSTOM.
+     *
+     * <p>This is required because CharacterEscapes is abstract. We don't need additional escaping
+     * for any characters, so per documentation this can return null for all inputs.
+     */
+    @Override
+    public SerializableString getEscapeSequence(int ch) {
+      return null;
+    }
+  }
+
   @Bean("objectMapper")
   public ObjectMapper objectMapper() {
-    return new ObjectMapper()
-        .registerModule(new ParameterNamesModule())
-        .registerModule(new Jdk8Module())
-        .registerModule(new JavaTimeModule())
-        .setDefaultPropertyInclusion(Include.NON_ABSENT);
+    ObjectMapper objectMapper =
+        new ObjectMapper()
+            .registerModule(new ParameterNamesModule())
+            .registerModule(new Jdk8Module())
+            .registerModule(new JavaTimeModule())
+            .setDefaultPropertyInclusion(Include.NON_ABSENT);
+    objectMapper.getFactory().setCharacterEscapes(new HTMLCharacterEscapes());
+    return objectMapper;
   }
 
   // This is a "magic bean": It supplies a method that Spring calls after the application is setup,


### PR DESCRIPTION
Informational finding from a pentest, recommendation was unicode-escaping certain characters in all JSON responses to prevent potential XSS attacks if the responses is rendered improperly in a UI.
This is difficult to test directly as the Java client our integration tests use automatically un-escapes the characters in responses, but I tested manually as follows:

1. Create a workspace with description `test string with characters " \n \t & < > \ /`
2. Prior to the change, calls to GET this workspace return description `test string with characters \" \\n \\t & < > \\ /` in the response. The UI displays a string matching the original description.
3. After this change, calls to GET this workspace return description `test string with characters \" \\n \\t \u0026 \u003C \u003E \\ /` in the response. The UI displays a string matching the original description.

Both the CLI and ET UI already display these characters properly, so this change is invisible to end-users.