### PR TITLE
TOAZ-118 [WSM] Add integration test for createVM API

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ControlledAzureVmNoPublicIpLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledAzureVmNoPublicIpLifecycle.java
@@ -1,0 +1,42 @@
+package scripts.testscripts;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.AzureVmCreationParameters;
+import bio.terra.workspace.model.CreateControlledAzureVmRequestBody;
+import bio.terra.workspace.model.CreatedControlledAzureDisk;
+import bio.terra.workspace.model.CreatedControlledAzureNetwork;
+import bio.terra.workspace.model.CreatedControlledAzureVmResult;
+import bio.terra.workspace.model.JobControl;
+import scripts.utils.ControlledAzureVmTestScriptBase;
+
+/** Creates VM with private IP and without Custom Script Extension. */
+public class ControlledAzureVmNoPublicIpLifecycle extends ControlledAzureVmTestScriptBase {
+  @Override
+  protected CreatedControlledAzureVmResult createVm(
+      String resourceSuffix,
+      String createVmJobId,
+      CreatedControlledAzureDisk disk,
+      CreatedControlledAzureNetwork network)
+      throws ApiException {
+    CreateControlledAzureVmRequestBody vmRequestBody =
+        new CreateControlledAzureVmRequestBody()
+            .common(createCommonFields("common-vm", resourceSuffix))
+            .jobControl(new JobControl().id(createVmJobId));
+    AzureVmCreationParameters vmCreationParameters =
+        new AzureVmCreationParameters()
+            .name(String.format("vm-%s", resourceSuffix))
+            .region(REGION)
+            .vmSize("Standard_D8s_v3")
+            .diskId(disk.getResourceId())
+            .networkId(network.getResourceId())
+            .vmImage(createAzureVmImage())
+            .vmUser(createUser());
+    vmRequestBody.azureVm(vmCreationParameters);
+    CreatedControlledAzureVmResult vmCreateResult =
+        azureApi.createAzureVm(vmRequestBody, getWorkspaceId());
+    assertNotNull(vmCreateResult);
+    return vmCreateResult;
+  }
+}

--- a/integration/src/main/java/scripts/testscripts/ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle.java
@@ -1,0 +1,44 @@
+package scripts.testscripts;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.AzureVmCreationParameters;
+import bio.terra.workspace.model.CreateControlledAzureVmRequestBody;
+import bio.terra.workspace.model.CreatedControlledAzureDisk;
+import bio.terra.workspace.model.CreatedControlledAzureNetwork;
+import bio.terra.workspace.model.CreatedControlledAzureVmResult;
+import bio.terra.workspace.model.JobControl;
+import scripts.utils.ControlledAzureVmTestScriptBase;
+
+/** Create Vm with private IP and with Custom Script Extension. Default scenario. */
+public class ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle
+    extends ControlledAzureVmTestScriptBase {
+  @Override
+  protected CreatedControlledAzureVmResult createVm(
+      String resourceSuffix,
+      String createVmJobId,
+      CreatedControlledAzureDisk disk,
+      CreatedControlledAzureNetwork network)
+      throws ApiException {
+    CreateControlledAzureVmRequestBody vmRequestBody =
+        new CreateControlledAzureVmRequestBody()
+            .common(createCommonFields("common-vm", resourceSuffix))
+            .jobControl(new JobControl().id(createVmJobId));
+    AzureVmCreationParameters vmCreationParameters =
+        new AzureVmCreationParameters()
+            .name(String.format("vm-%s", resourceSuffix))
+            .region(REGION)
+            .vmSize("Standard_D8s_v3")
+            .diskId(disk.getResourceId())
+            .networkId(network.getResourceId())
+            .vmImage(createAzureVmImage())
+            .customScriptExtension(createVmCustomScriptExtension())
+            .vmUser(createUser());
+    vmRequestBody.azureVm(vmCreationParameters);
+    CreatedControlledAzureVmResult vmCreateResult =
+        azureApi.createAzureVm(vmRequestBody, getWorkspaceId());
+    assertNotNull(vmCreateResult);
+    return vmCreateResult;
+  }
+}

