### PR TITLE
[PF-1476] Include destination resource ID on job enumerate object

### DIFF
--- a/openapi/src/parts/alpha1.yaml
+++ b/openapi/src/parts/alpha1.yaml
@@ -61,7 +61,8 @@ components:
           description: Data specific to the type of resource and whether it is controlled or not
           $ref: '#/components/schemas/ResourceAttributesUnion'
         destinationResourceId:
-          description: For resource clone operations, the ID of the destination resource.
+          description: |
+            For resource clone operations, the ID of the destination resource. Null otherwise.
           type: string
           format: uuid
 

--- a/openapi/src/parts/alpha1.yaml
+++ b/openapi/src/parts/alpha1.yaml
@@ -60,6 +60,10 @@ components:
         resourceAttributes:
           description: Data specific to the type of resource and whether it is controlled or not
           $ref: '#/components/schemas/ResourceAttributesUnion'
+        destinationResourceId:
+          description: For resource clone operations, the ID of the destination resource.
+          type: string
+          format: uuid
 
     EnumerateJobsResult:
       description: result of an enumerateJobs request

--- a/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
@@ -20,6 +20,7 @@ import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.workspace.Alpha1Service;
 import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.EnumeratedJob;
 import bio.terra.workspace.service.workspace.model.EnumeratedJobs;
 import bio.terra.workspace.service.workspace.model.JobStateFilter;
