### PR TITLE
[DDO-2025] Remove self-hosted runners from WSM

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   nightly-tests:
 
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     permissions:
       contents: 'read'


### PR DESCRIPTION
No longer has any benefit after https://broadinstitute.slack.com/archives/C2B7JFJ4S/p1649802203643319.

The action has run off of this branch successfully here: https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/2162363076, https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/2198707115, https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/2204640363