### PR TITLE
[PF-1428] don't check access on referenced resource create or update

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/CreateReferenceResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/CreateReferenceResourceFlight.java
@@ -21,10 +21,7 @@ public class CreateReferenceResourceFlight extends Flight {
 
     FlightBeanBag appContext = FlightBeanBag.getFromObject(beanBag);
 
-    // Perform access verification
-    addStep(new ValidateReferenceStep(appContext), RetryRules.cloud());
-
-    // If all is well, then store the reference metadata
+    // Store the reference metadata
     addStep(
         new CreateReferenceMetadataStep(appContext.getResourceDao()), RetryRules.shortDatabase());
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/ValidateReferenceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/ValidateReferenceStep.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResou
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 // Note: this is technically dead code, but will be used again soon in PF-1427
+
 public class ValidateReferenceStep implements Step {
 
   private final FlightBeanBag beanBag;

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/ValidateReferenceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/create/ValidateReferenceStep.java
@@ -11,7 +11,7 @@ import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
-
+// Note: this is technically dead code, but will be used again soon in PF-1427
 public class ValidateReferenceStep implements Step {
 
   private final FlightBeanBag beanBag;

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/update/UpdateReferenceResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/update/UpdateReferenceResourceFlight.java
@@ -25,9 +25,6 @@ public class UpdateReferenceResourceFlight extends Flight {
     final ReferencedResource resource =
         inputParameters.get(ResourceKeys.RESOURCE, ReferencedResource.class);
 
-    // Perform access verification
-    addStep(new ValidateReferenceStep(appContext), RetryRules.cloud());
-
     RetryRule shortDatabaseRetryRule = RetryRules.shortDatabase();
     addStep(
         new RetrieveReferenceMetadataStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/update/UpdateReferenceResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/update/UpdateReferenceResourceFlight.java
@@ -6,7 +6,6 @@ import bio.terra.stairway.RetryRule;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
-import bio.terra.workspace.service.resource.referenced.flight.create.ValidateReferenceStep;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 
 /** A flight to update the reference resource's name, description, and/or attributes. */

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -37,7 +37,6 @@ import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.Refer
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject.ReferencedGcsObjectResource;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.resource.referenced.flight.create.CreateReferenceMetadataStep;
-import bio.terra.workspace.service.resource.referenced.flight.create.ValidateReferenceStep;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -247,7 +247,6 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
     @Test
     void createReferencedResourceDo() {
       Map<String, StepStatus> retrySteps = new HashMap<>();
-      retrySteps.put(ValidateReferenceStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
       retrySteps.put(
           CreateReferenceMetadataStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
       FlightDebugInfo debugInfo = FlightDebugInfo.newBuilder().doStepFailures(retrySteps).build();
@@ -266,7 +265,6 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                 + "test undo step.")
     void createReferencedResourceUndo() {
       Map<String, StepStatus> retrySteps = new HashMap<>();
-      retrySteps.put(ValidateReferenceStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
       retrySteps.put(
           CreateReferenceMetadataStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
       FlightDebugInfo debugInfo =


### PR DESCRIPTION
Remove the access step check from the `CreateReferencedResourceFlight`, but don't delete it, as it will be needed again soon for the on-demand access check functionality.