### PR TITLE
[PF-1801] ControlledGcsbucketLifecycle keeps timing out

### DIFF
--- a/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ControlledGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 10,
+      "expectedTimeForEach": 12,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"


### PR DESCRIPTION
gcs bucket update sometimes run long and thread keeps getting killed before the test finish.