### PR TITLE
[PF-1635] Assign destination workspace ID as Job ID for clone

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -338,7 +338,8 @@ public class WorkspaceService {
         .userRequest(userRequest)
         .request(destinationWorkspace)
         .operationType(OperationType.CLONE)
-        .workspaceId(sourceWorkspaceId.toString())
+        // allow UI to watch this job (and sub-flights) from dest workspace page during clone
+        .workspaceId(destinationWorkspace.getWorkspaceId().toString())
         .addParameter(
             ControlledResourceKeys.SOURCE_WORKSPACE_ID,
             sourceWorkspaceId) // TODO: remove this duplication

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
@@ -46,10 +46,9 @@ public class StoreControlledResourceMetadataStepTest extends BaseUnitTest {
             .build();
     workspaceDao.createWorkspace(workspace);
 
-    gcpCloudContextService.createGcpCloudContextStart(
-        workspaceUuid, "flight-testentersinfo");
+    gcpCloudContextService.createGcpCloudContextStart(workspaceUuid, "flight-testentersinfo");
     gcpCloudContextService.createGcpCloudContextFinish(
-        workspaceUuid, new GcpCloudContext("fake-project"),"flight-testentersinfo");
+        workspaceUuid, new GcpCloudContext("fake-project"), "flight-testentersinfo");
 
     StoreMetadataStep storeGoogleBucketMetadataStep = new StoreMetadataStep(resourceDao);
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
@@ -248,7 +248,8 @@ class CreateGcpContextFlightV2Test extends BaseConnectedTest {
   private Map<String, StepStatus> getStepNameToStepStatusMap() {
     // Retry steps once to validate idempotency.
     Map<String, StepStatus> retrySteps = new HashMap<>();
-    retrySteps.put(CreateDbGcpCloudContextStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    retrySteps.put(
+        CreateDbGcpCloudContextStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(PullProjectFromPoolStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(SetProjectBillingStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(GrantWsmRoleAdminStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
@@ -256,7 +257,8 @@ class CreateGcpContextFlightV2Test extends BaseConnectedTest {
     retrySteps.put(SyncSamGroupsStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(GcpCloudSyncStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(CreatePetSaStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    retrySteps.put(UpdateDbGcpCloudContextStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    retrySteps.put(
+        UpdateDbGcpCloudContextStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     return retrySteps;
   }
 


### PR DESCRIPTION
This will allow the UI to create a rich experience on the destination workspace page while clone is happening. Previously, there was no way to know which workspaces were in the process of being cloned into, and no way to find the source workspace associated with a given destination workspace (to enumerate the clone job and/or its resource jobs).

Two spotless fixes stowed away here. These are necessary in order to pass the now-re-required lint checks.