### PR TITLE
[PF-1247] Include stacktrace in privateResourceCleanup failure logs

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupService.java
+++ b/service/src/main/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupService.java
@@ -83,8 +83,8 @@ public class PrivateResourceCleanupService {
     try {
       cleanupResources();
     } catch (Exception e) {
-      logger.error(
-          "Error during privateResourceCleanup execution: ", e, LoggingUtils.alertObject());
+      LoggingUtils.logAlert(logger, "Unexpected error during privateResourceCleanup execution, see stacktrace below");
+      logger.error("privateResourceCleanup stacktrace: ", e);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupService.java
+++ b/service/src/main/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupService.java
@@ -83,7 +83,8 @@ public class PrivateResourceCleanupService {
     try {
       cleanupResources();
     } catch (Exception e) {
-      LoggingUtils.logAlert(logger, "Unexpected error during privateResourceCleanup execution, see stacktrace below");
+      LoggingUtils.logAlert(
+          logger, "Unexpected error during privateResourceCleanup execution, see stacktrace below");
       logger.error("privateResourceCleanup stacktrace: ", e);
     }
   }


### PR DESCRIPTION
Unfortunately the SLF4J `Logger` interface doesn't support logging both a Throwable and an arbitrary JSON object in the same entry, so this needs to be two separate log entries. This approach will log the full stacktrace of the thrown exception. Previously, the exception wouldn't be included in the log at all, although the JSON object would be.

These stacktraces will only appear in logs, and are not returned as responses to users.