### PR TITLE
[No Ticket] Pin setup-gcloud Github Action to version

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -107,7 +107,7 @@ jobs:
         ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
     - name: Auth to GCR
       if: steps.skiptest.outputs.is-bump == 'no'
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         version: '270.0.0'
         service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}


### PR DESCRIPTION
The `google-github-actions/setup-gcloud` action is moving their main branch from `master` to `main`, we're currently pinned to the version at `master` (extensive warning here: https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/2040799754). This is the only usage of this action in this repo.

Pinning this at `v0` instead per above warning, since I don't think we should set `SETUP_GCLOUD_I_UNDERSTAND_USING_MASTER_WILL_BREAK_MY_WORKFLOW_ON_2022_04_05`