### PR TITLE
[PF-1658] Store UFID as notebook metadata instead of uuid

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -124,7 +124,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
       FlightBeanBag flightBeanBag) {
 
     WorkspaceDao workspaceDao = flightBeanBag.getWorkspaceDao();
-    String userFacingWorkspaceId = workspaceDao.getWorkspace(getWorkspaceId()).getUserFacingId();
+    String workspaceUserFacingId = workspaceDao.getWorkspace(getWorkspaceId()).getUserFacingId();
 
     RetryRule gcpRetryRule = RetryRules.cloud();
     flight.addStep(
@@ -140,7 +140,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
         gcpRetryRule);
     flight.addStep(
         new CreateAiNotebookInstanceStep(
-            this, petSaEmail, userFacingWorkspaceId, flightBeanBag.getCrlService(), flightBeanBag.getCliConfiguration()),
+            this, petSaEmail, workspaceUserFacingId, flightBeanBag.getCrlService(), flightBeanBag.getCliConfiguration()),
         gcpRetryRule);
     flight.addStep(
         new NotebookCloudSyncStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -10,6 +10,7 @@ import bio.terra.stairway.RetryRule;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceAttributes;
@@ -122,6 +123,9 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
       AuthenticatedUserRequest userRequest,
       FlightBeanBag flightBeanBag) {
 
+    WorkspaceDao workspaceDao = flightBeanBag.getWorkspaceDao();
+    String userFacingWorkspaceId = workspaceDao.getWorkspace(getWorkspaceId()).getUserFacingId();
+
     RetryRule gcpRetryRule = RetryRules.cloud();
     flight.addStep(
         new RetrieveNetworkNameStep(
@@ -136,7 +140,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
         gcpRetryRule);
     flight.addStep(
         new CreateAiNotebookInstanceStep(
-            this, petSaEmail, flightBeanBag.getCrlService(), flightBeanBag.getCliConfiguration()),
+            this, petSaEmail, userFacingWorkspaceId, flightBeanBag.getCrlService(), flightBeanBag.getCliConfiguration()),
         gcpRetryRule);
     flight.addStep(
         new NotebookCloudSyncStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/exception/ReservedMetadataKeyException.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/exception/ReservedMetadataKeyException.java
@@ -1,0 +1,14 @@
+package bio.terra.workspace.service.resource.controlled.exception;
+
+import bio.terra.common.exception.ConflictException;
+
+/**
+ * Exception thrown when user-specified metadata keys for notebooks conflict with keys which
+ * are reserved for the Terra system.
+ */
+public class ReservedMetadataKeyException extends ConflictException {
+
+  public ReservedMetadataKeyException(String message) {
+    super(message);
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -181,7 +181,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createAiNotebookInstanceDo() throws Exception {
     UUID workspaceUuid = workspace.getWorkspaceId();
-    String userFacingWorkspaceId = workspace.getUserFacingId();
+    String workspaceUserFacingId = workspace.getUserFacingId();
     var instanceId = "create-ai-notebook-instance-do";
     var serverName = "verily-autopush";
     cliConfiguration.setServerName(serverName);
@@ -257,7 +257,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     assertThat(instance.getMetadata(), Matchers.hasEntry("terra-cli-server", serverName));
     assertThat(
         instance.getMetadata(),
-        Matchers.hasEntry("terra-workspace-id", userFacingWorkspaceId));
+        Matchers.hasEntry("terra-workspace-id", workspaceUserFacingId));
     ServiceAccountName serviceAccountName =
         ServiceAccountName.builder()
             .projectId(instanceName.projectId())

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -180,7 +180,8 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createAiNotebookInstanceDo() throws Exception {
-    UUID workspaceUuid = reusableWorkspace(user).getWorkspaceId();
+    UUID workspaceUuid = workspace.getWorkspaceId();
+    String userFacingWorkspaceId = workspace.getUserFacingId();
     var instanceId = "create-ai-notebook-instance-do";
     var serverName = "verily-autopush";
     cliConfiguration.setServerName(serverName);
@@ -256,7 +257,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     assertThat(instance.getMetadata(), Matchers.hasEntry("terra-cli-server", serverName));
     assertThat(
         instance.getMetadata(),
-        Matchers.hasEntry("terra-workspace-id", resource.getWorkspaceId().toString()));
+        Matchers.hasEntry("terra-workspace-id", userFacingWorkspaceId));
     ServiceAccountName serviceAccountName =
         ServiceAccountName.builder()
             .projectId(instanceName.projectId())


### PR DESCRIPTION
The default notebook startup script currently retrieves the workspace ID from the notebook metadata key `instance/attributes/terra-workspace-id` and attempts to run the command `terra workspace set --id=${TERRA_WORKSPACE}`. 

WSM is still setting the UUID workspace ID as the value for this key, but terra workspace set now requires the user-facing ID instead of the UUID. This breaks the default startup script (and indirectly breaks git repo cloning because the script errors out before it gets there). I think the right behavior here is to store the UFID as the metadata key