### PR TITLE
[PF-1581] Add workspace.user_facing_id field to db schema

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -6,4 +6,5 @@
     <include file="changesets/20211130_private_resource_state.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20211201_cronjob_table.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220131_resource_type.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220418_workspace_user_facing_id.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20210301_revised_initial_schema.yaml
+++ b/service/src/main/resources/db/changesets/20210301_revised_initial_schema.yaml
@@ -18,7 +18,6 @@ databaseChangeLog:
           - column:
               name: display_name
               type: text
-              # Note: this is now required. A future changeset will add not-null constraint (PF-1583).
               remarks: |
                 A user-friendly name for the workspace. There is no guarantee of uniqueness across workspaces.
                 Can be null. Omitted for Rawls workspaces, since Rawls maintains its own name

--- a/service/src/main/resources/db/changesets/20210301_revised_initial_schema.yaml
+++ b/service/src/main/resources/db/changesets/20210301_revised_initial_schema.yaml
@@ -18,6 +18,7 @@ databaseChangeLog:
           - column:
               name: display_name
               type: text
+              # Note: this is now required. A future changeset will add not-null constraint (PF-1583).
               remarks: |
                 A user-friendly name for the workspace. There is no guarantee of uniqueness across workspaces.
                 Can be null. Omitted for Rawls workspaces, since Rawls maintains its own name

--- a/service/src/main/resources/db/changesets/20220418_workspace_user_facing_id.yaml
+++ b/service/src/main/resources/db/changesets/20220418_workspace_user_facing_id.yaml
@@ -12,12 +12,10 @@ databaseChangeLog:
               constraints:
                 unique: true
               remarks: |
-                See PF-1359. A later changeset will make this required (PF-1583).
+                A user-settable, mutable id. See PF-1359. Required (a later
+                changeset will add not null constraint PF-1583).
     - sql:
         # user_facing_id is a required field. For new workspaces, UI/CLI will
         # require it. For existing workspaces, backfill with workspace_id.
-        sql: update workspace set user_facing_id = workspace_id;
-    - sql:
-        # display_name is a required field. For new workspaces, UI/CLI will
-        # require it. For existing workspaces, backfill with workspace_id.
-        sql: update workspace set display_name = workspace_id where display_name is null or display_name = '';
+        # Prepend 'a' because user_facing_id must start with letter.
+        sql: update workspace set user_facing_id = concat('a', workspace_id);

--- a/service/src/main/resources/db/changesets/20220418_workspace_user_facing_id.yaml
+++ b/service/src/main/resources/db/changesets/20220418_workspace_user_facing_id.yaml
@@ -1,4 +1,3 @@
-# PF-1359
 databaseChangeLog:
 - changeSet:
     id: add workspace user_facing_id
@@ -13,7 +12,7 @@ databaseChangeLog:
               constraints:
                 unique: true
               remarks: |
-                A later changeset will add not null constraint (PF-1583).
+                See PF-1359. A later changeset will make this required (PF-1583).
     - sql:
         # user_facing_id is a required field. For new workspaces, UI/CLI will
         # require it. For existing workspaces, backfill with workspace_id.

--- a/service/src/main/resources/db/changesets/20220418_workspace_user_facing_id.yaml
+++ b/service/src/main/resources/db/changesets/20220418_workspace_user_facing_id.yaml
@@ -1,0 +1,24 @@
+# PF-1359
+databaseChangeLog:
+- changeSet:
+    id: add workspace user_facing_id
+    author: melchang
+    changes:
+    - addColumn:
+        tableName: workspace
+        columns:
+          - column:
+              name: user_facing_id
+              type: text
+              constraints:
+                unique: true
+              remarks: |
+                A later changeset will add not null constraint (PF-1583).
+    - sql:
+        # user_facing_id is a required field. For new workspaces, UI/CLI will
+        # require it. For existing workspaces, backfill with workspace_id.
+        sql: update workspace set user_facing_id = workspace_id;
+    - sql:
+        # display_name is a required field. For new workspaces, UI/CLI will
+        # require it. For existing workspaces, backfill with workspace_id.
+        sql: update workspace set display_name = workspace_id where display_name is null or display_name = '';


### PR DESCRIPTION
See [design doc Migration overview section.](https://docs.google.com/document/d/19urXR2VMmX2K0Z-_m1NibVnnFPe6gM1ezrnCfWW3044/edit#heading=h.3ixqx8m1j9m3)

I seeded some local workspaces. Before schema changes:

```
wsm_db=> select * from workspace;
             workspace_id             |     display_name     |         description         |      spend_profile       |      properties      | workspace_stage
--------------------------------------+----------------------+-----------------------------+--------------------------+----------------------+-----------------
 7b1b50a5-a9f3-42a1-8300-a50a175a2fe9 |                      |                             | wm-default-spend-profile | {}                   | MC_WORKSPACE
 5f4b1006-979c-4bd8-bf08-899ef43d1106 | First Workspace Name | First Workspace Description | wm-default-spend-profile | {"string": "string"} | MC_WORKSPACE
```

After:

```
wsm_db=> select * from workspace;
             workspace_id             |             display_name             |         description         |      spend_profile       |      properties      | workspace_stage |            user_facing_id
--------------------------------------+--------------------------------------+-----------------------------+--------------------------+----------------------+-----------------+--------------------------------------
 5f4b1006-979c-4bd8-bf08-899ef43d1106 | First Workspace Name                 | First Workspace Description | wm-default-spend-profile | {"string": "string"} | MC_WORKSPACE    | 5f4b1006-979c-4bd8-bf08-899ef43d1106
 7b1b50a5-a9f3-42a1-8300-a50a175a2fe9 | 7b1b50a5-a9f3-42a1-8300-a50a175a2fe9 |                             | wm-default-spend-profile | {}                   | MC_WORKSPACE    | 7b1b50a5-a9f3-42a1-8300-a50a175a2fe9
```

[postgresql doesn't supporting moving column positions](https://wiki.postgresql.org/wiki/Alter_column_position), so I couldn't put `user_facing_id` column where I wanted to.

Before I merge, I will:

- Discuss this project with Broad workspace folks
- Gives Verily ET users a heads up. They'll see the "Copy `workspace_id` to `display_name`" change.

Next PR will update OpenAPI.