--- a/integration/src/main/java/scripts/testscripts/ControlledAzureVmWithPublicIpLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledAzureVmWithPublicIpLifecycle.java
@@ -1,0 +1,57 @@
+package scripts.testscripts;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.AzureVmCreationParameters;
+import bio.terra.workspace.model.CreateControlledAzureVmRequestBody;
+import bio.terra.workspace.model.CreatedControlledAzureDisk;
+import bio.terra.workspace.model.CreatedControlledAzureNetwork;
+import bio.terra.workspace.model.CreatedControlledAzureVmResult;
+import bio.terra.workspace.model.JobControl;
+import java.util.List;
+import scripts.utils.ControlledAzureVmTestScriptBase;
+
+/** Create Vm with public IP and without Custom Script Extension. */
+public class ControlledAzureVmWithPublicIpLifecycle extends ControlledAzureVmTestScriptBase {
+  @Override
+  protected void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doSetup(testUsers, workspaceApi);
+    vmWithPublicIp = true;
+  }
+
+  @Override
+  protected CreatedControlledAzureVmResult createVm(
+      String resourceSuffix,
+      String createVmJobId,
+      CreatedControlledAzureDisk disk,
+      CreatedControlledAzureNetwork network)
+      throws ApiException {
+    CreateControlledAzureVmRequestBody vmRequestBody =
+        new CreateControlledAzureVmRequestBody()
+            .common(createCommonFields("common-vm", resourceSuffix))
+            .jobControl(new JobControl().id(createVmJobId));
+    AzureVmCreationParameters vmCreationParameters =
+        new AzureVmCreationParameters()
+            .name(String.format("vm-%s", resourceSuffix))
+            .region(REGION)
+            .vmSize("Standard_D8s_v3")
+            .diskId(disk.getResourceId())
+            .networkId(network.getResourceId())
+            .vmImage(createAzureVmImage())
+            .vmUser(createUser());
+
+    assertTrue(publicIp.isPresent(), "Public IP should be provisioned first.");
+    vmCreationParameters.ipId(publicIp.get().getResourceId());
+
+    vmRequestBody.azureVm(vmCreationParameters);
+    CreatedControlledAzureVmResult vmCreateResult =
+        azureApi.createAzureVm(vmRequestBody, getWorkspaceId());
+    assertNotNull(vmCreateResult);
+    return vmCreateResult;
+  }
+}

