### PR TITLE
[PF-1446] Return destination workspace ID immediately

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -261,7 +261,8 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
 
     final String jobId = cloneResult.getJobReport().getId();
     logger.info("Clone Job ID {}", jobId);
-
+    assertNotNull(cloneResult.getWorkspace().getDestinationWorkspaceId(),
+        "Destination workspace ID available immediately.");
     cloneResult =
         ClientTestUtils.pollWhileRunning(
             cloneResult,

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -261,7 +261,8 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
 
     final String jobId = cloneResult.getJobReport().getId();
     logger.info("Clone Job ID {}", jobId);
-    assertNotNull(cloneResult.getWorkspace().getDestinationWorkspaceId(),
+    assertNotNull(
+        cloneResult.getWorkspace().getDestinationWorkspaceId(),
         "Destination workspace ID available immediately.");
     cloneResult =
         ClientTestUtils.pollWhileRunning(

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -370,10 +370,11 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     Optional<SpendProfileId> spendProfileId =
         Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::new);
 
+    UUID destinationWorkspaceId = UUID.randomUUID();
     // Construct the target workspace object from the inputs
     Workspace destinationWorkspace =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(destinationWorkspaceId)
             .spendProfileId(spendProfileId.orElse(null))
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .displayName(body.getDisplayName())
@@ -385,7 +386,13 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
         workspaceService.cloneWorkspace(
             workspaceId, petRequest, body.getLocation(), destinationWorkspace);
 
+    // Set destination workspace ID ASAP so UI can build a landing page for it
     final ApiCloneWorkspaceResult result = fetchCloneWorkspaceResult(jobId, getAuthenticatedInfo());
+    final ApiClonedWorkspace clonedWorkspaceStub = new ApiClonedWorkspace()
+        .destinationWorkspaceId(destinationWorkspaceId)
+            .sourceWorkspaceId(workspaceId);
+    result.setWorkspace(clonedWorkspaceStub);
+
     return new ResponseEntity<>(result, getAsyncResponseCode(result.getJobReport()));
   }
 


### PR DESCRIPTION
Simply populate the `workspace` object in the result with what we already know.