### PR TITLE
[PF-1748] In ListWorkspaces, don't return data source workspaces for readers

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceConstants.java
@@ -1,0 +1,9 @@
+package bio.terra.workspace.service.workspace.model;
+
+public class WorkspaceConstants {
+  // For now, denote data source workspaces with this key/value. This may change, as product becomes
+  // more settled.
+  // "terra-" prefix means this key is used by Terra internally (as opposed to used by user).
+  public static final String DATA_SOURCE_KEY = "terra-type";
+  public static final String DATA_SOURCE_VALUE = "data-source";
+}


### PR DESCRIPTION
Tested in swagger, confirmed that data source workspace isn't returned (when requester is reader).