### PR TITLE
[PF-1576, PF-1596] Add Workspace.userFacingId and plumb through to API

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -185,16 +185,14 @@ View current usage information for `write-config.sh` by entering
 To run unit tests:
 
 ```sh
-cd service
-../gradlew unitTest
+./gradlew :service:unitTest
 ```
   
 To run connected tests:
 
 ```sh
 ./scripts/write-config.sh # First time only
-cd service
-../gradlew connectedTest
+./gradlew :service:connectedTest
 ```
 To run integration tests, we use Test Runner. Learn to run the Test Runner
 integration tests by reading [Integration README](integration/README.md)
@@ -206,8 +204,7 @@ and then launch the application:
 
 ```sh
 ./scripts/write-config.sh # First time only
-cd service
-../gradlew bootRun
+./gradlew :service:bootRun
 ```
 
 Then navigate to the Swagger: http://localhost:8080/swagger-ui.html

--- a/integration/src/main/java/scripts/testscripts/GetWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/GetWorkspace.java
@@ -2,6 +2,7 @@ package scripts.testscripts;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.WorkspaceApi;
@@ -20,5 +21,8 @@ public class GetWorkspace extends WorkspaceAllocateTestScriptBase {
      */
     final WorkspaceDescription workspaceDescription = workspaceApi.getWorkspace(getWorkspaceId());
     assertThat(workspaceDescription.getId(), equalTo(getWorkspaceId()));
+
+    // userFacingId was not set in CreateWorkspace request. Make sure it is set now.
+    assertThat(workspaceDescription.getUserFacingId().length(), greaterThan(0));
   }
 }

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -333,7 +333,7 @@ components:
         userFacingId:
           description: |
             Human-settable, mutable id. Optional. If this isn't set, one will
-            be generated based on displayName or id.
+            be generated based id.
           type: string
         displayName:
           description: The human readable name of the workspace
@@ -425,7 +425,7 @@ components:
 
     WorkspaceDescription:
       type: object
-      required: [id]
+      required: [id, userFacingId]
       properties:
         id:
           description: The ID of the workspace

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -333,7 +333,7 @@ components:
         userFacingId:
           description: |
             Human-settable, mutable id. Optional. If this isn't set, one will
-            be generated based id.
+            be generated based on id.
           type: string
         displayName:
           description: The human readable name of the workspace

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -330,6 +330,11 @@ components:
           description: The ID of the workspace
           type: string
           format: uuid
+        userFacingId:
+          description: |
+            Human-settable, mutable id. Optional. If this isn't set, one will
+            be generated based on displayName or id.
+          type: string
         displayName:
           description: The human readable name of the workspace
           type: string
@@ -404,6 +409,11 @@ components:
     UpdateWorkspaceRequestBody:
       type: object
       properties:
+        userFacingId:
+          description: |
+            Human-settable, mutable id. Optional. If this isn't set, one will
+            be generated based on displayName or id.
+          type: string
         displayName:
           description: The human readable name of the workspace
           type: string
@@ -422,6 +432,9 @@ components:
           description: The ID of the workspace
           type: string
           format: uuid
+        userFacingId:
+          description: Human-settable, mutable id
+          type: string
         displayName:
           description: The human readable name of the workspace
           type: string

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -411,8 +411,7 @@ components:
       properties:
         userFacingId:
           description: |
-            Human-settable, mutable id. Optional. If this isn't set, one will
-            be generated based on displayName or id.
+            Human-settable, mutable id
           type: string
         displayName:
           description: The human readable name of the workspace

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -112,10 +112,14 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     Optional<SpendProfileId> spendProfileId =
         Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::new);
 
+    // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't pass
+    // userFacingId in request, so use id. Prefix with "a" because userFacingId must start with letter.
+    String userFacingId = body.getUserFacingId() != null ? body.getUserFacingId() : "a" + body.getId();
+
     Workspace workspace =
         Workspace.builder()
             .workspaceId(body.getId())
-            .userFacingId(body.getUserFacingId())
+            .userFacingId(userFacingId)
             .displayName(body.getDisplayName())
             .description(body.getDescription())
             .spendProfileId(spendProfileId.orElse(null))

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -115,11 +115,11 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     Workspace workspace =
         Workspace.builder()
             .workspaceId(body.getId())
-            .spendProfileId(spendProfileId.orElse(null))
-            .workspaceStage(internalStage)
             .userFacingId(body.getUserFacingId())
             .displayName(body.getDisplayName())
             .description(body.getDescription())