--- a/integration/src/main/java/scripts/testscripts/ControlledAzureVmWithWrongCredentialsLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledAzureVmWithWrongCredentialsLifecycle.java
@@ -1,0 +1,77 @@
+package scripts.testscripts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.AzureVmCreationParameters;
+import bio.terra.workspace.model.AzureVmUser;
+import bio.terra.workspace.model.CreateControlledAzureVmRequestBody;
+import bio.terra.workspace.model.CreatedControlledAzureDisk;
+import bio.terra.workspace.model.CreatedControlledAzureNetwork;
+import bio.terra.workspace.model.CreatedControlledAzureVmResult;
+import bio.terra.workspace.model.JobControl;
+import bio.terra.workspace.model.JobReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scripts.utils.ControlledAzureVmTestScriptBase;
+
+public class ControlledAzureVmWithWrongCredentialsLifecycle
+    extends ControlledAzureVmTestScriptBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ControlledAzureVmWithWrongCredentialsLifecycle.class);
+
+  private static String AZURE_VM_PROVISION_ERROR_MESSAGE =
+      "The supplied password must be between 6-72 characters long and must satisfy at least 3 of password complexity requirements";
+
+  @Override
+  protected CreatedControlledAzureVmResult createVm(
+      String resourceSuffix,
+      String createVmJobId,
+      CreatedControlledAzureDisk disk,
+      CreatedControlledAzureNetwork network)
+      throws ApiException {
+    CreateControlledAzureVmRequestBody vmRequestBody =
+        new CreateControlledAzureVmRequestBody()
+            .common(createCommonFields("common-vm", resourceSuffix))
+            .jobControl(new JobControl().id(createVmJobId));
+    AzureVmCreationParameters vmCreationParameters =
+        new AzureVmCreationParameters()
+            .name(String.format("vm-%s", resourceSuffix))
+            .region(REGION)
+            .vmSize("Standard_D8s_v3")
+            .diskId(disk.getResourceId())
+            .networkId(network.getResourceId())
+            .vmImage(createAzureVmImage())
+            .vmUser(createUser());
+    vmRequestBody.azureVm(vmCreationParameters);
+    CreatedControlledAzureVmResult vmCreateResult =
+        azureApi.createAzureVm(vmRequestBody, getWorkspaceId());
+    assertNotNull(vmCreateResult);
+    return vmCreateResult;
+  }
+
+  @Override
+  protected void validateVm(CreatedControlledAzureVmResult vmCreateResult) {
+    assertEquals(JobReport.StatusEnum.FAILED, vmCreateResult.getJobReport().getStatus());
+    assertNotNull(vmCreateResult.getErrorReport());
+    assertTrue(
+        vmCreateResult.getErrorReport().getMessage().contains(AZURE_VM_PROVISION_ERROR_MESSAGE));
+    assertTrue(
+        vmCreateResult.getErrorReport().getMessage().contains("\"code\": \"InvalidParameter\""));
+    assertTrue(
+        vmCreateResult.getErrorReport().getMessage().contains("\"target\": \"adminPassword\""));
+    assertEquals(500, vmCreateResult.getErrorReport().getStatusCode());
+    assertNull(vmCreateResult.getAzureVm());
+    logger.info("VM provisioning failed.");
+  }
+
+  @Override
+  protected AzureVmUser createUser() {
+    String userName = "jupuser";
+    String userPassword = "1234"; // simple password
+    return new AzureVmUser().name(userName).password(userPassword);
+  }
+}

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -177,9 +177,10 @@ public class ClientTestUtils {
     return new ControlledGcpResourceApi(apiClient);
   }
 
