### PR TITLE
[PF-1690] Handle invalid http methods better

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.retry.backoff.BackOffInterruptedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -35,6 +36,7 @@ public class GlobalExceptionHandler {
     MethodArgumentNotValidException.class,
     MethodArgumentTypeMismatchException.class,
     HttpMessageNotReadableException.class,
+    HttpRequestMethodNotSupportedException.class,
     IllegalArgumentException.class,
     NoHandlerFoundException.class
   })


### PR DESCRIPTION
Currently WSM will respond with a 500 error (generated by the catchall error handler) if a user calls a valid endpoint with an invalid HTTP method (e.g. `DELETE /status`). I think a 400 is a more appropriate response here.