### PR TITLE
TOAZ-83 Run listener inside the Notebook VM.

### DIFF
--- a/openapi/src/parts/controlled_azure_vm.yaml
+++ b/openapi/src/parts/controlled_azure_vm.yaml
@@ -134,7 +134,7 @@ components:
           description: A valid data which identifies the VM image
           $ref: '#/components/schemas/AzureVmImage'
         vmUser:
-          description: A valid VM user data
+          description: A valid VM user data. This data is required only for marketplace VM image.
           $ref: '#/components/schemas/AzureVmUser'
         customScriptExtension:
           description: A custom script extension
@@ -147,7 +147,7 @@ components:
         For instance /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.1.0
         In order to use marketplace image following properties should be defined: publisher, offer, sku.
         For instance publisher=microsoft-dsvm, offer=ubuntu-1804, sku=1804-gen2
-        If all parameters are defined then uri parameter will take precedence.
+        If all parameters are defined then uri parameter will take precedence and vmUser parameter will be ignored.
       type: object
       properties:
         uri:

--- a/openapi/src/parts/controlled_azure_vm.yaml
+++ b/openapi/src/parts/controlled_azure_vm.yaml
@@ -105,7 +105,7 @@ components:
         Vm-specific properties to be set on creation. These are a subset of the values
         accepted by the azure resource API
       type: object
-      required: [name, region, ipId, diskId, networkId, vmSize, vmImageUri]
+      required: [name, region, ipId, diskId, networkId, vmSize, vmImage]
       properties:
         name:
           description: A valid vm name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
@@ -117,9 +117,6 @@ components:
           type: string
         vmSize:
           description: A valid image size as per com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
-          type: string
-        vmImageUri:
-          description: A valid image Uri. Must be in the same region specified. E.x. /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.1.0
           type: string
         ipId:
           description: A valid WSM identifier for an Azure Ip that corresponds to a valid azure resource
@@ -133,6 +130,111 @@ components:
           description: A valid WSM identifier for an Azure Network that corresponds to a valid azure resource
           type: string
           format: uuid
+        vmImage:
+          description: A valid data which identifies the VM image
+          $ref: '#/components/schemas/AzureVmImage'
+        vmUser:
+          description: A valid VM user data
+          $ref: '#/components/schemas/AzureVmUser'
+        customScriptExtension:
+          description: A custom script extension
+          $ref: '#/components/schemas/AzureVmCustomScriptExtension'
+
+    AzureVmImage:
+      description: >-
+        A valid data which identifies the VM image. It supports custom and marketplace images. Properties are mutually exclusive.
+        Either Uri can be defined or publisher, offer and sku. Uri should be assigned in order to refer to custom image. Custom image must be in the same region.
+        For instance /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.1.0
+        In order to use marketplace image following properties should be defined: publisher, offer, sku.
+        For instance publisher=microsoft-dsvm, offer=ubuntu-1804, sku=1804-gen2
+        If all parameters are defined then uri parameter will take precedence.
+      type: object
+      properties:
+        uri:
+          description: A valid image Uri
+          type: string
+        publisher:
+          description: A publisher of an image
+          type: string
+        offer:
+          description: An offer of an image
+          type: string
+        sku:
+          description: A sku of an image
+          type: string
+
+    AzureVmCustomScriptExtension:
+      description: >-
+        Azure VM custom script extension definition. Azure documentation https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux
+      type: object
+      required: [name, publisher]
+      properties:
+        name:
+          description: A name of the extension
+          type: string
+        publisher:
+          description: A publisher of the extension
+          type: string
+        type:
+          description: A type of the extension
+          type: string
+        version:
+          description: A version of the extension
+          type: string
+        minorVersionAutoUpgrade:
+          description: Flag which controls auto upgrade of the extension
+          type: boolean
+        publicSettings:
+          description: List of public settings of the extension
+          type: array
+          items:
+            $ref: '#/components/schemas/AzureVmCustomScriptExtensionSetting'
+        protectedSettings:
+          description: List of protected settings of the extension
+          type: array
+          items:
+            $ref: '#/components/schemas/AzureVmCustomScriptExtensionSetting'
+        tags:
+          description: List of tags of the extension
+          type: array
+          items:
+            $ref: '#/components/schemas/AzureVmCustomScriptExtensionTag'
+
+    AzureVmCustomScriptExtensionSetting:
+      description: Azure VM extension settings
+      type: object
+      required: [key, value]
+      properties:
+        key:
+          description: Name of the settings entry
+          type: string
+        value:
+          description: Value of the settings entry
+          type: object
+
+    AzureVmCustomScriptExtensionTag:
+      description: List of tags for VM extension
+      type: object
+      required: [key, value]
+      properties:
+        key:
+          description: Name of the tag
+          type: string
+        value:
+          description: Value of the tag
+          type: string
+
+    AzureVmUser:
+      description: User credentials which are required for VM creation
+      type: object
+      required: [name, password]
+      properties:
+        name:
+          description: Specifies an SSH root user name for the Linux virtual machine
+          type: string
+        password:
+          description: Specifies the SSH root password for the Linux virtual machine
+          type: string
 
     CreateControlledAzureVmRequestBody:
       description: Payload for requesting a new controlled Azure VM resource.