-  public static ControlledAzureResourceApi getControlledAzureResourceClient() {
-    // TODO: proper api client specification
-    return new ControlledAzureResourceApi();
+  public static ControlledAzureResourceApi getControlledAzureResourceClient(
+      TestUserSpecification testUser, ServerSpecification server) throws IOException {
+    final ApiClient apiClient = getClientForTestUser(testUser, server);
+    return new ControlledAzureResourceApi(apiClient);
   }
 
   public static ReferencedGcpResourceApi getReferencedGcpResourceClient(

--- a/integration/src/main/java/scripts/utils/ControlledAzureTestScriptBase.java
+++ b/integration/src/main/java/scripts/utils/ControlledAzureTestScriptBase.java
@@ -1,0 +1,76 @@
+package scripts.utils;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.ControlledAzureResourceApi;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.model.AzureContext;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for all Azure related integration tests. It reads configuration required for Azure
+ * cloud context creation and creates Azure cloud context based on these parameters. Each Azure test
+ * requires following parameters to be presented in the script's configuration: subscriptionId,
+ * resourceGroupId, tenantId
+ */
+public abstract class ControlledAzureTestScriptBase extends WorkspaceAllocateTestScriptBase {
+  private static final Logger logger = LoggerFactory.getLogger(ControlledAzureTestScriptBase.class);
+
+  protected static final String REGION = "westcentralus";
+
+  protected ControlledAzureResourceApi azureApi;
+  // resource suffix to easily locate resources in the resource group in case of troubleshooting
+  protected String suffix;
+
+  private String subscriptionId;
+  private String resourceGroupId;
+  private String tenantId;
+
+  protected String getSubscriptionId() {
+    return subscriptionId;
+  }
+
+  protected String getResourceGroupId() {
+    return resourceGroupId;
+  }
+
+  protected String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  protected void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    // create workspace
+    super.doSetup(testUsers, workspaceApi);
+
+    suffix = UUID.randomUUID().toString();
+    logger.info("Azure resource suffix {}", suffix);
+
+    // create Azure Cloud Context
+    logger.info(
+        "Azure cloud context params subscriptionId={}, resourceGroupId={}, tenantId={}",
+        getSubscriptionId(),
+        getResourceGroupId(),
+        getTenantId());
+    CloudContextMaker.createAzureCloudContext(
+        getWorkspaceId(),
+        workspaceApi,
+        new AzureContext()
+            .subscriptionId(getSubscriptionId())
+            .resourceGroupId(getResourceGroupId())
+            .tenantId(getTenantId()));
+    logger.info("Created Azure cloud context in workspace {}", getWorkspaceId());
+  }
+
+  @Override
+  public void setParametersMap(Map<String, String> parametersMap) throws Exception {
+    super.setParametersMap(parametersMap);
+    subscriptionId = ParameterUtils.getParamOrThrow(parametersMap, "subscriptionId");
+    resourceGroupId = ParameterUtils.getParamOrThrow(parametersMap, "resourceGroupId");
+    tenantId = ParameterUtils.getParamOrThrow(parametersMap, "tenantId");
+  }
+}

--- a/integration/src/main/java/scripts/utils/ControlledAzureVmTestScriptBase.java
+++ b/integration/src/main/java/scripts/utils/ControlledAzureVmTestScriptBase.java
@@ -1,0 +1,223 @@
+package scripts.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.AccessScope;
+import bio.terra.workspace.model.AzureDiskCreationParameters;
+import bio.terra.workspace.model.AzureIpCreationParameters;
+import bio.terra.workspace.model.AzureNetworkCreationParameters;
+import bio.terra.workspace.model.AzureVmCustomScriptExtension;
+import bio.terra.workspace.model.AzureVmCustomScriptExtensionSetting;
+import bio.terra.workspace.model.AzureVmCustomScriptExtensionTag;
+import bio.terra.workspace.model.AzureVmImage;
+import bio.terra.workspace.model.AzureVmUser;
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import bio.terra.workspace.model.ControlledResourceCommonFields;
+import bio.terra.workspace.model.CreateControlledAzureDiskRequestBody;
+import bio.terra.workspace.model.CreateControlledAzureIpRequestBody;
+import bio.terra.workspace.model.CreateControlledAzureNetworkRequestBody;
+import bio.terra.workspace.model.CreatedControlledAzureDisk;
+import bio.terra.workspace.model.CreatedControlledAzureIp;
+import bio.terra.workspace.model.CreatedControlledAzureNetwork;
+import bio.terra.workspace.model.CreatedControlledAzureVmResult;
+import bio.terra.workspace.model.JobReport;
+import bio.terra.workspace.model.ManagedBy;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for all Azure VM-based integration tests.
+ *
+ * <p>Defines common user journey for VM-based integration scenarios. It provides default happy path
+ * implementation for vm creation which includes provisioning of network, disk, public
+ * ip(optionally). This behavior can be changed in sub-classes.</>
+ */
+public abstract class ControlledAzureVmTestScriptBase extends ControlledAzureTestScriptBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ControlledAzureVmTestScriptBase.class);
+
+  protected static final int VM_CREATE_WAIT_POLL_INTERVAL_SECONDS = 5;
+
+  protected String createVmJobId;
+  // controls if we want to provision VM with public ip
+  protected boolean vmWithPublicIp;
+  protected Optional<CreatedControlledAzureIp> publicIp;
+
+  @Override
+  protected void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doSetup(testUsers, workspaceApi);
+    vmWithPublicIp = false;
+    publicIp = Optional.empty();
+  }
+
+  @Override
+  protected void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
+      throws Exception {
+    azureApi = ClientTestUtils.getControlledAzureResourceClient(testUser, server);
+
+    // create public ip
+    if (vmWithPublicIp) {
+      CreatedControlledAzureIp ip = createPublicIp(suffix);
+      publicIp = Optional.of(ip);
+    }
+
+    // create network
+    CreatedControlledAzureNetwork network = createNetwork(suffix);
+
+    // create disk
+    CreatedControlledAzureDisk disk = createDisk(suffix);
+
+    // create vm
+    createVmJobId = UUID.randomUUID().toString();
+    CreatedControlledAzureVmResult vmCreateResult = createVm(suffix, createVmJobId, disk, network);
+
+    vmCreateResult = waitForVmCreationCompletion(createVmJobId, vmCreateResult);
+
+    validateVm(vmCreateResult);
+  }
+
+  protected void validateVm(CreatedControlledAzureVmResult vmCreateResult) {
+    assertEquals(JobReport.StatusEnum.SUCCEEDED, vmCreateResult.getJobReport().getStatus());
+    assertNotNull(vmCreateResult.getAzureVm());
+    logger.info(
+        "Create VM name={} status is {}",
+        vmCreateResult.getAzureVm().getAttributes().getVmName(),
+        vmCreateResult.getJobReport().getStatus().toString());
+    logger.info(
+        "Created VM with following parameters Name={}, Resource Id={}",
+        vmCreateResult.getAzureVm().getAttributes().getVmName(),
+        vmCreateResult.getAzureVm().getMetadata().getResourceId());
+  }
+
+  protected abstract CreatedControlledAzureVmResult createVm(
+      String resourceSuffix,
+      String createVmJobId,
+      CreatedControlledAzureDisk disk,
+      CreatedControlledAzureNetwork network)
+      throws ApiException;
+
+  protected CreatedControlledAzureIp createPublicIp(String resourceSuffix) throws ApiException {
+    AzureIpCreationParameters ipCreationParameters =
+        new AzureIpCreationParameters().name(String.format("ip-%s", suffix)).region(REGION);
+    CreateControlledAzureIpRequestBody ipRequestBody =
+        new CreateControlledAzureIpRequestBody()
+            .common(createCommonFields("common-ip", resourceSuffix))
+            .azureIp(ipCreationParameters);
+    CreatedControlledAzureIp ip = azureApi.createAzureIp(ipRequestBody, getWorkspaceId());
+    assertNotNull(ip);
+    logger.info(
+        "Created IP with the following parameters Name={}, Resource Id={}",
+        ip.getAzureIp().getAttributes().getIpName(),
+        ip.getResourceId());
+    return ip;
+  }
+
+  protected CreatedControlledAzureNetwork createNetwork(String resourceSuffix) throws ApiException {
+    CreateControlledAzureNetworkRequestBody networkRequestBody =
+        new CreateControlledAzureNetworkRequestBody()
+            .common(createCommonFields("common-network", resourceSuffix));
+    AzureNetworkCreationParameters networkParameters =
+        new AzureNetworkCreationParameters()
+            .name(String.format("network-%s", suffix))
+            .subnetName(String.format("subnet-%s", suffix))
+            .addressSpaceCidr("192.168.0.0/16")
+            .subnetAddressCidr("192.168.1.0/24")
+            .region(REGION);
+    networkRequestBody.azureNetwork(networkParameters);
+    CreatedControlledAzureNetwork network =
+        azureApi.createAzureNetwork(networkRequestBody, getWorkspaceId());
+    assertNotNull(network.getResourceId());
+    logger.info(
+        "Created Network with following parameters Name={}, Resource Id={}",
+        network.getAzureNetwork().getAttributes().getNetworkName(),
+        network.getResourceId());
+    return network;
+  }
+
+  protected CreatedControlledAzureDisk createDisk(String resourceSuffix) throws ApiException {
+    CreateControlledAzureDiskRequestBody diskRequestBody =
+        new CreateControlledAzureDiskRequestBody()
+            .common(createCommonFields("common-disk", resourceSuffix));
+    AzureDiskCreationParameters diskParameters =
+        new AzureDiskCreationParameters()
+            .name(String.format("disk-%s", suffix))
+            .size(50)
+            .region(REGION);
+    diskRequestBody.azureDisk(diskParameters);
+    CreatedControlledAzureDisk disk = azureApi.createAzureDisk(diskRequestBody, getWorkspaceId());
+    assertNotNull(disk.getResourceId());
+    logger.info(
+        "Created Disk with following parameters Name={}, Resource Id={}",
+        disk.getAzureDisk().getAttributes().getDiskName(),
+        disk.getResourceId());
+    return disk;
+  }
+
+  protected CreatedControlledAzureVmResult waitForVmCreationCompletion(
+      String createVmJobId, CreatedControlledAzureVmResult vmCreateResult)
+      throws InterruptedException, ApiException {
+    while (ClientTestUtils.jobIsRunning(vmCreateResult.getJobReport())) {
+      TimeUnit.SECONDS.sleep(VM_CREATE_WAIT_POLL_INTERVAL_SECONDS);
+      vmCreateResult = azureApi.getCreateAzureVmResult(getWorkspaceId(), createVmJobId);
+    }
+
+    return vmCreateResult;
+  }
+
+  protected ControlledResourceCommonFields createCommonFields(String name, String suffix) {
+    return new ControlledResourceCommonFields()
+        .name(String.format("%s-%s", name, suffix))
+        .cloningInstructions(CloningInstructionsEnum.NOTHING)
+        .accessScope(AccessScope.PRIVATE_ACCESS)
+        .managedBy(ManagedBy.USER);
+  }
+
+  protected AzureVmImage createAzureVmImage() {
+    return new AzureVmImage()
+        .publisher("microsoft-dsvm")
+        .offer("ubuntu-1804")
+        .sku("1804-gen2")
+        .version("22.04.27");
+  }
+
+  protected AzureVmUser createUser() {
+    String userName = "jupuser";
+    String userPassword = "SuperStrongPassword12345!!";
+    return new AzureVmUser().name(userName).password(userPassword);
+  }
+
+  protected AzureVmCustomScriptExtension createVmCustomScriptExtension() {
+    String[] fileUrisValue = {
+      "https://raw.githubusercontent.com/DataBiosphere/leonardo/TOAZ-83-dummy-script/http/src/main/resources/init-resources/msdsvmcontent/dummy_script.sh"
+    };
+    return new AzureVmCustomScriptExtension()
+        .name("vm-custom-script-extension")
+        .publisher("Microsoft.Azure.Extensions")
+        .type("CustomScript")
+        .version("2.1")
+        .minorVersionAutoUpgrade(true)
+        .protectedSettings(
+            List.of(
+                new AzureVmCustomScriptExtensionSetting().key("fileUris").value(fileUrisValue),
+                new AzureVmCustomScriptExtensionSetting()
+                    .key("commandToExecute")
+                    .value(createCommandToExecute())))
+        .tags(
+            Collections.singletonList(
+                new AzureVmCustomScriptExtensionTag().key("Key").value("Value")));
+  }
+
+  protected String createCommandToExecute() {
+    return "bash dummy_script.sh hello";
+  }
+}

