### PR TITLE
[PF-1616] Have CloneWorkspace work with userFacingId

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -244,6 +244,9 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
   protected void doUserJourney(
       TestUserSpecification sourceOwnerUser, WorkspaceApi sourceOwnerWorkspaceApi)
       throws Exception {
+    // Perf tests run same test repeatedly. Use a different userFacingId for each invocation,
+    // otherwise the insert will fail.
+    String destinationUserFacingId = "cloned-workspace-" + UUID.randomUUID().toString();
     logger.info("Start User Journey");
     // As reader user, clone the workspace
     // Get a new workspace API for the reader
@@ -251,6 +254,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
 
     final CloneWorkspaceRequest cloneWorkspaceRequest =
         new CloneWorkspaceRequest()
+            .userFacingId(destinationUserFacingId)
             .displayName("Cloned Workspace")
             .description("A clone of workspace " + getWorkspaceId().toString())
             .spendProfile(getSpendProfileId()) // TODO- use a different one if available
@@ -263,6 +267,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
     logger.info("Clone Job ID {}", jobId);
     final UUID destinationWorkspaceId = cloneResult.getWorkspace().getDestinationWorkspaceId();
     assertNotNull(destinationWorkspaceId, "Destination workspace ID available immediately.");
+    assertEquals(destinationUserFacingId, cloneResult.getWorkspace().getDestinationUserFacingId());
     final WorkspaceDescription destinationWorkspaceDescription =
         cloningUserWorkspaceApi.getWorkspace(destinationWorkspaceId);
     assertNotNull(
@@ -333,6 +338,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
     // We need to get the destination bucket name and project ID
     final WorkspaceDescription destinationWorkspace =
         cloningUserWorkspaceApi.getWorkspace(destinationWorkspaceId);
+    assertEquals(destinationUserFacingId, destinationWorkspace.getUserFacingId());
     final String destinationProjectId = destinationWorkspace.getGcpContext().getProjectId();
     final var clonedSharedBucket =
         cloningUserResourceApi.getBucket(

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -244,9 +244,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
   protected void doUserJourney(
       TestUserSpecification sourceOwnerUser, WorkspaceApi sourceOwnerWorkspaceApi)
       throws Exception {
-    // Perf tests run same test repeatedly. Use a different userFacingId for each invocation,
-    // otherwise the insert will fail.
-    String destinationUserFacingId = "cloned-workspace-" + UUID.randomUUID().toString();
+    String destinationUserFacingId = "cloned-workspace-user-facing-id";
     logger.info("Start User Journey");
     // As reader user, clone the workspace
     // Get a new workspace API for the reader

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -256,7 +256,7 @@ components:
         destinationUserFacingId:
           description: |
             Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter. Required.
+            underscores, and start with lowercase letter.
           type: string
         resources:
           type: array
@@ -280,8 +280,9 @@ components:
       properties:
         userFacingId:
           description: |
-            Human-settable, mutable id. ID must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter. Optional. If this isn't set, one will be generated.
+            Human-settable, mutable id for cloned workspace. ID must have 3-63 characters, contain lowercase letters,
+            numbers, dashes, or underscores, and start with lowercase letter. Optional. If this isn't set, one will be
+            generated.
           type: string
         displayName:
           description: The human readable name of the workspace

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -273,6 +273,12 @@ components:
       required:
         - spendProfile
       properties:
+        userFacingId:
+          description: |
+            Human-settable, mutable id. ID must have 3-63 characters, contain lowercase letters, numbers, dashes, or
+            underscores, and start with lowercase letter. Optional. If this isn't set, one will be generated based on id
+            (guid).
+          type: string
         displayName:
           description: The human readable name of the workspace
           type: string

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -253,6 +253,11 @@ components:
         destinationWorkspaceId:
           type: string
           format: uuid
+        destinationUserFacingId:
+          description: |
+            Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
+            underscores, and start with lowercase letter. Required.
+          type: string
         resources:
           type: array
           items:
@@ -276,8 +281,7 @@ components:
         userFacingId:
           description: |
             Human-settable, mutable id. ID must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter. Optional. If this isn't set, one will be generated based on id
-            (guid).
+            underscores, and start with lowercase letter. Optional. If this isn't set, one will be generated.
           type: string
         displayName:
           description: The human readable name of the workspace

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -112,7 +112,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't
     // pass userFacingId in request, so use id. Prefix with "a" because userFacingId must start with
     // letter.
-    String userFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a" + body.getId());
+    String userFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a-" + body.getId());
     ControllerValidationUtils.validateUserFacingId(userFacingId);
 
     Workspace workspace =
@@ -400,7 +400,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't
     // pass userFacingId in request, so use id. Prefix with "a" because userFacingId must start with
     // letter.
-    String destinationUserFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a" + destinationWorkspaceId);
+    String destinationUserFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a-" + destinationWorkspaceId);
     ControllerValidationUtils.validateUserFacingId(destinationUserFacingId);
 
     // Construct the target workspace object from the inputs

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -400,14 +400,14 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't
     // pass userFacingId in request, so use id. Prefix with "a" because userFacingId must start with
     // letter.
-    String userFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a" + destinationWorkspaceId);
-    ControllerValidationUtils.validateUserFacingId(userFacingId);
+    String destinationUserFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a" + destinationWorkspaceId);
+    ControllerValidationUtils.validateUserFacingId(destinationUserFacingId);
 
     // Construct the target workspace object from the inputs
     final Workspace destinationWorkspace =
         Workspace.builder()
             .workspaceId(destinationWorkspaceId)
-            .userFacingId(userFacingId)
+            .userFacingId(destinationUserFacingId)
             .spendProfileId(spendProfileId.orElse(null))
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .displayName(body.getDisplayName())
@@ -423,6 +423,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     final ApiClonedWorkspace clonedWorkspaceStub =
         new ApiClonedWorkspace()
             .destinationWorkspaceId(destinationWorkspaceId)
+            .destinationUserFacingId(destinationUserFacingId)
             .sourceWorkspaceId(workspaceUuid);
     result.setWorkspace(clonedWorkspaceStub);
     return new ResponseEntity<>(result, getAsyncResponseCode(result.getJobReport()));

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.app.controller;
 
+import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.ControllerValidationUtils;
 import bio.terra.workspace.generated.controller.WorkspaceApi;
 import bio.terra.workspace.generated.model.ApiAzureContext;
@@ -109,8 +110,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
         Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::new);
 
     // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't
-    // pass
-    // userFacingId in request, so use id. Prefix with "a" because userFacingId must start with
+    // pass userFacingId in request, so use id. Prefix with "a" because userFacingId must start with
     // letter.
     String userFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a" + body.getId());
     ControllerValidationUtils.validateUserFacingId(userFacingId);
@@ -396,10 +396,18 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     Optional<SpendProfileId> spendProfileId =
         Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::new);
     final UUID destinationWorkspaceId = UUID.randomUUID();
+
+    // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't
+    // pass userFacingId in request, so use id. Prefix with "a" because userFacingId must start with
+    // letter.
+    String userFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a" + destinationWorkspaceId);
+    ControllerValidationUtils.validateUserFacingId(userFacingId);
+
     // Construct the target workspace object from the inputs
     final Workspace destinationWorkspace =
         Workspace.builder()
             .workspaceId(destinationWorkspaceId)
+            .userFacingId(userFacingId)
             .spendProfileId(spendProfileId.orElse(null))
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .displayName(body.getDisplayName())

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -85,6 +85,7 @@ public class WorkspaceDao {
             + " cast(:properties AS jsonb), :workspace_stage)";
 
     final String workspaceUuid = workspace.getWorkspaceId().toString();
+    // validateUserFacingId() is called in controller. Also call here to be safe (eg see bug PF-1616).
     ControllerValidationUtils.validateUserFacingId(workspace.getUserFacingId());
 
     MapSqlParameterSource params =
@@ -218,6 +219,7 @@ public class WorkspaceDao {
     params.addValue("workspace_id", workspaceUuid.toString());
 
     if (userFacingId != null) {
+      // validateUserFacingId() is called in controller. Also call here to be safe (eg see bug PF-1616).
       ControllerValidationUtils.validateUserFacingId(userFacingId);
       params.addValue("user_facing_id", userFacingId);
     }

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -4,6 +4,7 @@ import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.exception.InternalLogicException;
+import bio.terra.workspace.common.utils.ControllerValidationUtils;
 import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
@@ -84,6 +85,7 @@ public class WorkspaceDao {
             + " cast(:properties AS jsonb), :workspace_stage)";
 
     final String workspaceUuid = workspace.getWorkspaceId().toString();
+    ControllerValidationUtils.validateUserFacingId(workspace.getUserFacingId().get());
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -204,7 +206,7 @@ public class WorkspaceDao {
   @WriteTransaction
   public boolean updateWorkspace(
       UUID workspaceUuid,
-      @Nullable String userFacingId,
+      String userFacingId,
       @Nullable String name,
       @Nullable String description,
       @Nullable Map<String, String> propertyMap) {
@@ -215,9 +217,7 @@ public class WorkspaceDao {
     var params = new MapSqlParameterSource();
     params.addValue("workspace_id", workspaceUuid.toString());
 
-    if (userFacingId != null) {
-      params.addValue("user_facing_id", userFacingId);
-    }
+    ControllerValidationUtils.validateUserFacingId(userFacingId);
 
     if (name != null) {
       params.addValue("display_name", name);

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -206,7 +206,7 @@ public class WorkspaceDao {
   @WriteTransaction
   public boolean updateWorkspace(
       UUID workspaceUuid,
-      String userFacingId,
+      @Nullable String userFacingId,
       @Nullable String name,
       @Nullable String description,
       @Nullable Map<String, String> propertyMap) {

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -85,7 +85,7 @@ public class WorkspaceDao {
             + " cast(:properties AS jsonb), :workspace_stage)";
 
     final String workspaceUuid = workspace.getWorkspaceId().toString();
-    ControllerValidationUtils.validateUserFacingId(workspace.getUserFacingId().get());
+    ControllerValidationUtils.validateUserFacingId(workspace.getUserFacingId());
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -206,7 +206,7 @@ public class WorkspaceDao {
   @WriteTransaction
   public boolean updateWorkspace(
       UUID workspaceUuid,
-      String userFacingId,
+      @Nullable String userFacingId,
       @Nullable String name,
       @Nullable String description,
       @Nullable Map<String, String> propertyMap) {
@@ -217,7 +217,10 @@ public class WorkspaceDao {
     var params = new MapSqlParameterSource();
     params.addValue("workspace_id", workspaceUuid.toString());
 
-    ControllerValidationUtils.validateUserFacingId(userFacingId);
+    if (userFacingId != null) {
+      ControllerValidationUtils.validateUserFacingId(userFacingId);
+      params.addValue("user_facing_id", userFacingId);
+    }
 
     if (name != null) {
       params.addValue("display_name", name);

--- a/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
@@ -41,9 +41,11 @@ public class AzureTestUtils {
 
   /** Creates a workspace, returning its workspaceUuid. */
   public UUID createWorkspace(WorkspaceService workspaceService) {
+    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     return workspaceService.createWorkspace(request, userAccessUtils.defaultUserAuthRequest());

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -33,6 +33,7 @@ public class WorkspaceConnectedTestUtils {
         workspaceService.createWorkspace(
             Workspace.builder()
                 .workspaceId(UUID.randomUUID())
+                .userFacingId("a" + UUID.randomUUID().toString())
                 .spendProfileId(spendUtils.defaultSpendId())
                 .workspaceStage(WorkspaceStage.MC_WORKSPACE)
                 .build(),

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -39,9 +39,11 @@ public class ResourceDaoTest extends BaseUnitTest {
    * cloud context exists before storing the resource.
    */
   private UUID createGcpWorkspace() {
+    UUID uuid = UUID.randomUUID();
     Workspace workspace =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     workspaceDao.createWorkspace(workspace);

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -67,6 +67,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
     Workspace workspace =
         Workspace.builder()
             .workspaceId(workspaceUuid)
+            .userFacingId("a" + workspaceUuid)
             .spendProfileId(spendProfileId)
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .build();

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -134,9 +134,11 @@ class WorkspaceDaoTest extends BaseUnitTest {
   void offsetSkipsWorkspaceInList() {
     Workspace firstWorkspace = defaultWorkspace();
     workspaceDao.createWorkspace(firstWorkspace);
+    UUID uuid = UUID.randomUUID();
     Workspace secondWorkspace =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid)
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .build();
     workspaceDao.createWorkspace(secondWorkspace);
@@ -153,9 +155,11 @@ class WorkspaceDaoTest extends BaseUnitTest {
   void listWorkspaceLimitEnforced() {
     Workspace firstWorkspace = defaultWorkspace();
     workspaceDao.createWorkspace(firstWorkspace);
+    UUID uuid = UUID.randomUUID();
     Workspace secondWorkspace =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .build();
     workspaceDao.createWorkspace(secondWorkspace);
@@ -180,6 +184,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
       mcWorkspace =
           Workspace.builder()
               .workspaceId(mcWorkspaceId)
+              .userFacingId("a" + mcWorkspaceId)
               .workspaceStage(WorkspaceStage.MC_WORKSPACE)
               .build();
       workspaceDao.createWorkspace(mcWorkspace);
@@ -286,6 +291,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
   private Workspace defaultWorkspace() {
     return Workspace.builder()
         .workspaceId(workspaceUuid)
+        .userFacingId("a" + workspaceUuid)
         .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
         .build();
   }

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -167,6 +167,7 @@ class SamServiceTest extends BaseConnectedTest {
     Workspace rawlsWorkspace =
         Workspace.builder()
             .workspaceId(workspaceUuid)
+            .userFacingId("a" + workspaceUuid.toString())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .build();
     workspaceService.createWorkspace(rawlsWorkspace, defaultUserRequest());
@@ -385,9 +386,11 @@ class SamServiceTest extends BaseConnectedTest {
   }
 
   private UUID createWorkspaceForUser(AuthenticatedUserRequest userRequest) {
+    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     return workspaceService.createWorkspace(request, userRequest);

--- a/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -192,6 +192,7 @@ class JobServiceTest extends BaseUnitTest {
     Workspace workspace =
         Workspace.builder()
             .workspaceId(workspaceUuid)
+            .userFacingId("a" + workspaceUuid)
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .description("Workspace for runFlight: " + description)
             .build();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -40,11 +40,10 @@ public class AzureDisabledTest extends BaseConnectedTest {
 
   @Test
   public void azureDisabledTest() throws InterruptedException {
-    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
+            .workspaceId(UUID.randomUUID())
+            .userFacingId("a" + UUID.randomUUID())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     UUID workspaceUuid =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -40,9 +40,11 @@ public class AzureDisabledTest extends BaseConnectedTest {
 
   @Test
   public void azureDisabledTest() throws InterruptedException {
+    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     UUID workspaceUuid =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
@@ -42,6 +42,7 @@ public class StoreControlledResourceMetadataStepTest extends BaseUnitTest {
         Workspace.builder()
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .workspaceId(workspaceUuid)
+            .userFacingId("a" + workspaceUuid)
             .build();
     workspaceDao.createWorkspace(workspace);
     gcpCloudContextService.createGcpCloudContext(

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -241,9 +241,11 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
    * MC_WORKSPACE. Returns the generated workspace ID.
    */
   private UUID createMcTestWorkspace() {
+    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .spendProfileId(null)
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();

--- a/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
@@ -120,6 +120,7 @@ public class ApplicationServiceTest extends BaseUnitTest {
     var request =
         Workspace.builder()
             .workspaceId(workspaceUuid)
+            .userFacingId("a" + workspaceUuid)
             .spendProfileId(null)
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
@@ -130,6 +131,7 @@ public class ApplicationServiceTest extends BaseUnitTest {
     request =
         Workspace.builder()
             .workspaceId(workspaceId2)
+            .userFacingId("a" + workspaceId2)
             .spendProfileId(null)
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
@@ -36,9 +36,11 @@ public class AzureWorkspaceTest extends BaseAzureTest {
             .email("fake@email.com")
             .subjectId("fakeID123");
 
+    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .spendProfileId(spendUtils.defaultSpendId())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -181,7 +181,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void getWorkspaceByUserFacingId_existing() {
-    String userFacingId = "user-facing-id-getWorkspaceByUserFacingId_existing";
+    String userFacingId = "user-facing-id-getworkspacebyuserfacingid_existing";
     Workspace request = defaultRequestBuilder(UUID.randomUUID()).userFacingId(userFacingId).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
 
@@ -209,7 +209,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void getWorkspaceByUserFacingId_forbiddenExisting() throws Exception {
-    String userFacingId = "user-facing-id-getWorkspaceByUserFacingId_forbiddenExisting";
+    String userFacingId = "user-facing-id-getworkspacebyuserfacingid_forbiddenexisting";
     Workspace request = defaultRequestBuilder(UUID.randomUUID()).userFacingId(userFacingId).build();
     workspaceService.createWorkspace(request, USER_REQUEST);
     Workspace createdWorkspace =
@@ -619,6 +619,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     // Create a workspace
     final Workspace sourceWorkspace =
         defaultRequestBuilder(UUID.randomUUID())
+            .userFacingId("source-user-facing-id")
             .displayName("Source Workspace")
             .description("The original workspace.")
             .spendProfileId(new SpendProfileId(SPEND_PROFILE_ID))
@@ -676,6 +677,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         createdResource.castByEnum(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
     final Workspace destinationWorkspace =
         defaultRequestBuilder(UUID.randomUUID())
+            .userFacingId("dest-user-facing-id")
             .displayName("Destination Workspace")
             .description("Copied from source")
             .spendProfileId(new SpendProfileId(SPEND_PROFILE_ID))
@@ -730,6 +732,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   private Workspace.Builder defaultRequestBuilder(UUID workspaceUuid) {
     return Workspace.builder()
         .workspaceId(workspaceUuid)
+        .userFacingId("a" + workspaceUuid.toString())
         .spendProfileId(null)
         .workspaceStage(WorkspaceStage.MC_WORKSPACE);
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightTest.java
@@ -253,9 +253,11 @@ class CreateGcpContextFlightTest extends BaseConnectedTest {
    * not need to explicitly clean up the workspaces created here.
    */
   private UUID createWorkspace(@Nullable SpendProfileId spendProfileId) {
+    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .spendProfileId(spendProfileId)
             .build();

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
@@ -270,9 +270,11 @@ class CreateGcpContextFlightV2Test extends BaseConnectedTest {
    * not need to explicitly clean up the workspaces created here.
    */
   private UUID createWorkspace(@Nullable SpendProfileId spendProfileId) {
+    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid)
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .spendProfileId(spendProfileId)
             .build();

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlightTest.java
@@ -57,9 +57,11 @@ class DeleteGcpContextFlightTest extends BaseConnectedTest {
   @BeforeEach
   public void setup() {
     // Create a new workspace at the start of each test.
+    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .spendProfileId(spendUtils.defaultSpendId())
             .build();

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -61,9 +61,11 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void removeUserFromWorkspaceFlightDoUndo() throws Exception {
     // Create a workspace as the default test user
+    UUID uuid = UUID.randomUUID();
     Workspace request =
         Workspace.builder()
-            .workspaceId(UUID.randomUUID())
+            .workspaceId(uuid)
+            .userFacingId("a" + uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .spendProfileId(spendUtils.defaultSpendId())
             .build();


### PR DESCRIPTION
Before this PR:
- CloneWorkspaceRequest doesn't have `userFacingId` field
- In db, destination workspace dosen't have userFacingId set

After:
- CloneWorkspaceRequest has `userFacingId` field
- In db, destination workspace has userFacingId set

Before we validated (`ControllerValidationUtils.validateUserFacingId`) `userFacingId` in:

- controller `createWorkspace` `updateWorkspace`

In this PR, I added validation to:

- controller `cloneWorkspace`
- dao `createWorkspace` `updateWorkspace`

I added validation to dao to be extra-safe -- for example, what if there's some new endpoint in the future that calls `dao.createWorkspace`.

Dao validation meant I had to change a bunch of unit/connected tests to set `userFacingId`. (In normal application, this is set in controller, which unit/connected tests don't call.)

FYI @cbookg 