### PR TITLE
[PF-1519] Create a single combined jacoco report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
       run: ./gradlew :service:${{ matrix.gradleTask }} --scan
 
     - name: Codacy Coverage Reporter
-      if: matrix.gradleTask == 'unitTest' && steps.skiptest.outputs.is-bump == 'no'
+      if: steps.skiptest.outputs.is-bump == 'no'
       uses: codacy/codacy-coverage-reporter-action@0.2.0
       continue-on-error: true
       env:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -222,6 +222,18 @@ To run connected tests:
 To run integration tests, we use Test Runner. Learn to run the Test Runner
 integration tests by reading [Integration README](integration/README.md)
 
+### Code Coverage
+We use Jacoco to generate code coverage reports. Coverage information is written
+to `service/build/jacoco/{task_name}.exec`, and the `combinedJaCoCoReport` 
+gradle task will generate a single combined report for all test tasks run on
+the same machine. This task is run automatically after test tasks and can also
+be run manually.
+
+To get coverage from integration tests, start the server under test using
+`:service:jacocoBootRun` instead of `:service:bootRun`. See 
+[Running Workspace Manager Locally](#Running-Workspace-Manager-Locally) for
+more information.
+
 ### Running Workspace Manager Locally
 
 To run locally, you'll first need to write configs (if you haven't already)
