### PR TITLE
[PF-1449] Suppress unnecessary spotbugs warning

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
@@ -26,24 +26,23 @@ public class BeanConfig {
   }
 
   public static class HTMLCharacterEscapes extends CharacterEscapes {
-    private final int[] asciiEscapes;
+    private static final int[] asciiEscapes;
 
-    public HTMLCharacterEscapes() {
+    static {
       // Start with a copy of the default set of escaped characters, then modify.
-      int[] esc = CharacterEscapes.standardAsciiEscapesForJSON();
+      asciiEscapes = CharacterEscapes.standardAsciiEscapesForJSON();
       // Escape HTML metacharacters for security reasons. For JSON, CharacterEscapes.ESCAPE_STANDARD
       // means unicode-escaping.
-      esc['<'] = CharacterEscapes.ESCAPE_STANDARD;
-      esc['>'] = CharacterEscapes.ESCAPE_STANDARD;
-      esc['&'] = CharacterEscapes.ESCAPE_STANDARD;
-      asciiEscapes = esc;
+      asciiEscapes['<'] = CharacterEscapes.ESCAPE_STANDARD;
+      asciiEscapes['>'] = CharacterEscapes.ESCAPE_STANDARD;
+      asciiEscapes['&'] = CharacterEscapes.ESCAPE_STANDARD;
     }
 
     /** Return the escape codes used for ASCII characters. */
     @Override
     @SuppressFBWarnings(
         value = "EI",
-        justification = "per interface doc, callers should not modify returned value")
+        justification = "per base class documentation, callers may not modify returned value")
     public int[] getEscapeCodesForAscii() {
       return asciiEscapes;
     }

--- a/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -40,6 +41,9 @@ public class BeanConfig {
 
     /** Return the escape codes used for ASCII characters. */
     @Override
+    @SuppressFBWarnings(
+        value = "EI",
+        justification = "per interface doc, callers should not modify returned value")
     public int[] getEscapeCodesForAscii() {
       return asciiEscapes;
     }


### PR DESCRIPTION
Spotbugs warns that we're exposing a `private final` array via public method as required by the `CharacterEscapes` class. This is expected, and the class documentation notes "Caller is not to modify contents of this array, since this is expected to be a shared copy" on the return value of `getEscapeCodesForAscii`.