### PR TITLE
[PF-1672] Fix broken RevokePetUsagePermissionStep undo

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -378,8 +378,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
         userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.READ);
     String userEmail =
         SamRethrow.onInterrupted(() -> samService.getUserEmailFromSam(userRequest), "enablePet");
-    petSaService.enablePetServiceAccountImpersonation(
-        workspaceUuid, userEmail, userRequest.getRequiredToken());
+    petSaService.enablePetServiceAccountImpersonation(workspaceUuid, userEmail, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -974,32 +974,6 @@ public class SamService {
   }
 
   /**
-   * Add WSM's service account as the owner of a controlled resource in Sam. Used for admin
-   * reassignment of resources. This assumes samService.initialize() has already been called, which
-   * should happen on start.
-   */
-  private void addWsmResourceOwnerPolicy(CreateResourceRequestV2 request)
-      throws InterruptedException {
-    try {
-      AuthenticatedUserRequest wsmRequest =
-          new AuthenticatedUserRequest().token(Optional.of(getWsmServiceAccountToken()));
-      String wsmSaEmail = getUserEmailFromSam(wsmRequest);
-      AccessPolicyMembershipV2 ownerPolicy =
-          new AccessPolicyMembershipV2()
-              .addRolesItem(ControlledResourceIamRole.OWNER.toSamRole())
-              .addMemberEmailsItem(wsmSaEmail);
-      request.putPoliciesItem(ControlledResourceIamRole.OWNER.toSamRole(), ownerPolicy);
-    } catch (InternalServerErrorException e) {
-      // In cases where WSM is not running as a service account (e.g. unit tests), the above call to
-      // get application default credentials will fail. This is fine, as those cases don't create
-      // real resources.
-      logger.warn(
-          "Failed to add WSM service account as resource owner Sam. This is expected for tests.",
-          e);
-    }
-  }
-
-  /**
    * Fetch the email of a user's pet service account in a given project. This request to Sam will
    * create the pet SA if it doesn't already exist.
    */

--- a/service/src/main/java/bio/terra/workspace/service/petserviceaccount/PetSaService.java
+++ b/service/src/main/java/bio/terra/workspace/service/petserviceaccount/PetSaService.java
@@ -80,7 +80,9 @@ public class PetSaService {
    *
    * @param workspaceUuid ID of the workspace to enable pet SA in
    * @param userToEnableEmail The user whose proxy group will be granted permission.
-   * @param userReq Auth info for calling SAM.
+   * @param userReq Auth info for calling SAM. Do not use userReq.getEmail() here; it will return
+   *     the caller's email, but there's no guarantee whether that will be an end-user email or a
+   *     pet SA email.
    * @param eTag GCP eTag which must match the pet SA's current policy. If null, this is ignored.
    * @return The new IAM policy on the user's pet service account, or empty if the eTag value
    *     provided is non-null and does not match current IAM policy on the pet SA.

--- a/service/src/main/java/bio/terra/workspace/service/petserviceaccount/PetSaService.java
+++ b/service/src/main/java/bio/terra/workspace/service/petserviceaccount/PetSaService.java
@@ -156,17 +156,13 @@ public class PetSaService {
       }
 
       SetIamPolicyRequest request = new SetIamPolicyRequest().setPolicy(saPolicy);
-      Optional<Policy> myPolicy =
-          Optional.of(
+      return Optional.of(
               crlService
                   .getIamCow()
                   .projects()
                   .serviceAccounts()
                   .setIamPolicy(petSaName, request)
                   .execute());
-      Policy getAfterSet =
-          crlService.getIamCow().projects().serviceAccounts().getIamPolicy(petSaName).execute();
-      return myPolicy;
     } catch (IOException e) {
       return handleProxyUpdateError(e, "enabling");
     }
@@ -244,22 +240,13 @@ public class PetSaService {
       }
       bindingToModify.get().getMembers().remove(targetMember);
       SetIamPolicyRequest request = new SetIamPolicyRequest().setPolicy(saPolicy);
-      Optional<Policy> myPolicy =
-          Optional.of(
+      return Optional.of(
               crlService
                   .getIamCow()
                   .projects()
                   .serviceAccounts()
                   .setIamPolicy(userToDisablePetSA.get(), request)
                   .execute());
-      Policy getAfterSet =
-          crlService
-              .getIamCow()
-              .projects()
-              .serviceAccounts()
-              .getIamPolicy(userToDisablePetSA.get())
-              .execute();
-      return myPolicy;
     } catch (IOException e) {
       return handleProxyUpdateError(e, "disabling");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/GrantPetUsagePermissionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/GrantPetUsagePermissionStep.java
@@ -55,8 +55,7 @@ public class GrantPetUsagePermissionStep implements Step {
     Policy modifiedPolicy;
     try {
       modifiedPolicy =
-          petSaService.enablePetServiceAccountImpersonation(
-              workspaceUuid, userEmail, userRequest.getRequiredToken());
+          petSaService.enablePetServiceAccountImpersonation(workspaceUuid, userEmail, userRequest);
     } catch (ConflictException e) {
       // There was a conflict enabling the service account. Request retry.
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RevokePetUsagePermissionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RevokePetUsagePermissionStep.java
@@ -87,7 +87,7 @@ public class RevokePetUsagePermissionStep implements Step {
       return StepResult.getStepResultSuccess();
     }
     petSaService.enablePetServiceAccountImpersonationWithEtag(
-        workspaceUuid, userEmailToRemove, userRequest.getRequiredToken(), expectedEtag);
+        workspaceUuid, userEmailToRemove, userRequest, expectedEtag);
     return StepResult.getStepResultSuccess();
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -114,7 +114,6 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
         buildPrivateDataset(workspaceUuid, datasetId, cloudContext.getGcpProjectId());
     assertNotNull(privateDataset);
 
-    // test
     // Allow the secondary user to impersonate their pet SA.
     petSaService.enablePetServiceAccountImpersonation(
         workspaceUuid,


### PR DESCRIPTION
(small bug I noticed while adding test coverage)

Currently, the undo step of RevokePetUsagePermissionStep tries to re-grant the same permission it revokes in the do step. However, when this flight is triggered by one user removing another from the workspace, this step’s undo fetches the caller's pet SA, not the removed user’s pet, which breaks the undo.

This bug could affect real users, but it’s difficult to trigger, as the RemoveUserFromWorkspace flight would need to fail on or after the second-to-last step. This functionality is also not available in any WSM environments above dev, so it's unlikely this has affected any real users yet. If it affected a real user, I think they could fix it by calling the enablePet endpoint, though it would be pretty hard for them to know to do that.