### PR TITLE
[PF-1530] Make connected test dataset names more unique

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -62,7 +62,8 @@ import scripts.utils.MultiResourcesUtils;
 import scripts.utils.SamClientUtils;
 
 public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScriptBase {
-  private static final Logger logger = LoggerFactory.getLogger(ControlledBigQueryDatasetLifecycle.class);
+  private static final Logger logger =
+      LoggerFactory.getLogger(ControlledBigQueryDatasetLifecycle.class);
 
   private static final String DATASET_RESOURCE_NAME = "wsmtest_dataset";
   private static final String TABLE_NAME = "wsmtest_table";

--- a/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -62,7 +62,7 @@ import scripts.utils.MultiResourcesUtils;
 import scripts.utils.SamClientUtils;
 
 public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScriptBase {
-  private static final Logger logger = LoggerFactory.getLogger(ControlledGcsBucketLifecycle.class);
+  private static final Logger logger = LoggerFactory.getLogger(ControlledBigQueryDatasetLifecycle.class);
 
   private static final String DATASET_RESOURCE_NAME = "wsmtest_dataset";
   private static final String TABLE_NAME = "wsmtest_table";

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.common.fixtures;
 
+import bio.terra.stairway.ShortUUID;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
@@ -390,7 +391,7 @@ public class ControlledResourceFixtures {
   }
 
   public static String uniqueDatasetId() {
-    return "my_test_dataset_" + (int) (Math.floor(Math.random() * 10000));
+    return "my_test_dataset_" + ShortUUID.get().replace("-", "_");
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -641,11 +641,6 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             workspace.getWorkspaceId(), resource.getResourceId(), user.getAuthenticatedRequest()));
   }
 
-  /** Create a dataset name with a random 4-digit (rarely 5) suffix */
-  private String uniqueDatasetId() {
-    return "my_test_dataset_" + (int) (Math.floor(Math.random() * 10000));
-  }
-
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createBqDatasetUndo() throws Exception {


### PR DESCRIPTION
We recently had a failure due to a BQ dataset name conflict in `ControlledResourceServiceTest` resources. This should make those conflicts much less likely.

I also fixed a `Logger` bug in `ControlledBigQueryDatasetLifecycle`, I think the wrong class got copied when this test was written, which gave us slightly misleading logs. 