### PR TITLE
[WOR-92] Add the ability to create an Azure storage container

### DIFF
--- a/openapi/src/parts/controlled_azure_storage.yaml
+++ b/openapi/src/parts/controlled_azure_storage.yaml
@@ -31,9 +31,9 @@ components:
         Storage-specific properties to be set on creation. These are a subset of the values
         accepted by the azure resource API
       type: object
-      required: [ name, region ]
+      required: [ storageAccountName, region ]
       properties:
-        name:
+        storageAccountName:
           description: A valid storage account name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
           type: string
         region:

--- a/openapi/src/parts/controlled_azure_storage_container.yaml
+++ b/openapi/src/parts/controlled_azure_storage_container.yaml
@@ -1,0 +1,62 @@
+paths:
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/storageContainer:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+    post:
+      summary: Create a new controlled Azure Storage Container
+      operationId: createAzureStorageContainer
+      tags: [ControlledAzureResource]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateControlledAzureStorageContainerRequestBody'
+      responses:
+        '200':
+          description: Response to create controlled azure storage
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatedControlledAzureStorageContainer'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+components:
+  schemas:
+    AzureStorageContainerCreationParameters:
+      description: >-
+        Storage container-specific properties to be set on creation. These are a subset of the values
+        accepted by the azure resource API
+      type: object
+      required: [ name, storageAccountName ]
+      properties:
+        name:
+          description: A valid storage container name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+          type: string
+        storageAccountName:
+          description: A valid storage account name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+          type: string
+
+    CreateControlledAzureStorageContainerRequestBody:
+      description: Payload for requesting a new controlled Azure storage container resource.
+      type: object
+      properties:
+        common:
+          $ref: '#/components/schemas/ControlledResourceCommonFields'
+        azureStorageContainer:
+          $ref: '#/components/schemas/AzureStorageContainerCreationParameters'
+
+    CreatedControlledAzureStorageContainer:
+      description: Response payload for requesting a new Azure storage container
+      type: object
+      properties:
+        resourceId:
+          description: UUID of a newly-created resource.
+          type: string
+          format: uuid
+        azureStorageContainer:
+          $ref: '#/components/schemas/AzureStorageContainerResource'
+

--- a/openapi/src/parts/controlled_azure_storage_container.yaml
+++ b/openapi/src/parts/controlled_azure_storage_container.yaml
@@ -3,7 +3,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
     post:
-      summary: Create a new controlled Azure Storage Container
+      summary: Create a new controlled Azure Storage Container with private access
       operationId: createAzureStorageContainer
       tags: [ControlledAzureResource]
       requestBody:
@@ -29,7 +29,7 @@ components:
     AzureStorageContainerCreationParameters:
       description: >-
         Storage container-specific properties to be set on creation. These are a subset of the values
-        accepted by the azure resource API
+        accepted by the azure resource API (note that public access is disabled).
       type: object
       required: [ name, storageAccountName ]
       properties:
@@ -59,4 +59,3 @@ components:
           format: uuid
         azureStorageContainer:
           $ref: '#/components/schemas/AzureStorageContainerResource'
-

--- a/openapi/src/parts/controlled_azure_storage_container.yaml
+++ b/openapi/src/parts/controlled_azure_storage_container.yaml
@@ -31,13 +31,14 @@ components:
         Storage container-specific properties to be set on creation. These are a subset of the values
         accepted by the azure resource API (note that public access is disabled).
       type: object
-      required: [ name, storageAccountName ]
+      required: [ storageAccountId, storageContainerName ]
       properties:
-        name:
-          description: A valid storage container name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+        storageAccountId:
+          description: The resource ID of the storage account in which the container will be created.
           type: string
-        storageAccountName:
-          description: A valid storage account name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+          format: uuid
+        storageContainerName:
+          description: A valid storage container name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
           type: string
 
     CreateControlledAzureStorageContainerRequestBody:

--- a/openapi/src/resources/azure_storage_container.yaml
+++ b/openapi/src/resources/azure_storage_container.yaml
@@ -1,0 +1,26 @@
+components:
+  schemas:
+    AzureStorageContainerAttributes:
+      description: >-
+        Storage container properties included in post-creation get.
+      type: object
+      properties:
+        storageAccountName:
+          description: Name of the storage account.
+          type: string
+        storageContainerName:
+          description: Name of the storage container.
+          type: string
+
+    AzureStorageContainerResource:
+      type: object
+      description: Description of an Azure storage container.
+      required: [ metadata, attributes ]
+      properties:
+        metadata:
+          description: the resource metadata common to all resources
+          $ref: '#/components/schemas/ResourceMetadata'
+        attributes:
+          $ref: '#/components/schemas/AzureStorageContainerAttributes'
+
+

--- a/openapi/src/resources/azure_storage_container.yaml
+++ b/openapi/src/resources/azure_storage_container.yaml
@@ -22,5 +22,3 @@ components:
           $ref: '#/components/schemas/ResourceMetadata'
         attributes:
           $ref: '#/components/schemas/AzureStorageContainerAttributes'
-
-

--- a/openapi/src/resources/azure_storage_container.yaml
+++ b/openapi/src/resources/azure_storage_container.yaml
@@ -6,7 +6,7 @@ components:
       type: object
       properties:
         storageAccountId:
-          description: The resource ID of the storage account in which the container shoudl be created.
+          description: The resource ID of the storage account in which the container should be created.
           type: string
           format: uuid
         storageContainerName:

--- a/openapi/src/resources/azure_storage_container.yaml
+++ b/openapi/src/resources/azure_storage_container.yaml
@@ -5,9 +5,10 @@ components:
         Storage container properties included in post-creation get.
       type: object
       properties:
-        storageAccountName:
-          description: Name of the storage account.
+        storageAccountId:
+          description: The resource ID of the storage account in which the container shoudl be created.
           type: string
+          format: uuid
         storageContainerName:
           description: Name of the storage container.
           type: string

--- a/openapi/src/resources/resource_type.yaml
+++ b/openapi/src/resources/resource_type.yaml
@@ -17,6 +17,7 @@ components:
         - AZURE_VM
         - AZURE_RELAY_NAMESPACE
         - AZURE_STORAGE_ACCOUNT
+        - AZURE_STORAGE_CONTAINER
         - GIT_REPO
 
     ResourceAttributesUnion:
@@ -48,6 +49,8 @@ components:
           $ref: '#/components/schemas/AzureRelayNamespaceAttributes'
         azureStorage:
           $ref: '#/components/schemas/AzureStorageAttributes'
+        azureStorageContainer:
+          $ref: '#/components/schemas/AzureStorageContainerAttributes'
         azureVm:
           $ref: '#/components/schemas/AzureVmAttributes'
         gitRepo:
@@ -84,6 +87,8 @@ components:
           $ref: '#/components/schemas/AzureRelayNamespaceResource'
         azureStorageAccount:
           $ref: '#/components/schemas/AzureStorageResource'
+        azureStorageContainer:
+          $ref: '#/components/schemas/AzureStorageContainerResource'
         gitRepo:
           $ref: '#/components/schemas/GitRepoResource'
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -16,6 +16,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.Controlled
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.relayNamespace.ControlledAzureRelayNamespaceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
@@ -167,30 +168,58 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
   }
 
   @Override
