### PR TITLE
[PF-1701] Clone reference names and descriptions

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -633,6 +633,14 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
         StewardshipType.REFERENCED,
         bucketReferenceDetails.getStewardshipType(),
         "stewardship type preserved");
+    assertEquals(
+        sourceBucketReference.getMetadata().getName(),
+        bucketReferenceDetails.getName(),
+        "Resource name preserved");
+    assertEquals(
+        sourceBucketReference.getMetadata().getDescription(),
+        bucketReferenceDetails.getDescription(),
+        "Description preserved");
     assertNotNull(
         bucketReferenceDetails.getDestinationResourceId(), "destination resource ID populated");
     assertNull(bucketReferenceDetails.getErrorMessage(), "Error message omitted");

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateReferenceResourceFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateReferenceResourceFlightStep.java
@@ -54,12 +54,11 @@ public class LaunchCreateReferenceResourceFlightStep implements Step {
         context
             .getInputParameters()
             .get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
-    final String description =
-        String.format("Clone of Referenced Resource %s", resource.getResourceId());
 
     final ReferencedResource destinationResource =
         WorkspaceCloneUtils.buildDestinationReferencedResource(
-            resource, destinationWorkspaceId, null, description);
+            resource, destinationWorkspaceId, resource.getName(), resource.getDescription());
+
     // put the destination resource in the map, because it's not communicated
     // from the flight as the response (and we need the workspace ID)
     context


### PR DESCRIPTION
Previously I was overwriting the description with something like `Clone of referenced resource <id>`. This is a change to not do that.