--- a/openapi/src/resources/azure_vm.yaml
+++ b/openapi/src/resources/azure_vm.yaml
@@ -14,8 +14,8 @@ components:
         vmSize:
           description: A valid image size as per com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
           type: string
-        vmImageUri:
-          description: A valid image Uri. Must be in the same region specified. E.x. /subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.0.4
+        vmImage:
+          description: A valid data which identifies the VM image
           type: string
         ipId:
           description: A valid WSM identifier for an Azure Ip that corresponds to a valid azure resource

--- a/service/src/main/java/bio/terra/workspace/app/configuration/StoragetransferConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/StoragetransferConfiguration.java
@@ -3,16 +3,10 @@ package bio.terra.workspace.app.configuration;
 import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.StorageTransferServiceUtils;
 import com.google.api.client.googleapis.util.Utils;
 import com.google.api.services.storagetransfer.v1.Storagetransfer;
-import com.google.api.services.storagetransfer.v1.StoragetransferScopes;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
-import java.io.IOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 @Configuration
 public class StoragetransferConfiguration {

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.app.controller;
 
 import bio.terra.common.exception.ApiException;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.common.utils.AzureVmUtils;
 import bio.terra.workspace.generated.controller.ControlledAzureResourceApi;
 import bio.terra.workspace.generated.model.ApiAzureDiskResource;
 import bio.terra.workspace.generated.model.ApiAzureIpResource;
@@ -215,7 +216,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             .vmName(body.getAzureVm().getName())
             .region(body.getAzureVm().getRegion())
             .vmSize(body.getAzureVm().getVmSize())
-            .vmImageUri(body.getAzureVm().getVmImageUri())
+            .vmImage(AzureVmUtils.getImageData(body.getAzureVm().getVmImage()))
             .ipId(body.getAzureVm().getIpId())
             .networkId(body.getAzureVm().getNetworkId())
             .diskId(body.getAzureVm().getDiskId())

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -29,6 +29,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpResource;
@@ -210,6 +211,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     final ControlledResourceFields commonFields =
         toCommonFields(workspaceId, body.getCommon(), userRequest);
 
+    ResourceValidationUtils.validateApiAzureVmCreationParameters(body.getAzureVm());
     ControlledAzureVmResource resource =
         ControlledAzureVmResource.builder()
             .common(commonFields)

--- a/service/src/main/java/bio/terra/workspace/common/utils/AzureVmUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/AzureVmUtils.java
@@ -1,0 +1,51 @@
+package bio.terra.workspace.common.utils;
+
+import bio.terra.workspace.generated.model.ApiAzureVmCustomScriptExtensionSetting;
+import bio.terra.workspace.generated.model.ApiAzureVmCustomScriptExtensionTag;
+import bio.terra.workspace.generated.model.ApiAzureVmImage;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class AzureVmUtils {
+  private AzureVmUtils() {}
+
+  public static HashMap<String, Object> settingsFrom(
+      List<ApiAzureVmCustomScriptExtensionSetting> settingsList) {
+    return nullSafeListToStream(settingsList)
+        .flatMap(Stream::ofNullable)
+        .collect(
+            Collectors.toMap(
+                ApiAzureVmCustomScriptExtensionSetting::getKey,
+                ApiAzureVmCustomScriptExtensionSetting::getValue,
+                (prev, next) -> prev,
+                HashMap::new));
+  }
+
+  public static HashMap<String, String> tagsFrom(
+      List<ApiAzureVmCustomScriptExtensionTag> tagsList) {
+    return nullSafeListToStream(tagsList)
+        .flatMap(Stream::ofNullable)
+        .collect(
+            Collectors.toMap(
+                ApiAzureVmCustomScriptExtensionTag::getKey,
+                ApiAzureVmCustomScriptExtensionTag::getValue,
+                (prev, next) -> prev,
+                HashMap::new));
+  }
+
+  public static String getImageData(ApiAzureVmImage apiAzureVmImage) {
+    return apiAzureVmImage.getUri() != null
+        ? apiAzureVmImage.getUri()
+        : String.format(
+            "publisher=%s;offer=%s;sku=%s",
+            apiAzureVmImage.getPublisher(), apiAzureVmImage.getOffer(), apiAzureVmImage.getSku());
+  }
+
+  private static <T> Stream<T> nullSafeListToStream(Collection<T> collection) {
+    return Optional.ofNullable(collection).stream().flatMap(Collection::stream);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/common/utils/FlightBeanBag.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/FlightBeanBag.java
@@ -35,7 +35,7 @@ public class FlightBeanBag {
   private final ApplicationDao applicationDao;
   private final AzureCloudContextService azureCloudContextService;
   private final AzureConfiguration azureConfig;
-  private final BucketCloneRolesService bucketCloneRolesComponent;
+  private final BucketCloneRolesService bucketCloneRolesService;
   private final BufferService bufferService;
   private final CliConfiguration cliConfiguration;
   private final ControlledResourceMetadataManager controlledResourceMetadataManager;
@@ -58,7 +58,7 @@ public class FlightBeanBag {
       ApplicationDao applicationDao,
       AzureCloudContextService azureCloudContextService,
       AzureConfiguration azureConfig,
-      BucketCloneRolesService bucketCloneRolesComponent,
+      BucketCloneRolesService bucketCloneRolesService,
       BufferService bufferService,
       CliConfiguration cliConfiguration,
       ControlledResourceMetadataManager controlledResourceMetadataManager,
@@ -77,7 +77,7 @@ public class FlightBeanBag {
     this.applicationDao = applicationDao;
     this.azureCloudContextService = azureCloudContextService;
     this.azureConfig = azureConfig;
-    this.bucketCloneRolesComponent = bucketCloneRolesComponent;
+    this.bucketCloneRolesService = bucketCloneRolesService;
     this.bufferService = bufferService;
     this.cliConfiguration = cliConfiguration;
     this.controlledResourceMetadataManager = controlledResourceMetadataManager;
@@ -107,8 +107,8 @@ public class FlightBeanBag {
     return azureCloudContextService;
   }
 
-  public BucketCloneRolesService getBucketCloneRolesComponent() {
-    return bucketCloneRolesComponent;
+  public BucketCloneRolesService getBucketCloneRolesService() {
+    return bucketCloneRolesService;
   }
 
   public BufferService getBufferService() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.app.configuration.external.GitRepoReferencedResourceConfiguration;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.service.resource.exception.InvalidNameException;
@@ -399,6 +400,31 @@ public class ResourceValidationUtils {
     if (fieldValue == null) {
       throw new MissingRequiredFieldException(
           String.format("Missing required field '%s' for resource", fieldName));
+    }
+  }
+
+  public static void validateApiAzureVmCreationParameters(
+      ApiAzureVmCreationParameters apiAzureVmCreationParameters) {
+    var vmImage = apiAzureVmCreationParameters.getVmImage();
+    if (StringUtils.isEmpty(vmImage.getUri())
+            && StringUtils.isEmpty(vmImage.getPublisher())
+            && StringUtils.isEmpty(vmImage.getOffer())
+            && StringUtils.isEmpty(vmImage.getSku())) {
+      throw new MissingRequiredFieldException(
+              "Missing required fields for vmImage. Either uri or publisher, offer, sku should be defined.");
+    }
+    if (StringUtils.isEmpty(vmImage.getUri())
+            && (StringUtils.isEmpty(vmImage.getPublisher())
+            || StringUtils.isEmpty(vmImage.getOffer())
+            || StringUtils.isEmpty(vmImage.getSku()))) {
+      throw new MissingRequiredFieldException(
+              "Missing required fields for vmImage. Publisher, offer, sku should be defined.");
+    }
+    if (StringUtils.isEmpty(vmImage.getUri())
+        && (!StringUtils.isEmpty(vmImage.getPublisher())
+            && !StringUtils.isEmpty(vmImage.getOffer())
+            && !StringUtils.isEmpty(vmImage.getSku()))) {
+      checkFieldNonNull(apiAzureVmCreationParameters.getVmUser(), "vmUser");
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -407,18 +407,18 @@ public class ResourceValidationUtils {
       ApiAzureVmCreationParameters apiAzureVmCreationParameters) {
     var vmImage = apiAzureVmCreationParameters.getVmImage();
     if (StringUtils.isEmpty(vmImage.getUri())
-            && StringUtils.isEmpty(vmImage.getPublisher())
-            && StringUtils.isEmpty(vmImage.getOffer())
-            && StringUtils.isEmpty(vmImage.getSku())) {
+        && StringUtils.isEmpty(vmImage.getPublisher())
+        && StringUtils.isEmpty(vmImage.getOffer())
+        && StringUtils.isEmpty(vmImage.getSku())) {
       throw new MissingRequiredFieldException(
-              "Missing required fields for vmImage. Either uri or publisher, offer, sku should be defined.");
+          "Missing required fields for vmImage. Either uri or publisher, offer, sku should be defined.");
     }
     if (StringUtils.isEmpty(vmImage.getUri())
-            && (StringUtils.isEmpty(vmImage.getPublisher())
+        && (StringUtils.isEmpty(vmImage.getPublisher())
             || StringUtils.isEmpty(vmImage.getOffer())
             || StringUtils.isEmpty(vmImage.getSku()))) {
       throw new MissingRequiredFieldException(
-              "Missing required fields for vmImage. Publisher, offer, sku should be defined.");
+          "Missing required fields for vmImage. Publisher, offer, sku should be defined.");
     }
     if (StringUtils.isEmpty(vmImage.getUri())
         && (!StringUtils.isEmpty(vmImage.getPublisher())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmAttributes.java
@@ -8,7 +8,7 @@ public class ControlledAzureVmAttributes {
   private final String vmName;
   private final String region;
   private final String vmSize;
-  private final String vmImageUri;
+  private final String vmImage;
 
   private final UUID ipId;
   private final UUID networkId;
@@ -19,14 +19,14 @@ public class ControlledAzureVmAttributes {
       @JsonProperty("vmName") String vmName,
       @JsonProperty("region") String region,
       @JsonProperty("vmSize") String vmSize,
-      @JsonProperty("vmImageUri") String vmImageUri,
+      @JsonProperty("vmImage") String vmImage,
       @JsonProperty("ipId") UUID ipId,
       @JsonProperty("networkId") UUID networkId,
       @JsonProperty("diskId") UUID diskId) {
     this.vmName = vmName;
     this.region = region;
     this.vmSize = vmSize;
-    this.vmImageUri = vmImageUri;
+    this.vmImage = vmImage;
 
     this.ipId = ipId;
     this.networkId = networkId;
@@ -45,8 +45,8 @@ public class ControlledAzureVmAttributes {
     return vmSize;
   }
 
-  public String getVmImageUri() {
-    return vmImageUri;
+  public String getVmImage() {
+    return vmImage;
   }
 
   public UUID getIpId() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmHandler.java
@@ -27,7 +27,7 @@ public class ControlledAzureVmHandler implements WsmResourceHandler {
             .vmName(attributes.getVmName())
             .region(attributes.getRegion())
             .vmSize(attributes.getVmSize())
-            .vmImageUri(attributes.getVmImageUri())
+            .vmImage(attributes.getVmImage())
             .ipId(attributes.getIpId())
             .networkId(attributes.getNetworkId())
             .diskId(attributes.getDiskId())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -35,7 +35,7 @@ public class ControlledAzureVmResource extends ControlledResource {
   private final String vmName;
   private final String region;
   private final String vmSize;
-  private final String vmImageUri;
+  private final String vmImage;
 
   private final UUID ipId;
   private final UUID networkId;
@@ -56,7 +56,7 @@ public class ControlledAzureVmResource extends ControlledResource {
       @JsonProperty("vmName") String vmName,
       @JsonProperty("region") String region,
       @JsonProperty("vmSize") String vmSize,
-      @JsonProperty("vmImageUri") String vmImageUri,
+      @JsonProperty("vmImage") String vmImage,
       @JsonProperty("ipId") UUID ipId,
       @JsonProperty("networkId") UUID networkId,
       @JsonProperty("diskId") UUID diskId) {
@@ -75,7 +75,7 @@ public class ControlledAzureVmResource extends ControlledResource {
     this.vmName = vmName;
     this.region = region;
     this.vmSize = vmSize;
-    this.vmImageUri = vmImageUri;
+    this.vmImage = vmImage;
     this.ipId = ipId;
     this.networkId = networkId;
     this.diskId = diskId;
@@ -87,14 +87,14 @@ public class ControlledAzureVmResource extends ControlledResource {
       String vmName,
       String region,
       String vmSize,
-      String vmImageUri,
+      String vmImage,
       UUID ipId,
       UUID networkId,
       UUID diskId) {
     super(common);
     this.vmName = vmName;
     this.region = region;
-    this.vmImageUri = vmImageUri;
+    this.vmImage = vmImage;
     this.vmSize = vmSize;
     this.ipId = ipId;
     this.networkId = networkId;
@@ -161,8 +161,8 @@ public class ControlledAzureVmResource extends ControlledResource {
     return vmSize;
   }
 
-  public String getVmImageUri() {
-    return vmImageUri;
+  public String getVmImage() {
+    return vmImage;
   }
 
   public UUID getIpId() {
@@ -182,7 +182,7 @@ public class ControlledAzureVmResource extends ControlledResource {
         .vmName(getVmName())
         .region(getRegion())
         .vmSize(getVmSize())
-        .vmImageUri(getVmImageUri())
+        .vmImage(getVmImage())
         .ipId(getIpId())
         .diskId(getDiskId())
         .networkId(getNetworkId());
@@ -223,7 +223,7 @@ public class ControlledAzureVmResource extends ControlledResource {
             getVmName(),
             getRegion(),
             getVmSize(),
-            getVmImageUri(),
+            getVmImage(),
             getIpId(),
             getNetworkId(),
             getDiskId()));
@@ -249,9 +249,9 @@ public class ControlledAzureVmResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required valid vmSize field for ControlledAzureVm.");
     }
-    if (getVmImageUri() == null) {
+    if (getVmImage() == null) {
       throw new MissingRequiredFieldException(
-          "Missing required valid vmImageUri field for ControlledAzureVm.");
+          "Missing required valid vmImage field for ControlledAzureVm.");
     }
     if (getIpId() == null) {
       throw new MissingRequiredFieldException("Missing required ipId field for ControlledAzureVm.");
@@ -296,7 +296,7 @@ public class ControlledAzureVmResource extends ControlledResource {
     private String vmName;
     private String region;
     private String vmSize;
-    private String vmImageUri;
+    private String vmImage;
     private UUID ipId;
     private UUID networkId;
     private UUID diskId;
@@ -316,8 +316,8 @@ public class ControlledAzureVmResource extends ControlledResource {
       return this;
     }
 
-    public ControlledAzureVmResource.Builder vmImageUri(String vmImageUri) {
-      this.vmImageUri = vmImageUri;
+    public ControlledAzureVmResource.Builder vmImage(String vmImage) {
+      this.vmImage = vmImage;
       return this;
     }
 
@@ -343,7 +343,7 @@ public class ControlledAzureVmResource extends ControlledResource {
 
     public ControlledAzureVmResource build() {
       return new ControlledAzureVmResource(
-          common, vmName, region, vmSize, vmImageUri, ipId, networkId, diskId);
+          common, vmName, region, vmSize, vmImage, ipId, networkId, diskId);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
@@ -84,12 +84,12 @@ public class CloneControlledGcsBucketResourceFlight extends Flight {
             new SetBucketRolesStep(
                 sourceBucket,
                 flightBeanBag.getGcpCloudContextService(),
-                flightBeanBag.getBucketCloneRolesComponent(),
+                flightBeanBag.getBucketCloneRolesService(),
                 flightBeanBag.getStoragetransfer()));
         addStep(new CreateStorageTransferServiceJobStep(flightBeanBag.getStoragetransfer()));
         addStep(new CompleteTransferOperationStep(flightBeanBag.getStoragetransfer()));
         addStep(new DeleteStorageTransferServiceJobStep(flightBeanBag.getStoragetransfer()));
-        addStep(new RemoveBucketRolesStep(flightBeanBag.getBucketCloneRolesComponent()));
+        addStep(new RemoveBucketRolesStep(flightBeanBag.getBucketCloneRolesService()));
       }
     }
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/DeleteStorageTransferServiceJobStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/DeleteStorageTransferServiceJobStep.java
@@ -4,7 +4,6 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
-import bio.terra.workspace.service.resource.model.CloningInstructions;
 import com.google.api.services.storagetransfer.v1.Storagetransfer;
 
 /**
@@ -20,8 +19,7 @@ public class DeleteStorageTransferServiceJobStep implements Step {
 
   private final Storagetransfer storagetransfer;
 
-  public DeleteStorageTransferServiceJobStep(
-      Storagetransfer storagetransfer) {
+  public DeleteStorageTransferServiceJobStep(Storagetransfer storagetransfer) {
     this.storagetransfer = storagetransfer;
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -166,6 +166,23 @@ public class ControlledResourceFixtures {
                     "/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.1.0"))
         .ipId(UUID.randomUUID())
         .diskId(UUID.randomUUID())
+        .networkId(UUID.randomUUID());
+  }
+
+  public static ApiAzureVmCreationParameters
+      getAzureVmCreationParametersWithCustomScriptExtension() {
+    return new ApiAzureVmCreationParameters()
+        .name(uniqueAzureName(AZURE_VM_NAME_PREFIX))
+        .region("westcentralus")
+        .vmSize(VirtualMachineSizeTypes.STANDARD_D2S_V3.toString())
+        // TODO: it'd be nice to support standard Linux OSes in addition to custom image URIs.
+        // The below image is a Jupyter image and should be stable.
+        .vmImage(
+            new ApiAzureVmImage()
+                .uri(
+                    "/subscriptions/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/resourceGroups/mrg-qi-1-preview-20210517084351/providers/Microsoft.Compute/galleries/msdsvm/images/customized_ms_dsvm/versions/0.1.0"))
+        .ipId(UUID.randomUUID())
+        .diskId(UUID.randomUUID())
         .networkId(UUID.randomUUID())
         .customScriptExtension(getAzureVmCustomScriptExtension());
   }

--- a/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
@@ -4,6 +4,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.app.configuration.external.AzureTestConfiguration;
 import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
@@ -78,6 +79,17 @@ public class AzureTestUtils {
     inputs.put(ResourceKeys.STEWARDSHIP_TYPE, StewardshipType.CONTROLLED);
     inputs.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceId.toString());
     inputs.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), userRequest);
+    return inputs;
+  }
+
+  public FlightMap createControlledResourceInputParameters(
+      UUID workspaceId,
+      AuthenticatedUserRequest userRequest,
+      ControlledResource resource,
+      ApiAzureVmCreationParameters creationParameters) {
+    var inputs = createControlledResourceInputParameters(workspaceId, userRequest, resource);
+    inputs.put(
+        WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
     return inputs;
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -4,8 +4,11 @@ import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.def
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.exception.InconsistentFieldsException;
+import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.app.configuration.external.GitRepoReferencedResourceConfiguration;
 import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
+import bio.terra.workspace.generated.model.ApiAzureVmImage;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceContainerImage;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.service.resource.exception.InvalidNameException;
@@ -328,5 +331,41 @@ public class ValidationUtilsTest extends BaseUnitTest {
         () ->
             validationUtils.validateGitRepoUri(
                 "https://git@github.com:DataBiosphere/terra-workspace-manager"));
+  }
+
+  @Test
+  public void validateVmCreatePayload_missedVmImageParameters_throwsException() {
+    var apiVmCreationParameters =
+        new ApiAzureVmCreationParameters()
+            .vmImage(new ApiAzureVmImage().uri("").publisher("").offer("").sku(""));
+
+    assertThrows(
+        MissingRequiredFieldException.class,
+        () ->
+            ResourceValidationUtils.validateApiAzureVmCreationParameters(apiVmCreationParameters));
+  }
+
+  @Test
+  public void validateVmCreatePayload_missedMarketplaceImageParameters_throwsException() {
+    var apiVmCreationParameters =
+        new ApiAzureVmCreationParameters()
+            .vmImage(new ApiAzureVmImage().publisher("").offer("ubuntu").sku("gen2"));
+
+    assertThrows(
+        MissingRequiredFieldException.class,
+        () ->
+            ResourceValidationUtils.validateApiAzureVmCreationParameters(apiVmCreationParameters));
+  }
+
+  @Test
+  public void validateVmCreatePayload_missedVmUser_throwsException() {
+    var apiVmCreationParameters =
+        new ApiAzureVmCreationParameters()
+            .vmImage(new ApiAzureVmImage().publisher("microsoft").offer("ubuntu").sku("gen2"));
+
+    assertThrows(
+        MissingRequiredFieldException.class,
+        () ->
+            ResourceValidationUtils.validateApiAzureVmCreationParameters(apiVmCreationParameters));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.exception.FeatureNotSupportedException;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.utils.AzureVmUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
@@ -123,7 +124,7 @@ public class AzureDisabledTest extends BaseConnectedTest {
             .common(commonFields)
             .vmName(vmCreationParameters.getName())
             .vmSize(vmCreationParameters.getVmSize())
-            .vmImageUri(vmCreationParameters.getVmImageUri())
+            .vmImage(AzureVmUtils.getImageData(vmCreationParameters.getVmImage()))
             .region(vmCreationParameters.getRegion())
             .ipId(ipResource.getResourceId())
             .diskId(diskResource.getResourceId())

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -438,7 +438,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
     ControlledAzureNetworkResource networkResource = createNetwork(workspaceId, userRequest);
 
     final ApiAzureVmCreationParameters creationParameters =
-        ControlledResourceFixtures.getAzureVmCreationParameters();
+        ControlledResourceFixtures.getAzureVmCreationParametersWithCustomScriptExtension();
 
     // TODO: make this application-private resource once the POC supports it
     final UUID resourceId = UUID.randomUUID();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -64,8 +64,11 @@ public class CreateAzureStorageStepTest extends BaseAzureTest {
 
     when(mockStorageManager.storageAccounts()).thenReturn(mockStorageAccounts);
 
-    resourceNotFoundException = new ManagementException("Resource was not found.", /*response=*/
-        null, new ManagementError("ResourceNotFound", "Resource was not found."));
+    resourceNotFoundException =
+        new ManagementException(
+            "Resource was not found.",
+            /*response=*/ null,
+            new ManagementError("ResourceNotFound", "Resource was not found."));
 
     // Creation stages mocks
     when(mockStorageAccounts.define(anyString())).thenReturn(mockStorageBlankStage);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -23,7 +23,6 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.Controlled
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
-import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
@@ -307,8 +306,6 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
     when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
         .thenReturn(mockAzureCloudContext);
-//    when(mockFlightContext.getInputParameters()).thenReturn(mockInputParameters);
-    //when(mockInputParameters.get(ControlledResourceKeys.CREATION_PARAMETERS, ApiAzureVmCreationParameters.class)).thenReturn(mockApiAzureVmCreationParameters);
   }
 
   @Test
@@ -317,8 +314,7 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
         ControlledResourceFixtures.getAzureVmCreationParameters();
 
     final FlightMap creationParametersFlightMap = new FlightMap();
-    creationParametersFlightMap.put(
-            ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
+    creationParametersFlightMap.put(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
     creationParametersFlightMap.makeImmutable();
     when(mockFlightContext.getInputParameters()).thenReturn(creationParametersFlightMap);
 
@@ -369,8 +365,7 @@ public class CreateAzureVmStepTest extends BaseAzureTest {
         ControlledResourceFixtures.getAzureVmCreationParameters();
 
     final FlightMap creationParametersFlightMap = new FlightMap();
-    creationParametersFlightMap.put(
-            ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
+    creationParametersFlightMap.put(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
     creationParametersFlightMap.makeImmutable();
     when(mockFlightContext.getInputParameters()).thenReturn(creationParametersFlightMap);
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CreateStorageTransferServiceJobStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CreateStorageTransferServiceJobStepTest.java
@@ -43,7 +43,9 @@ public class CreateStorageTransferServiceJobStepTest extends BaseUnitTest {
   private CreateStorageTransferServiceJobStep createStorageTransferServiceJobStep;
 
   @BeforeEach
-  @SuppressFBWarnings(value = "RV", justification = "False positive for Mockito doReturn() statement")
+  @SuppressFBWarnings(
+      value = "RV",
+      justification = "False positive for Mockito doReturn() statement")
   public void setup() throws IOException {
     createStorageTransferServiceJobStep =
         new CreateStorageTransferServiceJobStep(mockStoragetransfer);


### PR DESCRIPTION
Extend 'Create VM' functionality with VM custom script extension. One of the main use case is to setup Data Science VM and expose Jupyter Notebook via Azure Relay.

VM create endpoint will handle optional parameter for 'custom script extension'. This allows to customize VM provisioning with custom startup script.  Also currently we can use standard VM image from marketplace. This functionality requires username/password for VM to be passed to the endpoint as well.

-Updated VM create endpoint payload with new optional parameter - customScriptExtension
-Updated CreateAzureVmStep to handle this new parameter.

!!Not all the files directly related to this feature. Some of the files just have updated formatting.