-  public ResponseEntity<ApiCreatedControlledAzureStorage> createAzureStorage(
-      UUID workspaceUuid, @Valid ApiCreateControlledAzureStorageRequestBody body) {
+  public ResponseEntity<ApiCreatedControlledAzureStorageContainer> createAzureStorageContainer(
+      UUID workspaceUuid, @Valid ApiCreateControlledAzureStorageContainerRequestBody body) {
     features.azureEnabledCheck();
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     final ControlledResourceFields commonFields =
         toCommonFields(workspaceUuid, body.getCommon(), userRequest);
 
-    ControlledAzureStorageResource resource =
-        ControlledAzureStorageResource.builder()
+    ControlledAzureStorageContainerResource resource =
+        ControlledAzureStorageContainerResource.builder()
             .common(commonFields)
-            .storageAccountName(body.getAzureStorage().getName())
-            .region(body.getAzureStorage().getRegion())
+            .storageAccountName(body.getAzureStorageContainer().getStorageAccountName())
+            .storageContainerName(body.getAzureStorageContainer().getName())
             .build();
 
-    final ControlledAzureStorageResource createdStorage =
+    final ControlledAzureStorageContainerResource createdStorageContainer =
         controlledResourceService
             .createControlledResourceSync(
-                resource, commonFields.getIamRole(), userRequest, body.getAzureStorage())
-            .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+                resource, commonFields.getIamRole(), userRequest, body.getAzureStorageContainer())
+            .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
     var response =
-        new ApiCreatedControlledAzureStorage()
-            .resourceId(createdStorage.getResourceId())
-            .azureStorage(createdStorage.toApiResource());
+        new ApiCreatedControlledAzureStorageContainer()
+            .resourceId(createdStorageContainer.getResourceId())
+            .azureStorageContainer(createdStorageContainer.toApiResource());
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ApiCreatedControlledAzureStorage> createAzureStorage(
+          UUID workspaceUuid, @Valid ApiCreateControlledAzureStorageRequestBody body) {
+    features.azureEnabledCheck();
+
+    final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    final ControlledResourceFields commonFields =
+            toCommonFields(workspaceUuid, body.getCommon(), userRequest);
+
+    ControlledAzureStorageResource resource =
+            ControlledAzureStorageResource.builder()
+                    .common(commonFields)
+                    .storageAccountName(body.getAzureStorage().getName())
+                    .region(body.getAzureStorage().getRegion())
+                    .build();
+
+    final ControlledAzureStorageResource createdStorage =
+            controlledResourceService
+                    .createControlledResourceSync(
+                            resource, commonFields.getIamRole(), userRequest, body.getAzureStorage())
+                    .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+    var response =
+            new ApiCreatedControlledAzureStorage()
+                    .resourceId(createdStorage.getResourceId())
+                    .azureStorage(createdStorage.toApiResource());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -179,7 +179,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     ControlledAzureStorageResource resource =
         ControlledAzureStorageResource.builder()
             .common(commonFields)
-            .storageAccountName(body.getAzureStorage().getName())
+            .storageAccountName(body.getAzureStorage().getStorageAccountName())
             .region(body.getAzureStorage().getRegion())
             .build();
 
@@ -206,8 +206,8 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     ControlledAzureStorageContainerResource resource =
         ControlledAzureStorageContainerResource.builder()
             .common(commonFields)
-            .storageAccountName(body.getAzureStorageContainer().getStorageAccountName())
-            .storageContainerName(body.getAzureStorageContainer().getName())
+            .storageAccountId(body.getAzureStorageContainer().getStorageAccountId())
+            .storageContainerName(body.getAzureStorageContainer().getStorageContainerName())
             .build();
 
     final ControlledAzureStorageContainerResource createdStorageContainer =

--- a/service/src/main/java/bio/terra/workspace/common/utils/ManagementExceptionUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ManagementExceptionUtils.java
@@ -1,0 +1,43 @@
+package bio.terra.workspace.common.utils;
+
+import com.azure.core.management.exception.ManagementException;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Parses the Azure ManagementException code for the reason of the failure.
+ *
+ * Azure error codes can be found here:
+ *   https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
+ */
+public class ManagementExceptionUtils {
+
+    /**
+     * Was the cause of the Azure ManagementException `ResourceNotFound`?
+     */
+    public static boolean isResourceNotFound(ManagementException ex) {
+        return StringUtils.equals(ex.getValue().getCode(), "ResourceNotFound");
+    }
+
+    /**
+     * Was the cause of the Azure ManagementException `ContainerNotFound`?
+     *
+     * See https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.table.storageerrorcodestrings
+     */
+    public static boolean isContainerNotFound(ManagementException ex) {
+        return StringUtils.equals(ex.getValue().getCode(), "ContainerNotFound");
+    }
+
+    /**
+     * Was the cause of the Azure ManagementException `Conflict`?
+     */
+    public static boolean isConflict(ManagementException ex) {
+        return StringUtils.equals(ex.getValue().getCode(), "Conflict");
+    }
+
+    /**
+     * Was the cause of the Azure ManagementException `SubnetsNotInSameVnet`?
+     */
+    public static boolean isSubnetsNotInSameVnet(ManagementException ex) {
+        return StringUtils.equals(ex.getValue().getCode(), "SubnetsNotInSameVnet");
+    }
+}

--- a/service/src/main/java/bio/terra/workspace/common/utils/ManagementExceptionUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ManagementExceptionUtils.java
@@ -8,36 +8,21 @@ import org.apache.commons.lang3.StringUtils;
  *
  * Azure error codes can be found here:
  *   https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
+ * and
+ *   https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-error-codes
  */
 public class ManagementExceptionUtils {
 
-    /**
-     * Was the cause of the Azure ManagementException `ResourceNotFound`?
-     */
-    public static boolean isResourceNotFound(ManagementException ex) {
-        return StringUtils.equals(ex.getValue().getCode(), "ResourceNotFound");
-    }
+    public static final String RESOURCE_NOT_FOUND = "ResourceNotFound";
+    public static final String CONTAINER_NOT_FOUND = "ContainerNotFound";
+    public static final String CONFLICT = "Conflict";
+    public static final String SUBNETS_NOT_IN_SAME_VNET = "SubnetsNotInSameVnet";
+    public static final String NIC_RESERVED_FOR_ANOTHER_VM = "NicReservedForAnotherVm";
 
     /**
-     * Was the cause of the Azure ManagementException `ContainerNotFound`?
-     *
-     * See https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.table.storageerrorcodestrings
+     * Returns true iff the exception's code matches the supplied value.
      */
-    public static boolean isContainerNotFound(ManagementException ex) {
-        return StringUtils.equals(ex.getValue().getCode(), "ContainerNotFound");
-    }
-
-    /**
-     * Was the cause of the Azure ManagementException `Conflict`?
-     */
-    public static boolean isConflict(ManagementException ex) {
-        return StringUtils.equals(ex.getValue().getCode(), "Conflict");
-    }
-
-    /**
-     * Was the cause of the Azure ManagementException `SubnetsNotInSameVnet`?
-     */
-    public static boolean isSubnetsNotInSameVnet(ManagementException ex) {
-        return StringUtils.equals(ex.getValue().getCode(), "SubnetsNotInSameVnet");
+    public static boolean isExceptionCode(ManagementException ex, String exceptionCode) {
+        return StringUtils.equals(ex.getValue().getCode(), exceptionCode);
     }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -66,6 +66,16 @@ public class ResourceValidationUtils {
       Pattern.compile("^[a-z0-9]{3,24}$");
 
   /**
+   * Azure Storage Container name validation. An storage container name must be between 3-63
+   * characters in length and may contain numbers, lowercase letters, and dash (-) character only.
+   * They must start and end with a letter or number. Matching this pattern is necessary but not sufficient for a
+   * valid container name (in particular, the dash character must be immediately preceded and followed by a letter or
+   * number; consecutive dashes are not permitted).
+   */
+  public static final Pattern AZURE_STORAGE_CONTAINER_NAME_VALIDATION_PATTERN =
+          Pattern.compile("^[a-z0-9][-a-z0-9]{1,61}[a-z0-9]$");
+
+  /**
    * BigQuery datasets must be 1-1024 characters, using letters (upper or lowercase), numbers, and
    * underscores.
    */
@@ -374,6 +384,16 @@ public class ResourceValidationUtils {
       logger.warn("Invalid Storage Account name: {}", storageAccountName);
       throw new InvalidReferenceException(
           "Invalid Azure Storage Account name. The name must be 3 to 24 alphanumeric lower case characters.");
+    }
+  }
+
+  public static void validateStorageContainerName(String storageContainerName) {
+    if (!AZURE_STORAGE_CONTAINER_NAME_VALIDATION_PATTERN.matcher(storageContainerName).matches() ||
+            storageContainerName.contains("--")) {
+      logger.warn("Invalid Storage Container name: {}", storageContainerName);
+      throw new InvalidReferenceException(
+              "Invalid Azure Storage Container name. The name must be 3 to 63 alphanumeric lower case characters " +
+                      "or dashes, must start and end with a letter or number, and cannot contain consecutive dashes.");
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -66,7 +66,7 @@ public class ResourceValidationUtils {
       Pattern.compile("^[a-z0-9]{3,24}$");
 
   /**
-   * Azure Storage Container name validation. An storage container name must be between 3-63
+   * Azure Storage Container name validation. A storage container name must be between 3-63
    * characters in length and may contain numbers, lowercase letters, and dash (-) characters only.
    * It must start and end with a letter or number. Matching this pattern is necessary but not sufficient for a
    * valid container name (in particular, the dash character must be immediately preceded and followed by a letter or

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -67,13 +67,13 @@ public class ResourceValidationUtils {
 
   /**
    * Azure Storage Container name validation. An storage container name must be between 3-63
-   * characters in length and may contain numbers, lowercase letters, and dash (-) character only.
-   * They must start and end with a letter or number. Matching this pattern is necessary but not sufficient for a
+   * characters in length and may contain numbers, lowercase letters, and dash (-) characters only.
+   * It must start and end with a letter or number. Matching this pattern is necessary but not sufficient for a
    * valid container name (in particular, the dash character must be immediately preceded and followed by a letter or
    * number; consecutive dashes are not permitted).
    */
   public static final Pattern AZURE_STORAGE_CONTAINER_NAME_VALIDATION_PATTERN =
-          Pattern.compile("^[a-z0-9][-a-z0-9]{1,61}[a-z0-9]$");
+      Pattern.compile("^[a-z0-9][-a-z0-9]{1,61}[a-z0-9]$");
 
   /**
    * BigQuery datasets must be 1-1024 characters, using letters (upper or lowercase), numbers, and

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStep.java
@@ -66,7 +66,7 @@ public class CreateAzureDiskStep implements Step {
       // other cases, surface the exception and attempt to retry.
       // Azure error codes can be found here:
       // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (ManagementExceptionUtils.isConflict(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONFLICT)) {
         logger.info(
             "Azure Disk {} in managed resource group {} already exists",
             resource.getDiskName(),
@@ -94,7 +94,7 @@ public class CreateAzureDiskStep implements Step {
               azureCloudContext.getAzureResourceGroupId(), resource.getDiskName());
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have deleted this resource.
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         logger.info(
             "Azure Disk {} in managed resource group {} already deleted",
             resource.getDiskName(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStep.java
@@ -8,13 +8,13 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +66,7 @@ public class CreateAzureDiskStep implements Step {
       // other cases, surface the exception and attempt to retry.
       // Azure error codes can be found here:
       // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (StringUtils.equals(e.getValue().getCode(), "Conflict")) {
+      if (ManagementExceptionUtils.isConflict(e)) {
         logger.info(
             "Azure Disk {} in managed resource group {} already exists",
             resource.getDiskName(),
@@ -94,7 +94,7 @@ public class CreateAzureDiskStep implements Step {
               azureCloudContext.getAzureResourceGroupId(), resource.getDiskName());
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have deleted this resource.
-      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isResourceNotFound(e)) {
         logger.info(
             "Azure Disk {} in managed resource group {} already deleted",
             resource.getDiskName(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStep.java
@@ -64,8 +64,6 @@ public class CreateAzureDiskStep implements Step {
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have created this resource. In all
       // other cases, surface the exception and attempt to retry.
-      // Azure error codes can be found here:
-      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
       if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONFLICT)) {
         logger.info(
             "Azure Disk {} in managed resource group {} already exists",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStep.java
@@ -48,7 +48,7 @@ public class GetAzureDiskStep implements Step {
                   "An Azure DISK with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getDiskName())));
     } catch (ManagementException e) {
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStep.java
@@ -6,13 +6,13 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Gets an Azure Disk, and fails if it already exists. This step is designed to run immediately
@@ -48,9 +48,7 @@ public class GetAzureDiskStep implements Step {
                   "An Azure DISK with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getDiskName())));
     } catch (ManagementException e) {
-      // Azure error codes can be found here:
-      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isResourceNotFound(e)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStep.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
@@ -15,7 +16,6 @@ import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.network.models.IpAllocationMethod;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,9 +65,7 @@ public class CreateAzureIpStep implements Step {
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have created this resource. In all
       // other cases, surface the exception and attempt to retry.
-      // Azure error codes can be found here:
-      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (StringUtils.equals(e.getValue().getCode(), "Conflict")) {
+      if (ManagementExceptionUtils.isConflict(e)) {
         logger.info(
             "Azure IP {} in managed resource group {} already exists",
             resource.getIpName(),
@@ -95,7 +93,7 @@ public class CreateAzureIpStep implements Step {
           .deleteByResourceGroup(azureCloudContext.getAzureResourceGroupId(), resource.getIpName());
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have deleted this resource.
-      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isResourceNotFound(e)) {
         logger.info(
             "Azure IP {} in managed resource group {} already deleted",
             resource.getIpName(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStep.java
@@ -65,7 +65,7 @@ public class CreateAzureIpStep implements Step {
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have created this resource. In all
       // other cases, surface the exception and attempt to retry.
-      if (ManagementExceptionUtils.isConflict(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONFLICT)) {
         logger.info(
             "Azure IP {} in managed resource group {} already exists",
             resource.getIpName(),
@@ -93,7 +93,7 @@ public class CreateAzureIpStep implements Step {
           .deleteByResourceGroup(azureCloudContext.getAzureResourceGroupId(), resource.getIpName());
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have deleted this resource.
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         logger.info(
             "Azure IP {} in managed resource group {} already deleted",
             resource.getIpName(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStep.java
@@ -6,15 +6,13 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Gets an Azure IP, and fails if it already exists. This step is designed to run immediately before
@@ -22,7 +20,6 @@ import org.slf4j.LoggerFactory;
  */
 public class GetAzureIpStep implements Step {
 
-  private static final Logger logger = LoggerFactory.getLogger(GetAzureIpStep.class);
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureIpResource resource;
@@ -53,9 +50,7 @@ public class GetAzureIpStep implements Step {
                   "An Azure IP with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getIpName())));
     } catch (ManagementException e) {
-      // Azure error codes can be found here:
-      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isResourceNotFound(e)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStep.java
@@ -50,7 +50,7 @@ public class GetAzureIpStep implements Step {
                   "An Azure IP with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getIpName())));
     } catch (ManagementException e) {
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStep.java
@@ -106,14 +106,14 @@ public class CreateAzureNetworkStep implements Step {
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have created this resource. In all
       // other cases, surface the exception and attempt to retry.
-      if (ManagementExceptionUtils.isConflict(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONFLICT)) {
         logger.info(
             "Azure Network {} in managed resource group {} already exists",
             resource.getNetworkName(),
             azureCloudContext.getAzureResourceGroupId());
         return StepResult.getStepResultSuccess();
       }
-      if (ManagementExceptionUtils.isSubnetsNotInSameVnet(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.SUBNETS_NOT_IN_SAME_VNET)) {
         logger.info(
             "Azure Network {} and Subnet {} in managed resource group {} must belong to the same virtual network",
             resource.getNetworkName(),
@@ -143,7 +143,7 @@ public class CreateAzureNetworkStep implements Step {
               azureCloudContext.getAzureResourceGroupId(), resource.getNetworkName());
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have deleted this resource.
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         logger.info(
             "Azure Network {} in managed resource group {} already deleted",
             resource.getNetworkName(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStep.java
@@ -6,15 +6,13 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Gets an Azure Network, and fails if it already exists. This step is designed to run immediately
@@ -22,7 +20,6 @@ import org.slf4j.LoggerFactory;
  */
 public class GetAzureNetworkStep implements Step {
 
-  private static final Logger logger = LoggerFactory.getLogger(GetAzureNetworkStep.class);
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureNetworkResource resource;
@@ -56,9 +53,7 @@ public class GetAzureNetworkStep implements Step {
                   "An Azure Network with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getNetworkName())));
     } catch (ManagementException e) {
-      // Azure error codes can be found here:
-      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isResourceNotFound(e)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStep.java
@@ -53,7 +53,7 @@ public class GetAzureNetworkStep implements Step {
                   "An Azure Network with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getNetworkName())));
     } catch (ManagementException e) {
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStep.java
@@ -64,7 +64,7 @@ public class CreateAzureRelayNamespaceStep implements Step {
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have created this resource. In all
       // other cases, surface the exception and attempt to retry.
-      if (ManagementExceptionUtils.isConflict(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONFLICT)) {
         logger.info(
             "Azure Relay Namepace {} in managed resource group {} already exists",
             resource.getNamespaceName(),
@@ -92,7 +92,7 @@ public class CreateAzureRelayNamespaceStep implements Step {
               azureCloudContext.getAzureResourceGroupId(), resource.getNamespaceName());
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have deleted this resource.
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         logger.info(
             "Azure Relay Namespace {} in managed resource group {} already deleted",
             resource.getNamespaceName(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStep.java
@@ -8,13 +8,13 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.relay.RelayManager;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,9 +64,7 @@ public class CreateAzureRelayNamespaceStep implements Step {
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have created this resource. In all
       // other cases, surface the exception and attempt to retry.
-      // Azure error codes can be found here:
-      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (StringUtils.equals(e.getValue().getCode(), "Conflict")) {
+      if (ManagementExceptionUtils.isConflict(e)) {
         logger.info(
             "Azure Relay Namepace {} in managed resource group {} already exists",
             resource.getNamespaceName(),
@@ -94,7 +92,7 @@ public class CreateAzureRelayNamespaceStep implements Step {
               azureCloudContext.getAzureResourceGroupId(), resource.getNamespaceName());
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have deleted this resource.
-      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isResourceNotFound(e)) {
         logger.info(
             "Azure Relay Namespace {} in managed resource group {} already deleted",
             resource.getNamespaceName(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStep.java
@@ -53,7 +53,7 @@ public class GetAzureRelayNamespaceStep implements Step {
                   "An Azure Relay Namespace with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getName())));
     } catch (ManagementException e) {
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStep.java
@@ -6,15 +6,13 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.relay.RelayManager;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Gets an Azure RelayNamespace, and fails if it already exists. This step is designed to run
@@ -23,7 +21,6 @@ import org.slf4j.LoggerFactory;
  */
 public class GetAzureRelayNamespaceStep implements Step {
 
-  private static final Logger logger = LoggerFactory.getLogger(GetAzureRelayNamespaceStep.class);
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureRelayNamespaceResource resource;
@@ -56,9 +53,7 @@ public class GetAzureRelayNamespaceStep implements Step {
                   "An Azure Relay Namespace with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getName())));
     } catch (ManagementException e) {
-      // Azure error codes can be found here:
-      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (StringUtils.contains(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isResourceNotFound(e)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
@@ -47,6 +47,7 @@ public class CreateAzureStorageStep implements Step {
           .withRegion(resource.getRegion())
           .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
           .withHnsEnabled(true)
+          .disableBlobPublicAccess()
           .withTag("workspaceId", resource.getWorkspaceId().toString())
           .withTag("resourceId", resource.getResourceId().toString())
           .create(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
@@ -47,7 +47,6 @@ public class CreateAzureStorageStep implements Step {
           .withRegion(resource.getRegion())
           .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
           .withHnsEnabled(true)
-          .disableBlobPublicAccess()
           .withTag("workspaceId", resource.getWorkspaceId().toString())
           .withTag("resourceId", resource.getResourceId().toString())
           .create(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/resourcemanager/StorageManagerOperation.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/resourcemanager/StorageManagerOperation.java
@@ -4,5 +4,6 @@ import bio.terra.cloudres.common.CloudOperation;
 
 /** {@link CloudOperation} for using StorageManager API. */
 public enum StorageManagerOperation implements CloudOperation {
-  AZURE_CREATE_STORAGE
+  AZURE_CREATE_STORAGE_ACCOUNT,
+  AZURE_CREATE_STORAGE_CONTAINER
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/resourcemanager/data/CreateStorageAccountRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/resourcemanager/data/CreateStorageAccountRequestData.java
@@ -11,7 +11,7 @@ public abstract class CreateStorageAccountRequestData extends BaseStorageRequest
 
   @Override
   public CloudOperation cloudOperation() {
-    return StorageManagerOperation.AZURE_CREATE_STORAGE;
+    return StorageManagerOperation.AZURE_CREATE_STORAGE_ACCOUNT;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerAttributes.java
@@ -6,23 +6,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 
 public class ControlledAzureStorageContainerAttributes {
-    private final UUID storageAccountId;
-    private final String storageContainerName;
+  private final UUID storageAccountId;
+  private final String storageContainerName;
 
-    @JsonCreator
-    public ControlledAzureStorageContainerAttributes(
-            @JsonProperty("storageAccountId") UUID storageAccountId,
-            @JsonProperty("storageContainerName") String storageContainerName) {
-        this.storageAccountId = storageAccountId;
-        this.storageContainerName = storageContainerName;
-    }
+  @JsonCreator
+  public ControlledAzureStorageContainerAttributes(
+      @JsonProperty("storageAccountId") UUID storageAccountId,
+      @JsonProperty("storageContainerName") String storageContainerName) {
+    this.storageAccountId = storageAccountId;
+    this.storageContainerName = storageContainerName;
+  }
 
-    public UUID getStorageAccountId() {
-        return storageAccountId;
-    }
+  public UUID getStorageAccountId() {
+    return storageAccountId;
+  }
 
-    public String getStorageContainerName() {
-        return storageContainerName;
-    }
-
+  public String getStorageContainerName() {
+    return storageContainerName;
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerAttributes.java
@@ -6,23 +6,23 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 
 public class ControlledAzureStorageContainerAttributes {
-  private final UUID storageAccountId;
-  private final String storageContainerName;
+    private final UUID storageAccountId;
+    private final String storageContainerName;
 
-  @JsonCreator
-  public ControlledAzureStorageContainerAttributes(
-          @JsonProperty("storageAccountId") UUID storageAccountId,
-          @JsonProperty("storageContainerName") String storageContainerName) {
-    this.storageAccountId = storageAccountId;
-    this.storageContainerName = storageContainerName;
-  }
+    @JsonCreator
+    public ControlledAzureStorageContainerAttributes(
+            @JsonProperty("storageAccountId") UUID storageAccountId,
+            @JsonProperty("storageContainerName") String storageContainerName) {
+        this.storageAccountId = storageAccountId;
+        this.storageContainerName = storageContainerName;
+    }
 
-  public UUID getStorageAccountId() {
-    return storageAccountId;
-  }
+    public UUID getStorageAccountId() {
+        return storageAccountId;
+    }
 
-  public String getStorageContainerName() {
-    return storageContainerName;
-  }
+    public String getStorageContainerName() {
+        return storageContainerName;
+    }
 
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerAttributes.java
@@ -1,0 +1,26 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ControlledAzureStorageContainerAttributes {
+  private final String storageAccountName;
+  private final String storageContainerName;
+
+  @JsonCreator
+  public ControlledAzureStorageContainerAttributes(
+          @JsonProperty("storageAccountName") String storageAccountName,
+          @JsonProperty("storageContainerName") String storageContainerName) {
+    this.storageAccountName = storageAccountName;
+    this.storageContainerName = storageContainerName;
+  }
+
+  public String getStorageAccountName() {
+    return storageAccountName;
+  }
+
+  public String getStorageContainerName() {
+    return storageContainerName;
+  }
+
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerAttributes.java
@@ -3,20 +3,22 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.storageConta
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.UUID;
+
 public class ControlledAzureStorageContainerAttributes {
-  private final String storageAccountName;
+  private final UUID storageAccountId;
   private final String storageContainerName;
 
   @JsonCreator
   public ControlledAzureStorageContainerAttributes(
-          @JsonProperty("storageAccountName") String storageAccountName,
+          @JsonProperty("storageAccountId") UUID storageAccountId,
           @JsonProperty("storageContainerName") String storageContainerName) {
-    this.storageAccountName = storageAccountName;
+    this.storageAccountId = storageAccountId;
     this.storageContainerName = storageContainerName;
   }
 
-  public String getStorageAccountName() {
-    return storageAccountName;
+  public UUID getStorageAccountId() {
+    return storageAccountId;
   }
 
   public String getStorageContainerName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerHandler.java
@@ -24,7 +24,7 @@ public class ControlledAzureStorageContainerHandler implements WsmResourceHandle
         DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureStorageContainerAttributes.class);
 
     return ControlledAzureStorageContainerResource.builder()
-            .storageAccountName(attributes.getStorageAccountName())
+            .storageAccountId(attributes.getStorageAccountId())
             .storageContainerName(attributes.getStorageContainerName())
             .common(new ControlledResourceFields(dbResource))
             .build();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerHandler.java
@@ -1,0 +1,32 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageAttributes;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+
+public class ControlledAzureStorageContainerHandler implements WsmResourceHandler {
+  private static ControlledAzureStorageContainerHandler theHandler;
+
+  public static ControlledAzureStorageContainerHandler getHandler() {
+    if (theHandler == null) {
+      theHandler = new ControlledAzureStorageContainerHandler();
+    }
+    return theHandler;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    ControlledAzureStorageContainerAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureStorageContainerAttributes.class);
+
+    return ControlledAzureStorageContainerResource.builder()
+            .storageAccountName(attributes.getStorageAccountName())
+            .storageContainerName(attributes.getStorageContainerName())
+            .common(new ControlledResourceFields(dbResource))
+            .build();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerHandler.java
@@ -2,31 +2,32 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.storageConta
 
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageAttributes;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 
 public class ControlledAzureStorageContainerHandler implements WsmResourceHandler {
-  private static ControlledAzureStorageContainerHandler theHandler;
+    private static ControlledAzureStorageContainerHandler theHandler;
 
-  public static ControlledAzureStorageContainerHandler getHandler() {
-    if (theHandler == null) {
-      theHandler = new ControlledAzureStorageContainerHandler();
+    public static ControlledAzureStorageContainerHandler getHandler() {
+        if (theHandler == null) {
+            theHandler = new ControlledAzureStorageContainerHandler();
+        }
+        return theHandler;
     }
-    return theHandler;
-  }
 
-  /** {@inheritDoc} */
-  @Override
-  public WsmResource makeResourceFromDb(DbResource dbResource) {
-    ControlledAzureStorageContainerAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureStorageContainerAttributes.class);
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WsmResource makeResourceFromDb(DbResource dbResource) {
+        ControlledAzureStorageContainerAttributes attributes =
+                DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureStorageContainerAttributes.class);
 
-    return ControlledAzureStorageContainerResource.builder()
-            .storageAccountId(attributes.getStorageAccountId())
-            .storageContainerName(attributes.getStorageContainerName())
-            .common(new ControlledResourceFields(dbResource))
-            .build();
-  }
+        return ControlledAzureStorageContainerResource.builder()
+                .storageAccountId(attributes.getStorageAccountId())
+                .storageContainerName(attributes.getStorageContainerName())
+                .common(new ControlledResourceFields(dbResource))
+                .build();
+    }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerHandler.java
@@ -7,27 +7,26 @@ import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 
 public class ControlledAzureStorageContainerHandler implements WsmResourceHandler {
-    private static ControlledAzureStorageContainerHandler theHandler;
+  private static ControlledAzureStorageContainerHandler theHandler;
 
-    public static ControlledAzureStorageContainerHandler getHandler() {
-        if (theHandler == null) {
-            theHandler = new ControlledAzureStorageContainerHandler();
-        }
-        return theHandler;
+  public static ControlledAzureStorageContainerHandler getHandler() {
+    if (theHandler == null) {
+      theHandler = new ControlledAzureStorageContainerHandler();
     }
+    return theHandler;
+  }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public WsmResource makeResourceFromDb(DbResource dbResource) {
-        ControlledAzureStorageContainerAttributes attributes =
-                DbSerDes.fromJson(dbResource.getAttributes(), ControlledAzureStorageContainerAttributes.class);
+  /** {@inheritDoc} */
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    ControlledAzureStorageContainerAttributes attributes =
+        DbSerDes.fromJson(
+            dbResource.getAttributes(), ControlledAzureStorageContainerAttributes.class);
 
-        return ControlledAzureStorageContainerResource.builder()
-                .storageAccountId(attributes.getStorageAccountId())
-                .storageContainerName(attributes.getStorageContainerName())
-                .common(new ControlledResourceFields(dbResource))
-                .build();
-    }
+    return ControlledAzureStorageContainerResource.builder()
+        .storageAccountId(attributes.getStorageAccountId())
+        .storageContainerName(attributes.getStorageContainerName())
+        .common(new ControlledResourceFields(dbResource))
+        .build();
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -12,7 +12,6 @@ import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
 import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageAttributes;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.*;
@@ -101,7 +100,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
       FlightBeanBag flightBeanBag) {
     RetryRule cloudRetry = RetryRules.cloud();
     flight.addStep(
-        new GetAzureStorageContainerStep(
+        new VerifyAzureStorageContainerCanBeCreatedStep(
             flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
         cloudRetry);
     flight.addStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -146,7 +146,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
 
   @Override
   public WsmResourceFamily getResourceFamily() {
-    return WsmResourceFamily.AZURE_STORAGE_ACCOUNT;
+    return WsmResourceFamily.AZURE_STORAGE_CONTAINER;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -1,0 +1,237 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import bio.terra.common.exception.BadRequestException;
+import bio.terra.common.exception.InconsistentFieldsException;
+import bio.terra.common.exception.MissingRequiredFieldException;
+import bio.terra.stairway.RetryRule;
+import bio.terra.workspace.common.utils.FlightBeanBag;
+import bio.terra.workspace.common.utils.RetryRules;
+import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
+import bio.terra.workspace.generated.model.*;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageAttributes;
+import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
+import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
+import bio.terra.workspace.service.resource.controlled.model.*;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class ControlledAzureStorageContainerResource extends ControlledResource {
+  private final String storageAccountName;
+  private final String storageContainerName;
+
+  @JsonCreator
+  public ControlledAzureStorageContainerResource(
+      @JsonProperty("workspaceId") UUID workspaceId,
+      @JsonProperty("resourceId") UUID resourceId,
+      @JsonProperty("name") String name,
+      @JsonProperty("description") String description,
+      @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
+      @JsonProperty("assignedUser") String assignedUser,
+      @JsonProperty("privateResourceState") PrivateResourceState privateResourceState,
+      @JsonProperty("accessScope") AccessScopeType accessScope,
+      @JsonProperty("managedBy") ManagedByType managedBy,
+      @JsonProperty("applicationId") String applicationId,
+      @JsonProperty("storageAccountName") String storageAccountName,
+      @JsonProperty("storageContainerName") String storageContainerName) {
+    super(
+        workspaceId,
+        resourceId,
+        name,
+        description,
+        cloningInstructions,
+        assignedUser,
+        accessScope,
+        managedBy,
+        applicationId,
+        privateResourceState);
+    this.storageAccountName = storageAccountName;
+    this.storageContainerName = storageContainerName;
+    validate();
+  }
+
+  private ControlledAzureStorageContainerResource(
+      ControlledResourceFields common, String storageAccountName, String storageContainerName) {
+    super(common);
+    this.storageAccountName = storageAccountName;
+    this.storageContainerName = storageContainerName;
+    validate();
+  }
+
+  public static ControlledAzureStorageContainerResource.Builder builder() {
+    return new ControlledAzureStorageContainerResource.Builder();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T castByEnum(WsmResourceType expectedType) {
+    if (getResourceType() != expectedType) {
+      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
+    }
+    return (T) this;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckAttributes() {
+    return Optional.of(
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.WORKSPACE)  // TODO: combination of storage account name and container name must be unique
+            .addParameter("storageAccountName", getStorageAccountName())
+            .addParameter("storageContainerName", getStorageContainerName()));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addCreateSteps(
+      CreateControlledResourceFlight flight,
+      String petSaEmail,
+      AuthenticatedUserRequest userRequest,
+      FlightBeanBag flightBeanBag) {
+    RetryRule cloudRetry = RetryRules.cloud();
+    flight.addStep(
+        new GetAzureStorageContainerStep(
+            flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
+        cloudRetry);
+    flight.addStep(
+        new CreateAzureStorageContainerStep(
+            flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
+        cloudRetry);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addDeleteSteps(DeleteControlledResourceFlight flight, FlightBeanBag flightBeanBag) {
+    flight.addStep(
+            new DeleteAzureStorageContainerStep(
+                    flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
+            RetryRules.cloud());
+  }
+
+  public String getStorageAccountName() {
+    return storageAccountName;
+  }
+
+  public String getStorageContainerName() {
+    return storageContainerName;
+  }
+
+  public ApiAzureStorageContainerAttributes toApiAttributes() {
+    return new ApiAzureStorageContainerAttributes()
+        .storageAccountName(getStorageAccountName())
+        .storageContainerName(getStorageContainerName());
+  }
+
+  public ApiAzureStorageContainerResource toApiResource() {
+    return new ApiAzureStorageContainerResource()
+        .metadata(super.toApiMetadata())
+        .attributes(toApiAttributes());
+  }
+
+  @Override
+  public WsmResourceType getResourceType() {
+    return WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER;
+  }
+
+  @Override
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.AZURE_STORAGE_ACCOUNT;
+  }
+
+  @Override
+  public String attributesToJson() {
+    return DbSerDes.toJson(
+        new ControlledAzureStorageContainerAttributes(getStorageAccountName(), getStorageContainerName()));
+  }
+
+  @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.azureStorageContainer(toApiAttributes());
+    return union;
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    ApiResourceUnion union = new ApiResourceUnion();
+    union.azureStorageContainer(toApiResource());
+    return union;
+  }
+
+  @Override
+  public void validate() {
+    super.validate();
+    if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER
+        || getResourceFamily() != WsmResourceFamily.AZURE_STORAGE_CONTAINER
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_STORAGE_CONTAINER");
+    }
+
+    if (getStorageAccountName() == null) {
+      throw new MissingRequiredFieldException(
+              "Missing required storage account name field for ControlledAzureStorageContainer.");
+    }
+
+    if (getStorageContainerName() == null) {
+      throw new MissingRequiredFieldException(
+          "Missing required storage container name field for ControlledAzureStorageContainer.");
+    }
+
+    ResourceValidationUtils.validateStorageAccountName(getStorageAccountName()); // TODO add validation for storage container name
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+
+    ControlledAzureStorageContainerResource that = (ControlledAzureStorageContainerResource) o;
+
+    return storageAccountName.equals(that.getStorageAccountName()) && storageContainerName.equals(that.getStorageContainerName());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + storageAccountName.hashCode();
+    result = 31 * result + storageContainerName.hashCode();
+    return result;
+  }
+
+  public static class Builder {
+    private ControlledResourceFields common;
+    private String storageAccountName;
+    private String storageContainerName;
+
+    public Builder common(ControlledResourceFields common) {
+      this.common = common;
+      return this;
+    }
+
+    public ControlledAzureStorageContainerResource.Builder storageAccountName(String storageAccountName) {
+      this.storageAccountName = storageAccountName;
+      return this;
+    }
+
+    public ControlledAzureStorageContainerResource.Builder storageContainerName(String storageContainerName) {
+      this.storageContainerName = storageContainerName;
+      return this;
+    }
+
+    public ControlledAzureStorageContainerResource build() {
+      return new ControlledAzureStorageContainerResource(common, storageAccountName, storageContainerName);
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -29,220 +29,221 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class ControlledAzureStorageContainerResource extends ControlledResource {
-    private final UUID storageAccountId;
-    private final String storageContainerName;
+  private final UUID storageAccountId;
+  private final String storageContainerName;
 
-    @JsonCreator
-    public ControlledAzureStorageContainerResource(
-            @JsonProperty("workspaceId") UUID workspaceId,
-            @JsonProperty("resourceId") UUID resourceId,
-            @JsonProperty("name") String name,
-            @JsonProperty("description") String description,
-            @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
-            @JsonProperty("assignedUser") String assignedUser,
-            @JsonProperty("privateResourceState") PrivateResourceState privateResourceState,
-            @JsonProperty("accessScope") AccessScopeType accessScope,
-            @JsonProperty("managedBy") ManagedByType managedBy,
-            @JsonProperty("applicationId") String applicationId,
-            @JsonProperty("storageAccountId") UUID storageAccountId,
-            @JsonProperty("storageContainerName") String storageContainerName) {
-        super(
-                workspaceId,
-                resourceId,
-                name,
-                description,
-                cloningInstructions,
-                assignedUser,
-                accessScope,
-                managedBy,
-                applicationId,
-                privateResourceState);
-        this.storageAccountId = storageAccountId;
-        this.storageContainerName = storageContainerName;
-        validate();
+  @JsonCreator
+  public ControlledAzureStorageContainerResource(
+      @JsonProperty("workspaceId") UUID workspaceId,
+      @JsonProperty("resourceId") UUID resourceId,
+      @JsonProperty("name") String name,
+      @JsonProperty("description") String description,
+      @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
+      @JsonProperty("assignedUser") String assignedUser,
+      @JsonProperty("privateResourceState") PrivateResourceState privateResourceState,
+      @JsonProperty("accessScope") AccessScopeType accessScope,
+      @JsonProperty("managedBy") ManagedByType managedBy,
+      @JsonProperty("applicationId") String applicationId,
+      @JsonProperty("storageAccountId") UUID storageAccountId,
+      @JsonProperty("storageContainerName") String storageContainerName) {
+    super(
+        workspaceId,
+        resourceId,
+        name,
+        description,
+        cloningInstructions,
+        assignedUser,
+        accessScope,
+        managedBy,
+        applicationId,
+        privateResourceState);
+    this.storageAccountId = storageAccountId;
+    this.storageContainerName = storageContainerName;
+    validate();
+  }
+
+  private ControlledAzureStorageContainerResource(
+      ControlledResourceFields common, UUID storageAccountId, String storageContainerName) {
+    super(common);
+    this.storageAccountId = storageAccountId;
+    this.storageContainerName = storageContainerName;
+    validate();
+  }
+
+  public static ControlledAzureStorageContainerResource.Builder builder() {
+    return new ControlledAzureStorageContainerResource.Builder();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T castByEnum(WsmResourceType expectedType) {
+    if (getResourceType() != expectedType) {
+      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
+    }
+    return (T) this;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckAttributes() {
+    return Optional.of(
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.WORKSPACE)
+            .addParameter("storageAccountId", getStorageAccountId().toString())
+            .addParameter("storageContainerName", getStorageContainerName()));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addCreateSteps(
+      CreateControlledResourceFlight flight,
+      String petSaEmail,
+      AuthenticatedUserRequest userRequest,
+      FlightBeanBag flightBeanBag) {
+    RetryRule cloudRetry = RetryRules.cloud();
+    flight.addStep(
+        new VerifyAzureStorageContainerCanBeCreatedStep(
+            flightBeanBag.getAzureConfig(),
+            flightBeanBag.getCrlService(),
+            flightBeanBag.getResourceDao(),
+            this),
+        cloudRetry);
+    flight.addStep(
+        new CreateAzureStorageContainerStep(
+            flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
+        cloudRetry);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addDeleteSteps(DeleteControlledResourceFlight flight, FlightBeanBag flightBeanBag) {
+    flight.addStep(
+        new DeleteAzureStorageContainerStep(
+            flightBeanBag.getAzureConfig(),
+            flightBeanBag.getCrlService(),
+            flightBeanBag.getResourceDao(),
+            this),
+        RetryRules.cloud());
+  }
+
+  public UUID getStorageAccountId() {
+    return storageAccountId;
+  }
+
+  public String getStorageContainerName() {
+    return storageContainerName;
+  }
+
+  public ApiAzureStorageContainerAttributes toApiAttributes() {
+    return new ApiAzureStorageContainerAttributes()
+        .storageAccountId(getStorageAccountId())
+        .storageContainerName(getStorageContainerName());
+  }
+
+  public ApiAzureStorageContainerResource toApiResource() {
+    return new ApiAzureStorageContainerResource()
+        .metadata(super.toApiMetadata())
+        .attributes(toApiAttributes());
+  }
+
+  @Override
+  public WsmResourceType getResourceType() {
+    return WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER;
+  }
+
+  @Override
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.AZURE_STORAGE_CONTAINER;
+  }
+
+  @Override
+  public String attributesToJson() {
+    return DbSerDes.toJson(
+        new ControlledAzureStorageContainerAttributes(
+            getStorageAccountId(), getStorageContainerName()));
+  }
+
+  @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.azureStorageContainer(toApiAttributes());
+    return union;
+  }
+
+  @Override
+  public ApiResourceUnion toApiResourceUnion() {
+    ApiResourceUnion union = new ApiResourceUnion();
+    union.azureStorageContainer(toApiResource());
+    return union;
+  }
+
+  @Override
+  public void validate() {
+    super.validate();
+    if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER
+        || getResourceFamily() != WsmResourceFamily.AZURE_STORAGE_CONTAINER
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_STORAGE_CONTAINER");
     }
 
-    private ControlledAzureStorageContainerResource(
-            ControlledResourceFields common, UUID storageAccountId, String storageContainerName) {
-        super(common);
-        this.storageAccountId = storageAccountId;
-        this.storageContainerName = storageContainerName;
-        validate();
+    if (getStorageAccountId() == null) {
+      throw new MissingRequiredFieldException(
+          "Missing required storage account ID field for ControlledAzureStorageContainer.");
     }
 
-    public static ControlledAzureStorageContainerResource.Builder builder() {
-        return new ControlledAzureStorageContainerResource.Builder();
+    if (getStorageContainerName() == null) {
+      throw new MissingRequiredFieldException(
+          "Missing required storage container name field for ControlledAzureStorageContainer.");
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> T castByEnum(WsmResourceType expectedType) {
-        if (getResourceType() != expectedType) {
-            throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-        }
-        return (T) this;
+    ResourceValidationUtils.validateStorageContainerName(getStorageContainerName());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+
+    ControlledAzureStorageContainerResource that = (ControlledAzureStorageContainerResource) o;
+
+    return storageAccountId.equals(that.getStorageAccountId())
+        && storageContainerName.equals(that.getStorageContainerName());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + storageAccountId.hashCode();
+    result = 31 * result + storageContainerName.hashCode();
+    return result;
+  }
+
+  public static class Builder {
+    private ControlledResourceFields common;
+    private UUID storageAccountId;
+    private String storageContainerName;
+
+    public Builder common(ControlledResourceFields common) {
+      this.common = common;
+      return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Optional<UniquenessCheckAttributes> getUniquenessCheckAttributes() {
-        return Optional.of(
-                new UniquenessCheckAttributes()
-                        .uniquenessScope(UniquenessScope.WORKSPACE)
-                        .addParameter("storageAccountId", getStorageAccountId().toString())
-                        .addParameter("storageContainerName", getStorageContainerName()));
+    public ControlledAzureStorageContainerResource.Builder storageAccountId(UUID storageAccountId) {
+      this.storageAccountId = storageAccountId;
+      return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addCreateSteps(
-            CreateControlledResourceFlight flight,
-            String petSaEmail,
-            AuthenticatedUserRequest userRequest,
-            FlightBeanBag flightBeanBag) {
-        RetryRule cloudRetry = RetryRules.cloud();
-        flight.addStep(
-                new VerifyAzureStorageContainerCanBeCreatedStep(
-                        flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), flightBeanBag.getResourceDao(), this),
-                cloudRetry);
-        flight.addStep(
-                new CreateAzureStorageContainerStep(
-                        flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
-                cloudRetry);
+    public ControlledAzureStorageContainerResource.Builder storageContainerName(
+        String storageContainerName) {
+      this.storageContainerName = storageContainerName;
+      return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addDeleteSteps(DeleteControlledResourceFlight flight, FlightBeanBag flightBeanBag) {
-        flight.addStep(
-                new DeleteAzureStorageContainerStep(
-                        flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(),
-                        flightBeanBag.getResourceDao(), this),
-                RetryRules.cloud());
+    public ControlledAzureStorageContainerResource build() {
+      return new ControlledAzureStorageContainerResource(
+          common, storageAccountId, storageContainerName);
     }
-
-    public UUID getStorageAccountId() {
-        return storageAccountId;
-    }
-
-    public String getStorageContainerName() {
-        return storageContainerName;
-    }
-
-    public ApiAzureStorageContainerAttributes toApiAttributes() {
-        return new ApiAzureStorageContainerAttributes()
-                .storageAccountId(getStorageAccountId())
-                .storageContainerName(getStorageContainerName());
-    }
-
-    public ApiAzureStorageContainerResource toApiResource() {
-        return new ApiAzureStorageContainerResource()
-                .metadata(super.toApiMetadata())
-                .attributes(toApiAttributes());
-    }
-
-    @Override
-    public WsmResourceType getResourceType() {
-        return WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER;
-    }
-
-    @Override
-    public WsmResourceFamily getResourceFamily() {
-        return WsmResourceFamily.AZURE_STORAGE_CONTAINER;
-    }
-
-    @Override
-    public String attributesToJson() {
-        return DbSerDes.toJson(
-                new ControlledAzureStorageContainerAttributes(getStorageAccountId(), getStorageContainerName()));
-    }
-
-    @Override
-    public ApiResourceAttributesUnion toApiAttributesUnion() {
-        ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
-        union.azureStorageContainer(toApiAttributes());
-        return union;
-    }
-
-    @Override
-    public ApiResourceUnion toApiResourceUnion() {
-        ApiResourceUnion union = new ApiResourceUnion();
-        union.azureStorageContainer(toApiResource());
-        return union;
-    }
-
-    @Override
-    public void validate() {
-        super.validate();
-        if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER
-                || getResourceFamily() != WsmResourceFamily.AZURE_STORAGE_CONTAINER
-                || getStewardshipType() != StewardshipType.CONTROLLED) {
-            throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_STORAGE_CONTAINER");
-        }
-
-        if (getStorageAccountId() == null) {
-            throw new MissingRequiredFieldException(
-                    "Missing required storage account ID field for ControlledAzureStorageContainer.");
-        }
-
-        if (getStorageContainerName() == null) {
-            throw new MissingRequiredFieldException(
-                    "Missing required storage container name field for ControlledAzureStorageContainer.");
-        }
-
-        ResourceValidationUtils.validateStorageContainerName(getStorageContainerName());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-
-        ControlledAzureStorageContainerResource that = (ControlledAzureStorageContainerResource) o;
-
-        return storageAccountId.equals(that.getStorageAccountId()) && storageContainerName.equals(that.getStorageContainerName());
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + storageAccountId.hashCode();
-        result = 31 * result + storageContainerName.hashCode();
-        return result;
-    }
-
-    public static class Builder {
-        private ControlledResourceFields common;
-        private UUID storageAccountId;
-        private String storageContainerName;
-
-        public Builder common(ControlledResourceFields common) {
-            this.common = common;
-            return this;
-        }
-
-        public ControlledAzureStorageContainerResource.Builder storageAccountId(UUID storageAccountId) {
-            this.storageAccountId = storageAccountId;
-            return this;
-        }
-
-        public ControlledAzureStorageContainerResource.Builder storageContainerName(String storageContainerName) {
-            this.storageContainerName = storageContainerName;
-            return this;
-        }
-
-        public ControlledAzureStorageContainerResource build() {
-            return new ControlledAzureStorageContainerResource(common, storageAccountId, storageContainerName);
-        }
-    }
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -87,7 +87,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
   public Optional<UniquenessCheckAttributes> getUniquenessCheckAttributes() {
     return Optional.of(
         new UniquenessCheckAttributes()
-            .uniquenessScope(UniquenessScope.WORKSPACE)  // TODO: combination of storage account name and container name must be unique
+            .uniquenessScope(UniquenessScope.WORKSPACE)
             .addParameter("storageAccountName", getStorageAccountName())
             .addParameter("storageContainerName", getStorageContainerName()));
   }
@@ -114,9 +114,9 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
   @Override
   public void addDeleteSteps(DeleteControlledResourceFlight flight, FlightBeanBag flightBeanBag) {
     flight.addStep(
-            new DeleteAzureStorageContainerStep(
-                    flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
-            RetryRules.cloud());
+        new DeleteAzureStorageContainerStep(
+                flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
+        RetryRules.cloud());
   }
 
   public String getStorageAccountName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -9,7 +9,10 @@ import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
-import bio.terra.workspace.generated.model.*;
+import bio.terra.workspace.generated.model.ApiAzureStorageContainerAttributes;
+import bio.terra.workspace.generated.model.ApiAzureStorageContainerResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
@@ -26,212 +29,220 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class ControlledAzureStorageContainerResource extends ControlledResource {
-  private final UUID storageAccountId;
-  private final String storageContainerName;
+    private final UUID storageAccountId;
+    private final String storageContainerName;
 
-  @JsonCreator
-  public ControlledAzureStorageContainerResource(
-      @JsonProperty("workspaceId") UUID workspaceId,
-      @JsonProperty("resourceId") UUID resourceId,
-      @JsonProperty("name") String name,
-      @JsonProperty("description") String description,
-      @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
-      @JsonProperty("assignedUser") String assignedUser,
-      @JsonProperty("privateResourceState") PrivateResourceState privateResourceState,
-      @JsonProperty("accessScope") AccessScopeType accessScope,
-      @JsonProperty("managedBy") ManagedByType managedBy,
-      @JsonProperty("applicationId") String applicationId,
-      @JsonProperty("storageAccountId") UUID storageAccountId,
-      @JsonProperty("storageContainerName") String storageContainerName) {
-    super(
-        workspaceId,
-        resourceId,
-        name,
-        description,
-        cloningInstructions,
-        assignedUser,
-        accessScope,
-        managedBy,
-        applicationId,
-        privateResourceState);
-    this.storageAccountId = storageAccountId;
-    this.storageContainerName = storageContainerName;
-    validate();
-  }
-
-  private ControlledAzureStorageContainerResource(
-      ControlledResourceFields common, UUID storageAccountId, String storageContainerName) {
-    super(common);
-    this.storageAccountId = storageAccountId;
-    this.storageContainerName = storageContainerName;
-    validate();
-  }
-
-  public static ControlledAzureStorageContainerResource.Builder builder() {
-    return new ControlledAzureStorageContainerResource.Builder();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public Optional<UniquenessCheckAttributes> getUniquenessCheckAttributes() {
-    return Optional.of(
-        new UniquenessCheckAttributes()
-            .uniquenessScope(UniquenessScope.WORKSPACE)
-            .addParameter("storageAccountId", getStorageAccountId().toString())
-            .addParameter("storageContainerName", getStorageContainerName()));
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public void addCreateSteps(
-      CreateControlledResourceFlight flight,
-      String petSaEmail,
-      AuthenticatedUserRequest userRequest,
-      FlightBeanBag flightBeanBag) {
-    RetryRule cloudRetry = RetryRules.cloud();
-    flight.addStep(
-        new VerifyAzureStorageContainerCanBeCreatedStep(
-            flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), flightBeanBag.getResourceDao(), this),
-        cloudRetry);
-    flight.addStep(
-        new CreateAzureStorageContainerStep(
-            flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
-        cloudRetry);
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public void addDeleteSteps(DeleteControlledResourceFlight flight, FlightBeanBag flightBeanBag) {
-    flight.addStep(
-        new DeleteAzureStorageContainerStep(
-                flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(),
-                flightBeanBag.getResourceDao(), this),
-        RetryRules.cloud());
-  }
-
-  public UUID getStorageAccountId() {
-    return storageAccountId;
-  }
-
-  public String getStorageContainerName() {
-    return storageContainerName;
-  }
-
-  public ApiAzureStorageContainerAttributes toApiAttributes() {
-    return new ApiAzureStorageContainerAttributes()
-        .storageAccountId(getStorageAccountId())
-        .storageContainerName(getStorageContainerName());
-  }
-
-  public ApiAzureStorageContainerResource toApiResource() {
-    return new ApiAzureStorageContainerResource()
-        .metadata(super.toApiMetadata())
-        .attributes(toApiAttributes());
-  }
-
-  @Override
-  public WsmResourceType getResourceType() {
-    return WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER;
-  }
-
-  @Override
-  public WsmResourceFamily getResourceFamily() {
-    return WsmResourceFamily.AZURE_STORAGE_CONTAINER;
-  }
-
-  @Override
-  public String attributesToJson() {
-    return DbSerDes.toJson(
-        new ControlledAzureStorageContainerAttributes(getStorageAccountId(), getStorageContainerName()));
-  }
-
-  @Override
-  public ApiResourceAttributesUnion toApiAttributesUnion() {
-    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
-    union.azureStorageContainer(toApiAttributes());
-    return union;
-  }
-
-  @Override
-  public ApiResourceUnion toApiResourceUnion() {
-    ApiResourceUnion union = new ApiResourceUnion();
-    union.azureStorageContainer(toApiResource());
-    return union;
-  }
-
-  @Override
-  public void validate() {
-    super.validate();
-    if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER
-        || getResourceFamily() != WsmResourceFamily.AZURE_STORAGE_CONTAINER
-        || getStewardshipType() != StewardshipType.CONTROLLED) {
-      throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_STORAGE_CONTAINER");
+    @JsonCreator
+    public ControlledAzureStorageContainerResource(
+            @JsonProperty("workspaceId") UUID workspaceId,
+            @JsonProperty("resourceId") UUID resourceId,
+            @JsonProperty("name") String name,
+            @JsonProperty("description") String description,
+            @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
+            @JsonProperty("assignedUser") String assignedUser,
+            @JsonProperty("privateResourceState") PrivateResourceState privateResourceState,
+            @JsonProperty("accessScope") AccessScopeType accessScope,
+            @JsonProperty("managedBy") ManagedByType managedBy,
+            @JsonProperty("applicationId") String applicationId,
+            @JsonProperty("storageAccountId") UUID storageAccountId,
+            @JsonProperty("storageContainerName") String storageContainerName) {
+        super(
+                workspaceId,
+                resourceId,
+                name,
+                description,
+                cloningInstructions,
+                assignedUser,
+                accessScope,
+                managedBy,
+                applicationId,
+                privateResourceState);
+        this.storageAccountId = storageAccountId;
+        this.storageContainerName = storageContainerName;
+        validate();
     }
 
-    if (getStorageAccountId() == null) {
-      throw new MissingRequiredFieldException(
-              "Missing required storage account ID field for ControlledAzureStorageContainer.");
+    private ControlledAzureStorageContainerResource(
+            ControlledResourceFields common, UUID storageAccountId, String storageContainerName) {
+        super(common);
+        this.storageAccountId = storageAccountId;
+        this.storageContainerName = storageContainerName;
+        validate();
     }
 
-    if (getStorageContainerName() == null) {
-      throw new MissingRequiredFieldException(
-          "Missing required storage container name field for ControlledAzureStorageContainer.");
+    public static ControlledAzureStorageContainerResource.Builder builder() {
+        return new ControlledAzureStorageContainerResource.Builder();
     }
 
-    ResourceValidationUtils.validateStorageContainerName(getStorageContainerName());
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-
-    ControlledAzureStorageContainerResource that = (ControlledAzureStorageContainerResource) o;
-
-    return storageAccountId.equals(that.getStorageAccountId()) && storageContainerName.equals(that.getStorageContainerName());
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + storageAccountId.hashCode();
-    result = 31 * result + storageContainerName.hashCode();
-    return result;
-  }
-
-  public static class Builder {
-    private ControlledResourceFields common;
-    private UUID storageAccountId;
-    private String storageContainerName;
-
-    public Builder common(ControlledResourceFields common) {
-      this.common = common;
-      return this;
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T castByEnum(WsmResourceType expectedType) {
+        if (getResourceType() != expectedType) {
+            throw new BadRequestException(String.format("Resource is not a %s", expectedType));
+        }
+        return (T) this;
     }
 
-    public ControlledAzureStorageContainerResource.Builder storageAccountId(UUID storageAccountId) {
-      this.storageAccountId = storageAccountId;
-      return this;
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<UniquenessCheckAttributes> getUniquenessCheckAttributes() {
+        return Optional.of(
+                new UniquenessCheckAttributes()
+                        .uniquenessScope(UniquenessScope.WORKSPACE)
+                        .addParameter("storageAccountId", getStorageAccountId().toString())
+                        .addParameter("storageContainerName", getStorageContainerName()));
     }
 
-    public ControlledAzureStorageContainerResource.Builder storageContainerName(String storageContainerName) {
-      this.storageContainerName = storageContainerName;
-      return this;
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addCreateSteps(
+            CreateControlledResourceFlight flight,
+            String petSaEmail,
+            AuthenticatedUserRequest userRequest,
+            FlightBeanBag flightBeanBag) {
+        RetryRule cloudRetry = RetryRules.cloud();
+        flight.addStep(
+                new VerifyAzureStorageContainerCanBeCreatedStep(
+                        flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), flightBeanBag.getResourceDao(), this),
+                cloudRetry);
+        flight.addStep(
+                new CreateAzureStorageContainerStep(
+                        flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
+                cloudRetry);
     }
 
-    public ControlledAzureStorageContainerResource build() {
-      return new ControlledAzureStorageContainerResource(common, storageAccountId, storageContainerName);
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addDeleteSteps(DeleteControlledResourceFlight flight, FlightBeanBag flightBeanBag) {
+        flight.addStep(
+                new DeleteAzureStorageContainerStep(
+                        flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(),
+                        flightBeanBag.getResourceDao(), this),
+                RetryRules.cloud());
     }
-  }
+
+    public UUID getStorageAccountId() {
+        return storageAccountId;
+    }
+
+    public String getStorageContainerName() {
+        return storageContainerName;
+    }
+
+    public ApiAzureStorageContainerAttributes toApiAttributes() {
+        return new ApiAzureStorageContainerAttributes()
+                .storageAccountId(getStorageAccountId())
+                .storageContainerName(getStorageContainerName());
+    }
+
+    public ApiAzureStorageContainerResource toApiResource() {
+        return new ApiAzureStorageContainerResource()
+                .metadata(super.toApiMetadata())
+                .attributes(toApiAttributes());
+    }
+
+    @Override
+    public WsmResourceType getResourceType() {
+        return WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER;
+    }
+
+    @Override
+    public WsmResourceFamily getResourceFamily() {
+        return WsmResourceFamily.AZURE_STORAGE_CONTAINER;
+    }
+
+    @Override
+    public String attributesToJson() {
+        return DbSerDes.toJson(
+                new ControlledAzureStorageContainerAttributes(getStorageAccountId(), getStorageContainerName()));
+    }
+
+    @Override
+    public ApiResourceAttributesUnion toApiAttributesUnion() {
+        ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+        union.azureStorageContainer(toApiAttributes());
+        return union;
+    }
+
+    @Override
+    public ApiResourceUnion toApiResourceUnion() {
+        ApiResourceUnion union = new ApiResourceUnion();
+        union.azureStorageContainer(toApiResource());
+        return union;
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+        if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER
+                || getResourceFamily() != WsmResourceFamily.AZURE_STORAGE_CONTAINER
+                || getStewardshipType() != StewardshipType.CONTROLLED) {
+            throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_STORAGE_CONTAINER");
+        }
+
+        if (getStorageAccountId() == null) {
+            throw new MissingRequiredFieldException(
+                    "Missing required storage account ID field for ControlledAzureStorageContainer.");
+        }
+
+        if (getStorageContainerName() == null) {
+            throw new MissingRequiredFieldException(
+                    "Missing required storage container name field for ControlledAzureStorageContainer.");
+        }
+
+        ResourceValidationUtils.validateStorageContainerName(getStorageContainerName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        ControlledAzureStorageContainerResource that = (ControlledAzureStorageContainerResource) o;
+
+        return storageAccountId.equals(that.getStorageAccountId()) && storageContainerName.equals(that.getStorageContainerName());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + storageAccountId.hashCode();
+        result = 31 * result + storageContainerName.hashCode();
+        return result;
+    }
+
+    public static class Builder {
+        private ControlledResourceFields common;
+        private UUID storageAccountId;
+        private String storageContainerName;
+
+        public Builder common(ControlledResourceFields common) {
+            this.common = common;
+            return this;
+        }
+
+        public ControlledAzureStorageContainerResource.Builder storageAccountId(UUID storageAccountId) {
+            this.storageAccountId = storageAccountId;
+            return this;
+        }
+
+        public ControlledAzureStorageContainerResource.Builder storageContainerName(String storageContainerName) {
+            this.storageContainerName = storageContainerName;
+            return this;
+        }
+
+        public ControlledAzureStorageContainerResource build() {
+            return new ControlledAzureStorageContainerResource(common, storageAccountId, storageContainerName);
+        }
+    }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -188,7 +188,8 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
           "Missing required storage container name field for ControlledAzureStorageContainer.");
     }
 
-    ResourceValidationUtils.validateStorageAccountName(getStorageAccountName()); // TODO add validation for storage container name
+    ResourceValidationUtils.validateStorageAccountName(getStorageAccountName());
+    ResourceValidationUtils.validateStorageContainerName(getStorageContainerName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -95,7 +95,7 @@ public class CreateAzureStorageContainerStep implements Step {
               .getByResourceGroup(
                       azureCloudContext.getAzureResourceGroupId(), storageAccountName);
     } catch (ManagementException ex) {
-      if (ManagementExceptionUtils.isResourceNotFound(ex)) {
+      if (ManagementExceptionUtils.isExceptionCode(ex, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         logger.warn(
                 "Deletion of the storage container is not required. Parent storage account does not exist. {}",
                 storageAccountName);
@@ -113,7 +113,7 @@ public class CreateAzureStorageContainerStep implements Step {
               storageAccountName,
               resource.getStorageContainerName());
     } catch (ManagementException ex) {
-      if (ManagementExceptionUtils.isContainerNotFound(ex)) {
+      if (ManagementExceptionUtils.isExceptionCode(ex, ManagementExceptionUtils.CONTAINER_NOT_FOUND)) {
         logger.warn(
                 "Deletion of the storage container is not required. Storage container does not exist. {}",
                 resource.getStorageContainerName());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -108,8 +108,9 @@ public class CreateAzureStorageContainerStep implements Step {
         return StepResult.getStepResultSuccess();
       }
       logger.error(
-          "Attempt to retrieve parent Azure Storage account before deleting container failed on this try: "
-              + resource.getStorageContainerName(),
+          "Attempt to retrieve parent Azure storage account before deleting container failed on this try: '{}'. Error Code: {}.",
+          resource.getStorageContainerName(),
+          ex.getValue().getCode(),
           ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }
@@ -129,8 +130,9 @@ public class CreateAzureStorageContainerStep implements Step {
         return StepResult.getStepResultSuccess();
       }
       logger.error(
-          "Attempt to retrieve Azure Storage Container before deleting it failed on this try: "
-              + resource.getStorageContainerName(),
+          "Attempt to retrieve Azure storage container before deleting it failed on this try: '{}'. Error Code: {}.",
+          resource.getStorageContainerName(),
+          ex.getValue().getCode(),
           ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }
@@ -153,8 +155,9 @@ public class CreateAzureStorageContainerStep implements Step {
       return StepResult.getStepResultSuccess();
     } catch (ManagementException ex) {
       logger.error(
-          "Attempt to delete Azure Storage Container failed on this try: "
-              + resource.getStorageContainerName(),
+          "Attempt to delete Azure storage container failed on this try: '{}'. Error Code: {}.",
+          resource.getStorageContainerName(),
+          ex.getValue().getCode(),
           ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -11,9 +11,10 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.resourcemanager.data.CreateStorageContainerRequestData;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.StorageManager;
-import com.azure.resourcemanager.storage.models.BlobContainer;
+import com.azure.resourcemanager.storage.fluent.models.ListContainerItemInner;
 import com.azure.resourcemanager.storage.models.PublicAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,7 +73,7 @@ public class CreateAzureStorageContainerStep implements Step {
   }
 
   /**
-   * Deletes the storage account if the account is available. If the storage account is available
+   * Deletes the storage container if the container is available. If the storage container is available
    * and deletes fails, the failure is considered fatal and must looked into it.
    *
    * @param context
@@ -82,42 +83,50 @@ public class CreateAzureStorageContainerStep implements Step {
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
     final AzureCloudContext azureCloudContext =
-        context
-            .getWorkingMap()
-            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+            context
+                    .getWorkingMap()
+                    .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
 
-
-    final BlobContainer container = storageManager.blobContainers().get(
-            azureCloudContext.getAzureResourceGroupId(),
-            resource.getStorageAccountName(),
-            resource.getStorageContainerName()
+    // TODO: should I first check if the storage account exists? Does it matter?
+    final PagedIterable<ListContainerItemInner> existingContainers = storageManager.blobContainers().list(
+            azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName()
     );
-
-//    // If the storage account does not exist (isAvailable == true)
-//    // then return success.
-//    if (storageManager
-//        .storageAccounts()
-//        .checkNameAvailability(resource.getStorageAccountName())
-//        .isAvailable()) {
-//      logger.warn(
-//          "Deletion of the storage account is not required. Storage account does not exist. {}",
-//          resource.getStorageAccountName());
-      return StepResult.getStepResultSuccess();
+    ListContainerItemInner existingContainer = null;
+    for (ListContainerItemInner item : existingContainers) {
+      if (item.name().equals(resource.getStorageContainerName())) {
+        existingContainer = item;
+        break;
+      }
     }
-
-//    try {
-//      logger.warn("Attempting to delete storage account: {}", resource.getStorageAccountName());
-//      storageManager
-//          .storageAccounts()
-//          .deleteByResourceGroup(
-//              azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName());
-//      logger.warn("Successfully deleted storage account: {}", resource.getStorageAccountName());
-//    } catch (ManagementException e) {
-//      logger.error("Failed to delete storage account: {}", resource.getStorageAccountName());
-//      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
-//    }
-//
-//    return StepResult.getStepResultSuccess();
-//  }
+    if (existingContainer == null) {
+      logger.warn(
+              "Deletion of the storage container is not required. Storage container does not exist. {}",
+              resource.getStorageContainerName());
+      return StepResult.getStepResultSuccess();
+    } else {
+      try {
+        logger.warn("Attempting to delete storage container '{}' in account '{}'",
+                resource.getStorageContainerName(),
+                resource.getStorageAccountName()
+        );
+        storageManager.blobContainers().delete(
+                azureCloudContext.getAzureResourceGroupId(),
+                resource.getStorageAccountName(),
+                resource.getStorageContainerName()
+        );
+        logger.warn("Successfully deleted storage container '{}' in account '{}'",
+                resource.getStorageContainerName(),
+                resource.getStorageAccountName()
+        );
+        return StepResult.getStepResultSuccess();
+      } catch (ManagementException ex) {
+        logger.error(
+                "Attempt to delete Azure Storage Container failed on this try: " + resource.getStorageContainerName(),
+                ex
+        );
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+      }
+    }
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -42,8 +42,15 @@ public class CreateAzureStorageContainerStep implements Step {
             .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     final StorageManager storageManager =
         crlService.getStorageManager(azureCloudContext, azureConfig);
+
+    // The storage account name is stored by VerifyAzureStorageContainerCanBeCreated.
     final String storageAccountName =
         context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
+    if (storageAccountName == null) {
+      logger.error("The storage account name has not been added to the working map. " +
+              "VerifyAzureStorageContainerCanBeCreated must be executed first." );
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL);
+    }
 
     try {
       storageManager

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -1,0 +1,124 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import bio.terra.cloudres.azure.resourcemanager.common.Defaults;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resourcemanager.data.CreateStorageAccountRequestData;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.resourcemanager.data.CreateStorageContainerRequestData;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.Region;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.storage.StorageManager;
+import com.azure.resourcemanager.storage.models.BlobContainer;
+import com.azure.resourcemanager.storage.models.PublicAccess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateAzureStorageContainerStep implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(CreateAzureStorageContainerStep.class);
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final ControlledAzureStorageContainerResource resource;
+
+  public CreateAzureStorageContainerStep(
+      AzureConfiguration azureConfig,
+      CrlService crlService,
+      ControlledAzureStorageContainerResource resource) {
+    this.azureConfig = azureConfig;
+    this.crlService = crlService;
+    this.resource = resource;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+    final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
+
+    try {
+      storageManager
+          .blobContainers()
+          .defineContainer(resource.getStorageContainerName())
+          .withExistingStorageAccount(azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName())
+          //.withTag("resourceId", resource.getResourceId().toString()) Maybe add metdata?
+          .withPublicAccess(PublicAccess.NONE).
+              create(  // TODO: what about access?
+                Defaults.buildContext(
+                  CreateStorageContainerRequestData.builder()
+                      .setName(resource.getStorageContainerName())
+                      .setStorageAccountName(resource.getStorageAccountName())
+                      .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
+                      .build()));
+
+    } catch (ManagementException e) {
+      logger.error(
+          "Failed to create the Azure storage container '{}' with storage account with the name '{}'. Error Code: {}",
+          resource.getStorageContainerName(),
+          resource.getStorageAccountName(),
+          e.getValue().getCode(),
+          e);
+
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  /**
+   * Deletes the storage account if the account is available. If the storage account is available
+   * and deletes fails, the failure is considered fatal and must looked into it.
+   *
+   * @param context
+   * @return Step result.
+   * @throws InterruptedException
+   */
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+    final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
+
+
+    final BlobContainer container = storageManager.blobContainers().get(
+            azureCloudContext.getAzureResourceGroupId(),
+            resource.getStorageAccountName(),
+            resource.getStorageContainerName()
+    );
+
+//    // If the storage account does not exist (isAvailable == true)
+//    // then return success.
+//    if (storageManager
+//        .storageAccounts()
+//        .checkNameAvailability(resource.getStorageAccountName())
+//        .isAvailable()) {
+//      logger.warn(
+//          "Deletion of the storage account is not required. Storage account does not exist. {}",
+//          resource.getStorageAccountName());
+      return StepResult.getStepResultSuccess();
+    }
+
+//    try {
+//      logger.warn("Attempting to delete storage account: {}", resource.getStorageAccountName());
+//      storageManager
+//          .storageAccounts()
+//          .deleteByResourceGroup(
+//              azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName());
+//      logger.warn("Successfully deleted storage account: {}", resource.getStorageAccountName());
+//    } catch (ManagementException e) {
+//      logger.error("Failed to delete storage account: {}", resource.getStorageAccountName());
+//      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
+//    }
+//
+//    return StepResult.getStepResultSuccess();
+//  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -101,6 +101,11 @@ public class CreateAzureStorageContainerStep implements Step {
         crlService.getStorageManager(azureCloudContext, azureConfig);
     final String storageAccountName =
         context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
+    if (storageAccountName == null) {
+      logger.warn("Deletion of the storage container is not required. " +
+              "Parent storage account was not found in the create.");
+      return StepResult.getStepResultSuccess();
+    }
 
     try {
       storageManager
@@ -119,7 +124,7 @@ public class CreateAzureStorageContainerStep implements Step {
           resource.getStorageContainerName(),
           ex.getValue().getCode(),
           ex);
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
     try {
       storageManager
@@ -141,7 +146,7 @@ public class CreateAzureStorageContainerStep implements Step {
           resource.getStorageContainerName(),
           ex.getValue().getCode(),
           ex);
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
 
     try {
@@ -162,7 +167,7 @@ public class CreateAzureStorageContainerStep implements Step {
       return StepResult.getStepResultSuccess();
     } catch (ManagementException ex) {
       logger.error(
-          "Attempt to delete Azure storage container failed on this try: '{}'. Error Code: {}.",
+          "Attempt to delete Azure storage container failed: '{}'. Error Code: {}.",
           resource.getStorageContainerName(),
           ex.getValue().getCode(),
           ex);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -88,7 +88,17 @@ public class CreateAzureStorageContainerStep implements Step {
                     .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
 
-    // TODO: should I first check if the storage account exists? Does it matter?
+    try {
+      storageManager
+              .storageAccounts()
+              .getByResourceGroup(
+                      azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName());
+    } catch (ManagementException ex) {
+      logger.warn(
+              "Deletion of the storage container is not required. Parent storage account does not exist. {}",
+              resource.getStorageAccountName());
+      return StepResult.getStepResultSuccess();
+    }
     final PagedIterable<ListContainerItemInner> existingContainers = storageManager.blobContainers().list(
             azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName()
     );

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -8,11 +8,9 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resourcemanager.data.CreateStorageAccountRequestData;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.resourcemanager.data.CreateStorageContainerRequestData;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
-import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.StorageManager;
 import com.azure.resourcemanager.storage.models.BlobContainer;
@@ -48,9 +46,10 @@ public class CreateAzureStorageContainerStep implements Step {
           .blobContainers()
           .defineContainer(resource.getStorageContainerName())
           .withExistingStorageAccount(azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName())
-          //.withTag("resourceId", resource.getResourceId().toString()) Maybe add metdata?
-          .withPublicAccess(PublicAccess.NONE).
-              create(  // TODO: what about access?
+          .withPublicAccess(PublicAccess.NONE)
+          .withMetadata("workspaceId", resource.getWorkspaceId().toString())
+          .withMetadata("resourceId", resource.getResourceId().toString()).
+              create(
                 Defaults.buildContext(
                   CreateStorageContainerRequestData.builder()
                       .setName(resource.getStorageContainerName())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -19,132 +19,132 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CreateAzureStorageContainerStep implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(CreateAzureStorageContainerStep.class);
-  private final AzureConfiguration azureConfig;
-  private final CrlService crlService;
-  private final ControlledAzureStorageContainerResource resource;
+    private static final Logger logger = LoggerFactory.getLogger(CreateAzureStorageContainerStep.class);
+    private final AzureConfiguration azureConfig;
+    private final CrlService crlService;
+    private final ControlledAzureStorageContainerResource resource;
 
-  public CreateAzureStorageContainerStep(
-      AzureConfiguration azureConfig,
-      CrlService crlService,
-      ControlledAzureStorageContainerResource resource) {
-    this.azureConfig = azureConfig;
-    this.crlService = crlService;
-    this.resource = resource;
-  }
-
-  @Override
-  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    final AzureCloudContext azureCloudContext =
-        context
-            .getWorkingMap()
-            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
-    final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
-    final String storageAccountName = context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
-
-    try {
-      storageManager
-          .blobContainers()
-          .defineContainer(resource.getStorageContainerName())
-          .withExistingStorageAccount(azureCloudContext.getAzureResourceGroupId(), storageAccountName)
-          .withPublicAccess(PublicAccess.NONE)
-          .withMetadata("workspaceId", resource.getWorkspaceId().toString())
-          .withMetadata("resourceId", resource.getResourceId().toString()).
-              create(
-                Defaults.buildContext(
-                  CreateStorageContainerRequestData.builder()
-                      .setStorageAccountId(resource.getStorageAccountId())
-                      .setStorageContainerName(resource.getStorageContainerName())
-                      .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
-                      .build()));
-
-    } catch (ManagementException e) {
-      logger.error(
-          "Failed to create the Azure storage container '{}' with storage account with the ID '{}'. Error Code: {}",
-          resource.getStorageContainerName(),
-          resource.getStorageAccountId(),
-          e.getValue().getCode(),
-          e);
-
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    public CreateAzureStorageContainerStep(
+            AzureConfiguration azureConfig,
+            CrlService crlService,
+            ControlledAzureStorageContainerResource resource) {
+        this.azureConfig = azureConfig;
+        this.crlService = crlService;
+        this.resource = resource;
     }
 
-    return StepResult.getStepResultSuccess();
-  }
+    @Override
+    public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+        final AzureCloudContext azureCloudContext =
+                context
+                        .getWorkingMap()
+                        .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+        final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
+        final String storageAccountName = context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
 
-  /**
-   * Deletes the storage container if the container is available. If the storage container is available
-   * and deletes fails, the failure is considered fatal and must looked into it.
-   *
-   * @param context
-   * @return Step result.
-   * @throws InterruptedException
-   */
-  @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
-    final AzureCloudContext azureCloudContext =
-            context
-                    .getWorkingMap()
-                    .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
-    final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
-    final String storageAccountName = context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
+        try {
+            storageManager
+                    .blobContainers()
+                    .defineContainer(resource.getStorageContainerName())
+                    .withExistingStorageAccount(azureCloudContext.getAzureResourceGroupId(), storageAccountName)
+                    .withPublicAccess(PublicAccess.NONE)
+                    .withMetadata("workspaceId", resource.getWorkspaceId().toString())
+                    .withMetadata("resourceId", resource.getResourceId().toString()).
+                    create(
+                            Defaults.buildContext(
+                                    CreateStorageContainerRequestData.builder()
+                                            .setStorageAccountId(resource.getStorageAccountId())
+                                            .setStorageContainerName(resource.getStorageContainerName())
+                                            .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
+                                            .build()));
 
-    try {
-      storageManager
-              .storageAccounts()
-              .getByResourceGroup(
-                      azureCloudContext.getAzureResourceGroupId(), storageAccountName);
-    } catch (ManagementException ex) {
-      if (ManagementExceptionUtils.isExceptionCode(ex, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
-        logger.warn(
-                "Deletion of the storage container is not required. Parent storage account does not exist. {}",
-                storageAccountName);
+        } catch (ManagementException e) {
+            logger.error(
+                    "Failed to create the Azure storage container '{}' with storage account with the ID '{}'. Error Code: {}",
+                    resource.getStorageContainerName(),
+                    resource.getStorageAccountId(),
+                    e.getValue().getCode(),
+                    e);
+
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+        }
+
         return StepResult.getStepResultSuccess();
-      }
-      logger.error(
-              "Attempt to retrieve parent Azure Storage account before deleting container failed on this try: " +
-                      resource.getStorageContainerName(), ex
-      );
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
-    }
-    try {
-      storageManager.blobContainers().get(
-              azureCloudContext.getAzureResourceGroupId(),
-              storageAccountName,
-              resource.getStorageContainerName());
-    } catch (ManagementException ex) {
-      if (ManagementExceptionUtils.isExceptionCode(ex, ManagementExceptionUtils.CONTAINER_NOT_FOUND)) {
-        logger.warn(
-                "Deletion of the storage container is not required. Storage container does not exist. {}",
-                resource.getStorageContainerName());
-        return StepResult.getStepResultSuccess();
-      }
-      logger.error(
-          "Attempt to retrieve Azure Storage Container before deleting it failed on this try: " +
-                  resource.getStorageContainerName(), ex
-      );
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }
 
-    try {
-      logger.warn("Attempting to delete storage container '{}' in account '{}'",
-              resource.getStorageContainerName(), storageAccountName
-      );
-      storageManager.blobContainers().delete(
-              azureCloudContext.getAzureResourceGroupId(),
-              storageAccountName,
-              resource.getStorageContainerName()
-      );
-      logger.warn("Successfully deleted storage container '{}' in account '{}'",
-              resource.getStorageContainerName(), storageAccountName
-      );
-      return StepResult.getStepResultSuccess();
-    } catch (ManagementException ex) {
-      logger.error(
-              "Attempt to delete Azure Storage Container failed on this try: " + resource.getStorageContainerName(),
-              ex
-      );
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+    /**
+     * Deletes the storage container if the container is available. If the storage container is available
+     * and deletes fails, the failure is considered fatal and must looked into it.
+     *
+     * @param context
+     * @return Step result.
+     * @throws InterruptedException
+     */
+    @Override
+    public StepResult undoStep(FlightContext context) throws InterruptedException {
+        final AzureCloudContext azureCloudContext =
+                context
+                        .getWorkingMap()
+                        .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+        final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
+        final String storageAccountName = context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
+
+        try {
+            storageManager
+                    .storageAccounts()
+                    .getByResourceGroup(
+                            azureCloudContext.getAzureResourceGroupId(), storageAccountName);
+        } catch (ManagementException ex) {
+            if (ManagementExceptionUtils.isExceptionCode(ex, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
+                logger.warn(
+                        "Deletion of the storage container is not required. Parent storage account does not exist. {}",
+                        storageAccountName);
+                return StepResult.getStepResultSuccess();
+            }
+            logger.error(
+                    "Attempt to retrieve parent Azure Storage account before deleting container failed on this try: " +
+                            resource.getStorageContainerName(), ex
+            );
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+        }
+        try {
+            storageManager.blobContainers().get(
+                    azureCloudContext.getAzureResourceGroupId(),
+                    storageAccountName,
+                    resource.getStorageContainerName());
+        } catch (ManagementException ex) {
+            if (ManagementExceptionUtils.isExceptionCode(ex, ManagementExceptionUtils.CONTAINER_NOT_FOUND)) {
+                logger.warn(
+                        "Deletion of the storage container is not required. Storage container does not exist. {}",
+                        resource.getStorageContainerName());
+                return StepResult.getStepResultSuccess();
+            }
+            logger.error(
+                    "Attempt to retrieve Azure Storage Container before deleting it failed on this try: " +
+                            resource.getStorageContainerName(), ex
+            );
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+        }
+
+        try {
+            logger.warn("Attempting to delete storage container '{}' in account '{}'",
+                    resource.getStorageContainerName(), storageAccountName
+            );
+            storageManager.blobContainers().delete(
+                    azureCloudContext.getAzureResourceGroupId(),
+                    storageAccountName,
+                    resource.getStorageContainerName()
+            );
+            logger.warn("Successfully deleted storage container '{}' in account '{}'",
+                    resource.getStorageContainerName(), storageAccountName
+            );
+            return StepResult.getStepResultSuccess();
+        } catch (ManagementException ex) {
+            logger.error(
+                    "Attempt to delete Azure Storage Container failed on this try: " + resource.getStorageContainerName(),
+                    ex
+            );
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+        }
     }
-  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -5,27 +5,35 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.StorageManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A step for deleting a controlled Azure Storage Container resource.
+ * A step for deleting a controlled Azure Storage Con resource.
  */
 public class DeleteAzureStorageContainerStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(DeleteAzureStorageContainerStep.class);
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureStorageContainerResource resource;
+  private final ResourceDao resourceDao;
 
   public DeleteAzureStorageContainerStep(AzureConfiguration azureConfig, CrlService crlService,
-                                         ControlledAzureStorageContainerResource resource) {
+                                         ResourceDao resourceDao, ControlledAzureStorageContainerResource resource ) {
     this.crlService = crlService;
     this.azureConfig = azureConfig;
     this.resource = resource;
+    this.resourceDao = resourceDao;
   }
 
   @Override
@@ -36,12 +44,18 @@ public class DeleteAzureStorageContainerStep implements Step {
             .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
 
     final StorageManager manager = crlService.getStorageManager(azureCloudContext, azureConfig);
+
     try {
-      logger.info("Attempting to delete storage container '{}' in account '{}'", resource.getStorageContainerName(), resource.getStorageAccountName());
+      WsmResource wsmResource = resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
+      ControlledAzureStorageResource storageAccount = wsmResource.castToControlledResource().castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+
+      logger.info("Attempting to delete storage container '{}' in account '{}'", resource.getStorageContainerName(), storageAccount.getStorageAccountName());
       manager.blobContainers().delete(
-              azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName(), resource.getStorageContainerName());
+              azureCloudContext.getAzureResourceGroupId(), storageAccount.getStorageAccountName(), resource.getStorageContainerName());
       return StepResult.getStepResultSuccess();
-    } catch (Exception ex) {
+    } catch (ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
+    } catch (ManagementException ex) {
       logger.warn(
           "Attempt to delete Azure Storage Container failed on this try: " + resource.getStorageContainerName(), ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -18,57 +18,73 @@ import com.azure.resourcemanager.storage.StorageManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * A step for deleting a controlled Azure Storage Con resource.
- */
+/** A step for deleting a controlled Azure Storage Con resource. */
 public class DeleteAzureStorageContainerStep implements Step {
-    private static final Logger logger = LoggerFactory.getLogger(DeleteAzureStorageContainerStep.class);
-    private final AzureConfiguration azureConfig;
-    private final CrlService crlService;
-    private final ControlledAzureStorageContainerResource resource;
-    private final ResourceDao resourceDao;
+  private static final Logger logger =
+      LoggerFactory.getLogger(DeleteAzureStorageContainerStep.class);
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final ControlledAzureStorageContainerResource resource;
+  private final ResourceDao resourceDao;
 
-    public DeleteAzureStorageContainerStep(AzureConfiguration azureConfig, CrlService crlService,
-                                           ResourceDao resourceDao, ControlledAzureStorageContainerResource resource) {
-        this.crlService = crlService;
-        this.azureConfig = azureConfig;
-        this.resource = resource;
-        this.resourceDao = resourceDao;
+  public DeleteAzureStorageContainerStep(
+      AzureConfiguration azureConfig,
+      CrlService crlService,
+      ResourceDao resourceDao,
+      ControlledAzureStorageContainerResource resource) {
+    this.crlService = crlService;
+    this.azureConfig = azureConfig;
+    this.resource = resource;
+    this.resourceDao = resourceDao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+
+    final StorageManager manager = crlService.getStorageManager(azureCloudContext, azureConfig);
+
+    try {
+      WsmResource wsmResource =
+          resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
+      ControlledAzureStorageResource storageAccount =
+          wsmResource
+              .castToControlledResource()
+              .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+
+      logger.info(
+          "Attempting to delete storage container '{}' in account '{}'",
+          resource.getStorageContainerName(),
+          storageAccount.getStorageAccountName());
+      manager
+          .blobContainers()
+          .delete(
+              azureCloudContext.getAzureResourceGroupId(),
+              storageAccount.getStorageAccountName(),
+              resource.getStorageContainerName());
+      return StepResult.getStepResultSuccess();
+    } catch (
+        ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
+    } catch (ManagementException ex) {
+      logger.warn(
+          "Attempt to delete Azure Storage Container failed on this try: "
+              + resource.getStorageContainerName(),
+          ex);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
+  }
 
-    @Override
-    public StepResult doStep(FlightContext context) throws InterruptedException {
-        final AzureCloudContext azureCloudContext =
-                context
-                        .getWorkingMap()
-                        .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
-
-        final StorageManager manager = crlService.getStorageManager(azureCloudContext, azureConfig);
-
-        try {
-            WsmResource wsmResource = resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
-            ControlledAzureStorageResource storageAccount = wsmResource.castToControlledResource().castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
-
-            logger.info("Attempting to delete storage container '{}' in account '{}'", resource.getStorageContainerName(), storageAccount.getStorageAccountName());
-            manager.blobContainers().delete(
-                    azureCloudContext.getAzureResourceGroupId(), storageAccount.getStorageAccountName(), resource.getStorageContainerName());
-            return StepResult.getStepResultSuccess();
-        } catch (ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
-        } catch (ManagementException ex) {
-            logger.warn(
-                    "Attempt to delete Azure Storage Container failed on this try: " + resource.getStorageContainerName(), ex);
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
-        }
-    }
-
-    @Override
-    public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-        logger.error(
-                "Cannot undo delete of Azure Storage Container resource {} in workspace {}.",
-                resource.getResourceId(),
-                resource.getWorkspaceId());
-        // Surface whatever error caused Stairway to begin undoing.
-        return flightContext.getResult();
-    }
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    logger.error(
+        "Cannot undo delete of Azure Storage Container resource {} in workspace {}.",
+        resource.getResourceId(),
+        resource.getWorkspaceId());
+    // Surface whatever error caused Stairway to begin undoing.
+    return flightContext.getResult();
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -1,0 +1,60 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.resourcemanager.storage.StorageManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A step for deleting a controlled Azure Storage Account resource.
+ */
+public class DeleteAzureStorageContainerStep implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(DeleteAzureStorageContainerStep.class);
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final ControlledAzureStorageContainerResource resource;
+
+  public DeleteAzureStorageContainerStep(AzureConfiguration azureConfig, CrlService crlService,
+                                         ControlledAzureStorageContainerResource resource) {
+    this.crlService = crlService;
+    this.azureConfig = azureConfig;
+    this.resource = resource;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+
+    final StorageManager manager = crlService.getStorageManager(azureCloudContext, azureConfig);
+    try {
+      logger.info("Attempting to delete storage container '{}' in account '{}'", resource.getStorageContainerName(), resource.getStorageAccountName());
+      manager.blobContainers().delete(
+              azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName(), resource.getStorageContainerName());
+      return StepResult.getStepResultSuccess();
+    } catch (Exception ex) {
+      logger.info(
+          "Attempt to delete Azure Storage Container failed on this try: " + resource.getStorageContainerName(), ex);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+    }
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    logger.error(
+        "Cannot undo delete of Azure Storage Container resource {} in workspace {}.",
+        resource.getResourceId(),
+        resource.getWorkspaceId());
+    // Surface whatever error caused Stairway to begin undoing.
+    return flightContext.getResult();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -22,53 +22,53 @@ import org.slf4j.LoggerFactory;
  * A step for deleting a controlled Azure Storage Con resource.
  */
 public class DeleteAzureStorageContainerStep implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(DeleteAzureStorageContainerStep.class);
-  private final AzureConfiguration azureConfig;
-  private final CrlService crlService;
-  private final ControlledAzureStorageContainerResource resource;
-  private final ResourceDao resourceDao;
+    private static final Logger logger = LoggerFactory.getLogger(DeleteAzureStorageContainerStep.class);
+    private final AzureConfiguration azureConfig;
+    private final CrlService crlService;
+    private final ControlledAzureStorageContainerResource resource;
+    private final ResourceDao resourceDao;
 
-  public DeleteAzureStorageContainerStep(AzureConfiguration azureConfig, CrlService crlService,
-                                         ResourceDao resourceDao, ControlledAzureStorageContainerResource resource ) {
-    this.crlService = crlService;
-    this.azureConfig = azureConfig;
-    this.resource = resource;
-    this.resourceDao = resourceDao;
-  }
-
-  @Override
-  public StepResult doStep(FlightContext context) throws InterruptedException {
-    final AzureCloudContext azureCloudContext =
-        context
-            .getWorkingMap()
-            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
-
-    final StorageManager manager = crlService.getStorageManager(azureCloudContext, azureConfig);
-
-    try {
-      WsmResource wsmResource = resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
-      ControlledAzureStorageResource storageAccount = wsmResource.castToControlledResource().castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
-
-      logger.info("Attempting to delete storage container '{}' in account '{}'", resource.getStorageContainerName(), storageAccount.getStorageAccountName());
-      manager.blobContainers().delete(
-              azureCloudContext.getAzureResourceGroupId(), storageAccount.getStorageAccountName(), resource.getStorageContainerName());
-      return StepResult.getStepResultSuccess();
-    } catch (ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
-    } catch (ManagementException ex) {
-      logger.warn(
-          "Attempt to delete Azure Storage Container failed on this try: " + resource.getStorageContainerName(), ex);
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+    public DeleteAzureStorageContainerStep(AzureConfiguration azureConfig, CrlService crlService,
+                                           ResourceDao resourceDao, ControlledAzureStorageContainerResource resource) {
+        this.crlService = crlService;
+        this.azureConfig = azureConfig;
+        this.resource = resource;
+        this.resourceDao = resourceDao;
     }
-  }
 
-  @Override
-  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    logger.error(
-        "Cannot undo delete of Azure Storage Container resource {} in workspace {}.",
-        resource.getResourceId(),
-        resource.getWorkspaceId());
-    // Surface whatever error caused Stairway to begin undoing.
-    return flightContext.getResult();
-  }
+    @Override
+    public StepResult doStep(FlightContext context) throws InterruptedException {
+        final AzureCloudContext azureCloudContext =
+                context
+                        .getWorkingMap()
+                        .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+
+        final StorageManager manager = crlService.getStorageManager(azureCloudContext, azureConfig);
+
+        try {
+            WsmResource wsmResource = resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
+            ControlledAzureStorageResource storageAccount = wsmResource.castToControlledResource().castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+
+            logger.info("Attempting to delete storage container '{}' in account '{}'", resource.getStorageContainerName(), storageAccount.getStorageAccountName());
+            manager.blobContainers().delete(
+                    azureCloudContext.getAzureResourceGroupId(), storageAccount.getStorageAccountName(), resource.getStorageContainerName());
+            return StepResult.getStepResultSuccess();
+        } catch (ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
+        } catch (ManagementException ex) {
+            logger.warn(
+                    "Attempt to delete Azure Storage Container failed on this try: " + resource.getStorageContainerName(), ex);
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+        }
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+        logger.error(
+                "Cannot undo delete of Azure Storage Container resource {} in workspace {}.",
+                resource.getResourceId(),
+                resource.getWorkspaceId());
+        // Surface whatever error caused Stairway to begin undoing.
+        return flightContext.getResult();
+    }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -68,11 +68,17 @@ public class DeleteAzureStorageContainerStep implements Step {
       return StepResult.getStepResultSuccess();
     } catch (
         ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new ResourceNotFoundException(
+              String.format(
+                  "The storage account with ID '%s' cannot be retrieved from the WSM resource manager.",
+                  resource.getStorageAccountId())));
     } catch (ManagementException ex) {
       logger.warn(
-          "Attempt to delete Azure Storage Container failed on this try: "
-              + resource.getStorageContainerName(),
+          "Attempt to delete Azure storage container failed on this try: '{}'. Error Code: {}.",
+          resource.getStorageContainerName(),
+          ex.getValue().getCode(),
           ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A step for deleting a controlled Azure Storage Account resource.
+ * A step for deleting a controlled Azure Storage Container resource.
  */
 public class DeleteAzureStorageContainerStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(DeleteAzureStorageContainerStep.class);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -42,7 +42,7 @@ public class DeleteAzureStorageContainerStep implements Step {
               azureCloudContext.getAzureResourceGroupId(), resource.getStorageAccountName(), resource.getStorageContainerName());
       return StepResult.getStepResultSuccess();
     } catch (Exception ex) {
-      logger.info(
+      logger.warn(
           "Attempt to delete Azure Storage Container failed on this try: " + resource.getStorageContainerName(), ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStep.java
@@ -43,12 +43,13 @@ public class GetAzureStorageContainerStep implements Step {
             .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
 
-    final BlobContainer container = storageManager.blobContainers().get(
-            azureCloudContext.getAzureResourceGroupId(),
-            resource.getStorageAccountName(),
-            resource.getStorageContainerName()
-    );
-
+//    final BlobContainer container = storageManager.blobContainers().get(
+//            azureCloudContext.getAzureResourceGroupId(),
+//            resource.getStorageAccountName(),
+//            resource.getStorageContainerName()
+//    );
+    // Throws exception when it does not exist, and then we didn't properly handle the exception.
+    // Failed to construct exception: com.azure.core.management.exception.ManagementException; Exception message: Status code 404,
       return StepResult.getStepResultSuccess();
 //    }
 //

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStep.java
@@ -1,0 +1,68 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.resourcemanager.storage.StorageManager;
+import com.azure.resourcemanager.storage.models.BlobContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gets an Azure Storage Container, and fails if it already exists. This step is designed to run
+ * immediately before {@link CreateAzureStorageContainerStep} to ensure idempotency of the create operation.
+ */
+public class GetAzureStorageContainerStep implements Step {
+
+  private static final Logger logger = LoggerFactory.getLogger(GetAzureStorageContainerStep.class); // TODO: delete if not used
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final ControlledAzureStorageContainerResource resource;
+
+  public GetAzureStorageContainerStep(
+      AzureConfiguration azureConfig,
+      CrlService crlService,
+      ControlledAzureStorageContainerResource resource) {
+    this.azureConfig = azureConfig;
+    this.crlService = crlService;
+    this.resource = resource;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+    final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
+
+    final BlobContainer container = storageManager.blobContainers().get(
+            azureCloudContext.getAzureResourceGroupId(),
+            resource.getStorageAccountName(),
+            resource.getStorageContainerName()
+    );
+
+      return StepResult.getStepResultSuccess();
+//    }
+//
+//    return new StepResult(
+//        StepStatus.STEP_RESULT_FAILURE_FATAL,
+//        new DuplicateResourceException(
+//            String.format(
+//                "An Azure Storage Account with name %s already exists",
+//                resource.getStorageAccountName())));
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Nothing to undo
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStep.java
@@ -17,8 +17,9 @@ import com.azure.resourcemanager.storage.fluent.models.ListContainerItemInner;
 
 
 /**
- * Gets an Azure Storage Container, and fails if it already exists. This step is designed to run
- * immediately before {@link CreateAzureStorageContainerStep} to ensure idempotency of the create operation.
+ * Gets an Azure Storage Container, and fails if it already exists or if the parent storage account does not exist.
+ * This step is designed to run immediately before {@link CreateAzureStorageContainerStep} to ensure idempotency
+ * of the create operation.
  */
 public class GetAzureStorageContainerStep implements Step {
 
@@ -38,9 +39,7 @@ public class GetAzureStorageContainerStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     final AzureCloudContext azureCloudContext =
-            context
-                    .getWorkingMap()
-                    .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+            context.getWorkingMap().get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
 
     if (storageManager
@@ -48,10 +47,8 @@ public class GetAzureStorageContainerStep implements Step {
             .checkNameAvailability(resource.getStorageAccountName())
             .isAvailable()) {
       return new StepResult(
-              StepStatus.STEP_RESULT_FAILURE_FATAL,
-              new ResourceNotFoundException(
-                      String.format(
-                              "No Azure storage account with name '%s' exists",
+              StepStatus.STEP_RESULT_FAILURE_FATAL, new ResourceNotFoundException(
+                      String.format("No Azure storage account with name '%s' exists",
                               resource.getStorageAccountName())));
     }
     final PagedIterable<ListContainerItemInner> existingContainers = storageManager.blobContainers().list(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStep.java
@@ -62,7 +62,7 @@ public class VerifyAzureStorageContainerCanBeCreatedStep implements Step {
     catch (ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
     } catch (ManagementException managementException) { // Thrown by storageManager
-      if (ManagementExceptionUtils.isResourceNotFound(managementException)) {
+      if (ManagementExceptionUtils.isExceptionCode(managementException, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         return new StepResult(
                 StepStatus.STEP_RESULT_FAILURE_FATAL, new ResourceNotFoundException(
                 String.format("The storage account with ID '%s' cannot be retrieved from Azure.",
@@ -85,7 +85,7 @@ public class VerifyAzureStorageContainerCanBeCreatedStep implements Step {
                               "An Azure Storage Container with name '%s' already exists in storage account '%s'",
                               resource.getStorageContainerName(), storageAccountName)));
     } catch (ManagementException e) {
-      if (ManagementExceptionUtils.isContainerNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONTAINER_NOT_FOUND)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStep.java
@@ -19,82 +19,97 @@ import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.StorageManager;
 
-
 /**
- * Verifies that the storage account exists in the workspace, and that the storage container does not already exist.
- * This step is designed to run immediately before {@link CreateAzureStorageContainerStep} to ensure idempotency
- * of the create operation.
+ * Verifies that the storage account exists in the workspace, and that the storage container does
+ * not already exist. This step is designed to run immediately before {@link
+ * CreateAzureStorageContainerStep} to ensure idempotency of the create operation.
  */
 public class VerifyAzureStorageContainerCanBeCreatedStep implements Step {
 
-    private final AzureConfiguration azureConfig;
-    private final CrlService crlService;
-    private final ResourceDao resourceDao;
-    private final ControlledAzureStorageContainerResource resource;
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final ResourceDao resourceDao;
+  private final ControlledAzureStorageContainerResource resource;
 
-    public VerifyAzureStorageContainerCanBeCreatedStep(
-            AzureConfiguration azureConfig,
-            CrlService crlService,
-            ResourceDao resourceDao,
-            ControlledAzureStorageContainerResource resource) {
-        this.azureConfig = azureConfig;
-        this.crlService = crlService;
-        this.resourceDao = resourceDao;
-        this.resource = resource;
+  public VerifyAzureStorageContainerCanBeCreatedStep(
+      AzureConfiguration azureConfig,
+      CrlService crlService,
+      ResourceDao resourceDao,
+      ControlledAzureStorageContainerResource resource) {
+    this.azureConfig = azureConfig;
+    this.crlService = crlService;
+    this.resourceDao = resourceDao;
+    this.resource = resource;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+    final StorageManager storageManager =
+        crlService.getStorageManager(azureCloudContext, azureConfig);
+
+    try {
+      final WsmResource wsmResource =
+          resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
+      final ControlledAzureStorageResource storageAccount =
+          wsmResource
+              .castToControlledResource()
+              .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+
+      context
+          .getWorkingMap()
+          .put(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, storageAccount.getStorageAccountName());
+
+      storageManager
+          .storageAccounts()
+          .getByResourceGroup(
+              azureCloudContext.getAzureResourceGroupId(), storageAccount.getStorageAccountName());
+    } catch (
+        ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
+    } catch (ManagementException managementException) { // Thrown by storageManager
+      if (ManagementExceptionUtils.isExceptionCode(
+          managementException, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
+        return new StepResult(
+            StepStatus.STEP_RESULT_FAILURE_FATAL,
+            new ResourceNotFoundException(
+                String.format(
+                    "The storage account with ID '%s' cannot be retrieved from Azure.",
+                    resource.getStorageAccountId())));
+      }
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, managementException);
     }
 
-    @Override
-    public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-        final AzureCloudContext azureCloudContext =
-                context.getWorkingMap().get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
-        final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
-
-        try {
-            final WsmResource wsmResource = resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
-            final ControlledAzureStorageResource storageAccount = wsmResource.castToControlledResource().castByEnum(
-                    WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
-
-            context.getWorkingMap().put(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, storageAccount.getStorageAccountName());
-
-            storageManager.storageAccounts().getByResourceGroup(
-                    azureCloudContext.getAzureResourceGroupId(), storageAccount.getStorageAccountName());
-        } catch (ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
-        } catch (ManagementException managementException) { // Thrown by storageManager
-            if (ManagementExceptionUtils.isExceptionCode(managementException, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
-                return new StepResult(
-                        StepStatus.STEP_RESULT_FAILURE_FATAL, new ResourceNotFoundException(
-                        String.format("The storage account with ID '%s' cannot be retrieved from Azure.",
-                                resource.getStorageAccountId())));
-            }
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, managementException);
-        }
-
-        try {
-            final String storageAccountName = context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
-            storageManager.blobContainers().get(
-                    azureCloudContext.getAzureResourceGroupId(),
-                    storageAccountName,
-                    resource.getStorageContainerName()
-            );
-            return new StepResult(
-                    StepStatus.STEP_RESULT_FAILURE_FATAL,
-                    new DuplicateResourceException(
-                            String.format(
-                                    "An Azure Storage Container with name '%s' already exists in storage account '%s'",
-                                    resource.getStorageContainerName(), storageAccountName)));
-        } catch (ManagementException e) {
-            if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONTAINER_NOT_FOUND)) {
-                return StepResult.getStepResultSuccess();
-            }
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
-        }
-    }
-
-
-    @Override
-    public StepResult undoStep(FlightContext context) throws InterruptedException {
-        // Nothing to undo
+    try {
+      final String storageAccountName =
+          context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
+      storageManager
+          .blobContainers()
+          .get(
+              azureCloudContext.getAzureResourceGroupId(),
+              storageAccountName,
+              resource.getStorageContainerName());
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new DuplicateResourceException(
+              String.format(
+                  "An Azure Storage Container with name '%s' already exists in storage account '%s'",
+                  resource.getStorageContainerName(), storageAccountName)));
+    } catch (ManagementException e) {
+      if (ManagementExceptionUtils.isExceptionCode(
+          e, ManagementExceptionUtils.CONTAINER_NOT_FOUND)) {
         return StepResult.getStepResultSuccess();
+      }
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Nothing to undo
+    return StepResult.getStepResultSuccess();
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStep.java
@@ -27,75 +27,74 @@ import com.azure.resourcemanager.storage.StorageManager;
  */
 public class VerifyAzureStorageContainerCanBeCreatedStep implements Step {
 
-  private final AzureConfiguration azureConfig;
-  private final CrlService crlService;
-  private final ResourceDao resourceDao;
-  private final ControlledAzureStorageContainerResource resource;
+    private final AzureConfiguration azureConfig;
+    private final CrlService crlService;
+    private final ResourceDao resourceDao;
+    private final ControlledAzureStorageContainerResource resource;
 
-  public VerifyAzureStorageContainerCanBeCreatedStep(
-      AzureConfiguration azureConfig,
-      CrlService crlService,
-      ResourceDao resourceDao,
-      ControlledAzureStorageContainerResource resource) {
-    this.azureConfig = azureConfig;
-    this.crlService = crlService;
-    this.resourceDao = resourceDao;
-    this.resource = resource;
-  }
-
-  @Override
-  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    final AzureCloudContext azureCloudContext =
-            context.getWorkingMap().get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
-    final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
-
-    try {
-      final WsmResource wsmResource = resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
-      final ControlledAzureStorageResource storageAccount = wsmResource.castToControlledResource().castByEnum(
-              WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
-
-      context.getWorkingMap().put(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, storageAccount.getStorageAccountName());
-
-      storageManager.storageAccounts().getByResourceGroup(
-              azureCloudContext.getAzureResourceGroupId(), storageAccount.getStorageAccountName());
-    }
-    catch (ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
-    } catch (ManagementException managementException) { // Thrown by storageManager
-      if (ManagementExceptionUtils.isExceptionCode(managementException, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
-        return new StepResult(
-                StepStatus.STEP_RESULT_FAILURE_FATAL, new ResourceNotFoundException(
-                String.format("The storage account with ID '%s' cannot be retrieved from Azure.",
-                        resource.getStorageAccountId())));
-      }
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, managementException);
+    public VerifyAzureStorageContainerCanBeCreatedStep(
+            AzureConfiguration azureConfig,
+            CrlService crlService,
+            ResourceDao resourceDao,
+            ControlledAzureStorageContainerResource resource) {
+        this.azureConfig = azureConfig;
+        this.crlService = crlService;
+        this.resourceDao = resourceDao;
+        this.resource = resource;
     }
 
-    try {
-      final String storageAccountName = context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
-      storageManager.blobContainers().get(
-              azureCloudContext.getAzureResourceGroupId(),
-              storageAccountName,
-              resource.getStorageContainerName()
-      );
-      return new StepResult(
-              StepStatus.STEP_RESULT_FAILURE_FATAL,
-              new DuplicateResourceException(
-                      String.format(
-                              "An Azure Storage Container with name '%s' already exists in storage account '%s'",
-                              resource.getStorageContainerName(), storageAccountName)));
-    } catch (ManagementException e) {
-      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONTAINER_NOT_FOUND)) {
+    @Override
+    public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+        final AzureCloudContext azureCloudContext =
+                context.getWorkingMap().get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+        final StorageManager storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
+
+        try {
+            final WsmResource wsmResource = resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
+            final ControlledAzureStorageResource storageAccount = wsmResource.castToControlledResource().castByEnum(
+                    WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+
+            context.getWorkingMap().put(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, storageAccount.getStorageAccountName());
+
+            storageManager.storageAccounts().getByResourceGroup(
+                    azureCloudContext.getAzureResourceGroupId(), storageAccount.getStorageAccountName());
+        } catch (ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, resourceNotFoundException);
+        } catch (ManagementException managementException) { // Thrown by storageManager
+            if (ManagementExceptionUtils.isExceptionCode(managementException, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
+                return new StepResult(
+                        StepStatus.STEP_RESULT_FAILURE_FATAL, new ResourceNotFoundException(
+                        String.format("The storage account with ID '%s' cannot be retrieved from Azure.",
+                                resource.getStorageAccountId())));
+            }
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, managementException);
+        }
+
+        try {
+            final String storageAccountName = context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
+            storageManager.blobContainers().get(
+                    azureCloudContext.getAzureResourceGroupId(),
+                    storageAccountName,
+                    resource.getStorageContainerName()
+            );
+            return new StepResult(
+                    StepStatus.STEP_RESULT_FAILURE_FATAL,
+                    new DuplicateResourceException(
+                            String.format(
+                                    "An Azure Storage Container with name '%s' already exists in storage account '%s'",
+                                    resource.getStorageContainerName(), storageAccountName)));
+        } catch (ManagementException e) {
+            if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONTAINER_NOT_FOUND)) {
+                return StepResult.getStepResultSuccess();
+            }
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+        }
+    }
+
+
+    @Override
+    public StepResult undoStep(FlightContext context) throws InterruptedException {
+        // Nothing to undo
         return StepResult.getStepResultSuccess();
-      }
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
-  }
-
-
-  @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
-    // Nothing to undo
-    return StepResult.getStepResultSuccess();
-  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
@@ -3,6 +3,8 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.storageConta
 import bio.terra.cloudres.azure.resourcemanager.common.ResourceManagerRequestData;
 import com.google.gson.JsonObject;
 
+import java.util.UUID;
+
 /**
  * Extends {@link ResourceManagerRequestData} to add common fields for working with the Storage
  * Resource Provider API.
@@ -15,13 +17,13 @@ import com.google.gson.JsonObject;
  */
 public abstract class BaseStorageContainerRequestData implements ResourceManagerRequestData {
   /** The name of the resource. */
-  public abstract String name();
+  public abstract String storageContainerName();
 
   /** The resource group of the resource. */
   public abstract String resourceGroupName();
 
-  /** The storage account name of the resource. */
-  public abstract String storageAccountName();
+  /** The storage account resource ID. */
+  public abstract UUID storageAccountId();
 
   /**
    * Serializes this object to JSON. Not overriding {@link ResourceManagerRequestData#serialize()}
@@ -30,8 +32,8 @@ public abstract class BaseStorageContainerRequestData implements ResourceManager
   protected JsonObject serializeCommon() {
     JsonObject requestData = new JsonObject();
     requestData.addProperty("resourceGroupName", resourceGroupName());
-    requestData.addProperty("name", name());
-    requestData.addProperty("storageAccountName", storageAccountName());
+    requestData.addProperty("storageContainerName", storageContainerName());
+    requestData.addProperty("storageAccountId", storageAccountId().toString());
     return requestData;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
@@ -16,24 +16,30 @@ import java.util.UUID;
  * azure-resourcemanager-common.
  */
 public abstract class BaseStorageContainerRequestData implements ResourceManagerRequestData {
-  /** The name of the resource. */
-  public abstract String storageContainerName();
+    /**
+     * The name of the resource.
+     */
+    public abstract String storageContainerName();
 
-  /** The resource group of the resource. */
-  public abstract String resourceGroupName();
+    /**
+     * The resource group of the resource.
+     */
+    public abstract String resourceGroupName();
 
-  /** The storage account resource ID. */
-  public abstract UUID storageAccountId();
+    /**
+     * The storage account resource ID.
+     */
+    public abstract UUID storageAccountId();
 
-  /**
-   * Serializes this object to JSON. Not overriding {@link ResourceManagerRequestData#serialize()}
-   * to ensure subclasses implement their own serialize method.
-   */
-  protected JsonObject serializeCommon() {
-    JsonObject requestData = new JsonObject();
-    requestData.addProperty("resourceGroupName", resourceGroupName());
-    requestData.addProperty("storageContainerName", storageContainerName());
-    requestData.addProperty("storageAccountId", storageAccountId().toString());
-    return requestData;
-  }
+    /**
+     * Serializes this object to JSON. Not overriding {@link ResourceManagerRequestData#serialize()}
+     * to ensure subclasses implement their own serialize method.
+     */
+    protected JsonObject serializeCommon() {
+        JsonObject requestData = new JsonObject();
+        requestData.addProperty("resourceGroupName", resourceGroupName());
+        requestData.addProperty("storageContainerName", storageContainerName());
+        requestData.addProperty("storageAccountId", storageAccountId().toString());
+        return requestData;
+    }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
@@ -16,30 +16,24 @@ import java.util.UUID;
  * azure-resourcemanager-common.
  */
 public abstract class BaseStorageContainerRequestData implements ResourceManagerRequestData {
-    /**
-     * The name of the resource.
-     */
-    public abstract String storageContainerName();
+  /** The name of the resource. */
+  public abstract String storageContainerName();
 
-    /**
-     * The resource group of the resource.
-     */
-    public abstract String resourceGroupName();
+  /** The resource group of the resource. */
+  public abstract String resourceGroupName();
 
-    /**
-     * The storage account resource ID.
-     */
-    public abstract UUID storageAccountId();
+  /** The storage account resource ID. */
+  public abstract UUID storageAccountId();
 
-    /**
-     * Serializes this object to JSON. Not overriding {@link ResourceManagerRequestData#serialize()}
-     * to ensure subclasses implement their own serialize method.
-     */
-    protected JsonObject serializeCommon() {
-        JsonObject requestData = new JsonObject();
-        requestData.addProperty("resourceGroupName", resourceGroupName());
-        requestData.addProperty("storageContainerName", storageContainerName());
-        requestData.addProperty("storageAccountId", storageAccountId().toString());
-        return requestData;
-    }
+  /**
+   * Serializes this object to JSON. Not overriding {@link ResourceManagerRequestData#serialize()}
+   * to ensure subclasses implement their own serialize method.
+   */
+  protected JsonObject serializeCommon() {
+    JsonObject requestData = new JsonObject();
+    requestData.addProperty("resourceGroupName", resourceGroupName());
+    requestData.addProperty("storageContainerName", storageContainerName());
+    requestData.addProperty("storageAccountId", storageAccountId().toString());
+    return requestData;
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.resourcemanager.data;
 
 import bio.terra.cloudres.azure.resourcemanager.common.ResourceManagerRequestData;
-import com.azure.core.management.Region;
 import com.google.gson.JsonObject;
 
 /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
@@ -1,0 +1,38 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.resourcemanager.data;
+
+import bio.terra.cloudres.azure.resourcemanager.common.ResourceManagerRequestData;
+import com.azure.core.management.Region;
+import com.google.gson.JsonObject;
+
+/**
+ * Extends {@link ResourceManagerRequestData} to add common fields for working with the Storage
+ * Resource Provider API.
+ *
+ * <p>Note: Azure Storage has its own resource provider. Therefore, the type structure should be
+ * independent from the Compute request types.
+ *
+ * <p>TODO: Consider creating a common base request type for compute and storage in
+ * azure-resourcemanager-common.
+ */
+public abstract class BaseStorageContainerRequestData implements ResourceManagerRequestData {
+  /** The name of the resource. */
+  public abstract String name();
+
+  /** The resource group of the resource. */
+  public abstract String resourceGroupName();
+
+  /** The storage account name of the resource. */
+  public abstract String storageAccountName();
+
+  /**
+   * Serializes this object to JSON. Not overriding {@link ResourceManagerRequestData#serialize()}
+   * to ensure subclasses implement their own serialize method.
+   */
+  protected JsonObject serializeCommon() {
+    JsonObject requestData = new JsonObject();
+    requestData.addProperty("resourceGroupName", resourceGroupName());
+    requestData.addProperty("name", name());
+    requestData.addProperty("storageAccountName", storageAccountName());
+    return requestData;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/CreateStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/CreateStorageContainerRequestData.java
@@ -1,0 +1,36 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.resourcemanager.data;
+
+import bio.terra.cloudres.common.CloudOperation;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resourcemanager.StorageManagerOperation;
+import com.google.auto.value.AutoValue;
+import com.google.gson.JsonObject;
+
+@AutoValue
+public abstract class CreateStorageContainerRequestData extends BaseStorageContainerRequestData {
+
+  @Override
+  public CloudOperation cloudOperation() {
+    return StorageManagerOperation.AZURE_CREATE_STORAGE_CONTAINER;
+  }
+
+  @Override
+  public JsonObject serialize() {
+    JsonObject requestData = super.serializeCommon();
+    return requestData;
+  }
+
+  public static Builder builder() {
+    return new AutoValue_CreateStorageContainerRequestData.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract CreateStorageContainerRequestData.Builder setName(String value);
+
+    public abstract CreateStorageContainerRequestData.Builder setStorageAccountName(String value);
+
+    public abstract CreateStorageContainerRequestData.Builder setResourceGroupName(String value);
+
+    public abstract CreateStorageContainerRequestData build();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/CreateStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/CreateStorageContainerRequestData.java
@@ -5,6 +5,8 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resou
 import com.google.auto.value.AutoValue;
 import com.google.gson.JsonObject;
 
+import java.util.UUID;
+
 @AutoValue
 public abstract class CreateStorageContainerRequestData extends BaseStorageContainerRequestData {
 
@@ -25,9 +27,10 @@ public abstract class CreateStorageContainerRequestData extends BaseStorageConta
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract CreateStorageContainerRequestData.Builder setName(String value);
 
-    public abstract CreateStorageContainerRequestData.Builder setStorageAccountName(String value);
+    public abstract CreateStorageContainerRequestData.Builder setStorageAccountId(UUID value);
+
+    public abstract CreateStorageContainerRequestData.Builder setStorageContainerName(String value);
 
     public abstract CreateStorageContainerRequestData.Builder setResourceGroupName(String value);
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/CreateStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/CreateStorageContainerRequestData.java
@@ -10,30 +10,30 @@ import java.util.UUID;
 @AutoValue
 public abstract class CreateStorageContainerRequestData extends BaseStorageContainerRequestData {
 
-    @Override
-    public CloudOperation cloudOperation() {
-        return StorageManagerOperation.AZURE_CREATE_STORAGE_CONTAINER;
-    }
+  @Override
+  public CloudOperation cloudOperation() {
+    return StorageManagerOperation.AZURE_CREATE_STORAGE_CONTAINER;
+  }
 
-    @Override
-    public JsonObject serialize() {
-        JsonObject requestData = super.serializeCommon();
-        return requestData;
-    }
+  @Override
+  public JsonObject serialize() {
+    JsonObject requestData = super.serializeCommon();
+    return requestData;
+  }
 
-    public static Builder builder() {
-        return new AutoValue_CreateStorageContainerRequestData.Builder();
-    }
+  public static Builder builder() {
+    return new AutoValue_CreateStorageContainerRequestData.Builder();
+  }
 
-    @AutoValue.Builder
-    public abstract static class Builder {
+  @AutoValue.Builder
+  public abstract static class Builder {
 
-        public abstract CreateStorageContainerRequestData.Builder setStorageAccountId(UUID value);
+    public abstract CreateStorageContainerRequestData.Builder setStorageAccountId(UUID value);
 
-        public abstract CreateStorageContainerRequestData.Builder setStorageContainerName(String value);
+    public abstract CreateStorageContainerRequestData.Builder setStorageContainerName(String value);
 
-        public abstract CreateStorageContainerRequestData.Builder setResourceGroupName(String value);
+    public abstract CreateStorageContainerRequestData.Builder setResourceGroupName(String value);
 
-        public abstract CreateStorageContainerRequestData build();
-    }
+    public abstract CreateStorageContainerRequestData build();
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/CreateStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/CreateStorageContainerRequestData.java
@@ -10,30 +10,30 @@ import java.util.UUID;
 @AutoValue
 public abstract class CreateStorageContainerRequestData extends BaseStorageContainerRequestData {
 
-  @Override
-  public CloudOperation cloudOperation() {
-    return StorageManagerOperation.AZURE_CREATE_STORAGE_CONTAINER;
-  }
+    @Override
+    public CloudOperation cloudOperation() {
+        return StorageManagerOperation.AZURE_CREATE_STORAGE_CONTAINER;
+    }
 
-  @Override
-  public JsonObject serialize() {
-    JsonObject requestData = super.serializeCommon();
-    return requestData;
-  }
+    @Override
+    public JsonObject serialize() {
+        JsonObject requestData = super.serializeCommon();
+        return requestData;
+    }
 
-  public static Builder builder() {
-    return new AutoValue_CreateStorageContainerRequestData.Builder();
-  }
+    public static Builder builder() {
+        return new AutoValue_CreateStorageContainerRequestData.Builder();
+    }
 
-  @AutoValue.Builder
-  public abstract static class Builder {
+    @AutoValue.Builder
+    public abstract static class Builder {
 
-    public abstract CreateStorageContainerRequestData.Builder setStorageAccountId(UUID value);
+        public abstract CreateStorageContainerRequestData.Builder setStorageAccountId(UUID value);
 
-    public abstract CreateStorageContainerRequestData.Builder setStorageContainerName(String value);
+        public abstract CreateStorageContainerRequestData.Builder setStorageContainerName(String value);
 
-    public abstract CreateStorageContainerRequestData.Builder setResourceGroupName(String value);
+        public abstract CreateStorageContainerRequestData.Builder setResourceGroupName(String value);
 
-    public abstract CreateStorageContainerRequestData build();
-  }
+        public abstract CreateStorageContainerRequestData build();
+    }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/AzureVmHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/AzureVmHelper.java
@@ -56,13 +56,13 @@ public final class AzureVmHelper {
           .deleteByResourceGroup(azureCloudContext.getAzureResourceGroupId(), networkInterfaceName);
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have deleted this resource.
-      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         logger.info(
             "Azure Network Interface {} in managed resource group {} already deleted",
             networkInterfaceName,
             azureCloudContext.getAzureResourceGroupId());
         return StepResult.getStepResultSuccess();
-      } else if (StringUtils.equals(e.getValue().getCode(), "NicReservedForAnotherVm")) {
+      } else if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.NIC_RESERVED_FOR_ANOTHER_VM)) {
         // In case of this particular error Azure asks to wait for 180 seconds before next retry. At
         // least at the time this code was written.
         // It would be good to have retry delay as a part of details field, so we can adjust
@@ -88,7 +88,7 @@ public final class AzureVmHelper {
   private static StepResult handleNotFound(
       ManagementException e, String resourceType, String resourceName, String resourceId) {
     // Stairway steps may run multiple times, so we may already have deleted this resource.
-    if (ManagementExceptionUtils.isResourceNotFound(e)) {
+    if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
       logger.info(
               "Azure {} {} in managed resource group {} already deleted",
               resourceType,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/AzureVmHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/AzureVmHelper.java
@@ -90,10 +90,10 @@ public final class AzureVmHelper {
     // Stairway steps may run multiple times, so we may already have deleted this resource.
     if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
       logger.info(
-              "Azure {} {} in managed resource group {} already deleted",
-              resourceType,
-              resourceName,
-              resourceId);
+          "Azure {} {} in managed resource group {} already deleted",
+          resourceType,
+          resourceName,
+          resourceId);
       return StepResult.getStepResultSuccess();
     }
     return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/AzureVmHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/AzureVmHelper.java
@@ -2,12 +2,12 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
 
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,12 +88,12 @@ public final class AzureVmHelper {
   private static StepResult handleNotFound(
       ManagementException e, String resourceType, String resourceName, String resourceId) {
     // Stairway steps may run multiple times, so we may already have deleted this resource.
-    if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+    if (ManagementExceptionUtils.isResourceNotFound(e)) {
       logger.info(
-          "Azure {} {} in managed resource group {} already deleted",
-          resourceType,
-          resourceName,
-          resourceId);
+              "Azure {} {} in managed resource group {} already deleted",
+              resourceType,
+              resourceName,
+              resourceId);
       return StepResult.getStepResultSuccess();
     }
     return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
@@ -153,14 +153,14 @@ public class CreateAzureVmStep implements Step {
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have created this resource. In all
       // other cases, surface the exception and attempt to retry.
-      if (ManagementExceptionUtils.isConflict(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.CONFLICT)) {
         logger.info(
             "Azure Vm {} in managed resource group {} already exists",
             resource.getVmName(),
             azureCloudContext.getAzureResourceGroupId());
         return StepResult.getStepResultSuccess();
       }
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         logger.info(
             "Either the disk, ip, or network passed into this createVm does not exist "
                 + String.format(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
@@ -2,15 +2,12 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
 
 import bio.terra.cloudres.azure.resourcemanager.common.Defaults;
 import bio.terra.cloudres.azure.resourcemanager.compute.data.CreateVirtualMachineRequestData;
-import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
-import bio.terra.stairway.StepResult;
-import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.*;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.utils.AzureVmUtils;
 import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -31,10 +28,10 @@ import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.azure.resourcemanager.network.models.Network;
 import com.azure.resourcemanager.network.models.NetworkInterface;
 import com.azure.resourcemanager.network.models.PublicIpAddress;
-import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
 
 public class CreateAzureVmStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(CreateAzureVmStep.class);
@@ -156,16 +153,14 @@ public class CreateAzureVmStep implements Step {
     } catch (ManagementException e) {
       // Stairway steps may run multiple times, so we may already have created this resource. In all
       // other cases, surface the exception and attempt to retry.
-      // Azure error codes can be found here:
-      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (StringUtils.equals(e.getValue().getCode(), "Conflict")) {
+      if (ManagementExceptionUtils.isConflict(e)) {
         logger.info(
             "Azure Vm {} in managed resource group {} already exists",
             resource.getVmName(),
             azureCloudContext.getAzureResourceGroupId());
         return StepResult.getStepResultSuccess();
       }
-      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isResourceNotFound(e)) {
         logger.info(
             "Either the disk, ip, or network passed into this createVm does not exist "
                 + String.format(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/GetAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/GetAzureVmStep.java
@@ -6,13 +6,13 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
-import org.apache.commons.lang3.StringUtils;
 
 public class GetAzureVmStep implements Step {
   private final AzureConfiguration azureConfig;
@@ -44,9 +44,7 @@ public class GetAzureVmStep implements Step {
                   "An Azure VM with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getVmName())));
     } catch (ManagementException e) {
-      // Azure error codes can be found here:
-      // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
-      if (StringUtils.equals(e.getValue().getCode(), "ResourceNotFound")) {
+      if (ManagementExceptionUtils.isResourceNotFound(e)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/GetAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/GetAzureVmStep.java
@@ -44,7 +44,7 @@ public class GetAzureVmStep implements Step {
                   "An Azure VM with name %s already exists in resource group %s",
                   azureCloudContext.getAzureResourceGroupId(), resource.getVmName())));
     } catch (ManagementException e) {
-      if (ManagementExceptionUtils.isResourceNotFound(e)) {
+      if (ManagementExceptionUtils.isExceptionCode(e, ManagementExceptionUtils.RESOURCE_NOT_FOUND)) {
         return StepResult.getStepResultSuccess();
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
@@ -57,10 +57,10 @@ public enum WsmResourceFamily {
       null,
       WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT),
   AZURE_STORAGE_CONTAINER(
-          "AZURE_STORAGE_CONTAINER",
-          ApiResourceType.AZURE_STORAGE_CONTAINER,
-          null,
-          WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER),
+      "AZURE_STORAGE_CONTAINER",
+      ApiResourceType.AZURE_STORAGE_CONTAINER,
+      null,
+      WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER),
   GIT_REPO("GIT_REPO", ApiResourceType.GIT_REPO, WsmResourceType.REFERENCED_ANY_GIT_REPO, null);
 
   private final String dbString; // serialized form of the resource type

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
@@ -56,6 +56,11 @@ public enum WsmResourceFamily {
       ApiResourceType.AZURE_STORAGE_ACCOUNT,
       null,
       WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT),
+  AZURE_STORAGE_CONTAINER(
+          "AZURE_STORAGE_CONTAINER",
+          ApiResourceType.AZURE_STORAGE_CONTAINER,
+          null,
+          WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER),
   GIT_REPO("GIT_REPO", ApiResourceType.GIT_REPO, WsmResourceType.REFERENCED_ANY_GIT_REPO, null);
 
   private final String dbString; // serialized form of the resource type

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
@@ -156,12 +156,12 @@ public enum WsmResourceType {
       ControlledAzureStorageResource.class,
       ControlledAzureStorageHandler::getHandler),
   CONTROLLED_AZURE_STORAGE_CONTAINER(
-          CloudPlatform.AZURE,
-          StewardshipType.CONTROLLED,
-          "CONTROLLED_AZURE_STORAGE_CONTAINER",
-          ApiResourceType.AZURE_STORAGE_CONTAINER,
-          ControlledAzureStorageContainerResource.class,
-          ControlledAzureStorageContainerHandler::getHandler);
+      CloudPlatform.AZURE,
+      StewardshipType.CONTROLLED,
+      "CONTROLLED_AZURE_STORAGE_CONTAINER",
+      ApiResourceType.AZURE_STORAGE_CONTAINER,
+      ControlledAzureStorageContainerResource.class,
+      ControlledAzureStorageContainerHandler::getHandler);
 
   private final CloudPlatform cloudPlatform;
   private final StewardshipType stewardshipType;

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
@@ -11,6 +11,8 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.relayNamespac
 import bio.terra.workspace.service.resource.controlled.cloud.azure.relayNamespace.ControlledAzureRelayNamespaceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerHandler;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookHandler;
@@ -152,7 +154,14 @@ public enum WsmResourceType {
       "CONTROLLED_AZURE_STORAGE_ACCOUNT",
       ApiResourceType.AZURE_STORAGE_ACCOUNT,
       ControlledAzureStorageResource.class,
-      ControlledAzureStorageHandler::getHandler);
+      ControlledAzureStorageHandler::getHandler),
+  CONTROLLED_AZURE_STORAGE_CONTAINER(
+          CloudPlatform.AZURE,
+          StewardshipType.CONTROLLED,
+          "CONTROLLED_AZURE_STORAGE_CONTAINER",
+          ApiResourceType.AZURE_STORAGE_CONTAINER,
+          ControlledAzureStorageContainerResource.class,
+          ControlledAzureStorageContainerHandler::getHandler);
 
   private final CloudPlatform cloudPlatform;
   private final StewardshipType stewardshipType;

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteControlledAzureResourcesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteControlledAzureResourcesStep.java
@@ -61,7 +61,7 @@ public class DeleteControlledAzureResourcesStep implements Step {
       throws InterruptedException, RetryException {
 
     List<ControlledResource> controlledResourceList =
-            resourceDao.listControlledResources(workspaceUuid, CloudPlatform.AZURE);
+        resourceDao.listControlledResources(workspaceUuid, CloudPlatform.AZURE);
 
     // Delete VMs first because they use other resources like disks, networks, etc.
     controlledResourceList = deleteResourcesOfType(controlledResourceList, WsmResourceType.CONTROLLED_AZURE_VM);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -60,6 +60,8 @@ public final class WorkspaceFlightMapKeys {
     public static final String STORAGE_TRANSFER_SERVICE_SA_EMAIL = "storageTransferServiceSAEmail";
     public static final String TABLE_TO_JOB_ID_MAP = "tableToJobIdMap";
     public static final String WORKSPACE_CREATE_FLIGHT_ID = "workspaceCreateFlightId";
+
+    public static final String STORAGE_ACCOUNT_NAME = "storageAccountName";
   }
 
   /** Common resource keys */

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -2,35 +2,13 @@ package bio.terra.workspace.common.fixtures;
 
 import bio.terra.stairway.ShortUUID;
 import bio.terra.workspace.common.utils.AzureVmUtils;
-import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureRelayNamespaceCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureVmCustomScriptExtension;
-import bio.terra.workspace.generated.model.ApiAzureVmCustomScriptExtensionSetting;
-import bio.terra.workspace.generated.model.ApiAzureVmCustomScriptExtensionTag;
-import bio.terra.workspace.generated.model.ApiAzureVmImage;
-import bio.terra.workspace.generated.model.ApiAzureVmUser;
-import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
-import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
-import bio.terra.workspace.generated.model.ApiGcpAiNotebookUpdateParameters;
-import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
-import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetUpdateParameters;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketDefaultStorageClass;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycle;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycleRule;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycleRuleAction;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycleRuleActionType;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycleRuleCondition;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketUpdateParameters;
+import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.relayNamespace.ControlledAzureRelayNamespaceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
@@ -143,6 +121,13 @@ public class ControlledResourceFixtures {
     return new ApiAzureStorageCreationParameters()
         .name(uniqueStorageAccountName())
         .region("eastus");
+  }
+
+  /** Construct a parameter object with a unique name to avoid unintended clashes. */
+  public static ApiAzureStorageContainerCreationParameters getAzureStorageContainerCreationParameters() {
+    return new ApiAzureStorageContainerCreationParameters()
+            .name(uniqueBucketName())
+            .storageAccountName(uniqueStorageAccountName());
   }
 
   /** Construct a parameter object with a unique bucket name to avoid unintended clashes. */
@@ -375,6 +360,24 @@ public class ControlledResourceFixtures {
         null,
         storageAccountName,
         region);
+  }
+
+  public static ControlledAzureStorageContainerResource getAzureStorageContainer(
+          String storageAccountName, String storageContainerName) {
+    return new ControlledAzureStorageContainerResource(
+            WORKSPACE_ID,
+            RESOURCE_ID,
+            RESOURCE_NAME,
+            RESOURCE_DESCRIPTION,
+            CLONING_INSTRUCTIONS,
+            OWNER_EMAIL,
+            // TODO: these should be changed when we group the resources
+            PrivateResourceState.ACTIVE,
+            AccessScopeType.ACCESS_SCOPE_PRIVATE,
+            ManagedByType.MANAGED_BY_USER,
+            null,
+            storageAccountName,
+            storageContainerName);
   }
 
   public static ControlledAzureVmResource getAzureVm(

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -126,8 +126,8 @@ public class ControlledResourceFixtures {
   /** Construct a parameter object with a unique name to avoid unintended clashes. */
   public static ApiAzureStorageContainerCreationParameters getAzureStorageContainerCreationParameters() {
     return new ApiAzureStorageContainerCreationParameters()
-            .storageContainerName(uniqueBucketName())
-            .storageAccountId(STORAGE_ACCOUNT_REFERENCE_ID);
+        .storageContainerName(uniqueBucketName())
+        .storageAccountId(STORAGE_ACCOUNT_REFERENCE_ID);
   }
 
   /** Construct a parameter object with a unique bucket name to avoid unintended clashes. */
@@ -365,19 +365,19 @@ public class ControlledResourceFixtures {
   public static ControlledAzureStorageContainerResource getAzureStorageContainer(
           UUID storageAccountId, String storageContainerName) {
     return new ControlledAzureStorageContainerResource(
-            WORKSPACE_ID,
-            RESOURCE_ID,
-            RESOURCE_NAME,
-            RESOURCE_DESCRIPTION,
-            CLONING_INSTRUCTIONS,
-            OWNER_EMAIL,
-            // TODO: these should be changed when we group the resources
-            PrivateResourceState.ACTIVE,
-            AccessScopeType.ACCESS_SCOPE_PRIVATE,
-            ManagedByType.MANAGED_BY_USER,
-            null,
-            storageAccountId,
-            storageContainerName);
+        WORKSPACE_ID,
+        RESOURCE_ID,
+        RESOURCE_NAME,
+        RESOURCE_DESCRIPTION,
+        CLONING_INSTRUCTIONS,
+        OWNER_EMAIL,
+        // TODO: these should be changed when we group the resources
+        PrivateResourceState.ACTIVE,
+        AccessScopeType.ACCESS_SCOPE_PRIVATE,
+        ManagedByType.MANAGED_BY_USER,
+        null,
+        storageAccountId,
+        storageContainerName);
   }
 
   public static ControlledAzureVmResource getAzureVm(

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -43,7 +43,7 @@ public class ControlledResourceFixtures {
 
   public static final UUID WORKSPACE_ID = UUID.fromString("00000000-fcf0-4981-bb96-6b8dd634e7c0");
   public static final UUID RESOURCE_ID = UUID.fromString("11111111-fcf0-4981-bb96-6b8dd634e7c0");
-  public static final UUID DATA_REFERENCE_ID =
+  public static final UUID STORAGE_ACCOUNT_REFERENCE_ID =
       UUID.fromString("33333333-fcf0-4981-bb96-6b8dd634e7c0");
   public static final String OWNER_EMAIL = "jay@all-the-bits-thats-fit-to-blit.dev";
   public static final ApiGcpGcsBucketLifecycleRule LIFECYCLE_RULE_1 =
@@ -119,15 +119,15 @@ public class ControlledResourceFixtures {
   /** Construct a parameter object with a unique name to avoid unintended clashes. */
   public static ApiAzureStorageCreationParameters getAzureStorageCreationParameters() {
     return new ApiAzureStorageCreationParameters()
-        .name(uniqueStorageAccountName())
+        .storageAccountName(uniqueStorageAccountName())
         .region("eastus");
   }
 
   /** Construct a parameter object with a unique name to avoid unintended clashes. */
   public static ApiAzureStorageContainerCreationParameters getAzureStorageContainerCreationParameters() {
     return new ApiAzureStorageContainerCreationParameters()
-            .name(uniqueBucketName())
-            .storageAccountName(uniqueStorageAccountName());
+            .storageContainerName(uniqueBucketName())
+            .storageAccountId(STORAGE_ACCOUNT_REFERENCE_ID);
   }
 
   /** Construct a parameter object with a unique bucket name to avoid unintended clashes. */
@@ -363,7 +363,7 @@ public class ControlledResourceFixtures {
   }
 
   public static ControlledAzureStorageContainerResource getAzureStorageContainer(
-          String storageAccountName, String storageContainerName) {
+          UUID storageAccountId, String storageContainerName) {
     return new ControlledAzureStorageContainerResource(
             WORKSPACE_ID,
             RESOURCE_ID,
@@ -376,7 +376,7 @@ public class ControlledResourceFixtures {
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_USER,
             null,
-            storageAccountName,
+            storageAccountId,
             storageContainerName);
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -1027,9 +1027,9 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
             STAIRWAY_FLIGHT_TIMEOUT,
             null);
 
-    if (findResource != null) {
-      assertEquals(FlightStatus.SUCCESS, deleteControlledResourceFlightState.getFlightStatus());
+    assertEquals(FlightStatus.SUCCESS, deleteControlledResourceFlightState.getFlightStatus());
 
+    if (findResource != null) {
       TimeUnit.SECONDS.sleep(5);
       com.azure.core.exception.HttpResponseException exception =
               assertThrows(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -998,32 +998,32 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
                 azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
     }
 
-  private <T extends ControlledResource, R> void submitControlledResourceDeletionFlight(
-      UUID workspaceUuid,
-      AuthenticatedUserRequest userRequest,
-      T controlledResource,
-      String azureResourceGroupId,
-      String resourceName,
-      BiFunction<String, String, R> findResource)
-      throws InterruptedException {
-    FlightState deleteControlledResourceFlightState =
-        StairwayTestUtils.blockUntilFlightCompletes(
-            jobService.getStairway(),
-            DeleteControlledResourceFlight.class,
-            azureTestUtils.deleteControlledResourceInputParameters(
-                workspaceUuid, controlledResource.getResourceId(), userRequest, controlledResource),
-            STAIRWAY_FLIGHT_TIMEOUT,
-            null);
+    private <T extends ControlledResource, R> void submitControlledResourceDeletionFlight(
+            UUID workspaceUuid,
+            AuthenticatedUserRequest userRequest,
+            T controlledResource,
+            String azureResourceGroupId,
+            String resourceName,
+            BiFunction<String, String, R> findResource)
+            throws InterruptedException {
+        FlightState deleteControlledResourceFlightState =
+                StairwayTestUtils.blockUntilFlightCompletes(
+                        jobService.getStairway(),
+                        DeleteControlledResourceFlight.class,
+                        azureTestUtils.deleteControlledResourceInputParameters(
+                                workspaceUuid, controlledResource.getResourceId(), userRequest, controlledResource),
+                        STAIRWAY_FLIGHT_TIMEOUT,
+                        null);
 
-    assertEquals(FlightStatus.SUCCESS, deleteControlledResourceFlightState.getFlightStatus());
+        assertEquals(FlightStatus.SUCCESS, deleteControlledResourceFlightState.getFlightStatus());
 
-    if (findResource != null) {
-      TimeUnit.SECONDS.sleep(5);
-      com.azure.core.exception.HttpResponseException exception =
-              assertThrows(
-                      com.azure.core.exception.HttpResponseException.class,
-                      () -> findResource.apply(azureResourceGroupId, resourceName));
-      assertEquals(404, exception.getResponse().getStatusCode());
+        if (findResource != null) {
+            TimeUnit.SECONDS.sleep(5);
+            com.azure.core.exception.HttpResponseException exception =
+                    assertThrows(
+                            com.azure.core.exception.HttpResponseException.class,
+                            () -> findResource.apply(azureResourceGroupId, resourceName));
+            assertEquals(404, exception.getResponse().getStatusCode());
+        }
     }
-  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -31,6 +31,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.network.Contr
 import bio.terra.workspace.service.resource.controlled.cloud.azure.relayNamespace.ControlledAzureRelayNamespaceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.AzureVmHelper;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
@@ -51,9 +52,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.uniqueBucketName;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureTest {
     private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(15);
@@ -222,40 +223,80 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
         AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
         createCloudContext(workspaceUuid, userRequest);
 
-        final ApiAzureStorageCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureStorageCreationParameters();
+    final ApiAzureStorageCreationParameters accountCreationParameters =
+            ControlledResourceFixtures.getAzureStorageCreationParameters();
 
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureStorageResource resource =
-                ControlledAzureStorageResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("rs"))
-                                        .description(getAzureName("rs-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .storageAccountName(creationParameters.getName())
-                        .region(creationParameters.getRegion())
-                        .build();
+    final UUID accountResourceId = UUID.randomUUID();
+    ControlledAzureStorageResource accountResource =
+            ControlledAzureStorageResource.builder()
+                    .common(
+                            ControlledResourceFields.builder()
+                                    .workspaceUuid(workspaceUuid)
+                                    .resourceId(accountResourceId)
+                                    .name(getAzureName("rs"))
+                                    .description(getAzureName("rs-desc"))
+                                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                                    .build())
+                    .storageAccountName(accountCreationParameters.getName())
+                    .region(accountCreationParameters.getRegion())
+                    .build();
 
-        // Submit a storage account creation flight and then verify the resource exists in the
-        // workspace.
-        createResource(
-                workspaceUuid, userRequest, resource, WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+    // Submit a storage account creation flight and then verify the resource exists in the workspace.
+    createResource(workspaceUuid, userRequest, accountResource, WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
 
-        // clean up resources - delete storage account resource
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                resource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                resource.getStorageAccountName(),
-                azureTestUtils.getStorageManager().storageAccounts()::getByResourceGroup);
-    }
+    // Submit a storage container creation flight and then verify the resource exists in the workspace.
+    final UUID containerResourceId = UUID.randomUUID();
+    final String containerName = uniqueBucketName();
+    ControlledAzureStorageContainerResource containerResource =
+            ControlledAzureStorageContainerResource.builder()
+                    .common(
+                            ControlledResourceFields.builder()
+                                    .workspaceUuid(workspaceUuid)
+                                    .resourceId(containerResourceId)
+                                    .name(getAzureName("rc"))
+                                    .description(getAzureName("rc-desc"))
+                                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                                    .build())
+                    .storageAccountName(accountCreationParameters.getName())
+                    .storageContainerName(containerName)
+                    .build();
+    createResource(workspaceUuid, userRequest, containerResource, WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
+
+    // Submit a storage container deletion flight.
+    FlightState deleteContainerFlightState =
+            StairwayTestUtils.blockUntilFlightCompletes(
+                    jobService.getStairway(),
+                    DeleteControlledResourceFlight.class,
+                    azureTestUtils.deleteControlledResourceInputParameters(
+                            workspaceUuid, containerResourceId, userRequest, containerResource),
+                    STAIRWAY_FLIGHT_TIMEOUT,
+                    null);
+    assertEquals(FlightStatus.SUCCESS, deleteContainerFlightState.getFlightStatus());
+
+    // Submit a storage account deletion flight.
+    FlightState deleteFlightState =
+            StairwayTestUtils.blockUntilFlightCompletes(
+                    jobService.getStairway(),
+                    DeleteControlledResourceFlight.class,
+                    azureTestUtils.deleteControlledResourceInputParameters(
+                            workspaceUuid, resourceId, userRequest, resource),
+                    STAIRWAY_FLIGHT_TIMEOUT,
+                    null);
+    assertEquals(FlightStatus.SUCCESS, deleteFlightState.getFlightStatus());
+
+    // clean up resources - delete storage account resource
+    submitControlledResourceDeletionFlight(
+            workspaceUuid,
+            userRequest,
+            resource,
+            azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+            resource.getStorageAccountName(),
+            azureTestUtils.getStorageManager().storageAccounts()::getByResourceGroup);
+  }
 
     @Test
     public void createAzureDiskControlledResource() throws InterruptedException {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -48,7 +48,6 @@ import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
-import java.util.function.BiFunction;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -56,8 +55,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.uniqueBucketName;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureTest {
     private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(15);
@@ -251,7 +251,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
 
     // Submit a storage container creation flight and then verify the resource exists in the workspace.
     final UUID containerResourceId = UUID.randomUUID();
-    final String containerName = uniqueBucketName();
+    final String containerName = ControlledResourceFixtures.uniqueBucketName();
     ControlledAzureStorageContainerResource containerResource =
             ControlledAzureStorageContainerResource.builder()
                     .common(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -1,10 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
 import bio.terra.workspace.common.BaseAzureTest;
@@ -13,14 +8,7 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureTestUtils;
 import bio.terra.workspace.common.utils.AzureVmUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
-import bio.terra.workspace.generated.model.ApiAccessScope;
-import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureRelayNamespaceCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
-import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
-import bio.terra.workspace.generated.model.ApiManagedBy;
+import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.WsmResourceService;
@@ -30,8 +18,8 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.Controlled
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.relayNamespace.ControlledAzureRelayNamespaceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.AzureVmHelper;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.AzureVmHelper;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
@@ -226,78 +214,78 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
         AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
         createCloudContext(workspaceUuid, userRequest);
 
-    final ApiAzureStorageCreationParameters accountCreationParameters =
-            ControlledResourceFixtures.getAzureStorageCreationParameters();
+        final ApiAzureStorageCreationParameters accountCreationParameters =
+                ControlledResourceFixtures.getAzureStorageCreationParameters();
 
-    final UUID accountResourceId = UUID.randomUUID();
-    ControlledAzureStorageResource accountResource =
-            ControlledAzureStorageResource.builder()
-                    .common(
-                            ControlledResourceFields.builder()
-                                    .workspaceUuid(workspaceUuid)
-                                    .resourceId(accountResourceId)
-                                    .name(getAzureName("rs"))
-                                    .description(getAzureName("rs-desc"))
-                                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                    .build())
-                    .storageAccountName(accountCreationParameters.getStorageAccountName())
-                    .region(accountCreationParameters.getRegion())
-                    .build();
+        final UUID accountResourceId = UUID.randomUUID();
+        ControlledAzureStorageResource accountResource =
+                ControlledAzureStorageResource.builder()
+                        .common(
+                                ControlledResourceFields.builder()
+                                        .workspaceUuid(workspaceUuid)
+                                        .resourceId(accountResourceId)
+                                        .name(getAzureName("rs"))
+                                        .description(getAzureName("rs-desc"))
+                                        .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                                        .build())
+                        .storageAccountName(accountCreationParameters.getStorageAccountName())
+                        .region(accountCreationParameters.getRegion())
+                        .build();
 
-    // Submit a storage account creation flight and then verify the resource exists in the workspace.
-    createResource(workspaceUuid, userRequest, accountResource, WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+        // Submit a storage account creation flight and then verify the resource exists in the workspace.
+        createResource(workspaceUuid, userRequest, accountResource, WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
 
-    // Submit a storage container creation flight and then verify the resource exists in the workspace.
-    final UUID containerResourceId = UUID.randomUUID();
-    final String containerName = ControlledResourceFixtures.uniqueBucketName();
-    ControlledAzureStorageContainerResource containerResource =
-            ControlledAzureStorageContainerResource.builder()
-                    .common(
-                            ControlledResourceFields.builder()
-                                    .workspaceUuid(workspaceUuid)
-                                    .resourceId(containerResourceId)
-                                    .name(getAzureName("rc"))
-                                    .description(getAzureName("rc-desc"))
-                                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                    .build())
-                    .storageAccountId(accountResourceId)
-                    .storageContainerName(containerName)
-                    .build();
-    createResource(workspaceUuid, userRequest, containerResource, WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
+        // Submit a storage container creation flight and then verify the resource exists in the workspace.
+        final UUID containerResourceId = UUID.randomUUID();
+        final String containerName = ControlledResourceFixtures.uniqueBucketName();
+        ControlledAzureStorageContainerResource containerResource =
+                ControlledAzureStorageContainerResource.builder()
+                        .common(
+                                ControlledResourceFields.builder()
+                                        .workspaceUuid(workspaceUuid)
+                                        .resourceId(containerResourceId)
+                                        .name(getAzureName("rc"))
+                                        .description(getAzureName("rc-desc"))
+                                        .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                                        .build())
+                        .storageAccountId(accountResourceId)
+                        .storageContainerName(containerName)
+                        .build();
+        createResource(workspaceUuid, userRequest, containerResource, WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
 
-    // clean up resources - delete storage container resource
-    submitControlledResourceDeletionFlight(
-            workspaceUuid,
-            userRequest,
-            containerResource,
-            azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-            containerResource.getStorageContainerName(),
-            null); // Don't sleep/verify deletion yet.
+        // clean up resources - delete storage container resource
+        submitControlledResourceDeletionFlight(
+                workspaceUuid,
+                userRequest,
+                containerResource,
+                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+                containerResource.getStorageContainerName(),
+                null); // Don't sleep/verify deletion yet.
 
-    // clean up resources - delete storage account resource
-    submitControlledResourceDeletionFlight(
-            workspaceUuid,
-            userRequest,
-            accountResource,
-            azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-            accountResource.getStorageAccountName(),
-            azureTestUtils.getStorageManager().storageAccounts()::getByResourceGroup);
+        // clean up resources - delete storage account resource
+        submitControlledResourceDeletionFlight(
+                workspaceUuid,
+                userRequest,
+                accountResource,
+                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+                accountResource.getStorageAccountName(),
+                azureTestUtils.getStorageManager().storageAccounts()::getByResourceGroup);
 
-    // Verify containers have been deleted (Can't do this in submitControlledResourceDeletionFlight because
-    // the get function takes a different number of arguments. Also no need to sleep another 5 seconds.)
-    com.azure.core.exception.HttpResponseException exception =
-            assertThrows(
-                    com.azure.core.exception.HttpResponseException.class,
-                    () -> azureTestUtils.getStorageManager().blobContainers().get(
-                            azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                            accountResource.getStorageAccountName(),
-                            containerName));
-    assertEquals(404, exception.getResponse().getStatusCode());
-  }
+        // Verify containers have been deleted (Can't do this in submitControlledResourceDeletionFlight because
+        // the get function takes a different number of arguments. Also no need to sleep another 5 seconds.)
+        com.azure.core.exception.HttpResponseException exception =
+                assertThrows(
+                        com.azure.core.exception.HttpResponseException.class,
+                        () -> azureTestUtils.getStorageManager().blobContainers().get(
+                                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+                                accountResource.getStorageAccountName(),
+                                containerName));
+        assertEquals(404, exception.getResponse().getStatusCode());
+    }
 
     @Test
     public void createAzureDiskControlledResource() throws InterruptedException {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -48,982 +48,998 @@ import java.util.function.BiFunction;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureTest {
-    private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(15);
+  private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(15);
 
-    @Autowired private WorkspaceService workspaceService;
-    @Autowired private JobService jobService;
-    @Autowired private AzureTestUtils azureTestUtils;
-    @Autowired private UserAccessUtils userAccessUtils;
-    @Autowired private ControlledResourceService controlledResourceService;
-    @Autowired private WsmResourceService wsmResourceService;
+  @Autowired private WorkspaceService workspaceService;
+  @Autowired private JobService jobService;
+  @Autowired private AzureTestUtils azureTestUtils;
+  @Autowired private UserAccessUtils userAccessUtils;
+  @Autowired private ControlledResourceService controlledResourceService;
+  @Autowired private WsmResourceService wsmResourceService;
 
-    private void createCloudContext(UUID workspaceUuid, AuthenticatedUserRequest userRequest)
-            throws InterruptedException {
-        FlightState createAzureContextFlightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        CreateAzureContextFlight.class,
-                        azureTestUtils.createAzureContextInputParameters(workspaceUuid, userRequest),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
+  private void createCloudContext(UUID workspaceUuid, AuthenticatedUserRequest userRequest)
+      throws InterruptedException {
+    FlightState createAzureContextFlightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateAzureContextFlight.class,
+            azureTestUtils.createAzureContextInputParameters(workspaceUuid, userRequest),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
 
-        assertEquals(FlightStatus.SUCCESS, createAzureContextFlightState.getFlightStatus());
-        assertTrue(
-                workspaceService.getAuthorizedAzureCloudContext(workspaceUuid, userRequest).isPresent());
+    assertEquals(FlightStatus.SUCCESS, createAzureContextFlightState.getFlightStatus());
+    assertTrue(
+        workspaceService.getAuthorizedAzureCloudContext(workspaceUuid, userRequest).isPresent());
+  }
+
+  private void createVMResource(
+      UUID workspaceUuid,
+      AuthenticatedUserRequest userRequest,
+      ControlledResource resource,
+      ApiAzureVmCreationParameters vmCreationParameters)
+      throws InterruptedException {
+    createResource(
+        workspaceUuid,
+        userRequest,
+        resource,
+        WsmResourceType.CONTROLLED_AZURE_VM,
+        vmCreationParameters);
+  }
+
+  private void createResource(
+      UUID workspaceUuid,
+      AuthenticatedUserRequest userRequest,
+      ControlledResource resource,
+      WsmResourceType resourceType)
+      throws InterruptedException {
+    createResource(workspaceUuid, userRequest, resource, resourceType, null);
+  }
+
+  private void createResource(
+      UUID workspaceUuid,
+      AuthenticatedUserRequest userRequest,
+      ControlledResource resource,
+      WsmResourceType resourceType,
+      ApiAzureVmCreationParameters vmCreationParameters)
+      throws InterruptedException {
+
+    FlightState flightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceUuid, userRequest, resource, vmCreationParameters),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+
+    assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
+
+    // Verify controlled resource exists in the workspace.
+    ControlledResource res =
+        controlledResourceService.getControlledResource(
+            workspaceUuid, resource.getResourceId(), userRequest);
+
+    try {
+      var castResource = res.castByEnum(resourceType);
+      assertEquals(resource, castResource);
+    } catch (Exception e) {
+      fail(String.format("Failed to cast resource to %s", resourceType), e);
     }
+  }
 
-    private void createVMResource(
-            UUID workspaceUuid,
-            AuthenticatedUserRequest userRequest,
-            ControlledResource resource,
-            ApiAzureVmCreationParameters vmCreationParameters)
-            throws InterruptedException {
-        createResource(
-                workspaceUuid,
-                userRequest,
-                resource,
-                WsmResourceType.CONTROLLED_AZURE_VM,
-                vmCreationParameters);
-    }
+  @Test
+  public void createAzureIpControlledResource() throws InterruptedException {
+    UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
 
-    private void createResource(
-            UUID workspaceUuid,
-            AuthenticatedUserRequest userRequest,
-            ControlledResource resource,
-            WsmResourceType resourceType)
-            throws InterruptedException {
-        createResource(workspaceUuid, userRequest, resource, resourceType, null);
-    }
+    final ApiAzureIpCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureIpCreationParameters();
 
-    private void createResource(
-            UUID workspaceUuid,
-            AuthenticatedUserRequest userRequest,
-            ControlledResource resource,
-            WsmResourceType resourceType,
-            ApiAzureVmCreationParameters vmCreationParameters)
-            throws InterruptedException {
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureIpResource resource =
+        ControlledAzureIpResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("ip"))
+                    .description(getAzureName("ip-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .ipName(creationParameters.getName())
+            .region(creationParameters.getRegion())
+            .build();
 
-        FlightState flightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        CreateControlledResourceFlight.class,
-                        azureTestUtils.createControlledResourceInputParameters(
-                                workspaceUuid, userRequest, resource, vmCreationParameters),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
+    // Submit an IP creation flight and verify the instance is created.
+    createResource(workspaceUuid, userRequest, resource, WsmResourceType.CONTROLLED_AZURE_IP);
 
-        assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
+    // clean up resources - delete ip resource
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        resource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        resource.getIpName(),
+        azureTestUtils.getComputeManager().networkManager().publicIpAddresses()
+            ::getByResourceGroup);
+  }
 
-        // Verify controlled resource exists in the workspace.
-        ControlledResource res =
-                controlledResourceService.getControlledResource(
-                        workspaceUuid, resource.getResourceId(), userRequest);
+  @Test
+  public void createAndDeleteAzureRelayNamespaceControlledResource() throws InterruptedException {
+    UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
 
-        try {
-            var castResource = res.castByEnum(resourceType);
-            assertEquals(resource, castResource);
-        } catch (Exception e) {
-            fail(String.format("Failed to cast resource to %s", resourceType), e);
-        }
-    }
+    final ApiAzureRelayNamespaceCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureRelayNamespaceCreationParameters();
 
-    @Test
-    public void createAzureIpControlledResource() throws InterruptedException {
-        UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
-        AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-        createCloudContext(workspaceUuid, userRequest);
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureRelayNamespaceResource resource =
+        ControlledAzureRelayNamespaceResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("relay"))
+                    .description(getAzureName("relay-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .namespaceName(creationParameters.getNamespaceName())
+            .region(creationParameters.getRegion())
+            .build();
 
-        final ApiAzureIpCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureIpCreationParameters();
+    // Submit a relay creation flight and verify the resource exists in the workspace.
+    createResource(
+        workspaceUuid, userRequest, resource, WsmResourceType.CONTROLLED_AZURE_RELAY_NAMESPACE);
 
-        // TODO: make this application-private resource once the POC supports it
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureIpResource resource =
-                ControlledAzureIpResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("ip"))
-                                        .description(getAzureName("ip-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .ipName(creationParameters.getName())
-                        .region(creationParameters.getRegion())
-                        .build();
+    // clean up resources - delete relay resource
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        resource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        resource.getNamespaceName(),
+        azureTestUtils.getRelayManager().namespaces()::getByResourceGroup);
+  }
 
-        // Submit an IP creation flight and verify the instance is created.
-        createResource(workspaceUuid, userRequest, resource, WsmResourceType.CONTROLLED_AZURE_IP);
+  @Test
+  public void createAndDeleteAzureStorageResource() throws InterruptedException {
+    UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
 
-        // clean up resources - delete ip resource
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                resource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                resource.getIpName(),
-                azureTestUtils.getComputeManager().networkManager().publicIpAddresses()
-                        ::getByResourceGroup);
-    }
+    final ApiAzureStorageCreationParameters accountCreationParameters =
+        ControlledResourceFixtures.getAzureStorageCreationParameters();
 
-    @Test
-    public void createAndDeleteAzureRelayNamespaceControlledResource() throws InterruptedException {
-        UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
-        AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-        createCloudContext(workspaceUuid, userRequest);
+    final UUID accountResourceId = UUID.randomUUID();
+    ControlledAzureStorageResource accountResource =
+        ControlledAzureStorageResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(accountResourceId)
+                    .name(getAzureName("rs"))
+                    .description(getAzureName("rs-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .storageAccountName(accountCreationParameters.getStorageAccountName())
+            .region(accountCreationParameters.getRegion())
+            .build();
 
-        final ApiAzureRelayNamespaceCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureRelayNamespaceCreationParameters();
+    // Submit a storage account creation flight and then verify the resource exists in the
+    // workspace.
+    createResource(
+        workspaceUuid,
+        userRequest,
+        accountResource,
+        WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
 
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureRelayNamespaceResource resource =
-                ControlledAzureRelayNamespaceResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("relay"))
-                                        .description(getAzureName("relay-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .namespaceName(creationParameters.getNamespaceName())
-                        .region(creationParameters.getRegion())
-                        .build();
+    // Submit a storage container creation flight and then verify the resource exists in the
+    // workspace.
+    final UUID containerResourceId = UUID.randomUUID();
+    final String containerName = ControlledResourceFixtures.uniqueBucketName();
+    ControlledAzureStorageContainerResource containerResource =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(containerResourceId)
+                    .name(getAzureName("rc"))
+                    .description(getAzureName("rc-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .storageAccountId(accountResourceId)
+            .storageContainerName(containerName)
+            .build();
+    createResource(
+        workspaceUuid,
+        userRequest,
+        containerResource,
+        WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
 
-        // Submit a relay creation flight and verify the resource exists in the workspace.
-        createResource(
-                workspaceUuid, userRequest, resource, WsmResourceType.CONTROLLED_AZURE_RELAY_NAMESPACE);
+    // clean up resources - delete storage container resource
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        containerResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        containerResource.getStorageContainerName(),
+        null); // Don't sleep/verify deletion yet.
 
-        // clean up resources - delete relay resource
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                resource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                resource.getNamespaceName(),
-                azureTestUtils.getRelayManager().namespaces()::getByResourceGroup);
-    }
+    // clean up resources - delete storage account resource
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        accountResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        accountResource.getStorageAccountName(),
+        azureTestUtils.getStorageManager().storageAccounts()::getByResourceGroup);
 
-    @Test
-    public void createAndDeleteAzureStorageResource() throws InterruptedException {
-        UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
-        AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-        createCloudContext(workspaceUuid, userRequest);
+    // Verify containers have been deleted (Can't do this in submitControlledResourceDeletionFlight
+    // because
+    // the get function takes a different number of arguments. Also no need to sleep another 5
+    // seconds.)
+    com.azure.core.exception.HttpResponseException exception =
+        assertThrows(
+            com.azure.core.exception.HttpResponseException.class,
+            () ->
+                azureTestUtils
+                    .getStorageManager()
+                    .blobContainers()
+                    .get(
+                        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+                        accountResource.getStorageAccountName(),
+                        containerName));
+    assertEquals(404, exception.getResponse().getStatusCode());
+  }
 
-        final ApiAzureStorageCreationParameters accountCreationParameters =
-                ControlledResourceFixtures.getAzureStorageCreationParameters();
+  @Test
+  public void createAzureDiskControlledResource() throws InterruptedException {
+    UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
 
-        final UUID accountResourceId = UUID.randomUUID();
-        ControlledAzureStorageResource accountResource =
-                ControlledAzureStorageResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(accountResourceId)
-                                        .name(getAzureName("rs"))
-                                        .description(getAzureName("rs-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .storageAccountName(accountCreationParameters.getStorageAccountName())
-                        .region(accountCreationParameters.getRegion())
-                        .build();
+    final ApiAzureDiskCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureDiskCreationParameters();
 
-        // Submit a storage account creation flight and then verify the resource exists in the workspace.
-        createResource(workspaceUuid, userRequest, accountResource, WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureDiskResource resource =
+        ControlledAzureDiskResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("disk"))
+                    .description(getAzureName("disk-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .diskName(creationParameters.getName())
+            .region(creationParameters.getRegion())
+            .size(creationParameters.getSize())
+            .build();
 
-        // Submit a storage container creation flight and then verify the resource exists in the workspace.
-        final UUID containerResourceId = UUID.randomUUID();
-        final String containerName = ControlledResourceFixtures.uniqueBucketName();
-        ControlledAzureStorageContainerResource containerResource =
-                ControlledAzureStorageContainerResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(containerResourceId)
-                                        .name(getAzureName("rc"))
-                                        .description(getAzureName("rc-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .storageAccountId(accountResourceId)
-                        .storageContainerName(containerName)
-                        .build();
-        createResource(workspaceUuid, userRequest, containerResource, WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
+    // Submit a Disk creation flight and verify the resource exists in the workspace.
+    createResource(workspaceUuid, userRequest, resource, WsmResourceType.CONTROLLED_AZURE_DISK);
 
-        // clean up resources - delete storage container resource
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                containerResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                containerResource.getStorageContainerName(),
-                null); // Don't sleep/verify deletion yet.
+    // clean up resources - delete disk resource
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        resource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        resource.getDiskName(),
+        azureTestUtils.getComputeManager().disks()::getByResourceGroup);
+  }
 
-        // clean up resources - delete storage account resource
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                accountResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                accountResource.getStorageAccountName(),
-                azureTestUtils.getStorageManager().storageAccounts()::getByResourceGroup);
+  @Test
+  public void createAndDeleteAzureVmControlledResource() throws InterruptedException {
+    // Setup workspace and cloud context
+    UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
 
-        // Verify containers have been deleted (Can't do this in submitControlledResourceDeletionFlight because
-        // the get function takes a different number of arguments. Also no need to sleep another 5 seconds.)
-        com.azure.core.exception.HttpResponseException exception =
+    // Create ip
+    ControlledAzureIpResource ipResource = createIp(workspaceUuid, userRequest);
+
+    // Create disk
+    ControlledAzureDiskResource diskResource = createDisk(workspaceUuid, userRequest);
+
+    // Create network
+    ControlledAzureNetworkResource networkResource = createNetwork(workspaceUuid, userRequest);
+
+    final ApiAzureVmCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureVmCreationParameters();
+
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureVmResource resource =
+        ControlledAzureVmResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("vm"))
+                    .description(getAzureName("vm-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .vmName(creationParameters.getName())
+            .vmSize(creationParameters.getVmSize())
+            .vmImage(AzureVmUtils.getImageData(creationParameters.getVmImage()))
+            .region(creationParameters.getRegion())
+            .ipId(ipResource.getResourceId())
+            .diskId(diskResource.getResourceId())
+            .networkId(networkResource.getResourceId())
+            .build();
+
+    // Submit a VM creation flight and verify the resource exists in the workspace.
+    createVMResource(workspaceUuid, userRequest, resource, creationParameters);
+
+    // Exercise resource enumeration for the underlying resources.
+    // Verify that the resources we created are in the enumeration.
+    List<WsmResource> resourceList =
+        wsmResourceService.enumerateResources(workspaceUuid, null, null, 0, 100, userRequest);
+    checkForResource(resourceList, ipResource);
+    checkForResource(resourceList, diskResource);
+    checkForResource(resourceList, networkResource);
+    checkForResource(resourceList, resource);
+
+    ComputeManager computeManager = azureTestUtils.getComputeManager();
+
+    final VirtualMachine resolvedVm = getVirtualMachine(creationParameters, computeManager);
+
+    // Submit a VM deletion flight.
+    FlightState deleteFlightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            DeleteControlledResourceFlight.class,
+            azureTestUtils.deleteControlledResourceInputParameters(
+                workspaceUuid, resourceId, userRequest, resource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+    assertEquals(FlightStatus.SUCCESS, deleteFlightState.getFlightStatus());
+
+    Thread.sleep(10000);
+    resolvedVm
+        .networkInterfaceIds()
+        .forEach(
+            nic ->
                 assertThrows(
-                        com.azure.core.exception.HttpResponseException.class,
-                        () -> azureTestUtils.getStorageManager().blobContainers().get(
-                                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                                accountResource.getStorageAccountName(),
-                                containerName));
-        assertEquals(404, exception.getResponse().getStatusCode());
+                    com.azure.core.exception.HttpResponseException.class,
+                    () -> computeManager.networkManager().networks().getById(nic)));
+    assertThrows(
+        com.azure.core.exception.HttpResponseException.class,
+        () -> computeManager.disks().getById(resolvedVm.osDiskId()));
+
+    // clean up resources - vm deletion flight doesn't remove network and ip resources, so we need
+    // to remove them;
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        networkResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        networkResource.getNetworkName(),
+        azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
+
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        ipResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        ipResource.getIpName(),
+        azureTestUtils.getComputeManager().networkManager().publicIpAddresses()
+            ::getByResourceGroup);
+
+    // we need to delete data disk as well
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        diskResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        diskResource.getDiskName(),
+        azureTestUtils.getComputeManager().disks()::getByResourceGroup);
+  }
+
+  @Test
+  public void createAndDeleteAzureVmControlledResourceWithCustomScriptExtension()
+      throws InterruptedException {
+    // Setup workspace and cloud context
+    UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
+
+    // Create ip
+    ControlledAzureIpResource ipResource = createIp(workspaceUuid, userRequest);
+
+    // Create disk
+    ControlledAzureDiskResource diskResource = createDisk(workspaceUuid, userRequest);
+
+    // Create network
+    ControlledAzureNetworkResource networkResource = createNetwork(workspaceUuid, userRequest);
+
+    final ApiAzureVmCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureVmCreationParametersWithCustomScriptExtension();
+
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureVmResource resource =
+        ControlledAzureVmResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("vm"))
+                    .description(getAzureName("vm-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .vmName(creationParameters.getName())
+            .vmSize(creationParameters.getVmSize())
+            .vmImage(AzureVmUtils.getImageData(creationParameters.getVmImage()))
+            .region(creationParameters.getRegion())
+            .ipId(ipResource.getResourceId())
+            .diskId(diskResource.getResourceId())
+            .networkId(networkResource.getResourceId())
+            .build();
+
+    // Submit a VM creation flight and verify the resource exists in the workspace.
+    createVMResource(workspaceUuid, userRequest, resource, creationParameters);
+
+    // Exercise resource enumeration for the underlying resources.
+    // Verify that the resources we created are in the enumeration.
+    List<WsmResource> resourceList =
+        wsmResourceService.enumerateResources(workspaceUuid, null, null, 0, 100, userRequest);
+    checkForResource(resourceList, ipResource);
+    checkForResource(resourceList, diskResource);
+    checkForResource(resourceList, networkResource);
+    checkForResource(resourceList, resource);
+
+    ComputeManager computeManager = azureTestUtils.getComputeManager();
+
+    final VirtualMachine resolvedVm = getVirtualMachine(creationParameters, computeManager);
+
+    // Submit a VM deletion flight.
+    FlightState deleteFlightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            DeleteControlledResourceFlight.class,
+            azureTestUtils.deleteControlledResourceInputParameters(
+                workspaceUuid, resourceId, userRequest, resource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+    assertEquals(FlightStatus.SUCCESS, deleteFlightState.getFlightStatus());
+
+    Thread.sleep(10000);
+    resolvedVm
+        .networkInterfaceIds()
+        .forEach(
+            nic ->
+                assertThrows(
+                    com.azure.core.exception.HttpResponseException.class,
+                    () -> computeManager.networkManager().networks().getById(nic)));
+    assertThrows(
+        com.azure.core.exception.HttpResponseException.class,
+        () -> computeManager.disks().getById(resolvedVm.osDiskId()));
+
+    // clean up resources - vm deletion flight doesn't remove network and ip resources, so we need
+    // to remove them;
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        networkResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        networkResource.getNetworkName(),
+        azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
+
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        ipResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        ipResource.getIpName(),
+        azureTestUtils.getComputeManager().networkManager().publicIpAddresses()
+            ::getByResourceGroup);
+
+    // we need to delete data disk as well
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        diskResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        diskResource.getDiskName(),
+        azureTestUtils.getComputeManager().disks()::getByResourceGroup);
+  }
+
+  @Test
+  public void createVmWithFailureMakeSureNetworkInterfaceIsNotAbandoned()
+      throws InterruptedException {
+    // Setup workspace and cloud context
+    UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+
+    // Cloud context needs to be created first
+    FlightState createAzureContextFlightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateAzureContextFlight.class,
+            azureTestUtils.createAzureContextInputParameters(workspaceUuid, userRequest),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+
+    assertEquals(FlightStatus.SUCCESS, createAzureContextFlightState.getFlightStatus());
+    assertTrue(
+        workspaceService.getAuthorizedAzureCloudContext(workspaceUuid, userRequest).isPresent());
+
+    // Create disk
+    ControlledAzureDiskResource diskResource = createDisk(workspaceUuid, userRequest);
+
+    // Create network
+    ControlledAzureNetworkResource networkResource = createNetwork(workspaceUuid, userRequest);
+
+    final ApiAzureVmCreationParameters creationParameters =
+        ControlledResourceFixtures.getInvalidAzureVmCreationParameters();
+
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureVmResource vmResource =
+        ControlledAzureVmResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("vm"))
+                    .description(getAzureName("vm-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .vmName(creationParameters.getName())
+            .vmSize(creationParameters.getVmSize())
+            .vmImage(AzureVmUtils.getImageData(creationParameters.getVmImage()))
+            .region(creationParameters.getRegion())
+            .diskId(diskResource.getResourceId())
+            .networkId(networkResource.getResourceId())
+            .build();
+
+    // Submit a VM creation flight. This flight will fail. It is made intentionally.
+    // We need this to test undo step and check if network interface is deleted.
+    FlightState vmCreationFlightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceUuid, userRequest, vmResource, creationParameters),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+
+    // VM flight was failed intentionally
+    assertEquals(FlightStatus.ERROR, vmCreationFlightState.getFlightStatus());
+    assertThrows(
+        bio.terra.workspace.service.resource.exception.ResourceNotFoundException.class,
+        () ->
+            controlledResourceService.getControlledResource(
+                workspaceUuid, resourceId, userRequest));
+
+    ComputeManager computeManager = azureTestUtils.getComputeManager();
+    AzureCloudContext azureCloudContext =
+        vmCreationFlightState
+            .getResultMap()
+            .get()
+            .get("azureCloudContext", AzureCloudContext.class);
+    // validate that VM doesn't exist
+    try {
+      computeManager
+          .virtualMachines()
+          .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), vmResource.getVmName());
+      fail("VM should not exist");
+    } catch (ManagementException e) {
+      assertEquals(404, e.getResponse().getStatusCode());
     }
 
-    @Test
-    public void createAzureDiskControlledResource() throws InterruptedException {
-        UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
-        AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-        createCloudContext(workspaceUuid, userRequest);
+    assertTrue(vmCreationFlightState.getResultMap().isPresent());
+    assertTrue(
+        vmCreationFlightState
+            .getResultMap()
+            .get()
+            .containsKey(AzureVmHelper.WORKING_MAP_NETWORK_INTERFACE_KEY));
+    assertTrue(vmCreationFlightState.getResultMap().get().containsKey("azureCloudContext"));
 
-        final ApiAzureDiskCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureDiskCreationParameters();
-
-        // TODO: make this application-private resource once the POC supports it
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureDiskResource resource =
-                ControlledAzureDiskResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("disk"))
-                                        .description(getAzureName("disk-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .diskName(creationParameters.getName())
-                        .region(creationParameters.getRegion())
-                        .size(creationParameters.getSize())
-                        .build();
-
-        // Submit a Disk creation flight and verify the resource exists in the workspace.
-        createResource(workspaceUuid, userRequest, resource, WsmResourceType.CONTROLLED_AZURE_DISK);
-
-        // clean up resources - delete disk resource
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                resource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                resource.getDiskName(),
-                azureTestUtils.getComputeManager().disks()::getByResourceGroup);
+    // validate that our network interface doesn't exist
+    String networkInterfaceName =
+        vmCreationFlightState
+            .getResultMap()
+            .get()
+            .get(AzureVmHelper.WORKING_MAP_NETWORK_INTERFACE_KEY, String.class);
+    try {
+      computeManager
+          .networkManager()
+          .networkInterfaces()
+          .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), networkInterfaceName);
+      fail("Network interface should not exist");
+    } catch (ManagementException e) {
+      assertEquals(404, e.getResponse().getStatusCode());
     }
 
-    @Test
-    public void createAndDeleteAzureVmControlledResource() throws InterruptedException {
-        // Setup workspace and cloud context
-        UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
-        AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-        createCloudContext(workspaceUuid, userRequest);
+    // since VM is not created we need to submit a disk deletion and network deletion flights
+    // separately
+    Thread.sleep(10000);
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        networkResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        networkResource.getNetworkName(),
+        azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
 
-        // Create ip
-        ControlledAzureIpResource ipResource = createIp(workspaceUuid, userRequest);
+    // despite on the fact that vm hasn't been created this flight might be completed with error.
+    // It might complain that disk is attached to a vm. As a result we need retry here.
+    // Number of cloud retry rules attempts might be not enough.
+    int deleteAttemptsNumber = 5;
+    FlightState deleteDiskResourceFlightState;
+    do {
+      deleteDiskResourceFlightState =
+          StairwayTestUtils.blockUntilFlightCompletes(
+              jobService.getStairway(),
+              DeleteControlledResourceFlight.class,
+              azureTestUtils.deleteControlledResourceInputParameters(
+                  workspaceUuid, diskResource.getResourceId(), userRequest, diskResource),
+              STAIRWAY_FLIGHT_TIMEOUT,
+              null);
+      deleteAttemptsNumber--;
+    } while (!deleteDiskResourceFlightState.getFlightStatus().equals(FlightStatus.SUCCESS)
+        || deleteAttemptsNumber == 0);
+    assertEquals(FlightStatus.SUCCESS, deleteDiskResourceFlightState.getFlightStatus());
 
-        // Create disk
-        ControlledAzureDiskResource diskResource = createDisk(workspaceUuid, userRequest);
-
-        // Create network
-        ControlledAzureNetworkResource networkResource = createNetwork(workspaceUuid, userRequest);
-
-        final ApiAzureVmCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureVmCreationParameters();
-
-        // TODO: make this application-private resource once the POC supports it
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureVmResource resource =
-                ControlledAzureVmResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("vm"))
-                                        .description(getAzureName("vm-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .vmName(creationParameters.getName())
-                        .vmSize(creationParameters.getVmSize())
-                        .vmImage(AzureVmUtils.getImageData(creationParameters.getVmImage()))
-                        .region(creationParameters.getRegion())
-                        .ipId(ipResource.getResourceId())
-                        .diskId(diskResource.getResourceId())
-                        .networkId(networkResource.getResourceId())
-                        .build();
-
-        // Submit a VM creation flight and verify the resource exists in the workspace.
-        createVMResource(workspaceUuid, userRequest, resource, creationParameters);
-
-        // Exercise resource enumeration for the underlying resources.
-        // Verify that the resources we created are in the enumeration.
-        List<WsmResource> resourceList =
-                wsmResourceService.enumerateResources(workspaceUuid, null, null, 0, 100, userRequest);
-        checkForResource(resourceList, ipResource);
-        checkForResource(resourceList, diskResource);
-        checkForResource(resourceList, networkResource);
-        checkForResource(resourceList, resource);
-
-        ComputeManager computeManager = azureTestUtils.getComputeManager();
-
-        final VirtualMachine resolvedVm = getVirtualMachine(creationParameters, computeManager);
-
-        // Submit a VM deletion flight.
-        FlightState deleteFlightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        DeleteControlledResourceFlight.class,
-                        azureTestUtils.deleteControlledResourceInputParameters(
-                                workspaceUuid, resourceId, userRequest, resource),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
-        assertEquals(FlightStatus.SUCCESS, deleteFlightState.getFlightStatus());
-
-        Thread.sleep(10000);
-        resolvedVm
-                .networkInterfaceIds()
-                .forEach(
-                        nic ->
-                                assertThrows(
-                                        com.azure.core.exception.HttpResponseException.class,
-                                        () -> computeManager.networkManager().networks().getById(nic)));
-        assertThrows(
-                com.azure.core.exception.HttpResponseException.class,
-                () -> computeManager.disks().getById(resolvedVm.osDiskId()));
-
-        // clean up resources - vm deletion flight doesn't remove network and ip resources, so we need
-        // to remove them;
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                networkResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                networkResource.getNetworkName(),
-                azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
-
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                ipResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                ipResource.getIpName(),
-                azureTestUtils.getComputeManager().networkManager().publicIpAddresses()
-                        ::getByResourceGroup);
-
-        // we need to delete data disk as well
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                diskResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                diskResource.getDiskName(),
-                azureTestUtils.getComputeManager().disks()::getByResourceGroup);
-    }
-
-    @Test
-    public void createAndDeleteAzureVmControlledResourceWithCustomScriptExtension()
-            throws InterruptedException {
-        // Setup workspace and cloud context
-        UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
-        AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-        createCloudContext(workspaceUuid, userRequest);
-
-        // Create ip
-        ControlledAzureIpResource ipResource = createIp(workspaceUuid, userRequest);
-
-        // Create disk
-        ControlledAzureDiskResource diskResource = createDisk(workspaceUuid, userRequest);
-
-        // Create network
-        ControlledAzureNetworkResource networkResource = createNetwork(workspaceUuid, userRequest);
-
-        final ApiAzureVmCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureVmCreationParametersWithCustomScriptExtension();
-
-        // TODO: make this application-private resource once the POC supports it
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureVmResource resource =
-                ControlledAzureVmResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("vm"))
-                                        .description(getAzureName("vm-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .vmName(creationParameters.getName())
-                        .vmSize(creationParameters.getVmSize())
-                        .vmImage(AzureVmUtils.getImageData(creationParameters.getVmImage()))
-                        .region(creationParameters.getRegion())
-                        .ipId(ipResource.getResourceId())
-                        .diskId(diskResource.getResourceId())
-                        .networkId(networkResource.getResourceId())
-                        .build();
-
-        // Submit a VM creation flight and verify the resource exists in the workspace.
-        createVMResource(workspaceUuid, userRequest, resource, creationParameters);
-
-        // Exercise resource enumeration for the underlying resources.
-        // Verify that the resources we created are in the enumeration.
-        List<WsmResource> resourceList =
-                wsmResourceService.enumerateResources(workspaceUuid, null, null, 0, 100, userRequest);
-        checkForResource(resourceList, ipResource);
-        checkForResource(resourceList, diskResource);
-        checkForResource(resourceList, networkResource);
-        checkForResource(resourceList, resource);
-
-        ComputeManager computeManager = azureTestUtils.getComputeManager();
-
-        final VirtualMachine resolvedVm = getVirtualMachine(creationParameters, computeManager);
-
-        // Submit a VM deletion flight.
-        FlightState deleteFlightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        DeleteControlledResourceFlight.class,
-                        azureTestUtils.deleteControlledResourceInputParameters(
-                                workspaceUuid, resourceId, userRequest, resource),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
-        assertEquals(FlightStatus.SUCCESS, deleteFlightState.getFlightStatus());
-
-        Thread.sleep(10000);
-        resolvedVm
-                .networkInterfaceIds()
-                .forEach(
-                        nic ->
-                                assertThrows(
-                                        com.azure.core.exception.HttpResponseException.class,
-                                        () -> computeManager.networkManager().networks().getById(nic)));
-        assertThrows(
-                com.azure.core.exception.HttpResponseException.class,
-                () -> computeManager.disks().getById(resolvedVm.osDiskId()));
-
-        // clean up resources - vm deletion flight doesn't remove network and ip resources, so we need
-        // to remove them;
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                networkResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                networkResource.getNetworkName(),
-                azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
-
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                ipResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                ipResource.getIpName(),
-                azureTestUtils.getComputeManager().networkManager().publicIpAddresses()
-                        ::getByResourceGroup);
-
-        // we need to delete data disk as well
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                diskResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                diskResource.getDiskName(),
-                azureTestUtils.getComputeManager().disks()::getByResourceGroup);
-    }
-
-    @Test
-    public void createVmWithFailureMakeSureNetworkInterfaceIsNotAbandoned()
-            throws InterruptedException {
-        // Setup workspace and cloud context
-        UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
-        AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-
-        // Cloud context needs to be created first
-        FlightState createAzureContextFlightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        CreateAzureContextFlight.class,
-                        azureTestUtils.createAzureContextInputParameters(workspaceUuid, userRequest),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
-
-        assertEquals(FlightStatus.SUCCESS, createAzureContextFlightState.getFlightStatus());
-        assertTrue(
-                workspaceService.getAuthorizedAzureCloudContext(workspaceUuid, userRequest).isPresent());
-
-        // Create disk
-        ControlledAzureDiskResource diskResource = createDisk(workspaceUuid, userRequest);
-
-        // Create network
-        ControlledAzureNetworkResource networkResource = createNetwork(workspaceUuid, userRequest);
-
-        final ApiAzureVmCreationParameters creationParameters =
-                ControlledResourceFixtures.getInvalidAzureVmCreationParameters();
-
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureVmResource vmResource =
-                ControlledAzureVmResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("vm"))
-                                        .description(getAzureName("vm-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .vmName(creationParameters.getName())
-                        .vmSize(creationParameters.getVmSize())
-                        .vmImage(AzureVmUtils.getImageData(creationParameters.getVmImage()))
-                        .region(creationParameters.getRegion())
-                        .diskId(diskResource.getResourceId())
-                        .networkId(networkResource.getResourceId())
-                        .build();
-
-        // Submit a VM creation flight. This flight will fail. It is made intentionally.
-        // We need this to test undo step and check if network interface is deleted.
-        FlightState vmCreationFlightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        CreateControlledResourceFlight.class,
-                        azureTestUtils.createControlledResourceInputParameters(
-                                workspaceUuid, userRequest, vmResource, creationParameters),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
-
-        // VM flight was failed intentionally
-        assertEquals(FlightStatus.ERROR, vmCreationFlightState.getFlightStatus());
-        assertThrows(
-                bio.terra.workspace.service.resource.exception.ResourceNotFoundException.class,
-                () ->
-                        controlledResourceService.getControlledResource(
-                                workspaceUuid, resourceId, userRequest));
-
-        ComputeManager computeManager = azureTestUtils.getComputeManager();
-        AzureCloudContext azureCloudContext =
-                vmCreationFlightState
-                        .getResultMap()
-                        .get()
-                        .get("azureCloudContext", AzureCloudContext.class);
-        // validate that VM doesn't exist
-        try {
+    assertThrows(
+        com.azure.core.exception.HttpResponseException.class,
+        () ->
             computeManager
-                    .virtualMachines()
-                    .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), vmResource.getVmName());
-            fail("VM should not exist");
-        } catch (ManagementException e) {
-            assertEquals(404, e.getResponse().getStatusCode());
-        }
+                .disks()
+                .getByResourceGroup(
+                    azureCloudContext.getAzureResourceGroupId(), diskResource.getDiskName()));
+  }
 
-        assertTrue(vmCreationFlightState.getResultMap().isPresent());
-        assertTrue(
-                vmCreationFlightState
-                        .getResultMap()
-                        .get()
-                        .containsKey(AzureVmHelper.WORKING_MAP_NETWORK_INTERFACE_KEY));
-        assertTrue(vmCreationFlightState.getResultMap().get().containsKey("azureCloudContext"));
+  @Test
+  public void createAndDeleteAzureVmControlledResourceWithCustomScriptExtensionWithNoPublicIp()
+      throws InterruptedException {
+    // Setup workspace and cloud context
+    UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
 
-        // validate that our network interface doesn't exist
-        String networkInterfaceName =
-                vmCreationFlightState
-                        .getResultMap()
-                        .get()
-                        .get(AzureVmHelper.WORKING_MAP_NETWORK_INTERFACE_KEY, String.class);
-        try {
-            computeManager
-                    .networkManager()
-                    .networkInterfaces()
-                    .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), networkInterfaceName);
-            fail("Network interface should not exist");
-        } catch (ManagementException e) {
-            assertEquals(404, e.getResponse().getStatusCode());
-        }
+    // Create disk
+    ControlledAzureDiskResource diskResource = createDisk(workspaceUuid, userRequest);
 
-        // since VM is not created we need to submit a disk deletion and network deletion flights
-        // separately
-        Thread.sleep(10000);
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                networkResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                networkResource.getNetworkName(),
-                azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
+    // Create network
+    ControlledAzureNetworkResource networkResource = createNetwork(workspaceUuid, userRequest);
 
-        // despite on the fact that vm hasn't been created this flight might be completed with error.
-        // It might complain that disk is attached to a vm. As a result we need retry here.
-        // Number of cloud retry rules attempts might be not enough.
-        int deleteAttemptsNumber = 5;
-        FlightState deleteDiskResourceFlightState;
-        do {
-            deleteDiskResourceFlightState =
-                    StairwayTestUtils.blockUntilFlightCompletes(
-                            jobService.getStairway(),
-                            DeleteControlledResourceFlight.class,
-                            azureTestUtils.deleteControlledResourceInputParameters(
-                                    workspaceUuid, diskResource.getResourceId(), userRequest, diskResource),
-                            STAIRWAY_FLIGHT_TIMEOUT,
-                            null);
-            deleteAttemptsNumber--;
-        } while (!deleteDiskResourceFlightState.getFlightStatus().equals(FlightStatus.SUCCESS)
-                || deleteAttemptsNumber == 0);
-        assertEquals(FlightStatus.SUCCESS, deleteDiskResourceFlightState.getFlightStatus());
+    final ApiAzureVmCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureVmCreationParametersWithCustomScriptExtension();
 
-        assertThrows(
-                com.azure.core.exception.HttpResponseException.class,
-                () ->
-                        computeManager
-                                .disks()
-                                .getByResourceGroup(
-                                        azureCloudContext.getAzureResourceGroupId(), diskResource.getDiskName()));
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureVmResource resource =
+        ControlledAzureVmResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("vm"))
+                    .description(getAzureName("vm-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .vmName(creationParameters.getName())
+            .vmSize(creationParameters.getVmSize())
+            .vmImage(AzureVmUtils.getImageData(creationParameters.getVmImage()))
+            .region(creationParameters.getRegion())
+            // .ipId(ipResource.getResourceId())
+            .diskId(diskResource.getResourceId())
+            .networkId(networkResource.getResourceId())
+            .build();
+
+    // Submit a VM creation flight and verify the resource exists in the workspace.
+    createVMResource(workspaceUuid, userRequest, resource, creationParameters);
+
+    // Exercise resource enumeration for the underlying resources.
+    // Verify that the resources we created are in the enumeration.
+    List<WsmResource> resourceList =
+        wsmResourceService.enumerateResources(workspaceUuid, null, null, 0, 100, userRequest);
+    // checkForResource(resourceList, ipResource);
+    checkForResource(resourceList, diskResource);
+    checkForResource(resourceList, networkResource);
+    checkForResource(resourceList, resource);
+
+    ComputeManager computeManager = azureTestUtils.getComputeManager();
+
+    final VirtualMachine resolvedVm = getVirtualMachine(creationParameters, computeManager);
+
+    // Submit a VM deletion flight.
+    FlightState deleteFlightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            DeleteControlledResourceFlight.class,
+            azureTestUtils.deleteControlledResourceInputParameters(
+                workspaceUuid, resourceId, userRequest, resource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+    assertEquals(FlightStatus.SUCCESS, deleteFlightState.getFlightStatus());
+
+    Thread.sleep(10000);
+    resolvedVm
+        .networkInterfaceIds()
+        .forEach(
+            nic ->
+                assertThrows(
+                    com.azure.core.exception.HttpResponseException.class,
+                    () -> computeManager.networkManager().networks().getById(nic)));
+    assertThrows(
+        com.azure.core.exception.HttpResponseException.class,
+        () -> computeManager.disks().getById(resolvedVm.osDiskId()));
+
+    // clean up resources - we need to remove only network since current VM has no public ip;
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        networkResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        networkResource.getNetworkName(),
+        azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
+
+    // we need to delete data disk as well
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        diskResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        diskResource.getDiskName(),
+        azureTestUtils.getComputeManager().disks()::getByResourceGroup);
+  }
+
+  private VirtualMachine getVirtualMachine(
+      ApiAzureVmCreationParameters creationParameters, ComputeManager computeManager)
+      throws InterruptedException {
+    var retries = 20;
+    VirtualMachine vmTemp = null;
+    while (vmTemp == null) {
+      try {
+        retries = retries - 1;
+
+        if (retries >= 0) {
+          vmTemp =
+              computeManager
+                  .virtualMachines()
+                  .getByResourceGroup(
+                      azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+                      creationParameters.getName());
+        } else
+          throw new RuntimeException(
+              String.format("%s is not created in time in Azure", creationParameters.getName()));
+      } catch (com.azure.core.exception.HttpResponseException ex) {
+        if (ex.getResponse().getStatusCode() == 404) Thread.sleep(10000);
+        else throw ex;
+      }
     }
+    return vmTemp;
+  }
 
-    @Test
-    public void createAndDeleteAzureVmControlledResourceWithCustomScriptExtensionWithNoPublicIp()
-            throws InterruptedException {
-        // Setup workspace and cloud context
-        UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
-        AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-        createCloudContext(workspaceUuid, userRequest);
-
-        // Create disk
-        ControlledAzureDiskResource diskResource = createDisk(workspaceUuid, userRequest);
-
-        // Create network
-        ControlledAzureNetworkResource networkResource = createNetwork(workspaceUuid, userRequest);
-
-        final ApiAzureVmCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureVmCreationParametersWithCustomScriptExtension();
-
-        // TODO: make this application-private resource once the POC supports it
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureVmResource resource =
-                ControlledAzureVmResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("vm"))
-                                        .description(getAzureName("vm-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .vmName(creationParameters.getName())
-                        .vmSize(creationParameters.getVmSize())
-                        .vmImage(AzureVmUtils.getImageData(creationParameters.getVmImage()))
-                        .region(creationParameters.getRegion())
-                        // .ipId(ipResource.getResourceId())
-                        .diskId(diskResource.getResourceId())
-                        .networkId(networkResource.getResourceId())
-                        .build();
-
-        // Submit a VM creation flight and verify the resource exists in the workspace.
-        createVMResource(workspaceUuid, userRequest, resource, creationParameters);
-
-        // Exercise resource enumeration for the underlying resources.
-        // Verify that the resources we created are in the enumeration.
-        List<WsmResource> resourceList =
-                wsmResourceService.enumerateResources(workspaceUuid, null, null, 0, 100, userRequest);
-        // checkForResource(resourceList, ipResource);
-        checkForResource(resourceList, diskResource);
-        checkForResource(resourceList, networkResource);
-        checkForResource(resourceList, resource);
-
-        ComputeManager computeManager = azureTestUtils.getComputeManager();
-
-        final VirtualMachine resolvedVm = getVirtualMachine(creationParameters, computeManager);
-
-        // Submit a VM deletion flight.
-        FlightState deleteFlightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        DeleteControlledResourceFlight.class,
-                        azureTestUtils.deleteControlledResourceInputParameters(
-                                workspaceUuid, resourceId, userRequest, resource),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
-        assertEquals(FlightStatus.SUCCESS, deleteFlightState.getFlightStatus());
-
-        Thread.sleep(10000);
-        resolvedVm
-                .networkInterfaceIds()
-                .forEach(
-                        nic ->
-                                assertThrows(
-                                        com.azure.core.exception.HttpResponseException.class,
-                                        () -> computeManager.networkManager().networks().getById(nic)));
-        assertThrows(
-                com.azure.core.exception.HttpResponseException.class,
-                () -> computeManager.disks().getById(resolvedVm.osDiskId()));
-
-        // clean up resources - we need to remove only network since current VM has no public ip;
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                networkResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                networkResource.getNetworkName(),
-                azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
-
-        // we need to delete data disk as well
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                diskResource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                diskResource.getDiskName(),
-                azureTestUtils.getComputeManager().disks()::getByResourceGroup);
+  private void checkForResource(List<WsmResource> resourceList, ControlledResource resource) {
+    for (WsmResource wsmResource : resourceList) {
+      if (wsmResource.getResourceId().equals(resource.getResourceId())) {
+        assertEquals(resource.getResourceType(), wsmResource.getResourceType());
+        assertEquals(resource.getWorkspaceId(), wsmResource.getWorkspaceId());
+        assertEquals(resource.getName(), wsmResource.getName());
+        return;
+      }
     }
+    fail("Failed to find resource in resource list");
+  }
 
-    private VirtualMachine getVirtualMachine(
-            ApiAzureVmCreationParameters creationParameters, ComputeManager computeManager)
-            throws InterruptedException {
-        var retries = 20;
-        VirtualMachine vmTemp = null;
-        while (vmTemp == null) {
-            try {
-                retries = retries - 1;
+  private ControlledAzureDiskResource createDisk(
+      UUID workspaceUuid, AuthenticatedUserRequest userRequest) throws InterruptedException {
+    final ApiAzureDiskCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureDiskCreationParameters();
 
-                if (retries >= 0) {
-                    vmTemp =
-                            computeManager
-                                    .virtualMachines()
-                                    .getByResourceGroup(
-                                            azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                                            creationParameters.getName());
-                } else
-                    throw new RuntimeException(
-                            String.format("%s is not created in time in Azure", creationParameters.getName()));
-            } catch (com.azure.core.exception.HttpResponseException ex) {
-                if (ex.getResponse().getStatusCode() == 404) Thread.sleep(10000);
-                else throw ex;
-            }
-        }
-        return vmTemp;
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureDiskResource resource =
+        ControlledAzureDiskResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("disk"))
+                    .description(getAzureName("disk-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .diskName(creationParameters.getName())
+            .region(creationParameters.getRegion())
+            .size(creationParameters.getSize())
+            .build();
+
+    // Submit a Disk creation flight.
+    FlightState flightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceUuid, userRequest, resource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+
+    assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
+    return resource;
+  }
+
+  ControlledAzureIpResource createIp(UUID workspaceUuid, AuthenticatedUserRequest userRequest)
+      throws InterruptedException {
+    final ApiAzureIpCreationParameters ipCreationParameters =
+        ControlledResourceFixtures.getAzureIpCreationParameters();
+
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureIpResource resource =
+        ControlledAzureIpResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("ip"))
+                    .description(getAzureName("ip-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .ipName(ipCreationParameters.getName())
+            .region(ipCreationParameters.getRegion())
+            .build();
+
+    // Submit an IP creation flight.
+    FlightState flightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceUuid, userRequest, resource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+
+    assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
+
+    return resource;
+  }
+
+  private ControlledAzureNetworkResource createNetwork(
+      UUID workspaceUuid, AuthenticatedUserRequest userRequest) throws InterruptedException {
+    final ApiAzureNetworkCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureNetworkCreationParameters();
+
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureNetworkResource resource =
+        ControlledAzureNetworkResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name(getAzureName("network"))
+                    .description(getAzureName("network-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .networkName(creationParameters.getName())
+            .region(creationParameters.getRegion())
+            .subnetName(creationParameters.getSubnetName())
+            .addressSpaceCidr(creationParameters.getAddressSpaceCidr())
+            .subnetAddressCidr(creationParameters.getSubnetAddressCidr())
+            .build();
+
+    // Submit a Disk creation flight.
+    FlightState flightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceUuid, userRequest, resource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+
+    assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
+    return resource;
+  }
+
+  private static String getAzureName(String tag) {
+    final String id = UUID.randomUUID().toString().substring(0, 6);
+    return String.format("wsm-integ-%s-%s", tag, id);
+  }
+
+  @Test
+  public void createAzureNetworkControlledResource() throws InterruptedException {
+    UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
+
+    final ApiAzureNetworkCreationParameters creationParams =
+        ControlledResourceFixtures.getAzureNetworkCreationParameters();
+
+    // TODO: make this application-private resource once the POC supports it
+    final UUID resourceId = UUID.randomUUID();
+    ControlledAzureNetworkResource resource =
+        ControlledAzureNetworkResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(resourceId)
+                    .name("testNetwork")
+                    .description("testDesc")
+                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .networkName(creationParams.getName())
+            .region(creationParams.getRegion())
+            .subnetName(creationParams.getSubnetName())
+            .addressSpaceCidr(creationParams.getAddressSpaceCidr())
+            .subnetAddressCidr(creationParams.getSubnetAddressCidr())
+            .build();
+
+    // Submit a Network creation flight and verify the resource exists in the workspace.
+    createResource(workspaceUuid, userRequest, resource, WsmResourceType.CONTROLLED_AZURE_NETWORK);
+
+    // clean up resources - delete network resource;
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        resource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        resource.getNetworkName(),
+        azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
+  }
+
+  private <T extends ControlledResource, R> void submitControlledResourceDeletionFlight(
+      UUID workspaceUuid,
+      AuthenticatedUserRequest userRequest,
+      T controlledResource,
+      String azureResourceGroupId,
+      String resourceName,
+      BiFunction<String, String, R> findResource)
+      throws InterruptedException {
+    FlightState deleteControlledResourceFlightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            DeleteControlledResourceFlight.class,
+            azureTestUtils.deleteControlledResourceInputParameters(
+                workspaceUuid, controlledResource.getResourceId(), userRequest, controlledResource),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+
+    assertEquals(FlightStatus.SUCCESS, deleteControlledResourceFlightState.getFlightStatus());
+
+    if (findResource != null) {
+      TimeUnit.SECONDS.sleep(5);
+      com.azure.core.exception.HttpResponseException exception =
+          assertThrows(
+              com.azure.core.exception.HttpResponseException.class,
+              () -> findResource.apply(azureResourceGroupId, resourceName));
+      assertEquals(404, exception.getResponse().getStatusCode());
     }
-
-    private void checkForResource(List<WsmResource> resourceList, ControlledResource resource) {
-        for (WsmResource wsmResource : resourceList) {
-            if (wsmResource.getResourceId().equals(resource.getResourceId())) {
-                assertEquals(resource.getResourceType(), wsmResource.getResourceType());
-                assertEquals(resource.getWorkspaceId(), wsmResource.getWorkspaceId());
-                assertEquals(resource.getName(), wsmResource.getName());
-                return;
-            }
-        }
-        fail("Failed to find resource in resource list");
-    }
-
-    private ControlledAzureDiskResource createDisk(
-            UUID workspaceUuid, AuthenticatedUserRequest userRequest) throws InterruptedException {
-        final ApiAzureDiskCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureDiskCreationParameters();
-
-        // TODO: make this application-private resource once the POC supports it
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureDiskResource resource =
-                ControlledAzureDiskResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("disk"))
-                                        .description(getAzureName("disk-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .diskName(creationParameters.getName())
-                        .region(creationParameters.getRegion())
-                        .size(creationParameters.getSize())
-                        .build();
-
-        // Submit a Disk creation flight.
-        FlightState flightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        CreateControlledResourceFlight.class,
-                        azureTestUtils.createControlledResourceInputParameters(
-                                workspaceUuid, userRequest, resource),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
-
-        assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
-        return resource;
-    }
-
-    ControlledAzureIpResource createIp(UUID workspaceUuid, AuthenticatedUserRequest userRequest)
-            throws InterruptedException {
-        final ApiAzureIpCreationParameters ipCreationParameters =
-                ControlledResourceFixtures.getAzureIpCreationParameters();
-
-        // TODO: make this application-private resource once the POC supports it
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureIpResource resource =
-                ControlledAzureIpResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("ip"))
-                                        .description(getAzureName("ip-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .ipName(ipCreationParameters.getName())
-                        .region(ipCreationParameters.getRegion())
-                        .build();
-
-        // Submit an IP creation flight.
-        FlightState flightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        CreateControlledResourceFlight.class,
-                        azureTestUtils.createControlledResourceInputParameters(
-                                workspaceUuid, userRequest, resource),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
-
-        assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
-
-        return resource;
-    }
-
-    private ControlledAzureNetworkResource createNetwork(
-            UUID workspaceUuid, AuthenticatedUserRequest userRequest) throws InterruptedException {
-        final ApiAzureNetworkCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureNetworkCreationParameters();
-
-        // TODO: make this application-private resource once the POC supports it
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureNetworkResource resource =
-                ControlledAzureNetworkResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name(getAzureName("network"))
-                                        .description(getAzureName("network-desc"))
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .networkName(creationParameters.getName())
-                        .region(creationParameters.getRegion())
-                        .subnetName(creationParameters.getSubnetName())
-                        .addressSpaceCidr(creationParameters.getAddressSpaceCidr())
-                        .subnetAddressCidr(creationParameters.getSubnetAddressCidr())
-                        .build();
-
-        // Submit a Disk creation flight.
-        FlightState flightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        CreateControlledResourceFlight.class,
-                        azureTestUtils.createControlledResourceInputParameters(
-                                workspaceUuid, userRequest, resource),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
-
-        assertEquals(FlightStatus.SUCCESS, flightState.getFlightStatus());
-        return resource;
-    }
-
-    private static String getAzureName(String tag) {
-        final String id = UUID.randomUUID().toString().substring(0, 6);
-        return String.format("wsm-integ-%s-%s", tag, id);
-    }
-
-    @Test
-    public void createAzureNetworkControlledResource() throws InterruptedException {
-        UUID workspaceUuid = azureTestUtils.createWorkspace(workspaceService);
-        AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-        createCloudContext(workspaceUuid, userRequest);
-
-        final ApiAzureNetworkCreationParameters creationParams =
-                ControlledResourceFixtures.getAzureNetworkCreationParameters();
-
-        // TODO: make this application-private resource once the POC supports it
-        final UUID resourceId = UUID.randomUUID();
-        ControlledAzureNetworkResource resource =
-                ControlledAzureNetworkResource.builder()
-                        .common(
-                                ControlledResourceFields.builder()
-                                        .workspaceUuid(workspaceUuid)
-                                        .resourceId(resourceId)
-                                        .name("testNetwork")
-                                        .description("testDesc")
-                                        .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                                        .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                                        .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                                        .build())
-                        .networkName(creationParams.getName())
-                        .region(creationParams.getRegion())
-                        .subnetName(creationParams.getSubnetName())
-                        .addressSpaceCidr(creationParams.getAddressSpaceCidr())
-                        .subnetAddressCidr(creationParams.getSubnetAddressCidr())
-                        .build();
-
-        // Submit a Network creation flight and verify the resource exists in the workspace.
-        createResource(workspaceUuid, userRequest, resource, WsmResourceType.CONTROLLED_AZURE_NETWORK);
-
-        // clean up resources - delete network resource;
-        submitControlledResourceDeletionFlight(
-                workspaceUuid,
-                userRequest,
-                resource,
-                azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                resource.getNetworkName(),
-                azureTestUtils.getComputeManager().networkManager().networks()::getByResourceGroup);
-    }
-
-    private <T extends ControlledResource, R> void submitControlledResourceDeletionFlight(
-            UUID workspaceUuid,
-            AuthenticatedUserRequest userRequest,
-            T controlledResource,
-            String azureResourceGroupId,
-            String resourceName,
-            BiFunction<String, String, R> findResource)
-            throws InterruptedException {
-        FlightState deleteControlledResourceFlightState =
-                StairwayTestUtils.blockUntilFlightCompletes(
-                        jobService.getStairway(),
-                        DeleteControlledResourceFlight.class,
-                        azureTestUtils.deleteControlledResourceInputParameters(
-                                workspaceUuid, controlledResource.getResourceId(), userRequest, controlledResource),
-                        STAIRWAY_FLIGHT_TIMEOUT,
-                        null);
-
-        assertEquals(FlightStatus.SUCCESS, deleteControlledResourceFlightState.getFlightStatus());
-
-        if (findResource != null) {
-            TimeUnit.SECONDS.sleep(5);
-            com.azure.core.exception.HttpResponseException exception =
-                    assertThrows(
-                            com.azure.core.exception.HttpResponseException.class,
-                            () -> findResource.apply(azureResourceGroupId, resourceName));
-            assertEquals(404, exception.getResponse().getStatusCode());
-        }
-    }
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -286,9 +286,8 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
         azureTestUtils.getStorageManager().storageAccounts()::getByResourceGroup);
 
     // Verify containers have been deleted (Can't do this in submitControlledResourceDeletionFlight
-    // because
-    // the get function takes a different number of arguments. Also no need to sleep another 5
-    // seconds.)
+    // because the get function takes a different number of arguments. Also no need to sleep another
+    // 5 seconds.)
     com.azure.core.exception.HttpResponseException exception =
         assertThrows(
             com.azure.core.exception.HttpResponseException.class,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -242,7 +242,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
                                     .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
                                     .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
                                     .build())
-                    .storageAccountName(accountCreationParameters.getName())
+                    .storageAccountName(accountCreationParameters.getStorageAccountName())
                     .region(accountCreationParameters.getRegion())
                     .build();
 
@@ -264,7 +264,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureT
                                     .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
                                     .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
                                     .build())
-                    .storageAccountName(accountCreationParameters.getName())
+                    .storageAccountId(accountResourceId)
                     .storageContainerName(containerName)
                     .build();
     createResource(workspaceUuid, userRequest, containerResource, WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -18,38 +18,36 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static org.mockito.Mockito.when;
 
-/**
- * Base class for storage account and storage container tests.
- */
+/** Base class for storage account and storage container tests. */
 @ActiveProfiles("azure")
 public class BaseStorageStepTest extends BaseAzureTest {
 
-    protected final String STUB_STRING_RETURN = "stubbed-return";
+  protected final String STUB_STRING_RETURN = "stubbed-return";
 
-    @Mock protected FlightContext mockFlightContext;
-    @Mock protected CrlService mockCrlService;
-    @Mock protected AzureConfiguration mockAzureConfig;
-    @Mock protected AzureCloudContext mockAzureCloudContext;
-    @Mock protected StorageManager mockStorageManager;
-    @Mock protected StorageAccounts mockStorageAccounts;
-    @Mock protected StorageAccount mockStorageAccount;
-    @Mock protected FlightMap mockWorkingMap;
-    final protected ManagementException resourceNotFoundException =
-            new ManagementException(
-                    "Resource was not found.",
-                    /*response=*/ null,
-                    new ManagementError("ResourceNotFound", "Resource was not found."));
+  @Mock protected FlightContext mockFlightContext;
+  @Mock protected CrlService mockCrlService;
+  @Mock protected AzureConfiguration mockAzureConfig;
+  @Mock protected AzureCloudContext mockAzureCloudContext;
+  @Mock protected StorageManager mockStorageManager;
+  @Mock protected StorageAccounts mockStorageAccounts;
+  @Mock protected StorageAccount mockStorageAccount;
+  @Mock protected FlightMap mockWorkingMap;
+  protected final ManagementException resourceNotFoundException =
+      new ManagementException(
+          "Resource was not found.",
+          /*response=*/ null,
+          new ManagementError("ResourceNotFound", "Resource was not found."));
 
-    @BeforeEach
-    public void setup() {
-        when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(STUB_STRING_RETURN);
-        when(mockCrlService.getStorageManager(mockAzureCloudContext, mockAzureConfig))
-                .thenReturn(mockStorageManager);
+  @BeforeEach
+  public void setup() {
+    when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(STUB_STRING_RETURN);
+    when(mockCrlService.getStorageManager(mockAzureCloudContext, mockAzureConfig))
+        .thenReturn(mockStorageManager);
 
-        when(mockStorageManager.storageAccounts()).thenReturn(mockStorageAccounts);
+    when(mockStorageManager.storageAccounts()).thenReturn(mockStorageAccounts);
 
-        when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-        when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
-                .thenReturn(mockAzureCloudContext);
-    }
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -4,6 +4,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
@@ -36,7 +37,7 @@ public class BaseStorageStepTest extends BaseAzureTest {
       new ManagementException(
           "Resource was not found.",
           /*response=*/ null,
-          new ManagementError("ResourceNotFound", "Resource was not found."));
+          new ManagementError(ManagementExceptionUtils.RESOURCE_NOT_FOUND, "Resource was not found."));
 
   @BeforeEach
   public void setup() {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -11,6 +11,7 @@ import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.StorageManager;
 import com.azure.resourcemanager.storage.models.CheckNameAvailabilityResult;
+import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.resourcemanager.storage.models.StorageAccounts;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
@@ -18,6 +19,9 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static org.mockito.Mockito.when;
 
+/**
+ * Base class for storage account and storage container tests.
+ */
 @ActiveProfiles("azure")
 public class BaseStorageStepTest extends BaseAzureTest {
 
@@ -28,10 +32,12 @@ public class BaseStorageStepTest extends BaseAzureTest {
     @Mock protected AzureConfiguration mockAzureConfig;
     @Mock protected AzureCloudContext mockAzureCloudContext;
     @Mock protected StorageManager mockStorageManager;
-    @Mock protected ManagementException mockException;
     @Mock protected CheckNameAvailabilityResult mockNameAvailabilityResult;
     @Mock protected StorageAccounts mockStorageAccounts;
+    @Mock protected StorageAccount mockStorageAccount;
     @Mock protected FlightMap mockWorkingMap;
+    protected ManagementException resourceNotFoundException;
+
 
     @BeforeEach
     public void setup() {
@@ -41,8 +47,11 @@ public class BaseStorageStepTest extends BaseAzureTest {
 
         when(mockStorageManager.storageAccounts()).thenReturn(mockStorageAccounts);
 
-        when(mockException.getValue())
-                .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
+        resourceNotFoundException =
+                new ManagementException(
+                        "Resource was not found.",
+                        /*response=*/ null,
+                        new ManagementError("ResourceNotFound", "Resource was not found."));
 
         when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
         when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -10,7 +10,6 @@ import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.StorageManager;
-import com.azure.resourcemanager.storage.models.CheckNameAvailabilityResult;
 import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.resourcemanager.storage.models.StorageAccounts;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +31,6 @@ public class BaseStorageStepTest extends BaseAzureTest {
     @Mock protected AzureConfiguration mockAzureConfig;
     @Mock protected AzureCloudContext mockAzureCloudContext;
     @Mock protected StorageManager mockStorageManager;
-    @Mock protected CheckNameAvailabilityResult mockNameAvailabilityResult;
     @Mock protected StorageAccounts mockStorageAccounts;
     @Mock protected StorageAccount mockStorageAccount;
     @Mock protected FlightMap mockWorkingMap;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -34,8 +34,11 @@ public class BaseStorageStepTest extends BaseAzureTest {
     @Mock protected StorageAccounts mockStorageAccounts;
     @Mock protected StorageAccount mockStorageAccount;
     @Mock protected FlightMap mockWorkingMap;
-    protected ManagementException resourceNotFoundException;
-
+    final protected ManagementException resourceNotFoundException =
+            new ManagementException(
+                    "Resource was not found.",
+                    /*response=*/ null,
+                    new ManagementError("ResourceNotFound", "Resource was not found."));
 
     @BeforeEach
     public void setup() {
@@ -44,12 +47,6 @@ public class BaseStorageStepTest extends BaseAzureTest {
                 .thenReturn(mockStorageManager);
 
         when(mockStorageManager.storageAccounts()).thenReturn(mockStorageAccounts);
-
-        resourceNotFoundException =
-                new ManagementException(
-                        "Resource was not found.",
-                        /*response=*/ null,
-                        new ManagementError("ResourceNotFound", "Resource was not found."));
 
         when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
         when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -1,0 +1,51 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storage;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.exception.ManagementError;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.storage.StorageManager;
+import com.azure.resourcemanager.storage.models.CheckNameAvailabilityResult;
+import com.azure.resourcemanager.storage.models.StorageAccounts;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("azure")
+public class BaseStorageStepTest extends BaseAzureTest {
+
+    protected final String STUB_STRING_RETURN = "stubbed-return";
+
+    @Mock protected FlightContext mockFlightContext;
+    @Mock protected CrlService mockCrlService;
+    @Mock protected AzureConfiguration mockAzureConfig;
+    @Mock protected AzureCloudContext mockAzureCloudContext;
+    @Mock protected StorageManager mockStorageManager;
+    @Mock protected ManagementException mockException;
+    @Mock protected CheckNameAvailabilityResult mockNameAvailabilityResult;
+    @Mock protected StorageAccounts mockStorageAccounts;
+    @Mock protected FlightMap mockWorkingMap;
+
+    @BeforeEach
+    public void setup() {
+        when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(STUB_STRING_RETURN);
+        when(mockCrlService.getStorageManager(mockAzureCloudContext, mockAzureConfig))
+                .thenReturn(mockStorageManager);
+
+        when(mockStorageManager.storageAccounts()).thenReturn(mockStorageAccounts);
+
+        when(mockException.getValue())
+                .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
+
+        when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+        when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+                .thenReturn(mockAzureCloudContext);
+    }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -24,121 +24,124 @@ import static org.mockito.Mockito.*;
 @ActiveProfiles("azure")
 public class CreateAzureStorageStepTest extends BaseStorageStepTest {
 
-    @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
-    @Mock private StorageAccount.DefinitionStages.Blank mockStorageBlankStage;
-    @Mock private StorageAccount.DefinitionStages.WithGroup mockStorageGroupStage;
-    @Mock private StorageAccount.DefinitionStages.WithCreate mockStorageCreateStage;
+  @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
+  @Mock private StorageAccount.DefinitionStages.Blank mockStorageBlankStage;
+  @Mock private StorageAccount.DefinitionStages.WithGroup mockStorageGroupStage;
+  @Mock private StorageAccount.DefinitionStages.WithCreate mockStorageCreateStage;
 
-    private ApiAzureStorageCreationParameters creationParameters;
-    private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+  private ApiAzureStorageCreationParameters creationParameters;
+  private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
 
-    @BeforeEach
-    public void setup() {
-        super.setup();
+  @BeforeEach
+  public void setup() {
+    super.setup();
 
-        // Creation stages mocks
-        when(mockStorageAccounts.define(anyString())).thenReturn(mockStorageBlankStage);
-        when(mockStorageBlankStage.withRegion(anyString())).thenReturn(mockStorageGroupStage);
-        when(mockStorageGroupStage.withExistingResourceGroup(anyString()))
-                .thenReturn(mockStorageCreateStage);
-        when(mockStorageCreateStage.withHnsEnabled(true)).thenReturn(mockStorageCreateStage);
-        when(mockStorageCreateStage.withTag(anyString(), anyString()))
-                .thenReturn(mockStorageCreateStage);
-        when(mockStorageCreateStage.create(any(Context.class))).thenReturn(mockStorageAccount);
-        when(mockStorageAccount.id()).thenReturn(STUB_STRING_RETURN);
-        creationParameters = ControlledResourceFixtures.getAzureStorageCreationParameters();
-    }
+    // Creation stages mocks
+    when(mockStorageAccounts.define(anyString())).thenReturn(mockStorageBlankStage);
+    when(mockStorageBlankStage.withRegion(anyString())).thenReturn(mockStorageGroupStage);
+    when(mockStorageGroupStage.withExistingResourceGroup(anyString()))
+        .thenReturn(mockStorageCreateStage);
+    when(mockStorageCreateStage.withHnsEnabled(true)).thenReturn(mockStorageCreateStage);
+    when(mockStorageCreateStage.withTag(anyString(), anyString()))
+        .thenReturn(mockStorageCreateStage);
+    when(mockStorageCreateStage.create(any(Context.class))).thenReturn(mockStorageAccount);
+    when(mockStorageAccount.id()).thenReturn(STUB_STRING_RETURN);
+    creationParameters = ControlledResourceFixtures.getAzureStorageCreationParameters();
+  }
 
-    @Test
-    void createStorageAccount() throws InterruptedException {
+  @Test
+  void createStorageAccount() throws InterruptedException {
 
-        CreateAzureStorageStep createAzureStorageStep = createCreateAzureStorageStep();
-        StepResult stepResult = createAzureStorageStep.doStep(mockFlightContext);
+    CreateAzureStorageStep createAzureStorageStep = createCreateAzureStorageStep();
+    StepResult stepResult = createAzureStorageStep.doStep(mockFlightContext);
 
-        // Verify step returns success
-        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
 
-        // Verify Azure create call was made correctly
-        verify(mockStorageCreateStage).create(contextCaptor.capture());
-        Context context = contextCaptor.getValue();
+    // Verify Azure create call was made correctly
+    verify(mockStorageCreateStage).create(contextCaptor.capture());
+    Context context = contextCaptor.getValue();
 
-        Optional<CreateStorageAccountRequestData> storageAccountRequestDataOpt =
-                context.getValues().values().stream()
-                        .filter(CreateStorageAccountRequestData.class::isInstance)
-                        .map(CreateStorageAccountRequestData.class::cast)
-                        .findFirst();
+    Optional<CreateStorageAccountRequestData> storageAccountRequestDataOpt =
+        context.getValues().values().stream()
+            .filter(CreateStorageAccountRequestData.class::isInstance)
+            .map(CreateStorageAccountRequestData.class::cast)
+            .findFirst();
 
-        CreateStorageAccountRequestData expected =
-                CreateStorageAccountRequestData.builder()
-                        .setName(creationParameters.getStorageAccountName())
-                        .setRegion(Region.fromName(creationParameters.getRegion()))
-                        .setResourceGroupName(mockAzureCloudContext.getAzureResourceGroupId())
-                        .build();
+    CreateStorageAccountRequestData expected =
+        CreateStorageAccountRequestData.builder()
+            .setName(creationParameters.getStorageAccountName())
+            .setRegion(Region.fromName(creationParameters.getRegion()))
+            .setResourceGroupName(mockAzureCloudContext.getAzureResourceGroupId())
+            .build();
 
-        assertThat(storageAccountRequestDataOpt, equalTo(Optional.of(expected)));
-    }
+    assertThat(storageAccountRequestDataOpt, equalTo(Optional.of(expected)));
+  }
 
-    @Test
-    public void createStorage_failsToCreate() throws InterruptedException {
-        CreateAzureStorageStep createAzureStorageStep = createCreateAzureStorageStep();
-        when(mockStorageCreateStage.create(any(Context.class))).thenThrow(resourceNotFoundException);
+  @Test
+  public void createStorage_failsToCreate() throws InterruptedException {
+    CreateAzureStorageStep createAzureStorageStep = createCreateAzureStorageStep();
+    when(mockStorageCreateStage.create(any(Context.class))).thenThrow(resourceNotFoundException);
 
-        StepResult stepResult = createAzureStorageStep.doStep(mockFlightContext);
+    StepResult stepResult = createAzureStorageStep.doStep(mockFlightContext);
 
-        // Verify step fails...
-        assertThat(stepResult.isSuccess(), equalTo(false));
-    }
+    // Verify step fails...
+    assertThat(stepResult.isSuccess(), equalTo(false));
+  }
 
-    private CreateAzureStorageStep createCreateAzureStorageStep() {
+  private CreateAzureStorageStep createCreateAzureStorageStep() {
 
-        CreateAzureStorageStep createAzureStorageStep =
-                new CreateAzureStorageStep(
-                        mockAzureConfig,
-                        mockCrlService,
-                        ControlledResourceFixtures.getAzureStorage(
-                                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
-        return createAzureStorageStep;
-    }
+    CreateAzureStorageStep createAzureStorageStep =
+        new CreateAzureStorageStep(
+            mockAzureConfig,
+            mockCrlService,
+            ControlledResourceFixtures.getAzureStorage(
+                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
+    return createAzureStorageStep;
+  }
 
-    @Test
-    public void undoStep_doesNotDeleteStorageIfStorageAccountDoesNotExist() throws InterruptedException {
+  @Test
+  public void undoStep_doesNotDeleteStorageIfStorageAccountDoesNotExist()
+      throws InterruptedException {
 
-        CreateAzureStorageStep createAzureStorageStep = createCreateAzureStorageStep();
+    CreateAzureStorageStep createAzureStorageStep = createCreateAzureStorageStep();
 
-        // Storage account does not exist
-        when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
-        when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
-                .thenReturn(mockNameAvailabilityResult);
+    // Storage account does not exist
+    when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
+        .thenReturn(mockNameAvailabilityResult);
 
-        StepResult stepResult = createAzureStorageStep.undoStep(mockFlightContext);
+    StepResult stepResult = createAzureStorageStep.undoStep(mockFlightContext);
 
-        // Verify step returns success
-        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
 
-        // Verify delete operation is not called.
-        verify(mockStorageAccounts, times(0))
-                .deleteByResourceGroup(
-                        mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName());
-    }
+    // Verify delete operation is not called.
+    verify(mockStorageAccounts, times(0))
+        .deleteByResourceGroup(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            creationParameters.getStorageAccountName());
+  }
 
-    @Test
-    public void undoStep_deletesStorageIfStorageAccountExists() throws InterruptedException {
+  @Test
+  public void undoStep_deletesStorageIfStorageAccountExists() throws InterruptedException {
 
-        CreateAzureStorageStep createAzureStorageStep = createCreateAzureStorageStep();
+    CreateAzureStorageStep createAzureStorageStep = createCreateAzureStorageStep();
 
-        // Storage account exists
-        when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
-        when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
-                .thenReturn(mockNameAvailabilityResult);
+    // Storage account exists
+    when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
+        .thenReturn(mockNameAvailabilityResult);
 
-        StepResult stepResult = createAzureStorageStep.undoStep(mockFlightContext);
+    StepResult stepResult = createAzureStorageStep.undoStep(mockFlightContext);
 
-        // Verify step returns success
-        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
 
-        // Verify delete operation is called.
-        verify(mockStorageAccounts)
-                .deleteByResourceGroup(
-                        mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName());
-    }
+    // Verify delete operation is called.
+    verify(mockStorageAccounts)
+        .deleteByResourceGroup(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            creationParameters.getStorageAccountName());
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -5,8 +5,6 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resourcemanager.data.CreateStorageAccountRequestData;
 import com.azure.core.management.Region;
-import com.azure.core.management.exception.ManagementError;
-import com.azure.core.management.exception.ManagementException;
 import com.azure.core.util.Context;
 import com.azure.resourcemanager.storage.models.StorageAccount;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,23 +24,15 @@ import static org.mockito.Mockito.*;
 public class CreateAzureStorageStepTest extends BaseStorageStepTest {
 
   private ApiAzureStorageCreationParameters creationParameters;
-  private ManagementException resourceNotFoundException;
   @Mock private StorageAccount.DefinitionStages.Blank mockStorageBlankStage;
   @Mock private StorageAccount.DefinitionStages.WithGroup mockStorageGroupStage;
   @Mock private StorageAccount.DefinitionStages.WithCreate mockStorageCreateStage;
-  @Mock private StorageAccount mockStorageAccount;
 
   private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
 
   @BeforeEach
   public void setup() {
     super.setup();
-
-    resourceNotFoundException =
-            new ManagementException(
-                    "Resource was not found.",
-                    /*response=*/ null,
-                    new ManagementError("ResourceNotFound", "Resource was not found."));
 
     // Creation stages mocks
     when(mockStorageAccounts.define(anyString())).thenReturn(mockStorageBlankStage);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -71,7 +71,7 @@ public class CreateAzureStorageStepTest extends BaseStorageStepTest {
 
     CreateStorageAccountRequestData expected =
         CreateStorageAccountRequestData.builder()
-            .setName(creationParameters.getName())
+            .setName(creationParameters.getStorageAccountName())
             .setRegion(Region.fromName(creationParameters.getRegion()))
             .setResourceGroupName(mockAzureCloudContext.getAzureResourceGroupId())
             .build();
@@ -97,7 +97,7 @@ public class CreateAzureStorageStepTest extends BaseStorageStepTest {
             mockAzureConfig,
             mockCrlService,
             ControlledResourceFixtures.getAzureStorage(
-                creationParameters.getName(), creationParameters.getRegion()));
+                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
     return createAzureStorageStep;
   }
 
@@ -108,7 +108,7 @@ public class CreateAzureStorageStepTest extends BaseStorageStepTest {
 
     // Storage account does not exist
     when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
-    when(mockStorageAccounts.checkNameAvailability(creationParameters.getName()))
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
         .thenReturn(mockNameAvailabilityResult);
 
     StepResult stepResult = createAzureStorageStep.undoStep(mockFlightContext);
@@ -119,7 +119,7 @@ public class CreateAzureStorageStepTest extends BaseStorageStepTest {
     // Verify delete operation is not called.
     verify(mockStorageAccounts, times(0))
         .deleteByResourceGroup(
-            mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getName());
+            mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName());
   }
 
   @Test
@@ -129,7 +129,7 @@ public class CreateAzureStorageStepTest extends BaseStorageStepTest {
 
     // Storage account exists
     when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
-    when(mockStorageAccounts.checkNameAvailability(creationParameters.getName()))
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
         .thenReturn(mockNameAvailabilityResult);
 
     StepResult stepResult = createAzureStorageStep.undoStep(mockFlightContext);
@@ -140,6 +140,6 @@ public class CreateAzureStorageStepTest extends BaseStorageStepTest {
     // Verify delete operation is called.
     verify(mockStorageAccounts)
         .deleteByResourceGroup(
-            mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getName());
+            mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -6,6 +6,7 @@ import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resourcemanager.data.CreateStorageAccountRequestData;
 import com.azure.core.management.Region;
 import com.azure.core.util.Context;
+import com.azure.resourcemanager.storage.models.CheckNameAvailabilityResult;
 import com.azure.resourcemanager.storage.models.StorageAccount;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,8 @@ import static org.mockito.Mockito.*;
 
 @ActiveProfiles("azure")
 public class CreateAzureStorageStepTest extends BaseStorageStepTest {
+
+  @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
 
   private ApiAzureStorageCreationParameters creationParameters;
   @Mock private StorageAccount.DefinitionStages.Blank mockStorageBlankStage;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -1,91 +1,60 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.storage;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
-import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
-import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resourcemanager.data.CreateStorageAccountRequestData;
-import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
-import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.Region;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.core.util.Context;
-import com.azure.resourcemanager.storage.StorageManager;
-import com.azure.resourcemanager.storage.models.CheckNameAvailabilityResult;
 import com.azure.resourcemanager.storage.models.StorageAccount;
-import com.azure.resourcemanager.storage.models.StorageAccounts;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
-public class CreateAzureStorageStepTest extends BaseAzureTest {
+import java.util.Optional;
 
-  private static final String STUB_STRING_RETURN = "stubbed-return";
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("azure")
+public class CreateAzureStorageStepTest extends BaseStorageStepTest {
+
   private ApiAzureStorageCreationParameters creationParameters;
-  @Mock private CrlService mockCrlService;
-  @Mock private AzureConfiguration mockAzureConfig;
-  @Mock private AzureCloudContext mockAzureCloudContext;
-  @Mock private StorageManager mockStorageManager;
   private ManagementException resourceNotFoundException;
-  @Mock private StorageAccounts mockStorageAccounts;
   @Mock private StorageAccount.DefinitionStages.Blank mockStorageBlankStage;
   @Mock private StorageAccount.DefinitionStages.WithGroup mockStorageGroupStage;
   @Mock private StorageAccount.DefinitionStages.WithCreate mockStorageCreateStage;
   @Mock private StorageAccount mockStorageAccount;
-  @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
-  @Mock private FlightContext mockFlightContext;
-  @Mock private FlightMap mockWorkingMap;
 
   private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
 
   @BeforeEach
   public void setup() {
-
-    when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(STUB_STRING_RETURN);
-    when(mockCrlService.getStorageManager(mockAzureCloudContext, mockAzureConfig))
-        .thenReturn(mockStorageManager);
-
-    when(mockStorageManager.storageAccounts()).thenReturn(mockStorageAccounts);
+    super.setup();
 
     resourceNotFoundException =
-        new ManagementException(
-            "Resource was not found.",
-            /*response=*/ null,
-            new ManagementError("ResourceNotFound", "Resource was not found."));
+            new ManagementException(
+                    "Resource was not found.",
+                    /*response=*/ null,
+                    new ManagementError("ResourceNotFound", "Resource was not found."));
 
     // Creation stages mocks
     when(mockStorageAccounts.define(anyString())).thenReturn(mockStorageBlankStage);
     when(mockStorageBlankStage.withRegion(anyString())).thenReturn(mockStorageGroupStage);
     when(mockStorageGroupStage.withExistingResourceGroup(anyString()))
-        .thenReturn(mockStorageCreateStage);
+            .thenReturn(mockStorageCreateStage);
     when(mockStorageCreateStage.withHnsEnabled(true)).thenReturn(mockStorageCreateStage);
     when(mockStorageCreateStage.withTag(anyString(), anyString()))
-        .thenReturn(mockStorageCreateStage);
+            .thenReturn(mockStorageCreateStage);
     when(mockStorageCreateStage.create(any(Context.class))).thenReturn(mockStorageAccount);
     when(mockStorageAccount.id()).thenReturn(STUB_STRING_RETURN);
     creationParameters = ControlledResourceFixtures.getAzureStorageCreationParameters();
-
-    // Exception mock
-    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
-        .thenReturn(mockAzureCloudContext);
   }
 
   @Test
@@ -140,7 +109,7 @@ public class CreateAzureStorageStepTest extends BaseAzureTest {
   }
 
   @Test
-  public void undoStep_deletesStorageIfStorageAccountDoesNotExist() throws InterruptedException {
+  public void undoStep_doesNotDeleteStorageIfStorageAccountDoesNotExist() throws InterruptedException {
 
     CreateAzureStorageStep createAzureStorageStep = createCreateAzureStorageStep();
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
@@ -5,58 +5,17 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.when;
 
-import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
-import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
-import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
-import bio.terra.workspace.service.workspace.model.AzureCloudContext;
-import com.azure.core.management.exception.ManagementError;
-import com.azure.core.management.exception.ManagementException;
-import com.azure.resourcemanager.storage.StorageManager;
-import com.azure.resourcemanager.storage.models.CheckNameAvailabilityResult;
-import com.azure.resourcemanager.storage.models.StorageAccounts;
-import org.junit.jupiter.api.BeforeEach;
+
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("azure")
-public class GetAzureStorageStepTest extends BaseAzureTest {
-
-  private static final String STUB_STRING_RETURN = "stubbed-return";
-
-  @Mock private FlightContext mockFlightContext;
-  @Mock private CrlService mockCrlService;
-  @Mock private AzureConfiguration mockAzureConfig;
-  @Mock private AzureCloudContext mockAzureCloudContext;
-  @Mock private StorageManager mockStorageManager;
-  @Mock private ManagementException mockException;
-  @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
-  @Mock private StorageAccounts mockStorageAccounts;
-  @Mock private FlightMap mockWorkingMap;
-
-  @BeforeEach
-  public void setup() {
-    when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(STUB_STRING_RETURN);
-    when(mockCrlService.getStorageManager(mockAzureCloudContext, mockAzureConfig))
-        .thenReturn(mockStorageManager);
-
-    when(mockStorageManager.storageAccounts()).thenReturn(mockStorageAccounts);
-
-    when(mockException.getValue())
-        .thenReturn(new ManagementError("ResourceNotFound", "Resource was not found."));
-
-    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
-        .thenReturn(mockAzureCloudContext);
-  }
+public class GetAzureStorageStepTest extends BaseStorageStepTest {
 
   @Test
   public void getStorageAccount_doesNotExist() throws InterruptedException {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
@@ -18,50 +18,50 @@ import static org.mockito.Mockito.when;
 @ActiveProfiles("azure")
 public class GetAzureStorageStepTest extends BaseStorageStepTest {
 
-    @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
+  @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
 
-    @Test
-    public void getStorageAccount_doesNotExist() throws InterruptedException {
-        final ApiAzureStorageCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureStorageCreationParameters();
+  @Test
+  public void getStorageAccount_doesNotExist() throws InterruptedException {
+    final ApiAzureStorageCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureStorageCreationParameters();
 
-        GetAzureStorageStep getAzureStorageStep =
-                new GetAzureStorageStep(
-                        mockAzureConfig,
-                        mockCrlService,
-                        ControlledResourceFixtures.getAzureStorage(
-                                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
+    GetAzureStorageStep getAzureStorageStep =
+        new GetAzureStorageStep(
+            mockAzureConfig,
+            mockCrlService,
+            ControlledResourceFixtures.getAzureStorage(
+                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
 
-        when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
-        when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
-                .thenReturn(mockNameAvailabilityResult);
+    when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
+        .thenReturn(mockNameAvailabilityResult);
 
-        final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);
+    final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);
 
-        // Verify step returns success
-        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
-    }
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+  }
 
-    @Test
-    public void getStorageAccount_alreadyExists() throws InterruptedException {
-        final ApiAzureStorageCreationParameters creationParameters =
-                ControlledResourceFixtures.getAzureStorageCreationParameters();
+  @Test
+  public void getStorageAccount_alreadyExists() throws InterruptedException {
+    final ApiAzureStorageCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureStorageCreationParameters();
 
-        GetAzureStorageStep getAzureStorageStep =
-                new GetAzureStorageStep(
-                        mockAzureConfig,
-                        mockCrlService,
-                        ControlledResourceFixtures.getAzureStorage(
-                                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
+    GetAzureStorageStep getAzureStorageStep =
+        new GetAzureStorageStep(
+            mockAzureConfig,
+            mockCrlService,
+            ControlledResourceFixtures.getAzureStorage(
+                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
 
-        when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
-        when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
-                .thenReturn(mockNameAvailabilityResult);
+    when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
+        .thenReturn(mockNameAvailabilityResult);
 
-        final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);
+    final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);
 
-        // Verify step returns error
-        assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
-        assertThat(stepResult.getException().get(), instanceOf(DuplicateResourceException.class));
-    }
+    // Verify step returns error
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(DuplicateResourceException.class));
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
@@ -11,11 +11,16 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 
+import com.azure.resourcemanager.storage.models.CheckNameAvailabilityResult;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("azure")
 public class GetAzureStorageStepTest extends BaseStorageStepTest {
+
+  @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
+
 
   @Test
   public void getStorageAccount_doesNotExist() throws InterruptedException {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
@@ -32,10 +32,10 @@ public class GetAzureStorageStepTest extends BaseStorageStepTest {
             mockAzureConfig,
             mockCrlService,
             ControlledResourceFixtures.getAzureStorage(
-                creationParameters.getName(), creationParameters.getRegion()));
+                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
 
     when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
-    when(mockStorageAccounts.checkNameAvailability(creationParameters.getName()))
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
         .thenReturn(mockNameAvailabilityResult);
 
     final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);
@@ -54,10 +54,10 @@ public class GetAzureStorageStepTest extends BaseStorageStepTest {
             mockAzureConfig,
             mockCrlService,
             ControlledResourceFixtures.getAzureStorage(
-                creationParameters.getName(), creationParameters.getRegion()));
+                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
 
     when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
-    when(mockStorageAccounts.checkNameAvailability(creationParameters.getName()))
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
         .thenReturn(mockNameAvailabilityResult);
 
     final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
@@ -1,69 +1,67 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.storage;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.Mockito.when;
-
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureStorageCreationParameters;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
-
 import com.azure.resourcemanager.storage.models.CheckNameAvailabilityResult;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.when;
+
 @ActiveProfiles("azure")
 public class GetAzureStorageStepTest extends BaseStorageStepTest {
 
-  @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
+    @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;
 
+    @Test
+    public void getStorageAccount_doesNotExist() throws InterruptedException {
+        final ApiAzureStorageCreationParameters creationParameters =
+                ControlledResourceFixtures.getAzureStorageCreationParameters();
 
-  @Test
-  public void getStorageAccount_doesNotExist() throws InterruptedException {
-    final ApiAzureStorageCreationParameters creationParameters =
-        ControlledResourceFixtures.getAzureStorageCreationParameters();
+        GetAzureStorageStep getAzureStorageStep =
+                new GetAzureStorageStep(
+                        mockAzureConfig,
+                        mockCrlService,
+                        ControlledResourceFixtures.getAzureStorage(
+                                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
 
-    GetAzureStorageStep getAzureStorageStep =
-        new GetAzureStorageStep(
-            mockAzureConfig,
-            mockCrlService,
-            ControlledResourceFixtures.getAzureStorage(
-                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
+        when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
+        when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
+                .thenReturn(mockNameAvailabilityResult);
 
-    when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
-    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
-        .thenReturn(mockNameAvailabilityResult);
+        final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);
 
-    final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);
+        // Verify step returns success
+        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    }
 
-    // Verify step returns success
-    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
-  }
+    @Test
+    public void getStorageAccount_alreadyExists() throws InterruptedException {
+        final ApiAzureStorageCreationParameters creationParameters =
+                ControlledResourceFixtures.getAzureStorageCreationParameters();
 
-  @Test
-  public void getStorageAccount_alreadyExists() throws InterruptedException {
-    final ApiAzureStorageCreationParameters creationParameters =
-        ControlledResourceFixtures.getAzureStorageCreationParameters();
+        GetAzureStorageStep getAzureStorageStep =
+                new GetAzureStorageStep(
+                        mockAzureConfig,
+                        mockCrlService,
+                        ControlledResourceFixtures.getAzureStorage(
+                                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
 
-    GetAzureStorageStep getAzureStorageStep =
-        new GetAzureStorageStep(
-            mockAzureConfig,
-            mockCrlService,
-            ControlledResourceFixtures.getAzureStorage(
-                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
+        when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
+        when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
+                .thenReturn(mockNameAvailabilityResult);
 
-    when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
-    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
-        .thenReturn(mockNameAvailabilityResult);
+        final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);
 
-    final StepResult stepResult = getAzureStorageStep.doStep(mockFlightContext);
-
-    // Verify step returns error
-    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
-    assertThat(stepResult.getException().get(), instanceOf(DuplicateResourceException.class));
-  }
+        // Verify step returns error
+        assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+        assertThat(stepResult.getException().get(), instanceOf(DuplicateResourceException.class));
+    }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStepTest.java
@@ -1,0 +1,168 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import bio.terra.stairway.StepResult;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.generated.model.ApiAzureStorageContainerCreationParameters;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.BaseStorageStepTest;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.resourcemanager.data.CreateStorageContainerRequestData;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.management.exception.ManagementError;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.core.util.Context;
+import com.azure.resourcemanager.storage.fluent.models.ListContainerItemInner;
+import com.azure.resourcemanager.storage.models.BlobContainer;
+import com.azure.resourcemanager.storage.models.BlobContainers;
+import com.azure.resourcemanager.storage.models.PublicAccess;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("azure")
+public class CreateAzureStorageContainerStepTest extends BaseStorageStepTest {
+
+  @Mock private BlobContainers mockBlobContainers;
+  @Mock private BlobContainer.DefinitionStages.Blank mockBlankStage;
+  @Mock private BlobContainer.DefinitionStages.WithPublicAccess mockPublicAccessStage;
+  @Mock private BlobContainer.DefinitionStages.WithCreate mockCreateStage;
+  @Mock private BlobContainer mockStorageContainer;
+  @Mock private PagedIterable<ListContainerItemInner> mockListResult;
+  @Mock private ListContainerItemInner mockContainerResult;
+
+  private ApiAzureStorageContainerCreationParameters creationParameters;
+  private ManagementException resourceNotFoundException;
+  private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
+    creationParameters = ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+    resourceNotFoundException =
+            new ManagementException(
+                    "Resource was not found.",
+                    /*response=*/ null,
+                    new ManagementError("ResourceNotFound", "Resource was not found."));
+
+    // Creation stages mocks
+    when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
+    when(mockBlobContainers.defineContainer(anyString())).thenReturn(mockBlankStage);
+    when(mockBlankStage.withExistingStorageAccount(
+            STUB_STRING_RETURN, creationParameters.getStorageAccountName()
+    )).thenReturn(mockPublicAccessStage);
+    when(mockPublicAccessStage.withPublicAccess(PublicAccess.NONE))
+            .thenReturn(mockCreateStage);
+    when(mockCreateStage.withMetadata(anyString(), anyString())).thenReturn(mockCreateStage);
+    when(mockCreateStage.create(any(Context.class))).thenReturn(mockStorageContainer);
+  }
+
+  @Test
+  void createStorageContainer() throws InterruptedException {
+
+    CreateAzureStorageContainerStep createAzureStorageContainerStep = createCreateAzureStorageContainerStep();
+    StepResult stepResult = createAzureStorageContainerStep.doStep(mockFlightContext);
+
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+
+    // Verify Azure create call was made correctly
+    verify(mockCreateStage).create(contextCaptor.capture());
+    Context context = contextCaptor.getValue();
+
+    Optional<CreateStorageContainerRequestData> storageContainerRequestDataOpt =
+        context.getValues().values().stream()
+            .filter(CreateStorageContainerRequestData.class::isInstance)
+            .map(CreateStorageContainerRequestData.class::cast)
+            .findFirst();
+
+    CreateStorageContainerRequestData expected =
+        CreateStorageContainerRequestData.builder()
+            .setName(creationParameters.getName())
+            .setStorageAccountName(creationParameters.getStorageAccountName())
+            .setResourceGroupName(mockAzureCloudContext.getAzureResourceGroupId())
+            .build();
+
+    assertThat(storageContainerRequestDataOpt, equalTo(Optional.of(expected)));
+  }
+
+  private CreateAzureStorageContainerStep createCreateAzureStorageContainerStep() {
+
+    CreateAzureStorageContainerStep createAzureStorageContainerStep =
+            new CreateAzureStorageContainerStep(
+                    mockAzureConfig,
+                    mockCrlService,
+                    ControlledResourceFixtures.getAzureStorageContainer(
+                            creationParameters.getStorageAccountName(), creationParameters.getName()));
+    return createAzureStorageContainerStep;
+  }
+
+  @Test
+  public void createStorageContainer_failsToCreate() throws InterruptedException {
+    CreateAzureStorageContainerStep createAzureStorageContainerStep = createCreateAzureStorageContainerStep();
+    when(mockCreateStage.create(any(Context.class))).thenThrow(resourceNotFoundException);
+
+    StepResult stepResult = createAzureStorageContainerStep.doStep(mockFlightContext);
+
+    // Verify step fails...
+    assertThat(stepResult.isSuccess(), equalTo(false));
+  }
+
+  @Test
+  public void undoStep_doesNotDeleteStorageContainerIfStorageAccountDoesNotExist() throws InterruptedException {
+
+    CreateAzureStorageContainerStep createAzureStorageContainerStep = createCreateAzureStorageContainerStep();
+
+    // Storage account does not exist. If I add a check for this, I would need these mocks.
+//    when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
+//    when(mockStorageAccounts.checkNameAvailability(containerCreationParameters.getStorageAccountName()))
+//        .thenReturn(mockNameAvailabilityResult);
+    when(mockBlobContainers.list(mockAzureCloudContext.getAzureResourceGroupId(),
+            creationParameters.getStorageAccountName()))
+            .thenReturn(mockListResult);
+    when(mockListResult.iterator()).thenReturn(Collections.emptyIterator());
+
+    StepResult stepResult = createAzureStorageContainerStep.undoStep(mockFlightContext);
+
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+
+    // Verify delete operation is not called.
+    verify(mockBlobContainers, times(0)).delete(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            creationParameters.getStorageAccountName(),
+            creationParameters.getName()
+    );
+  }
+
+  @Test
+  public void undoStep_deletesStorageIfStorageAccountExists() throws InterruptedException {
+
+    CreateAzureStorageContainerStep createAzureStorageContainerStep = createCreateAzureStorageContainerStep();
+
+    when(mockBlobContainers.list(mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName()))
+            .thenReturn(mockListResult);
+    when(mockListResult.iterator()).thenReturn(Collections.singletonList(mockContainerResult).iterator());
+    when(mockContainerResult.name()).thenReturn(creationParameters.getName());
+
+    StepResult stepResult = createAzureStorageContainerStep.undoStep(mockFlightContext);
+
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+
+    // Verify delete operation is called.
+    verify(mockBlobContainers).delete(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            creationParameters.getStorageAccountName(),
+            creationParameters.getName()
+      );
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStepTest.java
@@ -29,163 +29,178 @@ import static org.mockito.Mockito.*;
 @ActiveProfiles("azure")
 public class CreateAzureStorageContainerStepTest extends BaseStorageStepTest {
 
-    @Mock private BlobContainers mockBlobContainers;
-    @Mock private BlobContainer mockBlobContainer;
-    @Mock private BlobContainer.DefinitionStages.Blank mockBlankStage;
-    @Mock private BlobContainer.DefinitionStages.WithPublicAccess mockPublicAccessStage;
-    @Mock private BlobContainer.DefinitionStages.WithCreate mockCreateStage;
-    @Mock private BlobContainer mockStorageContainer;
+  @Mock private BlobContainers mockBlobContainers;
+  @Mock private BlobContainer mockBlobContainer;
+  @Mock private BlobContainer.DefinitionStages.Blank mockBlankStage;
+  @Mock private BlobContainer.DefinitionStages.WithPublicAccess mockPublicAccessStage;
+  @Mock private BlobContainer.DefinitionStages.WithCreate mockCreateStage;
+  @Mock private BlobContainer mockStorageContainer;
 
-    final private String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
-    final ApiAzureStorageContainerCreationParameters creationParameters =
-            ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
-    final private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
-    final private ManagementException containerNotFoundException =
-            new ManagementException(
-                    "Resource was not found.",
-                    /*response=*/ null,
-                    new ManagementError("ContainerNotFound", "Container was not found."));
+  private final String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
+  final ApiAzureStorageContainerCreationParameters creationParameters =
+      ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+  private final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+  private final ManagementException containerNotFoundException =
+      new ManagementException(
+          "Resource was not found.",
+          /*response=*/ null,
+          new ManagementError("ContainerNotFound", "Container was not found."));
 
-    @BeforeEach
-    public void setup() {
-        super.setup();
+  @BeforeEach
+  public void setup() {
+    super.setup();
 
-        // Creation stages mocks
-        when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
-        when(mockBlobContainers.defineContainer(anyString())).thenReturn(mockBlankStage);
-        when(mockBlankStage.withExistingStorageAccount(
-                STUB_STRING_RETURN, storageAccountName
-        )).thenReturn(mockPublicAccessStage);
-        when(mockPublicAccessStage.withPublicAccess(PublicAccess.NONE))
-                .thenReturn(mockCreateStage);
-        when(mockCreateStage.withMetadata(anyString(), anyString())).thenReturn(mockCreateStage);
-        when(mockCreateStage.create(any(Context.class))).thenReturn(mockStorageContainer);
-    }
+    // Creation stages mocks
+    when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
+    when(mockBlobContainers.defineContainer(anyString())).thenReturn(mockBlankStage);
+    when(mockBlankStage.withExistingStorageAccount(STUB_STRING_RETURN, storageAccountName))
+        .thenReturn(mockPublicAccessStage);
+    when(mockPublicAccessStage.withPublicAccess(PublicAccess.NONE)).thenReturn(mockCreateStage);
+    when(mockCreateStage.withMetadata(anyString(), anyString())).thenReturn(mockCreateStage);
+    when(mockCreateStage.create(any(Context.class))).thenReturn(mockStorageContainer);
+  }
 
-    @Test
-    void createStorageContainer() throws InterruptedException {
+  @Test
+  void createStorageContainer() throws InterruptedException {
 
-        CreateAzureStorageContainerStep createAzureStorageContainerStep = createCreateAzureStorageContainerStep();
-        StepResult stepResult = createAzureStorageContainerStep.doStep(mockFlightContext);
+    CreateAzureStorageContainerStep createAzureStorageContainerStep =
+        createCreateAzureStorageContainerStep();
+    StepResult stepResult = createAzureStorageContainerStep.doStep(mockFlightContext);
 
-        // Verify step returns success
-        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
 
-        // Verify Azure create call was made correctly
-        verify(mockCreateStage).create(contextCaptor.capture());
-        Context context = contextCaptor.getValue();
+    // Verify Azure create call was made correctly
+    verify(mockCreateStage).create(contextCaptor.capture());
+    Context context = contextCaptor.getValue();
 
-        Optional<CreateStorageContainerRequestData> storageContainerRequestDataOpt =
-                context.getValues().values().stream()
-                        .filter(CreateStorageContainerRequestData.class::isInstance)
-                        .map(CreateStorageContainerRequestData.class::cast)
-                        .findFirst();
+    Optional<CreateStorageContainerRequestData> storageContainerRequestDataOpt =
+        context.getValues().values().stream()
+            .filter(CreateStorageContainerRequestData.class::isInstance)
+            .map(CreateStorageContainerRequestData.class::cast)
+            .findFirst();
 
-        CreateStorageContainerRequestData expected =
-                CreateStorageContainerRequestData.builder()
-                        .setStorageContainerName(creationParameters.getStorageContainerName())
-                        .setStorageAccountId(creationParameters.getStorageAccountId())
-                        .setResourceGroupName(mockAzureCloudContext.getAzureResourceGroupId())
-                        .build();
+    CreateStorageContainerRequestData expected =
+        CreateStorageContainerRequestData.builder()
+            .setStorageContainerName(creationParameters.getStorageContainerName())
+            .setStorageAccountId(creationParameters.getStorageAccountId())
+            .setResourceGroupName(mockAzureCloudContext.getAzureResourceGroupId())
+            .build();
 
-        assertThat(storageContainerRequestDataOpt, equalTo(Optional.of(expected)));
-    }
+    assertThat(storageContainerRequestDataOpt, equalTo(Optional.of(expected)));
+  }
 
-    private CreateAzureStorageContainerStep createCreateAzureStorageContainerStep() {
-        when(mockFlightContext.getWorkingMap().get(
-                WorkspaceFlightMapKeys.ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class)
-        ).thenReturn(storageAccountName);
+  private CreateAzureStorageContainerStep createCreateAzureStorageContainerStep() {
+    when(mockFlightContext
+            .getWorkingMap()
+            .get(WorkspaceFlightMapKeys.ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class))
+        .thenReturn(storageAccountName);
 
-        CreateAzureStorageContainerStep createAzureStorageContainerStep =
-                new CreateAzureStorageContainerStep(
-                        mockAzureConfig,
-                        mockCrlService,
-                        ControlledResourceFixtures.getAzureStorageContainer(
-                                creationParameters.getStorageAccountId(), creationParameters.getStorageContainerName()));
-        return createAzureStorageContainerStep;
-    }
+    CreateAzureStorageContainerStep createAzureStorageContainerStep =
+        new CreateAzureStorageContainerStep(
+            mockAzureConfig,
+            mockCrlService,
+            ControlledResourceFixtures.getAzureStorageContainer(
+                creationParameters.getStorageAccountId(),
+                creationParameters.getStorageContainerName()));
+    return createAzureStorageContainerStep;
+  }
 
+  @Test
+  public void createStorageContainer_failsToCreate() throws InterruptedException {
+    CreateAzureStorageContainerStep createAzureStorageContainerStep =
+        createCreateAzureStorageContainerStep();
+    when(mockCreateStage.create(any(Context.class))).thenThrow(resourceNotFoundException);
 
-    @Test
-    public void createStorageContainer_failsToCreate() throws InterruptedException {
-        CreateAzureStorageContainerStep createAzureStorageContainerStep = createCreateAzureStorageContainerStep();
-        when(mockCreateStage.create(any(Context.class))).thenThrow(resourceNotFoundException);
+    StepResult stepResult = createAzureStorageContainerStep.doStep(mockFlightContext);
 
-        StepResult stepResult = createAzureStorageContainerStep.doStep(mockFlightContext);
+    // Verify step fails...
+    assertThat(stepResult.isSuccess(), equalTo(false));
+  }
 
-        // Verify step fails...
-        assertThat(stepResult.isSuccess(), equalTo(false));
-    }
+  @Test
+  public void undoStep_doesNotDeleteStorageContainerIfStorageAccountDoesNotExist()
+      throws InterruptedException {
 
-    @Test
-    public void undoStep_doesNotDeleteStorageContainerIfStorageAccountDoesNotExist() throws InterruptedException {
+    CreateAzureStorageContainerStep createAzureStorageContainerStep =
+        createCreateAzureStorageContainerStep();
 
-        CreateAzureStorageContainerStep createAzureStorageContainerStep = createCreateAzureStorageContainerStep();
+    // Storage account does not exist. We do not try to delete the container in this case.
+    when(mockStorageAccounts.getByResourceGroup(
+            mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName))
+        .thenThrow(resourceNotFoundException);
 
-        // Storage account does not exist. We do not try to delete the container in this case.
-        when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
-                storageAccountName)).thenThrow(resourceNotFoundException);
+    StepResult stepResult = createAzureStorageContainerStep.undoStep(mockFlightContext);
 
-        StepResult stepResult = createAzureStorageContainerStep.undoStep(mockFlightContext);
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
 
-        // Verify step returns success
-        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    // Verify delete operation is not called.
+    verify(mockBlobContainers, times(0))
+        .delete(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            storageAccountName,
+            creationParameters.getStorageContainerName());
+  }
 
-        // Verify delete operation is not called.
-        verify(mockBlobContainers, times(0)).delete(
-                mockAzureCloudContext.getAzureResourceGroupId(),
-                storageAccountName,
-                creationParameters.getStorageContainerName()
-        );
-    }
+  @Test
+  public void undoStep_doesNotDeleteStorageContainerIfStorageContainerDoesNotExist()
+      throws InterruptedException {
 
-    @Test
-    public void undoStep_doesNotDeleteStorageContainerIfStorageContainerDoesNotExist() throws InterruptedException {
+    CreateAzureStorageContainerStep createAzureStorageContainerStep =
+        createCreateAzureStorageContainerStep();
 
-        CreateAzureStorageContainerStep createAzureStorageContainerStep = createCreateAzureStorageContainerStep();
+    // Storage account does exist.
+    when(mockStorageAccounts.getByResourceGroup(
+            mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName))
+        .thenReturn(mockStorageAccount);
 
-        // Storage account does exist.
-        when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
-                storageAccountName)).thenReturn(mockStorageAccount);
+    // Storage container does not exist. We do not try to delete the container in this case.
+    when(mockBlobContainers.get(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            storageAccountName,
+            creationParameters.getStorageContainerName()))
+        .thenThrow(containerNotFoundException);
 
-        // Storage container does not exist. We do not try to delete the container in this case.
-        when(mockBlobContainers.get(mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName,
-                creationParameters.getStorageContainerName())).thenThrow(containerNotFoundException);
+    StepResult stepResult = createAzureStorageContainerStep.undoStep(mockFlightContext);
 
-        StepResult stepResult = createAzureStorageContainerStep.undoStep(mockFlightContext);
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
 
-        // Verify step returns success
-        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    // Verify delete operation is not called.
+    verify(mockBlobContainers, times(0))
+        .delete(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            storageAccountName,
+            creationParameters.getStorageContainerName());
+  }
 
-        // Verify delete operation is not called.
-        verify(mockBlobContainers, times(0)).delete(
-                mockAzureCloudContext.getAzureResourceGroupId(),
-                storageAccountName,
-                creationParameters.getStorageContainerName()
-        );
-    }
+  @Test
+  public void undoStep_deletesStorageIfStorageAccountExists() throws InterruptedException {
 
-    @Test
-    public void undoStep_deletesStorageIfStorageAccountExists() throws InterruptedException {
+    CreateAzureStorageContainerStep createAzureStorageContainerStep =
+        createCreateAzureStorageContainerStep();
 
-        CreateAzureStorageContainerStep createAzureStorageContainerStep = createCreateAzureStorageContainerStep();
+    // Storage account and container exist.
+    when(mockStorageAccounts.getByResourceGroup(
+            mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName))
+        .thenReturn(mockStorageAccount);
+    when(mockBlobContainers.get(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            storageAccountName,
+            creationParameters.getStorageContainerName()))
+        .thenReturn(mockBlobContainer);
 
-        // Storage account and container exist.
-        when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
-                storageAccountName)).thenReturn(mockStorageAccount);
-        when(mockBlobContainers.get(mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName,
-                creationParameters.getStorageContainerName())).thenReturn(mockBlobContainer);
+    StepResult stepResult = createAzureStorageContainerStep.undoStep(mockFlightContext);
 
-        StepResult stepResult = createAzureStorageContainerStep.undoStep(mockFlightContext);
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
 
-        // Verify step returns success
-        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
-
-        // Verify delete operation is called.
-        verify(mockBlobContainers).delete(
-                mockAzureCloudContext.getAzureResourceGroupId(),
-                storageAccountName,
-                creationParameters.getStorageContainerName()
-        );
-    }
+    // Verify delete operation is called.
+    verify(mockBlobContainers)
+        .delete(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            storageAccountName,
+            creationParameters.getStorageContainerName());
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStepTest.java
@@ -1,0 +1,120 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.generated.model.ApiAzureStorageContainerCreationParameters;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.BaseStorageStepTest;
+import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.resourcemanager.storage.fluent.models.ListContainerItemInner;
+import com.azure.resourcemanager.storage.models.BlobContainers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("azure")
+public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
+
+  @Mock private BlobContainers mockBlobContainers;
+  @Mock private PagedIterable<ListContainerItemInner> mockListResult;
+  @Mock private ListContainerItemInner mockContainerResult;
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
+    when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
+  }
+
+  @Test
+  public void getStorageContainer_containerDoesNotExist() throws InterruptedException {
+    final ApiAzureStorageContainerCreationParameters creationParameters =
+        ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+
+    GetAzureStorageContainerStep getAzureStorageContainerStep =
+        new GetAzureStorageContainerStep(
+            mockAzureConfig,
+            mockCrlService,
+            ControlledResourceFixtures.getAzureStorageContainer(
+                creationParameters.getStorageAccountName(), creationParameters.getName()));
+
+    // In order to be able to create a storage container, a storage account with the name must already exist
+    // (so availability of the name is false because it is in use).
+    when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
+        .thenReturn(mockNameAvailabilityResult);
+
+    // The storage container must not already exist.
+    when(mockBlobContainers.list(mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName()))
+            .thenReturn(mockListResult);
+    when(mockListResult.iterator()).thenReturn(Collections.emptyIterator());
+
+    final StepResult stepResult = getAzureStorageContainerStep.doStep(mockFlightContext);
+
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+  }
+
+  @Test
+  public void getStorageAccountContainer_storageAccountDoesNotExist() throws InterruptedException {
+    final ApiAzureStorageContainerCreationParameters creationParameters =
+            ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+
+    GetAzureStorageContainerStep getAzureStorageContainerStep =
+            new GetAzureStorageContainerStep(
+                    mockAzureConfig,
+                    mockCrlService,
+                    ControlledResourceFixtures.getAzureStorageContainer(
+                            creationParameters.getStorageAccountName(), creationParameters.getName()));
+
+    when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
+        .thenReturn(mockNameAvailabilityResult);
+
+    final StepResult stepResult = getAzureStorageContainerStep.doStep(mockFlightContext);
+
+    // Verify step returns error because storage account does not exist.
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(ResourceNotFoundException.class));
+  }
+
+  @Test
+  public void getStorageContainer_containerAlreadyExists() throws InterruptedException {
+    final ApiAzureStorageContainerCreationParameters creationParameters =
+            ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+
+    GetAzureStorageContainerStep getAzureStorageContainerStep =
+            new GetAzureStorageContainerStep(
+                    mockAzureConfig,
+                    mockCrlService,
+                    ControlledResourceFixtures.getAzureStorageContainer(
+                            creationParameters.getStorageAccountName(), creationParameters.getName()));
+
+    // In order to be able to create a storage container, a storage account with the name must already exist
+    // (so availability of the name is false because it is in use).
+    when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
+    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
+            .thenReturn(mockNameAvailabilityResult);
+
+    // A storage container with this name already exists.
+    when(mockBlobContainers.list(mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName()))
+            .thenReturn(mockListResult);
+    when(mockListResult.iterator()).thenReturn(Collections.singletonList(mockContainerResult).iterator());
+    when(mockContainerResult.name()).thenReturn(creationParameters.getName());
+
+    final StepResult stepResult = getAzureStorageContainerStep.doStep(mockFlightContext);
+
+    // Verify step fails.
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(DuplicateResourceException.class));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStepTest.java
@@ -47,11 +47,9 @@ public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
             ControlledResourceFixtures.getAzureStorageContainer(
                 creationParameters.getStorageAccountName(), creationParameters.getName()));
 
-    // In order to be able to create a storage container, a storage account with the name must already exist
-    // (so availability of the name is false because it is in use).
-    when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
-    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
-        .thenReturn(mockNameAvailabilityResult);
+    // Storage account exists.
+    when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
+            creationParameters.getStorageAccountName())).thenReturn(mockStorageAccount);
 
     // The storage container must not already exist.
     when(mockBlobContainers.list(mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName()))

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/GetAzureStorageContainerStepTest.java
@@ -76,9 +76,9 @@ public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
                     ControlledResourceFixtures.getAzureStorageContainer(
                             creationParameters.getStorageAccountName(), creationParameters.getName()));
 
-    when(mockNameAvailabilityResult.isAvailable()).thenReturn(true);
-    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
-        .thenReturn(mockNameAvailabilityResult);
+    // Storage account doesn't exist.
+    when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
+            creationParameters.getStorageAccountName())).thenThrow(resourceNotFoundException);
 
     final StepResult stepResult = getAzureStorageContainerStep.doStep(mockFlightContext);
 
@@ -99,11 +99,9 @@ public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
                     ControlledResourceFixtures.getAzureStorageContainer(
                             creationParameters.getStorageAccountName(), creationParameters.getName()));
 
-    // In order to be able to create a storage container, a storage account with the name must already exist
-    // (so availability of the name is false because it is in use).
-    when(mockNameAvailabilityResult.isAvailable()).thenReturn(false);
-    when(mockStorageAccounts.checkNameAvailability(creationParameters.getStorageAccountName()))
-            .thenReturn(mockNameAvailabilityResult);
+    // Storage account exists.
+    when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
+            creationParameters.getStorageAccountName())).thenReturn(mockStorageAccount);
 
     // A storage container with this name already exists.
     when(mockBlobContainers.list(mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName()))

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
@@ -27,100 +27,115 @@ import static org.mockito.Mockito.when;
 @ActiveProfiles("azure")
 public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorageStepTest {
 
-    @Mock private BlobContainers mockBlobContainers;
-    @Mock private BlobContainer mockBlobContainer;
-    @Mock private ResourceDao mockResourceDao;
+  @Mock private BlobContainers mockBlobContainers;
+  @Mock private BlobContainer mockBlobContainer;
+  @Mock private ResourceDao mockResourceDao;
 
-    final private String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
-    final ApiAzureStorageContainerCreationParameters creationParameters =
-            ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
-    final ControlledAzureStorageContainerResource storageContainerResource = ControlledResourceFixtures.getAzureStorageContainer(
-            creationParameters.getStorageAccountId(), creationParameters.getStorageContainerName());
-    final private ControlledAzureStorageResource storageAccountResource = ControlledResourceFixtures.getAzureStorage(
-            storageAccountName, "mockRegion");
-    final private ManagementException containerNotFoundException =
-            new ManagementException(
-                    "Resource was not found.",
-                    /*response=*/ null,
-                    new ManagementError("ContainerNotFound", "Container was not found."));
+  private final String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
+  final ApiAzureStorageContainerCreationParameters creationParameters =
+      ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+  final ControlledAzureStorageContainerResource storageContainerResource =
+      ControlledResourceFixtures.getAzureStorageContainer(
+          creationParameters.getStorageAccountId(), creationParameters.getStorageContainerName());
+  private final ControlledAzureStorageResource storageAccountResource =
+      ControlledResourceFixtures.getAzureStorage(storageAccountName, "mockRegion");
+  private final ManagementException containerNotFoundException =
+      new ManagementException(
+          "Resource was not found.",
+          /*response=*/ null,
+          new ManagementError("ContainerNotFound", "Container was not found."));
 
-    private VerifyAzureStorageContainerCanBeCreatedStep verifyCanBeCreatedStep;
+  private VerifyAzureStorageContainerCanBeCreatedStep verifyCanBeCreatedStep;
 
-    @BeforeEach
-    public void setup() {
-        super.setup();
-        when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
-        verifyCanBeCreatedStep = new VerifyAzureStorageContainerCanBeCreatedStep(
-                mockAzureConfig, mockCrlService, mockResourceDao, storageContainerResource);
-    }
+  @BeforeEach
+  public void setup() {
+    super.setup();
+    when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
+    verifyCanBeCreatedStep =
+        new VerifyAzureStorageContainerCanBeCreatedStep(
+            mockAzureConfig, mockCrlService, mockResourceDao, storageContainerResource);
+  }
 
-    private void mockStorageAccountExists() {
-        when(mockResourceDao.getResource(storageContainerResource.getWorkspaceId(),
-                creationParameters.getStorageAccountId())).thenReturn(storageAccountResource);
-        when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
-                storageAccountName)).thenReturn(mockStorageAccount);
-        when(mockFlightContext.getWorkingMap().get(
-                WorkspaceFlightMapKeys.ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class)
-        ).thenReturn(storageAccountName);
-    }
+  private void mockStorageAccountExists() {
+    when(mockResourceDao.getResource(
+            storageContainerResource.getWorkspaceId(), creationParameters.getStorageAccountId()))
+        .thenReturn(storageAccountResource);
+    when(mockStorageAccounts.getByResourceGroup(
+            mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName))
+        .thenReturn(mockStorageAccount);
+    when(mockFlightContext
+            .getWorkingMap()
+            .get(WorkspaceFlightMapKeys.ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class))
+        .thenReturn(storageAccountName);
+  }
 
-    @Test
-    public void getStorageContainer_containerCanBeCreated() throws InterruptedException {
-        mockStorageAccountExists();
+  @Test
+  public void getStorageContainer_containerCanBeCreated() throws InterruptedException {
+    mockStorageAccountExists();
 
-        // The storage container must not already exist.
-        when(mockBlobContainers.get(mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName,
-                creationParameters.getStorageContainerName())).thenThrow(containerNotFoundException);
+    // The storage container must not already exist.
+    when(mockBlobContainers.get(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            storageAccountName,
+            creationParameters.getStorageContainerName()))
+        .thenThrow(containerNotFoundException);
 
-        final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
 
-        // Verify step returns success
-        assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
-    }
+    // Verify step returns success
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+  }
 
-    @Test
-    public void getStorageAccountContainer_storageAccountDoesNotExistInWSM() throws InterruptedException {
-        // Storage account doesn't exist in WSM
-        when(mockResourceDao.getResource(
-                storageContainerResource.getWorkspaceId(), creationParameters.getStorageAccountId())).thenThrow(
-                new ResourceNotFoundException("Not Found"));
+  @Test
+  public void getStorageAccountContainer_storageAccountDoesNotExistInWSM()
+      throws InterruptedException {
+    // Storage account doesn't exist in WSM
+    when(mockResourceDao.getResource(
+            storageContainerResource.getWorkspaceId(), creationParameters.getStorageAccountId()))
+        .thenThrow(new ResourceNotFoundException("Not Found"));
 
-        final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
 
-        // Verify step returns error because storage account does not exist.
-        assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
-        assertThat(stepResult.getException().get(), instanceOf(ResourceNotFoundException.class));
-    }
+    // Verify step returns error because storage account does not exist.
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(ResourceNotFoundException.class));
+  }
 
-    @Test
-    public void getStorageAccountContainer_storageAccountDoesNotExistInAzure() throws InterruptedException {
-        // Storage account exists in WSM.
-        when(mockResourceDao.getResource(storageContainerResource.getWorkspaceId(),
-                creationParameters.getStorageAccountId())).thenReturn(storageAccountResource);
+  @Test
+  public void getStorageAccountContainer_storageAccountDoesNotExistInAzure()
+      throws InterruptedException {
+    // Storage account exists in WSM.
+    when(mockResourceDao.getResource(
+            storageContainerResource.getWorkspaceId(), creationParameters.getStorageAccountId()))
+        .thenReturn(storageAccountResource);
 
-        // Storage account doesn't exist in Azure
-        when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
-                storageAccountName)).thenThrow(resourceNotFoundException);
+    // Storage account doesn't exist in Azure
+    when(mockStorageAccounts.getByResourceGroup(
+            mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName))
+        .thenThrow(resourceNotFoundException);
 
-        final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
 
-        // Verify step returns error because storage account does not exist.
-        assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
-        assertThat(stepResult.getException().get(), instanceOf(ResourceNotFoundException.class));
-    }
+    // Verify step returns error because storage account does not exist.
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(ResourceNotFoundException.class));
+  }
 
-    @Test
-    public void getStorageContainer_containerAlreadyExists() throws InterruptedException {
-        mockStorageAccountExists();
+  @Test
+  public void getStorageContainer_containerAlreadyExists() throws InterruptedException {
+    mockStorageAccountExists();
 
-        // A storage container with this name already exists.
-        when(mockBlobContainers.get(mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName,
-                creationParameters.getStorageContainerName())).thenReturn(mockBlobContainer);
+    // A storage container with this name already exists.
+    when(mockBlobContainers.get(
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            storageAccountName,
+            creationParameters.getStorageContainerName()))
+        .thenReturn(mockBlobContainer);
 
-        final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
 
-        // Verify step fails.
-        assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
-        assertThat(stepResult.getException().get(), instanceOf(DuplicateResourceException.class));
-    }
+    // Verify step fails.
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(DuplicateResourceException.class));
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("azure")
-public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
+public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorageStepTest {
 
   @Mock private BlobContainers mockBlobContainers;
   @Mock private PagedIterable<ListContainerItemInner> mockListResult;
@@ -40,8 +40,8 @@ public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
     final ApiAzureStorageContainerCreationParameters creationParameters =
         ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
 
-    GetAzureStorageContainerStep getAzureStorageContainerStep =
-        new GetAzureStorageContainerStep(
+    VerifyAzureStorageContainerCanBeCreatedStep verifyAzureStorageContainerCanBeCreatedStep =
+        new VerifyAzureStorageContainerCanBeCreatedStep(
             mockAzureConfig,
             mockCrlService,
             ControlledResourceFixtures.getAzureStorageContainer(
@@ -56,7 +56,7 @@ public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
             .thenReturn(mockListResult);
     when(mockListResult.iterator()).thenReturn(Collections.emptyIterator());
 
-    final StepResult stepResult = getAzureStorageContainerStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyAzureStorageContainerCanBeCreatedStep.doStep(mockFlightContext);
 
     // Verify step returns success
     assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
@@ -67,8 +67,8 @@ public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
     final ApiAzureStorageContainerCreationParameters creationParameters =
             ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
 
-    GetAzureStorageContainerStep getAzureStorageContainerStep =
-            new GetAzureStorageContainerStep(
+    VerifyAzureStorageContainerCanBeCreatedStep verifyAzureStorageContainerCanBeCreatedStep =
+            new VerifyAzureStorageContainerCanBeCreatedStep(
                     mockAzureConfig,
                     mockCrlService,
                     ControlledResourceFixtures.getAzureStorageContainer(
@@ -78,7 +78,7 @@ public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
     when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
             creationParameters.getStorageAccountName())).thenThrow(resourceNotFoundException);
 
-    final StepResult stepResult = getAzureStorageContainerStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyAzureStorageContainerCanBeCreatedStep.doStep(mockFlightContext);
 
     // Verify step returns error because storage account does not exist.
     assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
@@ -90,8 +90,8 @@ public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
     final ApiAzureStorageContainerCreationParameters creationParameters =
             ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
 
-    GetAzureStorageContainerStep getAzureStorageContainerStep =
-            new GetAzureStorageContainerStep(
+    VerifyAzureStorageContainerCanBeCreatedStep verifyAzureStorageContainerCanBeCreatedStep =
+            new VerifyAzureStorageContainerCanBeCreatedStep(
                     mockAzureConfig,
                     mockCrlService,
                     ControlledResourceFixtures.getAzureStorageContainer(
@@ -107,7 +107,7 @@ public class GetAzureStorageContainerStepTest extends BaseStorageStepTest {
     when(mockListResult.iterator()).thenReturn(Collections.singletonList(mockContainerResult).iterator());
     when(mockContainerResult.name()).thenReturn(creationParameters.getName());
 
-    final StepResult stepResult = getAzureStorageContainerStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyAzureStorageContainerCanBeCreatedStep.doStep(mockFlightContext);
 
     // Verify step fails.
     assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
@@ -3,19 +3,21 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.storageConta
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.generated.model.ApiAzureStorageContainerCreationParameters;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.BaseStorageStepTest;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
-import com.azure.core.http.rest.PagedIterable;
-import com.azure.resourcemanager.storage.fluent.models.ListContainerItemInner;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import com.azure.core.management.exception.ManagementError;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.storage.models.BlobContainer;
 import com.azure.resourcemanager.storage.models.BlobContainers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -26,59 +28,81 @@ import static org.mockito.Mockito.when;
 public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorageStepTest {
 
   @Mock private BlobContainers mockBlobContainers;
-  @Mock private PagedIterable<ListContainerItemInner> mockListResult;
-  @Mock private ListContainerItemInner mockContainerResult;
+  @Mock private BlobContainer mockBlobContainer;
+  @Mock private ResourceDao mockResourceDao;
+
+  final private String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
+  final ApiAzureStorageContainerCreationParameters creationParameters =
+          ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+  final ControlledAzureStorageContainerResource storageContainerResource = ControlledResourceFixtures.getAzureStorageContainer(
+          creationParameters.getStorageAccountId(), creationParameters.getStorageContainerName());
+  final private ControlledAzureStorageResource storageAccountResource = ControlledResourceFixtures.getAzureStorage(
+          storageAccountName, "mockRegion");
+  final private ManagementException containerNotFoundException =
+          new ManagementException(
+                  "Resource was not found.",
+                  /*response=*/ null,
+                  new ManagementError("ContainerNotFound", "Container was not found."));
+
+  private VerifyAzureStorageContainerCanBeCreatedStep verifyCanBeCreatedStep;
 
   @BeforeEach
   public void setup() {
     super.setup();
     when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
+    verifyCanBeCreatedStep = new VerifyAzureStorageContainerCanBeCreatedStep(
+            mockAzureConfig, mockCrlService, mockResourceDao, storageContainerResource);
+  }
+
+  private void mockStorageAccountExists() {
+    when(mockResourceDao.getResource(storageContainerResource.getWorkspaceId(),
+            creationParameters.getStorageAccountId())).thenReturn(storageAccountResource);
+    when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
+            storageAccountName)).thenReturn(mockStorageAccount);
+    when(mockFlightContext.getWorkingMap().get(
+            WorkspaceFlightMapKeys.ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class)
+    ).thenReturn(storageAccountName);
   }
 
   @Test
-  public void getStorageContainer_containerDoesNotExist() throws InterruptedException {
-    final ApiAzureStorageContainerCreationParameters creationParameters =
-        ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
-
-    VerifyAzureStorageContainerCanBeCreatedStep verifyAzureStorageContainerCanBeCreatedStep =
-        new VerifyAzureStorageContainerCanBeCreatedStep(
-            mockAzureConfig,
-            mockCrlService,
-            ControlledResourceFixtures.getAzureStorageContainer(
-                creationParameters.getStorageAccountName(), creationParameters.getName()));
-
-    // Storage account exists.
-    when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
-            creationParameters.getStorageAccountName())).thenReturn(mockStorageAccount);
+  public void getStorageContainer_containerCanBeCreated() throws InterruptedException {
+    mockStorageAccountExists();
 
     // The storage container must not already exist.
-    when(mockBlobContainers.list(mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName()))
-            .thenReturn(mockListResult);
-    when(mockListResult.iterator()).thenReturn(Collections.emptyIterator());
+    when(mockBlobContainers.get(mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName,
+            creationParameters.getStorageContainerName())).thenThrow(containerNotFoundException);
 
-    final StepResult stepResult = verifyAzureStorageContainerCanBeCreatedStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
 
     // Verify step returns success
     assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
   }
 
   @Test
-  public void getStorageAccountContainer_storageAccountDoesNotExist() throws InterruptedException {
-    final ApiAzureStorageContainerCreationParameters creationParameters =
-            ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+  public void getStorageAccountContainer_storageAccountDoesNotExistInWSM() throws InterruptedException {
+    // Storage account doesn't exist in WSM
+    when(mockResourceDao.getResource(
+            storageContainerResource.getWorkspaceId(), creationParameters.getStorageAccountId())).thenThrow(
+                    new ResourceNotFoundException("Not Found"));
 
-    VerifyAzureStorageContainerCanBeCreatedStep verifyAzureStorageContainerCanBeCreatedStep =
-            new VerifyAzureStorageContainerCanBeCreatedStep(
-                    mockAzureConfig,
-                    mockCrlService,
-                    ControlledResourceFixtures.getAzureStorageContainer(
-                            creationParameters.getStorageAccountName(), creationParameters.getName()));
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
 
-    // Storage account doesn't exist.
+    // Verify step returns error because storage account does not exist.
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(ResourceNotFoundException.class));
+  }
+
+  @Test
+  public void getStorageAccountContainer_storageAccountDoesNotExistInAzure() throws InterruptedException {
+    // Storage account exists in WSM.
+    when(mockResourceDao.getResource(storageContainerResource.getWorkspaceId(),
+            creationParameters.getStorageAccountId())).thenReturn(storageAccountResource);
+
+    // Storage account doesn't exist in Azure
     when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
-            creationParameters.getStorageAccountName())).thenThrow(resourceNotFoundException);
+            storageAccountName)).thenThrow(resourceNotFoundException);
 
-    final StepResult stepResult = verifyAzureStorageContainerCanBeCreatedStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
 
     // Verify step returns error because storage account does not exist.
     assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
@@ -87,27 +111,13 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
 
   @Test
   public void getStorageContainer_containerAlreadyExists() throws InterruptedException {
-    final ApiAzureStorageContainerCreationParameters creationParameters =
-            ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
-
-    VerifyAzureStorageContainerCanBeCreatedStep verifyAzureStorageContainerCanBeCreatedStep =
-            new VerifyAzureStorageContainerCanBeCreatedStep(
-                    mockAzureConfig,
-                    mockCrlService,
-                    ControlledResourceFixtures.getAzureStorageContainer(
-                            creationParameters.getStorageAccountName(), creationParameters.getName()));
-
-    // Storage account exists.
-    when(mockStorageAccounts.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(),
-            creationParameters.getStorageAccountName())).thenReturn(mockStorageAccount);
+    mockStorageAccountExists();
 
     // A storage container with this name already exists.
-    when(mockBlobContainers.list(mockAzureCloudContext.getAzureResourceGroupId(), creationParameters.getStorageAccountName()))
-            .thenReturn(mockListResult);
-    when(mockListResult.iterator()).thenReturn(Collections.singletonList(mockContainerResult).iterator());
-    when(mockContainerResult.name()).thenReturn(creationParameters.getName());
+    when(mockBlobContainers.get(mockAzureCloudContext.getAzureResourceGroupId(), storageAccountName,
+            creationParameters.getStorageContainerName())).thenReturn(mockBlobContainer);
 
-    final StepResult stepResult = verifyAzureStorageContainerCanBeCreatedStep.doStep(mockFlightContext);
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
 
     // Verify step fails.
     assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.storageConta
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.generated.model.ApiAzureStorageContainerCreationParameters;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.BaseStorageStepTest;
@@ -43,7 +44,7 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
       new ManagementException(
           "Resource was not found.",
           /*response=*/ null,
-          new ManagementError("ContainerNotFound", "Container was not found."));
+          new ManagementError(ManagementExceptionUtils.CONTAINER_NOT_FOUND, "Container was not found."));
 
   private VerifyAzureStorageContainerCanBeCreatedStep verifyCanBeCreatedStep;
 


### PR DESCRIPTION
This adds the ability to create and delete storage containers within a workspace's storage account. Note that deletion is not exposed through the Swagger API (this is true of storage accounts as well).

I have followed https://github.com/DataBiosphere/terra-workspace-manager/blob/main/ADDING_RESOURCES.md to the best of my ability, though I did not add an integration test. To the best of my knowledge, we do not have integration tests in WSM for Azure resources (storage accounts, relays, etc.).