--- a/integration/src/main/resources/configs/integration/ControlledAzureVmNoPublicIpLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledAzureVmNoPublicIpLifecycle.json
@@ -1,0 +1,23 @@
+{
+  "name": "ControlledAzureVmNoPublicIpLifecycle",
+  "description": "Create controlled Azure VM (NO custom script extension and NO public IP) resource test.",
+  "serverSpecificationFile": "workspace-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ControlledAzureVmNoPublicIpLifecycle",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 1,
+      "expectedTimeForEach": 10,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parametersMap": {
+        "spend-profile-id": "wm-default-spend-profile",
+        "subscriptionId": "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c",
+        "resourceGroupId": "mrg-terra-integration-test-20211118",
+        "tenantId": "0cb7a640-45a2-4ed6-be9f-63519f86e04b"
+      }
+    }
+  ],
+  "testUserFiles": ["bella.json"]
+}

--- a/integration/src/main/resources/configs/integration/ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle.json
@@ -1,0 +1,23 @@
+{
+  "name": "ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle",
+  "description": "Create controlled Azure VM (with custom script extension and NO public IP) resource test.",
+  "serverSpecificationFile": "workspace-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 1,
+      "expectedTimeForEach": 10,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parametersMap": {
+        "spend-profile-id": "wm-default-spend-profile",
+        "subscriptionId": "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c",
+        "resourceGroupId": "mrg-terra-integration-test-20211118",
+        "tenantId": "0cb7a640-45a2-4ed6-be9f-63519f86e04b"
+      }
+    }
+  ],
+  "testUserFiles": ["bella.json"]
+}

