### PR TITLE
[IA-3326] Handle pet impersonation IAM roles properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ config/
 
 ### Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
+
+### jEnv
+.java-version


### PR DESCRIPTION
Previously, WSM was the only service which would grant the ServiceAccountUser role on pet service accounts. Now that Sam is also giving pet SAs permission to impersonate themselves, some of the logic inside WSM for handling IAM bindings is incorrect. 

GCP IAM bindings have one role and a list of members with that role. WSM previously tried to create/remove bindings with exactly one member, but it's now possible (and technically should always be true) that there will be a second member with that role, since pets have permission to impersonate themselves.

This issue broke a few tests (connected test `createAiNotebookInstanceUndo` and integration test `EnablePet`) which check that we can revoke a user's permission on their pet, but the test logic is actually still correct, the issue is in the service code.