### PR TITLE
[No Ticket] Use latest bumper GHA version

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -75,7 +75,7 @@ jobs:
         event-name: ${{ github.event_name }}
     - name: Bump the tag to a new version
       if: steps.skiptest.outputs.is-bump == 'no'
-      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.4
+      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
       id: tag
       env:
         DEFAULT_BUMP: patch


### PR DESCRIPTION
The current `bumper` action version is currently broken due to Github's mitigation of a security issue, moving this to the latest version which has a patch (https://github.com/DataBiosphere/github-actions/pull/32)

Example failure (see `Bump tag to a new version`): https://github.com/DataBiosphere/terra-workspace-manager/runs/6011344595?check_suite_focus=true