@@ -102,6 +103,13 @@ public class Alpha1ApiController implements Alpha1Api {
           jobService.mapFlightStateToApiJobReport(enumeratedJob.getFlightState());
       Optional<WsmResource> optResource = enumeratedJob.getResource();
 
+      Optional<UUID> destinationResourceIdMaybe =
+          Optional.ofNullable(
+              enumeratedJob
+                  .getFlightState()
+                  .getInputParameters()
+                  .get(ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class));
+
       ApiEnumeratedJob apiJob =
           new ApiEnumeratedJob()
               .jobReport(jobReport)
@@ -115,7 +123,8 @@ public class Alpha1ApiController implements Alpha1Api {
               .operationType(enumeratedJob.getOperationType().toApiModel())
               .resourceType(optResource.map(r -> r.getResourceType().toApiModel()).orElse(null))
               .metadata(optResource.map(WsmResource::toApiMetadata).orElse(null))
-              .resourceAttributes(optResource.map(WsmResource::toApiAttributesUnion).orElse(null));
+              .resourceAttributes(optResource.map(WsmResource::toApiAttributesUnion).orElse(null))
+              .destinationResourceId(destinationResourceIdMaybe.orElse(null));
       apiJobList.add(apiJob);
     }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -167,6 +167,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
             workspaceUuid,
             resourceId,
             body.getDestinationWorkspaceId(),
+            UUID.randomUUID(), // resourceId is not pre-allocated for individual clone endpoints
             body.getJobControl(),
             petRequest,
             body.getName(),
@@ -425,6 +426,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
             workspaceUuid,
             resourceId,
             body.getDestinationWorkspaceId(),
+            UUID.randomUUID(), // resourceId is not pre-allocated for individual clone endpoints
             body.getJobControl(),
             petRequest,
             body.getName(),

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -598,6 +598,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
             .cloneReferencedResource(
                 sourceReferencedResource,
                 body.getDestinationWorkspaceId(),
+                UUID.randomUUID(), // resourceId is not pre-allocated for individual clone endpoints
                 body.getName(),
                 body.getDescription(),
                 userRequest)
@@ -641,6 +642,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
             .cloneReferencedResource(
                 sourceReferencedResource,
                 body.getDestinationWorkspaceId(),
+                UUID.randomUUID(), // resourceId is not pre-allocated for individual clone endpoints
                 body.getName(),
                 body.getDescription(),
                 petRequest)
@@ -685,6 +687,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
             .cloneReferencedResource(
                 sourceReferencedResource,
                 body.getDestinationWorkspaceId(),
+                UUID.randomUUID(), // resourceId is not pre-allocated for individual clone endpoints
                 body.getName(),
                 body.getDescription(),
                 userRequest)
@@ -729,6 +732,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
             .cloneReferencedResource(
                 sourceReferencedResource,
                 body.getDestinationWorkspaceId(),
+                UUID.randomUUID(), // resourceId is not pre-allocated for individual clone endpoints
                 body.getName(),
                 body.getDescription(),
                 petRequest)
@@ -774,6 +778,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
             .cloneReferencedResource(
                 sourceReferencedResource,
                 body.getDestinationWorkspaceId(),
+                UUID.randomUUID(), // resourceId is not pre-allocated for individual clone endpoints
                 body.getName(),
                 body.getDescription(),
                 userRequest)
@@ -905,6 +910,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
             .cloneReferencedResource(
                 sourceReferencedResource,
                 body.getDestinationWorkspaceId(),
+                UUID.randomUUID(), // resourceId is not pre-allocated for individual clone endpoints
                 body.getName(),
                 body.getDescription(),
                 userRequest)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -198,6 +198,7 @@ public class ControlledResourceService {
       UUID sourceWorkspaceId,
       UUID sourceResourceId,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       ApiJobControl jobControl,
       AuthenticatedUserRequest userRequest,
       @Nullable String destinationResourceName,
@@ -229,7 +230,9 @@ public class ControlledResourceService {
             .resource(sourceBucketResource)
             .userRequest(userRequest)
             .workspaceId(sourceWorkspaceId.toString())
+            .operationType(OperationType.CLONE)
             .addParameter(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, destinationWorkspaceId)
+            .addParameter(ControlledResourceKeys.DESTINATION_RESOURCE_ID, destinationResourceId)
             .addParameter(ResourceKeys.RESOURCE_NAME, destinationResourceName)
             .addParameter(ResourceKeys.RESOURCE_DESCRIPTION, destinationDescription)
             .addParameter(ControlledResourceKeys.DESTINATION_BUCKET_NAME, destinationBucketName)
@@ -318,6 +321,7 @@ public class ControlledResourceService {
       UUID sourceWorkspaceId,
       UUID sourceResourceId,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       ApiJobControl jobControl,
       AuthenticatedUserRequest userRequest,
       @Nullable String destinationResourceName,
@@ -352,6 +356,7 @@ public class ControlledResourceService {
             .stewardshipType(sourceDatasetResource.getStewardshipType())
             .workspaceId(sourceWorkspaceId.toString())
             .addParameter(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, destinationWorkspaceId)
+            .addParameter(ControlledResourceKeys.DESTINATION_RESOURCE_ID, destinationResourceId)
             .addParameter(ResourceKeys.RESOURCE_NAME, destinationResourceName)
             .addParameter(ResourceKeys.RESOURCE_DESCRIPTION, destinationDescription)
             .addParameter(ControlledResourceKeys.LOCATION, destinationLocation)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
@@ -37,7 +37,10 @@ public class CloneControlledGcsBucketResourceFlight extends Flight {
       FlightMap inputParameters, Object applicationContext) {
     super(inputParameters, applicationContext);
     FlightUtils.validateRequiredEntries(
-        inputParameters, ResourceKeys.RESOURCE, JobMapKeys.AUTH_USER_INFO.getKeyName());
+        inputParameters,
+        ResourceKeys.RESOURCE,
+        JobMapKeys.AUTH_USER_INFO.getKeyName(),
+        ControlledResourceKeys.DESTINATION_RESOURCE_ID);
 
     final FlightBeanBag flightBeanBag = FlightBeanBag.getFromObject(applicationContext);
     final ControlledResource sourceResource =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
@@ -64,7 +64,9 @@ public class CopyGcsBucketDefinitionStep implements Step {
     final FlightMap inputParameters = flightContext.getInputParameters();
     final FlightMap workingMap = flightContext.getWorkingMap();
     FlightUtils.validateRequiredEntries(
-        inputParameters, ControlledResourceKeys.DESTINATION_WORKSPACE_ID);
+        inputParameters,
+        ControlledResourceKeys.DESTINATION_WORKSPACE_ID,
+        ControlledResourceKeys.DESTINATION_RESOURCE_ID);
     final String resourceName =
         FlightUtils.getInputParameterOrWorkingValue(
             flightContext,
@@ -89,7 +91,8 @@ public class CopyGcsBucketDefinitionStep implements Step {
     workingMap.put(ControlledResourceKeys.DESTINATION_BUCKET_NAME, bucketName);
     final UUID destinationWorkspaceId =
         inputParameters.get(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, UUID.class);
-
+    final var destinationResourceId =
+        inputParameters.get(ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class);
     // bucket resource for create flight
     ControlledGcsBucketResource destinationBucketResource =
         ControlledGcsBucketResource.builder()
@@ -97,7 +100,7 @@ public class CopyGcsBucketDefinitionStep implements Step {
             .common(
                 ControlledResourceFields.builder()
                     .workspaceUuid(destinationWorkspaceId)
-                    .resourceId(UUID.randomUUID()) // random ID for new resource
+                    .resourceId(destinationResourceId)
                     .name(resourceName)
                     .description(description)
                     .cloningInstructions(sourceBucket.getCloningInstructions())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
@@ -27,7 +27,8 @@ public class CloneControlledGcpBigQueryDatasetResourceFlight extends Flight {
         inputParameters,
         ResourceKeys.RESOURCE,
         JobMapKeys.AUTH_USER_INFO.getKeyName(),
-        ControlledResourceKeys.CLONING_INSTRUCTIONS);
+        ControlledResourceKeys.CLONING_INSTRUCTIONS,
+        ControlledResourceKeys.DESTINATION_RESOURCE_ID);
 
     final FlightBeanBag flightBeanBag = FlightBeanBag.getFromObject(applicationContext);
     final ControlledResource sourceResource =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
@@ -57,6 +57,7 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
     final FlightMap inputParameters = flightContext.getInputParameters();
+    FlightUtils.validateRequiredEntries(inputParameters, ControlledResourceKeys.DESTINATION_RESOURCE_ID);
     final FlightMap workingMap = flightContext.getWorkingMap();
     final String resourceName =
         FlightUtils.getInputParameterOrWorkingValue(
@@ -85,6 +86,8 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
             String.class);
     final String destinationProjectId =
         gcpCloudContextService.getRequiredGcpProject(destinationWorkspaceId);
+    final var destinationResourceId = inputParameters.get(
+        ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class);
     final ControlledResourceFields commonFields =
         ControlledResourceFields.builder()
             .accessScope(sourceDataset.getAccessScope())
@@ -93,7 +96,7 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
             .description(description)
             .managedBy(sourceDataset.getManagedBy())
             .name(resourceName)
-            .resourceId(UUID.randomUUID())
+            .resourceId(destinationResourceId)
             .workspaceUuid(destinationWorkspaceId)
             .build();
     final ControlledBigQueryDatasetResource destinationResource =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
@@ -57,7 +57,8 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
     final FlightMap inputParameters = flightContext.getInputParameters();
-    FlightUtils.validateRequiredEntries(inputParameters, ControlledResourceKeys.DESTINATION_RESOURCE_ID);
+    FlightUtils.validateRequiredEntries(
+        inputParameters, ControlledResourceKeys.DESTINATION_RESOURCE_ID);
     final FlightMap workingMap = flightContext.getWorkingMap();
     final String resourceName =
         FlightUtils.getInputParameterOrWorkingValue(
@@ -86,8 +87,8 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
             String.class);
     final String destinationProjectId =
         gcpCloudContextService.getRequiredGcpProject(destinationWorkspaceId);
-    final var destinationResourceId = inputParameters.get(
-        ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class);
+    final var destinationResourceId =
+        inputParameters.get(ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class);
     final ControlledResourceFields commonFields =
         ControlledResourceFields.builder()
             .accessScope(sourceDataset.getAccessScope())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
@@ -43,7 +43,8 @@ public class CloneAllResourcesFlight extends Flight {
             new LaunchCreateReferenceResourceFlightStep(
                 flightBeanBag.getReferencedResourceService(),
                 resourceCloneInputs.getResource().castToReferencedResource(),
-                resourceCloneInputs.getFlightId()));
+                resourceCloneInputs.getFlightId(),
+                resourceCloneInputs.getDestinationResourceId()));
         addStep(
             new AwaitCreateReferenceResourceFlightStep(
                 resourceCloneInputs.getResource().castToReferencedResource(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/FindResourcesToCloneStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/FindResourcesToCloneStep.java
@@ -40,14 +40,17 @@ public class FindResourcesToCloneStep implements Step {
     int offset = 0;
     final int limit = 100;
     List<WsmResource> batch;
-    final List<ResourceWithFlightId> result = new ArrayList<>();
+    final List<ResourceCloneInputs> result = new ArrayList<>();
     do {
       batch = resourceDao.enumerateResources(sourceWorkspaceId, null, null, offset, limit);
       offset += limit;
       final List<WsmResource> cloneableResources =
           batch.stream().filter(FindResourcesToCloneStep::isCloneable).toList();
       cloneableResources.forEach(
-          r -> result.add(new ResourceWithFlightId(r, context.getStairway().createFlightId())));
+          r ->
+              result.add(
+                  new ResourceCloneInputs(
+                      r, context.getStairway().createFlightId(), UUID.randomUUID())));
     } while (batch.size() == limit);
 
     // sort the resources by stewardship type reversed, so reference types go first

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneAllResourcesFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneAllResourcesFlightStep.java
@@ -48,7 +48,7 @@ public class LaunchCloneAllResourcesFlightStep implements Step {
             .getWorkingMap()
             .get(ControlledResourceKeys.CLONE_ALL_RESOURCES_FLIGHT_ID, String.class);
 
-    final List<ResourceCloneInputs> resourcesAndFlightIds =
+    final List<ResourceCloneInputs> resourceCloneInputs =
         context
             .getWorkingMap()
             .get(ControlledResourceKeys.RESOURCES_TO_CLONE, new TypeReference<>() {});
@@ -59,7 +59,7 @@ public class LaunchCloneAllResourcesFlightStep implements Step {
 
     final FlightMap subflightInputParameters = new FlightMap();
     subflightInputParameters.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), userRequest);
-    subflightInputParameters.put(ControlledResourceKeys.RESOURCES_TO_CLONE, resourcesAndFlightIds);
+    subflightInputParameters.put(ControlledResourceKeys.RESOURCES_TO_CLONE, resourceCloneInputs);
     subflightInputParameters.put(
         ControlledResourceKeys.DESTINATION_WORKSPACE_ID, destinationWorkspace.getWorkspaceId());
     subflightInputParameters.put(ControlledResourceKeys.LOCATION, location);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneAllResourcesFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneAllResourcesFlightStep.java
@@ -48,7 +48,7 @@ public class LaunchCloneAllResourcesFlightStep implements Step {
             .getWorkingMap()
             .get(ControlledResourceKeys.CLONE_ALL_RESOURCES_FLIGHT_ID, String.class);
 
-    final List<ResourceWithFlightId> resourcesAndFlightIds =
+    final List<ResourceCloneInputs> resourcesAndFlightIds =
         context
             .getWorkingMap()
             .get(ControlledResourceKeys.RESOURCES_TO_CLONE, new TypeReference<>() {});

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep.java
@@ -25,7 +25,7 @@ public class LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep implement
 
   private final ControlledBigQueryDatasetResource resource;
   private final String subflightId;
-  private UUID destinationResourceId;
+  private final UUID destinationResourceId;
 
   public LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep(
       ControlledBigQueryDatasetResource resource, String subflightId, UUID destinationResourceId) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep.java
@@ -68,7 +68,8 @@ public class LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep implement
     subflightInputParameters.put(
         JobMapKeys.DESCRIPTION.getKeyName(),
         String.format("Clone BigQuery Dataset %s", resource.getResourceId().toString()));
-    subflightInputParameters.put(ControlledResourceKeys.DESTINATION_RESOURCE_ID, destinationResourceId);
+    subflightInputParameters.put(
+        ControlledResourceKeys.DESTINATION_RESOURCE_ID, destinationResourceId);
 
     // launch the flight
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep.java
@@ -25,11 +25,13 @@ public class LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep implement
 
   private final ControlledBigQueryDatasetResource resource;
   private final String subflightId;
+  private UUID destinationResourceId;
 
   public LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep(
-      ControlledBigQueryDatasetResource resource, String subflightId) {
+      ControlledBigQueryDatasetResource resource, String subflightId, UUID destinationResourceId) {
     this.resource = resource;
     this.subflightId = subflightId;
+    this.destinationResourceId = destinationResourceId;
   }
 
   @Override
@@ -66,6 +68,7 @@ public class LaunchCloneControlledGcpBigQueryDatasetResourceFlightStep implement
     subflightInputParameters.put(
         JobMapKeys.DESCRIPTION.getKeyName(),
         String.format("Clone BigQuery Dataset %s", resource.getResourceId().toString()));
+    subflightInputParameters.put(ControlledResourceKeys.DESTINATION_RESOURCE_ID, destinationResourceId);
 
     // launch the flight
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneGcsBucketResourceFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCloneGcsBucketResourceFlightStep.java
@@ -25,11 +25,13 @@ public class LaunchCloneGcsBucketResourceFlightStep implements Step {
 
   private final ControlledGcsBucketResource resource;
   private final String subflightId;
+  private final UUID destinationResourceId;
 
   public LaunchCloneGcsBucketResourceFlightStep(
-      ControlledGcsBucketResource resource, String subflightId) {
+      ControlledGcsBucketResource resource, String subflightId, UUID destinationResourceId) {
     this.resource = resource;
     this.subflightId = subflightId;
+    this.destinationResourceId = destinationResourceId;
   }
 
   @Override
@@ -65,6 +67,8 @@ public class LaunchCloneGcsBucketResourceFlightStep implements Step {
     subflightInputParameters.put(
         JobMapKeys.DESCRIPTION.getKeyName(),
         String.format("Clone GCS Bucket resource %s", resource.getResourceId().toString()));
+    subflightInputParameters.put(
+        ControlledResourceKeys.DESTINATION_RESOURCE_ID, destinationResourceId);
 
     // submit flight
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateReferenceResourceFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateReferenceResourceFlightStep.java
@@ -26,7 +26,7 @@ public class LaunchCreateReferenceResourceFlightStep implements Step {
   private final ReferencedResourceService referencedResourceService;
   private final ReferencedResource resource;
   private final String subflightId;
-  private UUID destinationResourceId;
+  private final UUID destinationResourceId;
 
   public LaunchCreateReferenceResourceFlightStep(
       ReferencedResourceService referencedResourceService,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateReferenceResourceFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateReferenceResourceFlightStep.java
@@ -26,14 +26,17 @@ public class LaunchCreateReferenceResourceFlightStep implements Step {
   private final ReferencedResourceService referencedResourceService;
   private final ReferencedResource resource;
   private final String subflightId;
+  private UUID destinationResourceId;
 
   public LaunchCreateReferenceResourceFlightStep(
       ReferencedResourceService referencedResourceService,
       ReferencedResource resource,
-      String subflightId) {
+      String subflightId,
+      UUID destinationResourceId) {
     this.referencedResourceService = referencedResourceService;
     this.resource = resource;
     this.subflightId = subflightId;
+    this.destinationResourceId = destinationResourceId;
   }
 
   @Override
@@ -57,7 +60,11 @@ public class LaunchCreateReferenceResourceFlightStep implements Step {
 
     final ReferencedResource destinationResource =
         WorkspaceCloneUtils.buildDestinationReferencedResource(
-            resource, destinationWorkspaceId, resource.getName(), resource.getDescription());
+            resource,
+            destinationWorkspaceId,
+            destinationResourceId,
+            resource.getName(),
+            resource.getDescription());
 
     // put the destination resource in the map, because it's not communicated
     // from the flight as the response (and we need the workspace ID)
@@ -75,7 +82,8 @@ public class LaunchCreateReferenceResourceFlightStep implements Step {
     subflightInputParameters.put(
         JobMapKeys.DESCRIPTION.getKeyName(),
         String.format("Clone referenced resource %s", resource.getResourceId().toString()));
-
+    subflightInputParameters.put(
+        ControlledResourceKeys.DESTINATION_RESOURCE_ID, destinationResourceId);
     try {
       context
           .getStairway()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ResourceCloneInputs.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ResourceCloneInputs.java
@@ -1,17 +1,20 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.workspace;
 
 import bio.terra.workspace.service.resource.model.WsmResource;
+import java.util.UUID;
 
-public class ResourceWithFlightId {
+public class ResourceCloneInputs {
 
   private WsmResource resource;
   private String flightId;
+  private UUID destinationResourceId;
 
-  public ResourceWithFlightId() {}
+  public ResourceCloneInputs() {}
 
-  public ResourceWithFlightId(WsmResource resource, String flightId) {
+  public ResourceCloneInputs(WsmResource resource, String flightId, UUID destinationResourceId) {
     this.resource = resource;
     this.flightId = flightId;
+    this.destinationResourceId = destinationResourceId;
   }
 
   public WsmResource getResource() {
@@ -28,5 +31,13 @@ public class ResourceWithFlightId {
 
   public void setFlightId(String flightId) {
     this.flightId = flightId;
+  }
+
+  public UUID getDestinationResourceId() {
+    return destinationResourceId;
+  }
+
+  public void setDestinationResourceId(UUID destinationResourceId) {
+    this.destinationResourceId = destinationResourceId;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
@@ -47,6 +47,7 @@ public class WorkspaceCloneUtils {
   public static ReferencedResource buildDestinationReferencedResource(
       ReferencedResource sourceReferencedResource,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       String name,
       String description) {
     final ReferencedResource destinationResource;
@@ -56,6 +57,7 @@ public class WorkspaceCloneUtils {
             buildDestinationGcsBucketReference(
                 sourceReferencedResource.castByEnum(WsmResourceType.REFERENCED_GCP_GCS_BUCKET),
                 destinationWorkspaceId,
+                destinationResourceId,
                 name,
                 description);
         break;
@@ -64,6 +66,7 @@ public class WorkspaceCloneUtils {
             buildDestinationGcsObjectReference(
                 sourceReferencedResource.castByEnum(WsmResourceType.REFERENCED_GCP_GCS_OBJECT),
                 destinationWorkspaceId,
+                destinationResourceId,
                 name,
                 description);
         break;
@@ -73,6 +76,7 @@ public class WorkspaceCloneUtils {
                 sourceReferencedResource.castByEnum(
                     WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT),
                 destinationWorkspaceId,
+                destinationResourceId,
                 name,
                 description);
         break;
@@ -82,6 +86,7 @@ public class WorkspaceCloneUtils {
                 sourceReferencedResource.castByEnum(
                     WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET),
                 destinationWorkspaceId,
+                destinationResourceId,
                 name,
                 description);
         break;
@@ -91,6 +96,7 @@ public class WorkspaceCloneUtils {
                 sourceReferencedResource.castByEnum(
                     WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE),
                 destinationWorkspaceId,
+                destinationResourceId,
                 name,
                 description);
         break;
@@ -99,6 +105,7 @@ public class WorkspaceCloneUtils {
             buildDestinationGitHubRepoReference(
                 sourceReferencedResource.castByEnum(WsmResourceType.REFERENCED_ANY_GIT_REPO),
                 destinationWorkspaceId,
+                destinationResourceId,
                 name,
                 description);
         break;
@@ -117,6 +124,7 @@ public class WorkspaceCloneUtils {
    *
    * @param sourceBucketResource - original resource to be cloned
    * @param destinationWorkspaceId - workspace ID for new reference
+   * @param destinationResourceId - resource ID for new reference
    * @param name - resource name for cloned reference. Will use original name if this is null.
    * @param description - resource description for cloned reference. Uses original if left null.
    * @return referenced resource
@@ -124,13 +132,14 @@ public class WorkspaceCloneUtils {
   private static ReferencedResource buildDestinationGcsBucketReference(
       ReferencedGcsBucketResource sourceBucketResource,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
 
     final ReferencedGcsBucketResource.Builder resultBuilder =
         sourceBucketResource.toBuilder()
             .workspaceId(destinationWorkspaceId)
-            .resourceId(UUID.randomUUID());
+            .resourceId(destinationResourceId);
     // apply optional override variables
     Optional.ofNullable(name).ifPresent(resultBuilder::name);
     Optional.ofNullable(description).ifPresent(resultBuilder::description);
@@ -140,12 +149,13 @@ public class WorkspaceCloneUtils {
   private static ReferencedResource buildDestinationGcsObjectReference(
       ReferencedGcsObjectResource sourceBucketFileResource,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
     final ReferencedGcsObjectResource.Builder resultBuilder =
         sourceBucketFileResource.toBuilder()
             .workspaceId(destinationWorkspaceId)
-            .resourceId(UUID.randomUUID());
+            .resourceId(destinationResourceId);
     // apply optional override variables
     Optional.ofNullable(name).ifPresent(resultBuilder::name);
     Optional.ofNullable(description).ifPresent(resultBuilder::description);
@@ -155,13 +165,14 @@ public class WorkspaceCloneUtils {
   private static ReferencedResource buildDestinationBigQueryDatasetReference(
       ReferencedBigQueryDatasetResource sourceBigQueryResource,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
     // keep projectId and dataset name the same since they are for the referent
     final ReferencedBigQueryDatasetResource.Builder resultBuilder =
         sourceBigQueryResource.toBuilder()
             .workspaceId(destinationWorkspaceId)
-            .resourceId(UUID.randomUUID());
+            .resourceId(destinationResourceId);
     Optional.ofNullable(name).ifPresent(resultBuilder::name);
     Optional.ofNullable(description).ifPresent(resultBuilder::description);
     return resultBuilder.build();
@@ -170,13 +181,14 @@ public class WorkspaceCloneUtils {
   private static ReferencedResource buildDestinationBigQueryDataTableReference(
       ReferencedBigQueryDataTableResource sourceBigQueryResource,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
     // keep projectId, dataset name and data table name the same since they are for the referent
     final ReferencedBigQueryDataTableResource.Builder resultBuilder =
         sourceBigQueryResource.toBuilder()
             .workspaceId(destinationWorkspaceId)
-            .resourceId(UUID.randomUUID());
+            .resourceId(destinationResourceId);
     Optional.ofNullable(name).ifPresent(resultBuilder::name);
     Optional.ofNullable(description).ifPresent(resultBuilder::description);
     return resultBuilder.build();
@@ -185,12 +197,13 @@ public class WorkspaceCloneUtils {
   private static ReferencedResource buildDestinationDataRepoSnapshotReference(
       ReferencedDataRepoSnapshotResource sourceReferencedDataRepoSnapshotResource,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
     final ReferencedDataRepoSnapshotResource.Builder resultBuilder =
         sourceReferencedDataRepoSnapshotResource.toBuilder()
             .workspaceId(destinationWorkspaceId)
-            .resourceId(UUID.randomUUID());
+            .resourceId(destinationResourceId);
     Optional.ofNullable(name).ifPresent(resultBuilder::name);
     Optional.ofNullable(description).ifPresent(resultBuilder::description);
     return resultBuilder.build();
@@ -199,12 +212,13 @@ public class WorkspaceCloneUtils {
   private static ReferencedResource buildDestinationGitHubRepoReference(
       ReferencedGitRepoResource gitHubRepoResource,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
     ReferencedGitRepoResource.Builder resultBuilder =
         gitHubRepoResource.toBuilder()
             .workspaceId(destinationWorkspaceId)
-            .resourceId(UUID.randomUUID());
+            .resourceId(destinationResourceId);
     Optional.ofNullable(name).ifPresent(resultBuilder::name);
     Optional.ofNullable(description).ifPresent(resultBuilder::description);
     return resultBuilder.build();

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResourceService.java
@@ -228,12 +228,17 @@ public class ReferencedResourceService {
   public ReferencedResource cloneReferencedResource(
       ReferencedResource sourceReferencedResource,
       UUID destinationWorkspaceId,
+      UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description,
       AuthenticatedUserRequest userRequest) {
     final ReferencedResource destinationResource =
         WorkspaceCloneUtils.buildDestinationReferencedResource(
-            sourceReferencedResource, destinationWorkspaceId, name, description);
+            sourceReferencedResource,
+            destinationWorkspaceId,
+            destinationResourceId,
+            name,
+            description);
     // launch the creation flight
     return createReferenceResource(destinationResource, userRequest);
   }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -60,8 +60,8 @@ public final class WorkspaceFlightMapKeys {
     public static final String STORAGE_TRANSFER_SERVICE_SA_EMAIL = "storageTransferServiceSAEmail";
     public static final String TABLE_TO_JOB_ID_MAP = "tableToJobIdMap";
     public static final String WORKSPACE_CREATE_FLIGHT_ID = "workspaceCreateFlightId";
-
     public static final String STORAGE_ACCOUNT_NAME = "storageAccountName";
+    public static final String DESTINATION_RESOURCE_ID = "destinationResourceId";
   }
 
   /** Common resource keys */

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -1477,6 +1477,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             workspace.getWorkspaceId(),
             createdBucket.getResourceId(),
             workspace.getWorkspaceId(), // copy back into same workspace
+            UUID.randomUUID(),
             apiJobControl,
             user.getAuthenticatedRequest(),
             "cloned_bucket",

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
@@ -26,6 +26,7 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -57,6 +58,7 @@ public class CopyGcsBucketDefinitionStepTest extends BaseUnitTest {
     inputParameters.put(ControlledResourceKeys.DESTINATION_BUCKET_NAME, DESTINATION_BUCKET_NAME);
     inputParameters.put(
         ControlledResourceKeys.CREATION_PARAMETERS, SOURCE_BUCKET_CREATION_PARAMETERS);
+    inputParameters.put(ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.randomUUID());
     doReturn(inputParameters).when(mockFlightContext).getInputParameters();
 
     final var workingMap = new FlightMap();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/FindResourcesToCloneStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/FindResourcesToCloneStepTest.java
@@ -80,7 +80,7 @@ public class FindResourcesToCloneStepTest extends BaseUnitTest {
 
     final StepResult stepResult = findResourcesToCloneStep.doStep(mockFlightContext);
     assertEquals(StepResult.getStepResultSuccess(), stepResult);
-    final List<ResourceWithFlightId> result =
+    final List<ResourceCloneInputs> result =
         workingMap.get(ControlledResourceKeys.RESOURCES_TO_CLONE, new TypeReference<>() {});
     assertThat(result, hasSize(120));
     assertEquals(resource, result.get(0).getResource());
@@ -95,7 +95,7 @@ public class FindResourcesToCloneStepTest extends BaseUnitTest {
         .enumerateResources(any(UUID.class), eq(null), eq(null), eq(0), eq(100));
     final StepResult stepResult = findResourcesToCloneStep.doStep(mockFlightContext);
     assertEquals(StepResult.getStepResultSuccess(), stepResult);
-    final List<ResourceWithFlightId> result =
+    final List<ResourceCloneInputs> result =
         workingMap.get(ControlledResourceKeys.RESOURCES_TO_CLONE, new TypeReference<>() {});
     assertThat(result, hasSize(3));
     assertEquals(resource, result.get(0).getResource());


### PR DESCRIPTION
In order to inform the UI about the resources being created by cloning, we need to give it the destination resource ID via the Enumerate Jobs API. This involves pre-computing all the IDs and passing them through a couple levels of flights so that they're available in the flight input parameters later when the enumeration happens and we hydrate all the extra goodies like resource metadata and attributes.

My original thought was to include a key-value map instead of an individual parameter, but that's inviting abuse. We can tolerate a null value for destination resource id on the non-clone jobs.