### PR TITLE
[PF-1488] [PF-1496] Improve Pet SA impersonation processing

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/StorageTransferServiceUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/StorageTransferServiceUtils.java
@@ -48,9 +48,13 @@ public final class StorageTransferServiceUtils {
       Storagetransfer storageTransferService, String transferJobName, String controlPlaneProjectId)
       throws IOException {
     // If there's no job  to delete, return early
-    final TransferJob existingTransferJob = storageTransferService.transferJobs().get(transferJobName, controlPlaneProjectId).execute();
+    final TransferJob existingTransferJob =
+        storageTransferService.transferJobs().get(transferJobName, controlPlaneProjectId).execute();
     if (existingTransferJob == null) {
-      logger.info("Transfer Job {} in project {} was not found when trying to delete it.", transferJobName, controlPlaneProjectId);
+      logger.info(
+          "Transfer Job {} in project {} was not found when trying to delete it.",
+          transferJobName,
+          controlPlaneProjectId);
       return;
     }
     final TransferJob patchedTransferJob = new TransferJob().setStatus(DELETED_STATUS);


### PR DESCRIPTION
Two changes to the pet SA impersonation implementation:
1. Test the policy bindings before making a policy update. The setIam call is rate limited and we hit the limit in testing. We can avoid the call when the same user makes and/or deletes multiple notebooks.
2. Add handling for the conflict (409) error from GCP. We use the step's retry, so it is a matter of making a good error and then returning `Retry` from the step.
