### PR TITLE
PF-1826 - fix policy change waiting code

### DIFF
--- a/service/src/main/java/bio/terra/workspace/common/utils/GcpUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/GcpUtils.java
@@ -14,8 +14,6 @@ import com.google.cloud.ServiceOptions;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -80,28 +78,6 @@ public class GcpUtils {
               "Error polling operation. name [%s] message [%s]",
               operation.getOperationAdapter().getName(),
               operation.getOperationAdapter().getError().getMessage()));
-    }
-  }
-
-  /**
-   * Retry a supplier method until the value supplied equals an expected value. Useful for verifying
-   * a set value has propagated cloudward and may now be relied upon.
-   *
-   * @param expected - expected (previously set on cloud) value
-   * @param supplier - function to get the value from the cloud
-   * @param retryInterval - time to sleep between retries
-   * @param maxRetries - maximum number of times to retry the supplier
-   * @param <T> - type of expected and supplier specialization
-   */
-  public static <T> void pollUntilEqual(
-      T expected, Supplier<T> supplier, Duration retryInterval, int maxRetries)
-      throws InterruptedException {
-    T actual = supplier.get();
-    int retryAttempts = 0;
-    while (!actual.equals(expected) && retryAttempts++ < maxRetries) {
-      TimeUnit.MILLISECONDS.sleep(retryInterval.toMillis());
-      logger.info(String.format("#pollUntilEquals retry attempts: %d", retryAttempts));
-      actual = supplier.get();
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/BucketCloneRolesService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/BucketCloneRolesService.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.bucket;
 
 import bio.terra.cloudres.google.storage.StorageCow;
+import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.common.utils.GcpUtils;
 import bio.terra.workspace.service.crl.CrlService;
@@ -10,13 +11,18 @@ import com.google.cloud.Identity;
 import com.google.cloud.Policy;
 import com.google.cloud.Role;
 import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class BucketCloneRolesService {
-
+  private static final Logger logger = LoggerFactory.getLogger(BucketCloneRolesService.class);
   private static final int MAX_RETRY_ATTEMPTS = 30;
   private static final Duration RETRY_INTERVAL = Duration.ofSeconds(2);
   private final CrlService crlService;
@@ -67,6 +73,13 @@ public class BucketCloneRolesService {
   /**
    * Add or remove roles for an Identity.
    *
+   * <p>NOTE: The previous implementation used {@link GcpUtils.pollUntilEqual} to compare the
+   * newPolicy against the updated policy. That would never match, because the etag in the Policy
+   * object is part of the equals evaluation. The updated comparison technique just looks at the
+   * specific roles with the specific identity to see whether it is added or removed. This is not
+   * 100% safe, since concurrent changes to the policy would be a problem. At this point in time,
+   * WSM is not programmed to prevent concurrent access and that is outside the scope of this fix.
+   *
    * @param operation - flag for add or remove
    * @param inputs - source or destination input object
    * @param transferServiceSAEmail - STS SA email address
@@ -76,7 +89,8 @@ public class BucketCloneRolesService {
       BucketCloneInputs inputs,
       String transferServiceSAEmail)
       throws InterruptedException {
-    if (inputs.getRoleNames().isEmpty()) {
+    List<String> roles = inputs.getRoleNames();
+    if (roles.isEmpty()) {
       // No-op
       return;
     }
@@ -85,20 +99,41 @@ public class BucketCloneRolesService {
 
     final Policy.Builder policyBuilder =
         storageCow.getIamPolicy(inputs.getBucketName()).toBuilder();
-    for (String roleName : inputs.getRoleNames()) {
+    for (String roleName : roles) {
       switch (operation) {
         case ADD -> policyBuilder.addIdentity(Role.of(roleName), saIdentity);
         case REMOVE -> policyBuilder.removeIdentity(Role.of(roleName), saIdentity);
       }
     }
     final Policy newPolicy = policyBuilder.build();
-    storageCow.setIamPolicy(inputs.getBucketName(), newPolicy);
+    Policy updatedPolicy = storageCow.setIamPolicy(inputs.getBucketName(), newPolicy);
 
-    // verify the role changes have propagated, as we may need to work on this bucket immediately
-    GcpUtils.pollUntilEqual(
-        newPolicy,
-        () -> storageCow.getIamPolicy(inputs.getBucketName()),
-        RETRY_INTERVAL,
-        MAX_RETRY_ATTEMPTS);
+    for (int i = 1; i <= MAX_RETRY_ATTEMPTS; i++) {
+      int roleCount = countRoles(updatedPolicy, roles, saIdentity);
+      if ((operation == BucketPolicyIdentityOperation.ADD && roleCount == roles.size())
+          || (operation == BucketPolicyIdentityOperation.REMOVE && roleCount == 0)) {
+        return;
+      }
+      TimeUnit.MILLISECONDS.sleep(RETRY_INTERVAL.toMillis());
+      logger.info(String.format("addRemoveBucketIdentities retry attempts: %d", i));
+      updatedPolicy = storageCow.getIamPolicy(inputs.getBucketName());
+    }
+    throw new InternalServerErrorException("Bucket policy update propagation timed out");
+  }
+
+  private int countRoles(Policy testPolicy, List<String> roles, Identity saIdentity) {
+    int counter = 0;
+    for (var role : roles) {
+      if (isRolePresent(testPolicy, role, saIdentity)) {
+        counter++;
+      }
+    }
+    return counter;
+  }
+
+  private boolean isRolePresent(Policy testPolicy, String roleName, Identity saIdentity) {
+    Set<Identity> identities = testPolicy.getBindings().get(Role.of(roleName));
+    return (identities != null
+        && identities.stream().anyMatch(identity -> identity.equals(saIdentity)));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/BucketCloneRolesService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/BucketCloneRolesService.java
@@ -65,11 +65,6 @@ public class BucketCloneRolesService {
     }
   }
 
-  private enum BucketPolicyIdentityOperation {
-    ADD,
-    REMOVE
-  }
-
   /**
    * Add or remove roles for an Identity.
    *
@@ -132,8 +127,17 @@ public class BucketCloneRolesService {
   }
 
   private boolean isRolePresent(Policy testPolicy, String roleName, Identity saIdentity) {
+    if (testPolicy == null || testPolicy.getBindings() == null) {
+      return false;
+    }
+
     Set<Identity> identities = testPolicy.getBindings().get(Role.of(roleName));
     return (identities != null
         && identities.stream().anyMatch(identity -> identity.equals(saIdentity)));
+  }
+
+  private enum BucketPolicyIdentityOperation {
+    ADD,
+    REMOVE
   }
 }


### PR DESCRIPTION
The waiting code in BucketCloneRolesService introduced for PF-1500 did not work as intended. An `equals` comparison on two `Policy` objects compares the `etag`. The `etag` on the input to `setIamPolicy` is (by semantics of etags) never the same as the `etag` resulting from the call.

The new version of the code implements a specific comparison for the added/removed roles showing up/disappearing. The code change required a change to the unit tests.

I removed the `GcpUtils.pollUntilEqual` since it was unused and slightly broken. We can write such a thing again if the case comes up.

All of that done, I am not sure either the old code or this new code is actually needed. Do we know that there is a case where a `getIamPolicy` following a successful `setIamPolicy` will return something other than what was just set?


