### PR TITLE
[PF-1817] Add lastUpdatedDate to workspace description

### DIFF
--- a/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
@@ -3,7 +3,9 @@ package scripts.testscripts;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.WorkspaceApi;
@@ -59,6 +61,8 @@ public class WorkspaceLifecycle extends WorkspaceApiTestScriptBase {
     ClientTestUtils.assertHttpSuccess(workspaceApi, "GET workspace");
     assertThat(workspaceDescription.getId(), equalTo(workspaceUuid));
     assertThat(workspaceDescription.getStage(), equalTo(WorkspaceStageModel.MC_WORKSPACE));
+    assertNotNull(workspaceDescription.getLastUpdatedDate());
+    var lastUpdatedDate = workspaceDescription.getLastUpdatedDate();
 
     UpdateWorkspaceRequestBody updateBody =
         new UpdateWorkspaceRequestBody()
@@ -80,6 +84,10 @@ public class WorkspaceLifecycle extends WorkspaceApiTestScriptBase {
     assertThat(updatedDescription.getUserFacingId(), equalTo(validUserFacingId2));
     assertThat(updatedDescription.getDisplayName(), equalTo(WORKSPACE_NAME));
     assertThat(updatedDescription.getDescription(), equalTo(WORKSPACE_DESCRIPTION));
+    assertNotNull(updatedDescription.getLastUpdatedDate());
+    assertTrue(
+        lastUpdatedDate.isBefore(
+            updatedDescription.getLastUpdatedDate()));
 
     workspaceApi.deleteWorkspace(workspaceUuid);
     ClientTestUtils.assertHttpSuccess(workspaceApi, "DELETE workspace");

--- a/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
@@ -85,9 +85,7 @@ public class WorkspaceLifecycle extends WorkspaceApiTestScriptBase {
     assertThat(updatedDescription.getDisplayName(), equalTo(WORKSPACE_NAME));
     assertThat(updatedDescription.getDescription(), equalTo(WORKSPACE_DESCRIPTION));
     assertNotNull(updatedDescription.getLastUpdatedDate());
-    assertTrue(
-        lastUpdatedDate.isBefore(
-            updatedDescription.getLastUpdatedDate()));
+    assertTrue(lastUpdatedDate.isBefore(updatedDescription.getLastUpdatedDate()));
 
     workspaceApi.deleteWorkspace(workspaceUuid);
     ClientTestUtils.assertHttpSuccess(workspaceApi, "DELETE workspace");

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -494,6 +494,11 @@ components:
           $ref: '#/components/schemas/AzureContext'
         properties:
           $ref: '#/components/schemas/Properties'
+        lastUpdatedDate:
+          description: Lastest timestamp when the workspace is changed.
+          type: string
+          format: date-time
+
 
     WorkspaceDescriptionList:
       type: object

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -145,7 +145,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     logger.info("Listing workspaces for {}", userRequest.getEmail());
     ControllerValidationUtils.validatePaginationParams(offset, limit);
     List<WorkspaceAndAdditionalAttributes> workspacesAndHighestRoles =
-        workspaceService.listWorkspacesAndHighestRoles(userRequest, offset, limit);
+        workspaceService.listWorkspacesAndAdditionalAttributes(userRequest, offset, limit);
     var response =
         new ApiWorkspaceDescriptionList()
             .workspaces(

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -253,7 +253,8 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     logger.info("Getting workspace {} for {}", userFacingId, userRequest.getEmail());
     var workspaceAndAdditionalAttributes =
-        workspaceService.getWorkspaceByUserFacingId(userFacingId, userRequest);
+        workspaceService.getWorkspaceAndAdditionalAttributesByUserFacingId(
+            userFacingId, userRequest);
 
     ApiWorkspaceDescription desc = buildWorkspaceDescription(workspaceAndAdditionalAttributes);
     logger.info("Got workspace {} for {}", desc, userRequest.getEmail());

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -194,7 +194,7 @@ public class WorkspaceService {
 
   /** Retrieves an existing workspace and its relative attributes by userFacingId */
   @Traced
-  public WorkspaceAndAdditionalAttributes getWorkspaceByUserFacingId(
+  public WorkspaceAndAdditionalAttributes getWorkspaceAndAdditionalAttributesByUserFacingId(
       String userFacingId, AuthenticatedUserRequest userRequest) {
     logger.info(
         "getWorkspaceByUserFacingId - userRequest: {}\nuserFacingId: {}",

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -162,7 +162,7 @@ public class WorkspaceService {
    * @param limit The maximum number of items to return.
    */
   @Traced
-  public List<WorkspaceAndAdditionalAttributes> listWorkspacesAndHighestRoles(
+  public List<WorkspaceAndAdditionalAttributes> listWorkspacesAndAdditionalAttributes(
       AuthenticatedUserRequest userRequest, int offset, int limit) {
     Map<UUID, WsmIamRole> samWorkspaceIdsAndHighestRoles =
         SamRethrow.onInterrupted(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceAndAdditionalAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceAndAdditionalAttributes.java
@@ -4,5 +4,10 @@ import bio.terra.workspace.service.iam.model.WsmIamRole;
 import java.time.Instant;
 import java.util.Optional;
 
+/**
+ * Workspace and a set of attributes that are part of the {@link
+ * bio.terra.workspace.generated.model.ApiWorkspaceDescription} but not stored in the workspace data
+ * table and needed to be fetched elsewhere.
+ */
 public record WorkspaceAndAdditionalAttributes(
     Workspace workspace, WsmIamRole highestRole, Optional<Instant> lastUpdatedDate) {}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceAndAdditionalAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceAndAdditionalAttributes.java
@@ -1,0 +1,8 @@
+package bio.terra.workspace.service.workspace.model;
+
+import bio.terra.workspace.service.iam.model.WsmIamRole;
+import java.time.Instant;
+import java.util.Optional;
+
+public record WorkspaceAndAdditionalAttributes(
+    Workspace workspace, WsmIamRole highestRole, Optional<Instant> lastUpdatedDate) {}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceAndHighestRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceAndHighestRole.java
@@ -1,5 +1,0 @@
-package bio.terra.workspace.service.workspace.model;
-
-import bio.terra.workspace.service.iam.model.WsmIamRole;
-
-public record WorkspaceAndHighestRole(Workspace workspace, WsmIamRole highestRole) {}

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -84,15 +84,19 @@ class SamServiceTest extends BaseConnectedTest {
     // Before being granted permission, secondary user should be rejected.
     assertThrows(
         ForbiddenException.class,
-        () -> workspaceService.getWorkspace(workspaceUuid, secondaryUserRequest()));
+        () ->
+            workspaceService.getWorkspaceAndAdditionalAttributes(
+                workspaceUuid, secondaryUserRequest()));
     // After being granted permission, secondary user can read the workspace.
     samService.grantWorkspaceRole(
         workspaceUuid,
         defaultUserRequest(),
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    Workspace readWorkspace = workspaceService.getWorkspace(workspaceUuid, secondaryUserRequest());
-    assertEquals(workspaceUuid, readWorkspace.getWorkspaceId());
+    var readWorkspaceAndAdditionalAttributes =
+        workspaceService.getWorkspaceAndAdditionalAttributes(workspaceUuid, secondaryUserRequest());
+    assertEquals(workspaceUuid, readWorkspaceAndAdditionalAttributes.workspace().getWorkspaceId());
+    assertEquals(WsmIamRole.READER, readWorkspaceAndAdditionalAttributes.highestRole());
   }
 
   @Test
@@ -126,14 +130,19 @@ class SamServiceTest extends BaseConnectedTest {
     // Before being granted permission, secondary user should be rejected.
     assertThrows(
         ForbiddenException.class,
-        () -> workspaceService.getWorkspace(workspaceUuid, secondaryUserRequest()));
+        () ->
+            workspaceService.getWorkspaceAndAdditionalAttributes(
+                workspaceUuid, secondaryUserRequest()));
     // After being granted permission, secondary user can read the workspace.
     samService.grantWorkspaceRole(
         workspaceUuid,
         defaultUserRequest(),
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    Workspace readWorkspace = workspaceService.getWorkspace(workspaceUuid, secondaryUserRequest());
+    Workspace readWorkspace =
+        workspaceService
+            .getWorkspaceAndAdditionalAttributes(workspaceUuid, secondaryUserRequest())
+            .workspace();
     assertEquals(workspaceUuid, readWorkspace.getWorkspaceId());
     // After removing permission, secondary user can no longer read.
     samService.removeWorkspaceRole(
@@ -143,7 +152,9 @@ class SamServiceTest extends BaseConnectedTest {
         userAccessUtils.getSecondUserEmail());
     assertThrows(
         ForbiddenException.class,
-        () -> workspaceService.getWorkspace(workspaceUuid, secondaryUserRequest()));
+        () ->
+            workspaceService.getWorkspaceAndAdditionalAttributes(
+                workspaceUuid, secondaryUserRequest()));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureControlledStorageResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureControlledStorageResourceServiceTest.java
@@ -99,7 +99,10 @@ public class AzureControlledStorageResourceServiceTest extends BaseAzureTest {
                 .build(),
             workspaceOwner.getAuthenticatedRequest());
     workspace =
-        workspaceService.getWorkspace(workspaceUuid, workspaceOwner.getAuthenticatedRequest());
+        workspaceService
+            .getWorkspaceAndAdditionalAttributes(
+                workspaceUuid, workspaceOwner.getAuthenticatedRequest())
+            .workspace();
 
     workspaceService.createAzureCloudContext(
         workspaceUuid,

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -405,7 +405,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     var updatedDateAfterWorkspaceUpdate = workspaceActivityLogDao.getLastUpdatedDate(workspaceUuid);
     assertTrue(lastUpdatedDate.get().isBefore(updatedDateAfterWorkspaceUpdate.get()));
     assertEquals(
-        updatedWorkspaceAndAttributes.lastUpdatedDate().get(), updatedDateAfterWorkspaceUpdate.get());
+        updatedWorkspaceAndAttributes.lastUpdatedDate().get(),
+        updatedDateAfterWorkspaceUpdate.get());
 
     assertEquals(userFacingId, updatedWorkspace.getUserFacingId());
     assertTrue(updatedWorkspace.getDisplayName().isPresent());

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -156,10 +156,12 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .thenReturn(Map.of(workspaceId, WsmIamRole.OWNER));
 
     List<WorkspaceAndAdditionalAttributes> actual =
-        workspaceService.listWorkspacesAndHighestRoles(USER_REQUEST, /*offset=*/ 0, /*limit=*/ 10);
+        workspaceService.listWorkspacesAndAdditionalAttributes(
+            USER_REQUEST, /*offset=*/ 0, /*limit=*/ 10);
     assertEquals(1, actual.size());
     assertEquals(request.getWorkspaceId(), actual.get(0).workspace().getWorkspaceId());
     assertEquals(WsmIamRole.OWNER, actual.get(0).highestRole());
+    assertTrue(actual.get(0).lastUpdatedDate().isPresent());
   }
 
   @Test
@@ -172,7 +174,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
             request.getWorkspaceId(), USER_REQUEST);
     assertEquals(request.getWorkspaceId(), workspaceAndDescription.workspace().getWorkspaceId());
     assertEquals(WsmIamRole.OWNER, workspaceAndDescription.highestRole());
-    assertNotNull(workspaceAndDescription.lastUpdatedDate());
+    assertTrue(workspaceAndDescription.lastUpdatedDate().isPresent());
   }
 
   @Test
@@ -220,7 +222,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
             userFacingId, USER_REQUEST);
     assertEquals(request.getWorkspaceId(), workspaceByUserFacingId.workspace().getWorkspaceId());
     assertEquals(WsmIamRole.OWNER, workspaceByUserFacingId.highestRole());
-    assertNotNull(workspaceByUserFacingId.lastUpdatedDate());
+    assertTrue(workspaceByUserFacingId.lastUpdatedDate().isPresent());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -405,7 +405,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     var updatedDateAfterWorkspaceUpdate = workspaceActivityLogDao.getLastUpdatedDate(workspaceUuid);
     assertTrue(lastUpdatedDate.get().isBefore(updatedDateAfterWorkspaceUpdate.get()));
     assertEquals(
-        updatedWorkspaceAndAttributes.lastUpdatedDate().get(), updatedDateAfterWorkspaceUpdate);
+        updatedWorkspaceAndAttributes.lastUpdatedDate().get(), updatedDateAfterWorkspaceUpdate.get());
 
     assertEquals(userFacingId, updatedWorkspace.getUserFacingId());
     assertTrue(updatedWorkspace.getDisplayName().isPresent());

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -216,7 +216,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     workspaceService.createWorkspace(request, USER_REQUEST);
 
     WorkspaceAndAdditionalAttributes workspaceByUserFacingId =
-        workspaceService.getWorkspaceByUserFacingId(userFacingId, USER_REQUEST);
+        workspaceService.getWorkspaceAndAdditionalAttributesByUserFacingId(
+            userFacingId, USER_REQUEST);
     assertEquals(request.getWorkspaceId(), workspaceByUserFacingId.workspace().getWorkspaceId());
     assertEquals(WsmIamRole.OWNER, workspaceByUserFacingId.highestRole());
     assertNotNull(workspaceByUserFacingId.lastUpdatedDate());
@@ -226,7 +227,9 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   void getWorkspaceByUserFacingId_missing() {
     assertThrows(
         WorkspaceNotFoundException.class,
-        () -> workspaceService.getWorkspaceByUserFacingId("missing-workspace", USER_REQUEST));
+        () ->
+            workspaceService.getWorkspaceAndAdditionalAttributesByUserFacingId(
+                "missing-workspace", USER_REQUEST));
   }
 
   @Test
@@ -236,7 +239,9 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .checkAuthz(any(), any(), any(), any());
     assertThrows(
         WorkspaceNotFoundException.class,
-        () -> workspaceService.getWorkspaceByUserFacingId("missing-workspace", USER_REQUEST));
+        () ->
+            workspaceService.getWorkspaceAndAdditionalAttributesByUserFacingId(
+                "missing-workspace", USER_REQUEST));
   }
 
   @Test
@@ -250,7 +255,9 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .checkAuthz(any(), any(), any(), any());
     assertThrows(
         ForbiddenException.class,
-        () -> workspaceService.getWorkspaceByUserFacingId(userFacingId, USER_REQUEST));
+        () ->
+            workspaceService.getWorkspaceAndAdditionalAttributesByUserFacingId(
+                userFacingId, USER_REQUEST));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlightTest.java
@@ -287,6 +287,6 @@ public class DeleteAzureContextFlightTest extends BaseAzureTest {
         () -> controlledResourceService.getControlledResource(mcWorkspaceUuid, ipId, userRequest));
     assertThrows(
         WorkspaceNotFoundException.class,
-        () -> workspaceService.getWorkspace(mcWorkspaceUuid, userRequest));
+        () -> workspaceService.getWorkspaceAndAdditionalAttributes(mcWorkspaceUuid, userRequest));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
@@ -98,7 +98,9 @@ public class WorkspaceDeleteFlightTest extends BaseConnectedTest {
                 dataset.getWorkspaceId(), dataset.getResourceId(), userRequest));
     assertThrows(
         WorkspaceNotFoundException.class,
-        () -> workspaceService.getWorkspace(workspace.getWorkspaceId(), userRequest));
+        () ->
+            workspaceService.getWorkspaceAndAdditionalAttributes(
+                workspace.getWorkspaceId(), userRequest));
   }
 
   @Test
@@ -150,6 +152,8 @@ public class WorkspaceDeleteFlightTest extends BaseConnectedTest {
                 dataset.getWorkspaceId(), dataset.getResourceId(), userRequest));
     assertThrows(
         WorkspaceNotFoundException.class,
-        () -> workspaceService.getWorkspace(workspace.getWorkspaceId(), userRequest));
+        () ->
+            workspaceService.getWorkspaceAndAdditionalAttributes(
+                workspace.getWorkspaceId(), userRequest));
   }
 }


### PR DESCRIPTION
i'm piggyback on which is previously `WorkspaceAndHighestRole` and added `lastUpdatedDate` there. I'm planning to add CreatedDate in `WorkspaceAndAdditionalAttributes` as well in a following pr.

I'm putting the `WorkspaecAndAdditionalattributes` construction logic in workspaceService instead of workspaceapicontroller to force caller to get those instead of `workspace` and include these additional attributes in the workspace description. 

The other way is to have the construction logic in the controller but because we don't have unit test for the controller, testing it there is rather awkward and I don't like the controller to do the complicated thing. 