### PR TITLE
[PF-1641] Bump the test time for EnablePet

### DIFF
--- a/integration/src/main/resources/configs/integration/EnablePet.json
+++ b/integration/src/main/resources/configs/integration/EnablePet.json
@@ -9,7 +9,7 @@
       "name": "EnablePet",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 3,
+      "expectedTimeForEach": 12,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"


### PR DESCRIPTION
Increase the run time for EnablePet to allow for slow permission propagation.