+            .spendProfileId(spendProfileId.orElse(null))
+            .workspaceStage(internalStage)
             .properties(propertyMapFromApi(body.getProperties()))
             .build();
     UUID createdId = workspaceService.createWorkspace(workspace, userRequest);

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -114,7 +114,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
 
     // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't pass
     // userFacingId in request, so use id. Prefix with "a" because userFacingId must start with letter.
-    String userFacingId = body.getUserFacingId() != null ? body.getUserFacingId() : "a" + body.getId();
+    String userFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a" + body.getId());
 
     Workspace workspace =
         Workspace.builder()

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -117,6 +117,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
             .workspaceId(body.getId())
             .spendProfileId(spendProfileId.orElse(null))
             .workspaceStage(internalStage)
+            .userFacingId(body.getUserFacingId())
             .displayName(body.getDisplayName())
             .description(body.getDescription())
             .properties(propertyMapFromApi(body.getProperties()))
@@ -170,6 +171,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
         .stage(workspace.getWorkspaceStage().toApiModel())
         .gcpContext(gcpContext)
         .azureContext(azureContext)
+        .userFacingId(workspace.getUserFacingId().orElse(null))
         .displayName(workspace.getDisplayName().orElse(null))
         .description(workspace.getDescription().orElse(null))
         .properties(apiProperties);