--- a/integration/src/main/resources/configs/integration/ControlledAzureVmWithPublicIpLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledAzureVmWithPublicIpLifecycle.json
@@ -1,0 +1,23 @@
+{
+  "name": "ControlledAzureVmWithPublicIpLifecycle",
+  "description": "Create controlled Azure VM (with public IP) resource test.",
+  "serverSpecificationFile": "workspace-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ControlledAzureVmWithPublicIpLifecycle",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 1,
+      "expectedTimeForEach": 10,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parametersMap": {
+        "spend-profile-id": "wm-default-spend-profile",
+        "subscriptionId": "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c",
+        "resourceGroupId": "mrg-terra-integration-test-20211118",
+        "tenantId": "0cb7a640-45a2-4ed6-be9f-63519f86e04b"
+      }
+    }
+  ],
+  "testUserFiles": ["bella.json"]
+}

--- a/integration/src/main/resources/configs/integration/ControlledAzureVmWithWrongCredentialsLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledAzureVmWithWrongCredentialsLifecycle.json
@@ -1,0 +1,23 @@
+{
+  "name": "ControlledAzureVmWithWrongCredentialsLifecycle",
+  "description": "Create controlled Azure VM (with wrong credentials) resource test.",
+  "serverSpecificationFile": "workspace-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ControlledAzureVmWithWrongCredentialsLifecycle",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 1,
+      "expectedTimeForEach": 10,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parametersMap": {
+        "spend-profile-id": "wm-default-spend-profile",
+        "subscriptionId": "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c",
+        "resourceGroupId": "mrg-terra-integration-test-20211118",
+        "tenantId": "0cb7a640-45a2-4ed6-be9f-63519f86e04b"
+      }
+    }
+  ],
+  "testUserFiles": ["bella.json"]
+}

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -23,6 +23,10 @@
     "integration/ReferencedGitRepoLifecycle.json",
     "integration/ReferencedTerraWorkspaceLifecycle.json",
     "integration/RemoveUser.json",
