### PR TITLE
[PF-548] Pass request ID in header for RBS calls

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/buffer/BufferService.java
+++ b/service/src/main/java/bio/terra/workspace/service/buffer/BufferService.java
@@ -33,8 +33,11 @@ public class BufferService {
   }
 
   private ApiClient getApiClient(String accessToken) {
-    ApiClient client = new ApiClient().setHttpClient(commonHttpClient).addDefaultHeader(
-        RequestIdFilter.REQUEST_ID_HEADER, MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY));
+    ApiClient client =
+        new ApiClient()
+            .setHttpClient(commonHttpClient)
+            .addDefaultHeader(
+                RequestIdFilter.REQUEST_ID_HEADER, MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY));
     client.setAccessToken(accessToken);
     return client;
   }


### PR DESCRIPTION
This change adds the `X-Request-Id` header in calls from WSM to RBS. Both services use the common logging code from TCL, so when RBS receives a request with this header it will associate the request ID with logs for that request. This lets us track requests across services, which is great for debugging.