### PR TITLE
[no ticket] use latest dev toolbox image

### DIFF
--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -161,7 +161,7 @@ function dovault {
     local dofilename=$2
     case $vaultenv in
         docker)
-            docker run --rm -e VAULT_TOKEN="${vaulttoken}" broadinstitute/dsde-toolbox:consul-0.20.0 \
+            docker run --rm -e VAULT_TOKEN="${vaulttoken}" broadinstitute/dsde-toolbox:dev \
                    vault read -format=json "${dovaultpath}" > "${dofilename}"
             ;;
 


### PR DESCRIPTION
The old toolbox image isn't compatible with the M1 Mac chip. This changes to use the dev branch, which is more up-to-date.