@@ -201,7 +203,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
 
     Workspace workspace =
         workspaceService.updateWorkspace(
-            userRequest, workspaceId, body.getDisplayName(), body.getDescription(), propertyMap);
+            userRequest, workspaceId, body.getUserFacingId(), body.getDisplayName(), body.getDescription(), propertyMap);
 
     ApiWorkspaceDescription desc = buildWorkspaceDescription(workspace);
     logger.info("Updated workspace {} for {}", desc, userRequest.getEmail());

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -182,11 +182,12 @@ public class WorkspaceService {
   public Workspace updateWorkspace(
       AuthenticatedUserRequest userRequest,
       UUID workspaceId,
+      @Nullable String userFacingId,
       @Nullable String name,
       @Nullable String description,
       @Nullable Map<String, String> properties) {
     validateWorkspaceAndAction(userRequest, workspaceId, SamConstants.SamWorkspaceAction.WRITE);
-    workspaceDao.updateWorkspace(workspaceId, name, description, properties);
+    workspaceDao.updateWorkspace(workspaceId, userFacingId, name, description, properties);
     return workspaceDao.getWorkspace(workspaceId);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/workspace/exceptions/DuplicateUserFacingIdException.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/exceptions/DuplicateUserFacingIdException.java
@@ -1,0 +1,14 @@
+package bio.terra.workspace.service.workspace.exceptions;
+
+import bio.terra.common.exception.BadRequestException;
+
+/** A workspace with this workspace_id already exists. */
+public class DuplicateUserFacingIdException extends BadRequestException {
+    public DuplicateUserFacingIdException(String message) {
+        super(message);
+    }
+
+    public DuplicateUserFacingIdException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/exceptions/DuplicateWorkspaceException.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/exceptions/DuplicateWorkspaceException.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.workspace.exceptions;
 
 import bio.terra.common.exception.BadRequestException;
 
+/** A workspace with this workspace_id already exists. */
 public class DuplicateWorkspaceException extends BadRequestException {
   public DuplicateWorkspaceException(String message) {
     super(message);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -40,10 +40,6 @@ public class CreateWorkspaceStep implements Step {
       if (!workspace.equals(existingWorkspace)) {
         throw ex;
       }
-    } catch (DuplicateUserFacingIdException ex) {
-      // workspace_id is new and user_facing_id already exists. This is user error -- user is trying to create a
-      // workspace with an existing user_facing_id.
-      throw ex;
     }
 
     FlightUtils.setResponse(flightContext, workspaceId, HttpStatus.OK);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -6,7 +6,6 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.WorkspaceDao;
-import bio.terra.workspace.service.workspace.exceptions.DuplicateUserFacingIdException;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateWorkspaceException;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import java.util.UUID;

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceStep.java
@@ -6,6 +6,7 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.workspace.exceptions.DuplicateUserFacingIdException;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateWorkspaceException;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import java.util.UUID;
@@ -39,6 +40,10 @@ public class CreateWorkspaceStep implements Step {
       if (!workspace.equals(existingWorkspace)) {
         throw ex;
       }
+    } catch (DuplicateUserFacingIdException ex) {
+      // workspace_id is new and user_facing_id already exists. This is user error -- user is trying to create a
+      // workspace with an existing user_facing_id.
+      throw ex;
     }
 
     FlightUtils.setResponse(flightContext, workspaceId, HttpStatus.OK);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/Workspace.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/Workspace.java
@@ -172,7 +172,6 @@ public class Workspace {
       if (properties == null) {
         properties = new HashMap<>();
       }
-      // Don't need to check userFacingId since it is required.
       if (displayName == null) {
         displayName = "";
       }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/Workspace.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/Workspace.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 @JsonDeserialize(builder = Workspace.Builder.class)
 public class Workspace {
   private final UUID workspaceId;
+  private final String userFacingId;
   private final String displayName;
   private final String description;
   private final SpendProfileId spendProfileId;
@@ -29,12 +30,14 @@ public class Workspace {
 
   public Workspace(
       UUID workspaceId,
+      String userFacingId,
       String displayName,
       String description,
       SpendProfileId spendProfileId,
       Map<String, String> properties,
       WorkspaceStage workspaceStage) {
     this.workspaceId = workspaceId;
+    this.userFacingId = userFacingId;
     this.displayName = displayName;
     this.description = description;
     this.spendProfileId = spendProfileId;
@@ -45,6 +48,11 @@ public class Workspace {
   /** The globally unique identifier of this workspace */
   public UUID getWorkspaceId() {
     return workspaceId;
+  }
+
+  /** User facing id. Required in db, but optional in API requests (eg CreateWorkspaceRequestBody. */
+  public Optional<String> getUserFacingId() {
+    return Optional.ofNullable(userFacingId);
   }
 
   /** Optional display name for the workspace. */
@@ -88,6 +96,7 @@ public class Workspace {
 
     return new EqualsBuilder()
         .append(workspaceId, workspace.workspaceId)
+        .append(userFacingId, workspace.userFacingId)
         .append(displayName, workspace.displayName)
         .append(description, workspace.description)
         .append(spendProfileId, workspace.spendProfileId)
@@ -100,6 +109,7 @@ public class Workspace {
   public int hashCode() {
     return new HashCodeBuilder(17, 37)
         .append(workspaceId)
+        .append(userFacingId)
         .append(displayName)
         .append(description)
         .append(spendProfileId)
@@ -115,6 +125,7 @@ public class Workspace {
   @JsonPOJOBuilder(withPrefix = "")
   public static class Builder {
     private UUID workspaceId;
+    private String userFacingId;
     private String displayName;
     private String description;
     private SpendProfileId spendProfileId;
@@ -123,6 +134,11 @@ public class Workspace {
 
     public Builder workspaceId(UUID workspaceId) {
       this.workspaceId = workspaceId;
+      return this;
+    }
+
+    public Builder userFacingId(String userFacingId) {
+      this.userFacingId = userFacingId;
       return this;
     }
 
@@ -156,6 +172,7 @@ public class Workspace {
       if (properties == null) {
         properties = new HashMap<>();
       }
+      // Don't need to check userFacingId since it is required.
       if (displayName == null) {
         displayName = "";
       }
@@ -166,7 +183,7 @@ public class Workspace {
         throw new MissingRequiredFieldsException("Workspace requires id and stage");
       }
       return new Workspace(
-          workspaceId, displayName, description, spendProfileId, properties, workspaceStage);
+          workspaceId, userFacingId, displayName, description, spendProfileId, properties, workspaceStage);
     }
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
@@ -128,6 +128,7 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
     var workspace =
         new Workspace(
             workspaceId,
+            "cloud-context-user-facing-id",
             "gcpCloudContextAutoUpgradeTest",
             "cloud context description",
             new SpendProfileId("spend-profile"),

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -230,6 +230,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     assertEquals("", createdWorkspace.getDescription().orElse(null));
 
     UUID workspaceId = request.getWorkspaceId();
+    String userFacingId = "my-user-facing-id";
     String name = "My workspace";
     String description = "The greatest workspace";
     Map<String, String> propertyMap2 = new HashMap<>();
@@ -238,7 +239,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
     Workspace updatedWorkspace =
         workspaceService.updateWorkspace(
-            USER_REQUEST, workspaceId, name, description, propertyMap2);
+            USER_REQUEST, workspaceId, userFacingId, name, description, propertyMap2);
 
     assertEquals(name, updatedWorkspace.getDisplayName().orElse(null));
     assertEquals(description, updatedWorkspace.getDescription().orElse(null));
@@ -247,9 +248,10 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     String otherDescription = "The deprecated workspace";
 
     Workspace secondUpdatedWorkspace =
-        workspaceService.updateWorkspace(USER_REQUEST, workspaceId, null, otherDescription, null);
+        workspaceService.updateWorkspace(USER_REQUEST, workspaceId, null, null, otherDescription, null);
 
     // Since name is null, leave it alone. Description should be updated.
+    assertEquals(userFacingId, secondUpdatedWorkspace.getUserFacingId().orElse(null));
     assertEquals(name, secondUpdatedWorkspace.getDisplayName().orElse(null));
     assertEquals(otherDescription, secondUpdatedWorkspace.getDescription().orElse(null));
     assertEquals(propertyMap2, updatedWorkspace.getProperties());
@@ -257,13 +259,14 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     // Sending through empty strings and an empty map clears the values.
     Map<String, String> propertyMap3 = new HashMap<>();
     Workspace thirdUpdatedWorkspace =
-        workspaceService.updateWorkspace(USER_REQUEST, workspaceId, "", "", propertyMap3);
+        workspaceService.updateWorkspace(USER_REQUEST, workspaceId, "", "", "", propertyMap3);
+    assertEquals("", thirdUpdatedWorkspace.getUserFacingId().orElse(null));
     assertEquals("", thirdUpdatedWorkspace.getDisplayName().orElse(null));
     assertEquals("", thirdUpdatedWorkspace.getDescription().orElse(null));
 
     assertThrows(
         MissingRequiredFieldException.class,
-        () -> workspaceService.updateWorkspace(USER_REQUEST, workspaceId, null, null, null));
+        () -> workspaceService.updateWorkspace(USER_REQUEST, workspaceId, null, null, null, null));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -169,7 +169,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void duplicateWorkspaceUserFacingIdRequestsRejected() {
-    String userFacingId = "user-facing-id";
+    String userFacingId = "create-workspace-user-facing-id";
     Workspace request = defaultRequestBuilder(UUID.randomUUID()).userFacingId(userFacingId).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
     Workspace duplicateUserFacingId =
@@ -288,7 +288,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   @Test
   void testUpdateWorkspaceUserFacingIdAlreadyExistsRejected() {
     // Create one workspace with userFacingId, one without.
-    String userFacingId = "user-facing-id";
+    String userFacingId = "update-workspace-user-facing-id";
     Workspace request = defaultRequestBuilder(UUID.randomUUID()).userFacingId(userFacingId).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
     UUID secondWorkspaceUuid = UUID.randomUUID();


### PR DESCRIPTION
Tested with swagger: create succeeds, create fails, update succeeds, update fails.

If someone tries to create a workspace with an existing userFacingId, we show friendly error:

![image](https://user-images.githubusercontent.com/10929390/164569438-01a21186-83af-4e3c-bd16-cf1f6014ecb5.png)

Same with update workspace:

![image](https://user-images.githubusercontent.com/10929390/164569452-8022220c-8337-4c45-9932-ef63370b41dd.png)

----

[In Workspace.build()](https://github.com/DataBiosphere/terra-workspace-manager/blob/19c461a3d0e94c5be0f4cf3f674a0c7f3ffb566d/service/src/main/java/bio/terra/workspace/service/workspace/model/Workspace.java#L170), I can't do this:

```
      if (userFacingId == null) {
        userFacingId = "";
      }
```
Because for tests that don't set `userFacingId`, it will be set to `""` in DB. Creating the first workspace works. Creating the second workspace fails; the uniqueness constraint for `userFacingId` fails because there is already a workspace with `userFacingId = ""`.

In PF-1596, I will auto-populate `userFacingId` if it isn't set. In pseudocode:

```
      if (userFacingId == null) {
        generated userFacingId based on displayName or workspaceId
      }

```
---

Instead of creating `DuplicateUserFacingIdException`, my first attempt was to add an enum field to `DuplicateWorkspaceException` indicating which field was being duplicated. I ran into problems with `StairwayExceptionSerializer`; it wasn't worth adding that enum field to `StairwayExceptionFields`.