-    "integration/WorkspaceLifecycle.json"
+    "integration/WorkspaceLifecycle.json",
+    "integration/ControlledAzureVmNoPublicIpLifecycle.json",
+    "integration/ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle.json",
+    "integration/ControlledAzureVmWithPublicIpLifecycle.json",
+    "integration/ControlledAzureVmWithWrongCredentialsLifecycle.json"
   ]
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -149,7 +149,7 @@ terra.common:
 # into the appropriate values file. That includes the values file in local_dev.
 feature:
   # azure-enabled - Controls inclusion of Azure support in WSM
-  azure-enabled: false
+  azure-enabled: true
   # alpha1-enabled - Controls support of the Alpha1 experimental API and service
   alpha1-enabled: false
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -31,19 +32,30 @@ import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 // Test to make sure things properly do not work when Azure feature is not enabled
 @AutoConfigureMockMvc
+// We are modifying application context here. Need to clean up once tests are done.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AzureDisabledTest extends BaseConnectedTest {
   @Autowired private MockMvc mockMvc;
 
   @Autowired private WorkspaceService workspaceService;
   @Autowired private UserAccessUtils userAccessUtils;
   @Autowired private ObjectMapper objectMapper;
+  @Autowired private FeatureConfiguration featureConfiguration;
+
+  @BeforeEach
+  public void setUp() {
+    // explicitly disable Azure feature regardless of the configuration files
+    featureConfiguration.setAzureEnabled(false);
+  }
 
   @Test
   public void azureDisabledTest() throws Exception {


### PR DESCRIPTION
TOAZ-118 [WSM] Add integration test for createVM API

-create vm with private ip and custom script extension (main scenario for Jupyter VM)
-create vm with private ip
-create vm with public ip
-create vm with incorrect credentials. Expected failure.