### PR TITLE
[PF-1524] Add permissions for GAR and Cloudbuild

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -28,7 +28,6 @@ public class CloudSyncRoleMapping {
           "artifactregistry.files.list",
           "artifactregistry.files.get",
           "artifactregistry.packages.list",
-          "artifactregistry.packages.listTagBindings",
           "artifactregistry.repositories.listEffectiveTags",
           "artifactregistry.packages.list",
           "artifactregistry.tags.list",

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -22,10 +22,27 @@ public class CloudSyncRoleMapping {
   // See https://cloud.google.com/iam/docs/understanding-custom-roles#known_limitations
   private static final List<String> PROJECT_READER_PERMISSIONS =
       ImmutableList.of(
+          "artifactregistry.repositories.list",
+          "artifactregistry.repositories.get",
+          "artifactregistry.repositories.downloadArtifacts",
+          "artifactregistry.files.list",
+          "artifactregistry.files.get",
+          "artifactregistry.packages.list",
+          "artifactregistry.packages.listTagBindings",
+          "artifactregistry.repositories.listEffectiveTags",
+          "artifactregistry.packages.list",
+          "artifactregistry.tags.list",
+          "artifactregistry.tags.get", 
+          "artifactregistry.versions.list",
+          "artifactregistry.versions.get",
+          "artifactregistry.locations.list",
+          "artifactregistry.locations.get",
           "bigquery.jobs.create",
           "bigquery.readsessions.create",
           "bigquery.readsessions.getData",
           "bigquery.readsessions.update",
+          "cloudbuild.builds.get",
+          "cloudbuild.builds.list",
           "compute.acceleratorTypes.list",
           "compute.diskTypes.list",
           "compute.instances.list",
@@ -46,6 +63,11 @@ public class CloudSyncRoleMapping {
       new ImmutableList.Builder<String>()
           .addAll(PROJECT_READER_PERMISSIONS)
           .add(
+              "artifactregistry.repositories.uploadArtifacts",
+              "artifactregistry.tags.create",
+              "artifactregistry.tags.update",
+              "cloudbuild.builds.create",
+              "cloudbuild.builds.update",
               "iam.serviceAccounts.get",
               "iam.serviceAccounts.list",
               "lifesciences.operations.cancel",


### PR DESCRIPTION
https://cloud.google.com/artifact-registry/docs/access-control

PROJECT_READER_PERMISSION maps to roles/artifactregistry.reader (view and get artifacts, view repository metadata)
PROJECT_WRITER_PERMISSION maps to roles/artifactregistry.writer (READA and write artifacts)

https://cloud.google.com/build/docs/iam-roles-permissions

PROJECT_READER_PERMISSION maps to cloudbuild.builds.viewer (can view cloud build resources)
PROJECT_WRITER_PERMISSION maps to cloudbuild.builds.editor (full control of cloud build resources)