### PR TITLE
PF-1218: Disallow PrivateResourceUser on user-private resources

### DIFF
--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -1,6 +1,7 @@
 package scripts.testscripts;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -166,24 +167,29 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             .userName(privateResourceUser.userEmail)
             .privateResourceIamRoles(roles);
 
-    CreatedControlledGcpGcsBucket userFullBucket =
-        GcsBucketUtils.makeControlledGcsBucket(
-            privateUserResourceApi,
-            getWorkspaceId(),
-            RESOURCE_PREFIX + UUID.randomUUID().toString(),
-            /*bucketName=*/ null,
-            AccessScope.PRIVATE_ACCESS,
-            ManagedBy.USER,
-            CloningInstructionsEnum.NOTHING,
-            privateUserFull);
-    assertNotNull(userFullBucket.getGcpBucket().getAttributes().getBucketName());
-    deleteBucket(workspaceOwnerResourceApi, userFullBucket.getResourceId());
+    var ex = assertThrows(
+        ApiException.class,
+        () ->
+            GcsBucketUtils.makeControlledGcsBucket(
+                privateUserResourceApi,
+                getWorkspaceId(),
+                RESOURCE_PREFIX + UUID.randomUUID().toString(),
+                /*bucketName=*/ null,
+                AccessScope.PRIVATE_ACCESS,
+                ManagedBy.USER,
+                CloningInstructionsEnum.NOTHING,
+                privateUserFull));
+    assertThat(ex.getMessage(),
+        containsString("PrivateResourceUser can only be specified by applications for private resources"));
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     // Supply just the roles, but no email
     PrivateResourceUser privateUserNoEmail =
         new PrivateResourceUser().userName(null).privateResourceIamRoles(roles);
 
-    CreatedControlledGcpGcsBucket userNoEmailBucket =
+    ex = assertThrows(
+        ApiException.class,
+        () ->
         GcsBucketUtils.makeControlledGcsBucket(
             privateUserResourceApi,
             getWorkspaceId(),
@@ -192,9 +198,10 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             AccessScope.PRIVATE_ACCESS,
             ManagedBy.USER,
             CloningInstructionsEnum.NOTHING,
-            privateUserNoEmail);
-    assertNotNull(userNoEmailBucket.getGcpBucket().getAttributes().getBucketName());
-    deleteBucket(workspaceOwnerResourceApi, userNoEmailBucket.getResourceId());
+            privateUserNoEmail));
+    assertThat(ex.getMessage(),
+        containsString("PrivateResourceUser can only be specified by applications for private resources"));
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     String uniqueBucketName = String.format("terra-%s-bucket", UUID.randomUUID().toString());
     CreatedControlledGcpGcsBucket bucketWithBucketNameSpecified =
@@ -206,7 +213,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             AccessScope.PRIVATE_ACCESS,
             ManagedBy.USER,
             CloningInstructionsEnum.NOTHING,
-            privateUserFull);
+            null);
     assertEquals(
         uniqueBucketName,
         bucketWithBucketNameSpecified.getGcpBucket().getAttributes().getBucketName());

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -3,7 +3,6 @@ package scripts.testscripts;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static scripts.utils.GcsBucketUtils.makeControlledGcsBucketUserPrivate;
@@ -167,40 +166,46 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             .userName(privateResourceUser.userEmail)
             .privateResourceIamRoles(roles);
 
-    var ex = assertThrows(
-        ApiException.class,
-        () ->
-            GcsBucketUtils.makeControlledGcsBucket(
-                privateUserResourceApi,
-                getWorkspaceId(),
-                RESOURCE_PREFIX + UUID.randomUUID().toString(),
-                /*bucketName=*/ null,
-                AccessScope.PRIVATE_ACCESS,
-                ManagedBy.USER,
-                CloningInstructionsEnum.NOTHING,
-                privateUserFull));
-    assertThat(ex.getMessage(),
-        containsString("PrivateResourceUser can only be specified by applications for private resources"));
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                GcsBucketUtils.makeControlledGcsBucket(
+                    privateUserResourceApi,
+                    getWorkspaceId(),
+                    RESOURCE_PREFIX + UUID.randomUUID().toString(),
+                    /*bucketName=*/ null,
+                    AccessScope.PRIVATE_ACCESS,
+                    ManagedBy.USER,
+                    CloningInstructionsEnum.NOTHING,
+                    privateUserFull));
+    assertThat(
+        ex.getMessage(),
+        containsString(
+            "PrivateResourceUser can only be specified by applications for private resources"));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     // Supply just the roles, but no email
     PrivateResourceUser privateUserNoEmail =
         new PrivateResourceUser().userName(null).privateResourceIamRoles(roles);
 
-    ex = assertThrows(
-        ApiException.class,
-        () ->
-        GcsBucketUtils.makeControlledGcsBucket(
-            privateUserResourceApi,
-            getWorkspaceId(),
-            RESOURCE_PREFIX + UUID.randomUUID().toString(),
-            /*bucketName=*/ null,
-            AccessScope.PRIVATE_ACCESS,
-            ManagedBy.USER,
-            CloningInstructionsEnum.NOTHING,
-            privateUserNoEmail));
-    assertThat(ex.getMessage(),
-        containsString("PrivateResourceUser can only be specified by applications for private resources"));
+    ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                GcsBucketUtils.makeControlledGcsBucket(
+                    privateUserResourceApi,
+                    getWorkspaceId(),
+                    RESOURCE_PREFIX + UUID.randomUUID().toString(),
+                    /*bucketName=*/ null,
+                    AccessScope.PRIVATE_ACCESS,
+                    ManagedBy.USER,
+                    CloningInstructionsEnum.NOTHING,
+                    privateUserNoEmail));
+    assertThat(
+        ex.getMessage(),
+        containsString(
+            "PrivateResourceUser can only be specified by applications for private resources"));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     String uniqueBucketName = String.format("terra-%s-bucket", UUID.randomUUID().toString());

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
@@ -179,30 +179,12 @@ public class ControllerBase {
 
       case MANAGED_BY_USER:
         {
-          // TODO: PF-1218 The target state is that supplying a user is not allowed.
-          //  However, current CLI and maybe UI are supplying all or part of the structure,
-          //  so tolerate all states: no-input, only roles, roles and user
-          /* Target state:
-          // Supplying a user is not allowed. The creating user is always the assigned user.
           validateNoInputUser(inputUser);
-          */
 
           // Fill in the user role for the creating user
           String userEmail =
               SamRethrow.onInterrupted(
                   () -> samService.getUserEmailFromSam(userRequest), "getUserEmailFromSam");
-
-          // TODO: PF-1218 temporarily allow user spec and make sure it matches the requesting
-          //  user. Ignore the role list. If the user name is specified, then make sure it
-          //  matches the requesting name.
-          if (inputUser != null && inputUser.getUserName() != null) {
-            if (!StringUtils.equalsIgnoreCase(userEmail, inputUser.getUserName())) {
-              throw new BadRequestException(
-                  "User ("
-                      + userEmail
-                      + ") may only assign a private controlled resource to themselves");
-            }
-          }
 
           // At this time, all private resources grant EDITOR permission to the resource user.
           // This could be parameterized if we ever have reason to grant different permissions

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.app.controller;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.ValidationException;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.ControllerValidationUtils;
@@ -22,7 +21,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 
 /**


### PR DESCRIPTION
Have the controller return an error if the PrivateResourceUser is sent when creating private resources. Update tests to account for this.