### PR TITLE
fix missed spotless application

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -100,8 +100,7 @@ public class CloudSyncRoleMapping {
               "artifactregistry.repositories.getIamPolicy",
               "artifactregistry.repositories.setIamPolicy",
               "artifactregistry.repositories.update",
-              "cloudbuild.builds.approve"
-          )
+              "cloudbuild.builds.approve")
           .build();
 
   private static final CustomGcpIamRole PROJECT_READER =


### PR DESCRIPTION
In #676, it looks like an un-spotlessed change was pulled in during the final merge. Post-commit linter test [failed](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/2468989326) on this file. Fix is simply to run `spotlessApply` on head.