### PR TITLE
Use jre:17-debian base docker image

### DIFF
--- a/service/gradle/deploy.gradle
+++ b/service/gradle/deploy.gradle
@@ -5,7 +5,7 @@ jib {
   from {
     // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
     // Google's distroless images are openjdk, this is the simplest with adoptopenjdk
-    image = "us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian"
+    image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian"
   }
   extraDirectories {
     paths = [file(jibExtraDirectory)]


### PR DESCRIPTION
The only way to test this in the nightly test context is to merge it, so I am going to force merge.