@@ -233,6 +245,10 @@ and then launch the application:
 ```
 
 Then navigate to the Swagger: http://localhost:8080/swagger-ui.html
+
+You can also use the `:service:jacocoBootRun` task to run the server 
+instrumented with Jacoco coverage tracking. This is useful for tracking
+integration test coverage, but may incur a small performance cost.
 
 
 ## Publishing and Versioning

--- a/buildSrc/src/main/groovy/terra-workspace-manager.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/terra-workspace-manager.java-conventions.gradle
@@ -34,12 +34,19 @@ jacoco {
     toolVersion = '0.8.8'
 }
 
-jacocoTestReport {
+// The default jacocoTestReport step cannot handle inputs from multiple gradle
+// tasks. Instead, we define our own task to generate a combined report from the
+// output of all tasks (unitTest, connectedTest, azureTest, and even bootRun for
+// integration tests) we've run.
+task combineJaCoCoReports(type: JacocoReport) {
+    executionData fileTree("$buildDir/jacoco").include("*.exec")
+    classDirectories.setFrom files(project.sourceSets.main.output)
+    sourceDirectories.setFrom files(project.sourceSets.main.allSource.srcDirs)
+
     reports {
-        xml.enabled = true
+        xml.enabled(true)
         xml.destination = file("$buildDir/reports/jacoco/test/jacoco.xml")
     }
-    dependsOn test
 }
 
 version = gradle.wsmVersion

--- a/buildSrc/src/main/groovy/terra-workspace-manager.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/terra-workspace-manager.java-conventions.gradle
@@ -38,15 +38,23 @@ jacoco {
 // tasks. Instead, we define our own task to generate a combined report from the
 // output of all tasks (unitTest, connectedTest, azureTest, and even bootRun for
 // integration tests) we've run.
-task combineJaCoCoReports(type: JacocoReport) {
+task combinedJaCoCoReport(type: JacocoReport) {
     executionData fileTree("$buildDir/jacoco").include("*.exec")
-    classDirectories.setFrom files(project.sourceSets.main.output)
-    sourceDirectories.setFrom files(project.sourceSets.main.allSource.srcDirs)
+    classDirectories.setFrom(files(project.sourceSets.main.output))
+    sourceDirectories.setFrom(files(project.sourceSets.main.allSource.srcDirs))
 
     reports {
         xml.enabled(true)
         xml.destination = file("$buildDir/reports/jacoco/test/jacoco.xml")
     }
+
+    // Ignore coverage of generated code.
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: 'bio/terra/workspace/generated/**')
+        }))
+    }
+
 }
 
 version = gradle.wsmVersion

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -40,3 +40,19 @@ apply(from: "$rootDir/gradle/quality.gradle")
 apply(from: "$includeDir/taskDependencies.gradle")
 apply(from: "$includeDir/dependencies.gradle")
 apply(from: "$includeDir/testing.gradle")
+
+// A small wrapper around bootRun to run the server instrumented with Jacoco
+// code coverage tracking. This is useful for running a local server for
+// integration tests, but live environments should use `bootRun` instead and
+// should not be instrumented.
+// This must live in the same file that the Spring Boot plugin is applied in or
+// else it can't find the task type.
+def googleCredentialsFile = "${rootDir}/config/wsm-sa.json"
+task jacocoBootRun(type: org.springframework.boot.gradle.tasks.run.BootRun) {
+    environment.put("GOOGLE_APPLICATION_CREDENTIALS", "${googleCredentialsFile}")
+    classpath = sourceSets.main.runtimeClasspath
+    main("bio.terra.workspace.app.Main")
+}
+jacoco {
+    applyTo jacocoBootRun
+}

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -23,6 +23,7 @@ test {
     includeTags "unit"
   }
   outputs.upToDateWhen { false }
+  finalizedBy tasks.combineJaCoCoReports
 }
 
 task unitTest(type: Test) {
@@ -30,7 +31,7 @@ task unitTest(type: Test) {
     includeTags "unit"
   }
   outputs.upToDateWhen { false }
-  finalizedBy jacocoTestReport
+  finalizedBy tasks.combineJaCoCoReports
 }
 
 task connectedTest(type: Test) {
@@ -39,6 +40,7 @@ task connectedTest(type: Test) {
     includeTags "connected"
   }
   outputs.upToDateWhen { false }
+  finalizedBy tasks.combineJaCoCoReports
 }
 
 task azureTest(type: Test) {
@@ -46,4 +48,5 @@ task azureTest(type: Test) {
     includeTags "azure"
   }
   outputs.upToDateWhen { false }
+  finalizedBy tasks.combineJaCoCoReports
 }

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -23,7 +23,7 @@ test {
     includeTags "unit"
   }
   outputs.upToDateWhen { false }
-  finalizedBy tasks.combineJaCoCoReports
+  finalizedBy tasks.combinedJaCoCoReport
 }
 
 task unitTest(type: Test) {
@@ -31,7 +31,7 @@ task unitTest(type: Test) {
     includeTags "unit"
   }
   outputs.upToDateWhen { false }
-  finalizedBy tasks.combineJaCoCoReports
+  finalizedBy tasks.combinedJaCoCoReport
 }
 
 task connectedTest(type: Test) {
@@ -40,7 +40,7 @@ task connectedTest(type: Test) {
     includeTags "connected"
   }
   outputs.upToDateWhen { false }
-  finalizedBy tasks.combineJaCoCoReports
+  finalizedBy tasks.combinedJaCoCoReport
 }
 
 task azureTest(type: Test) {
@@ -48,5 +48,5 @@ task azureTest(type: Test) {
     includeTags "azure"
   }
   outputs.upToDateWhen { false }
-  finalizedBy tasks.combineJaCoCoReports
+  finalizedBy tasks.combinedJaCoCoReport
 }


### PR DESCRIPTION
Currently, we only generate a Jacoco report showing coverage for the most recently run task. Instead, when running multiple tasks (such as `unitTest` + `connectedTest` like we do for PRs), this should now give us the combined coverage from all test types we've run.

This also creates and documents a new `jacocoBootRun` task which runs the server instrumented by Jacoco. This is useful for integration tests which run against a local server, but I think there's a moderate performance hit so it's better to keep using `bootRun` for live environments.

Incidentally I think removing `dependsOn test` from the jacoco test report task also fixes the bug where running `unitTest` would run the unit tests twice! Previously the `unitTest` task triggered the `jacocoTestReport` which depended on the `test` task (which also ran unit tests), so `unitTest` indirectly depended on `test`