### PR TITLE
PF-1218: Change the resource role list to a single role

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
@@ -18,7 +18,6 @@ import bio.terra.workspace.model.ControlledResourceIamRole;
 import bio.terra.workspace.model.CreatedControlledGcpGcsBucket;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
-import bio.terra.workspace.model.PrivateResourceIamRoles;
 import bio.terra.workspace.model.PrivateResourceUser;
 import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.ResourceType;

--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
@@ -145,10 +145,9 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
 
   private void testAssignedReader(ControlledGcpResourceApi resourceApi, String projectId)
       throws Exception {
-    PrivateResourceIamRoles iamRoles = new PrivateResourceIamRoles();
-    iamRoles.add(ControlledResourceIamRole.READER);
+    ControlledResourceIamRole iamRole = ControlledResourceIamRole.READER;
     PrivateResourceUser privateUser =
-        new PrivateResourceUser().privateResourceIamRoles(iamRoles).userName(writer.userEmail);
+        new PrivateResourceUser().privateResourceIamRole(iamRole).userName(writer.userEmail);
 
     String bucketResourceName = RandomStringUtils.random(6, true, false);
     CreatedControlledGcpGcsBucket createdBucket =
@@ -172,10 +171,9 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
 
   private void testAssignedWriter(ControlledGcpResourceApi resourceApi, String projectId)
       throws Exception {
-    PrivateResourceIamRoles iamRoles = new PrivateResourceIamRoles();
-    iamRoles.add(ControlledResourceIamRole.WRITER);
+    ControlledResourceIamRole iamRole = ControlledResourceIamRole.WRITER;
     PrivateResourceUser privateUser =
-        new PrivateResourceUser().privateResourceIamRoles(iamRoles).userName(reader.userEmail);
+        new PrivateResourceUser().privateResourceIamRole(iamRole).userName(reader.userEmail);
 
     String bucketResourceName = RandomStringUtils.random(6, true, false);
     CreatedControlledGcpGcsBucket createdBucket =

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -154,17 +154,11 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     Bucket maybeBucket = ownerStorageClient.get(bucketName);
     assertNull(maybeBucket);
 
-    // TODO: PF-1218 - change these to negative tests - should error - when
-    //  the ticket is complete. These exercise two create cases with currently
-    //  valid combinations of private user.
-    PrivateResourceIamRoles roles = new PrivateResourceIamRoles();
-    roles.add(ControlledResourceIamRole.READER);
-
     // Supply all private user parameters
     PrivateResourceUser privateUserFull =
         new PrivateResourceUser()
             .userName(privateResourceUser.userEmail)
-            .privateResourceIamRoles(roles);
+            .privateResourceIamRole(ControlledResourceIamRole.READER);
 
     var ex =
         assertThrows(
@@ -187,7 +181,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
 
     // Supply just the roles, but no email
     PrivateResourceUser privateUserNoEmail =
-        new PrivateResourceUser().userName(null).privateResourceIamRoles(roles);
+        new PrivateResourceUser().userName(null).privateResourceIamRole(ControlledResourceIamRole.READER);
 
     ex =
         assertThrows(

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -200,7 +200,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     assertThat(
         ex.getMessage(),
         containsString(
-            "PrivateResourceUser can only be specified by applications for private resources"));
+            "Request could not be parsed or was invalid: MethodArgumentNotValidException. Ensure that all types are correct and that enums have valid values."));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     String uniqueBucketName = String.format("terra-%s-bucket", UUID.randomUUID().toString());

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -23,7 +23,6 @@ import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.ManagedBy;
-import bio.terra.workspace.model.PrivateResourceIamRoles;
 import bio.terra.workspace.model.PrivateResourceUser;
 import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.ResourceType;
@@ -181,7 +180,9 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
 
     // Supply just the roles, but no email
     PrivateResourceUser privateUserNoEmail =
-        new PrivateResourceUser().userName(null).privateResourceIamRole(ControlledResourceIamRole.READER);
+        new PrivateResourceUser()
+            .userName(null)
+            .privateResourceIamRole(ControlledResourceIamRole.READER);
 
     ex =
         assertThrows(

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -200,7 +200,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     assertThat(
         ex.getMessage(),
         containsString(
-            "Request could not be parsed or was invalid: MethodArgumentNotValidException. Ensure that all types are correct and that enums have valid values."));
+            "PrivateResourceUser can only be specified by applications for private resources"));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     String uniqueBucketName = String.format("terra-%s-bucket", UUID.randomUUID().toString());

--- a/openapi/src/common/schemas.yaml
+++ b/openapi/src/common/schemas.yaml
@@ -154,6 +154,14 @@ components:
       type: string
       pattern: '^[a-zA-Z0-9][-_a-zA-Z0-9]{0,1023}$'
 
+    PrivateResourceIamRoles:
+      description: >-
+        List of role(s) granted to the user of a private resource. In the current permission model
+        EDITOR includes WRITER includes READER by definition. We only grant the maximum role listed.
+      type: array
+      items:
+        $ref: '#/components/schemas/ControlledResourceIamRole'
+
     PrivateResourceUser:
       description: >-
         This text describes the target state:
@@ -162,13 +170,18 @@ components:
         users will have no direct access to the associated cloud resource. If this element
         is specified both fields are required.
       type: object
-      required: [userName, privateResourceIamRole]
+      # TODO: PF-1218 - This is disallowed for user private resources. Both the single role and role list are
+      # accepted as an interim step. Once the CLI and UI are updated, we should only accept the single role
+      # and require both fields to be present.
+      #      required: [ userName, privateResourceIamRole ]
       properties:
         userName:
           description: email of the workspace user to grant access
           type: string
         privateResourceIamRole:
           $ref: '#/components/schemas/ControlledResourceIamRole'
+        privateResourceIamRoles:
+          $ref: '#/components/schemas/PrivateResourceIamRoles'
   
     PrivateResourceState:
       description: >-

--- a/openapi/src/common/schemas.yaml
+++ b/openapi/src/common/schemas.yaml
@@ -154,14 +154,6 @@ components:
       type: string
       pattern: '^[a-zA-Z0-9][-_a-zA-Z0-9]{0,1023}$'
 
-    PrivateResourceIamRoles:
-      description: >-
-        List of role(s) granted to the user of a private resource. In the current permission model
-        EDITOR includes WRITER includes READER by definition. We only grant the maximum role listed.
-      type: array
-      items:
-        $ref: '#/components/schemas/ControlledResourceIamRole'
-  
     PrivateResourceUser:
       description: >-
         This text describes the target state:
@@ -170,9 +162,7 @@ components:
         users will have no direct access to the associated cloud resource. If this element
         is specified both fields are required.
       type: object
-  # TODO: PF-1218 - when CLI and UI are no longer passing this, disallow it for user-private
-  #  resources, make the role List into a single role, and require both fields to be present.
-  #      required: [ userName, privateResourceIamRole ]
+      required: [userName, privateResourceIamRole]
       properties:
         userName:
           description: email of the workspace user to grant access

--- a/openapi/src/common/schemas.yaml
+++ b/openapi/src/common/schemas.yaml
@@ -172,13 +172,13 @@ components:
       type: object
   # TODO: PF-1218 - when CLI and UI are no longer passing this, disallow it for user-private
   #  resources, make the role List into a single role, and require both fields to be present.
-  #      required: [ userName, privateResourceIamRoles ]
+  #      required: [ userName, privateResourceIamRole ]
       properties:
         userName:
           description: email of the workspace user to grant access
           type: string
-        privateResourceIamRoles:
-          $ref: '#/components/schemas/PrivateResourceIamRoles'
+        privateResourceIamRole:
+          $ref: '#/components/schemas/ControlledResourceIamRole'
   
     PrivateResourceState:
       description: >-

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
@@ -17,7 +17,10 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateUserRole;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
@@ -142,30 +145,43 @@ public class ControllerBase {
                       userRequest),
               "validate private user is workspace member");
 
-          // Translate the incoming role into our internal model form
+          // Translate the incoming role list into our internal model form
           // This also validates that the incoming API model values are correct.
+          List<ControlledResourceIamRole> roles;
           ApiControlledResourceIamRole apiControlledResourceIamRole =
               commonFields.getPrivateResourceUser().getPrivateResourceIamRole();
 
-          if (apiControlledResourceIamRole == null) {
-            throw new ValidationException(
-                "You must specify at least one role when you specify PrivateResourceIamRoles");
+          if (apiControlledResourceIamRole != null) {
+            roles = new ArrayList<ControlledResourceIamRole>();
+            roles.add(
+                ControlledResourceIamRole.fromApiModel(
+                    commonFields.getPrivateResourceUser().getPrivateResourceIamRole()));
+          } else {
+            // PF-1218 - Once UI & CLI are no longer sending this for application managed resources,
+            // remove this block.
+            roles =
+                commonFields.getPrivateResourceUser().getPrivateResourceIamRoles().stream()
+                    .map(ControlledResourceIamRole::fromApiModel)
+                    .collect(Collectors.toList());
+            if (roles.isEmpty()) {
+              throw new ValidationException(
+                  "You must specify at least one role when you specify PrivateResourceIamRoles");
+            }
           }
-
-          ControlledResourceIamRole role =
-              ControlledResourceIamRole.fromApiModel(apiControlledResourceIamRole);
 
           // The legal options for the assigned user of an application is READER
           // or WRITER. EDITOR is not allowed. We take the "max" of READER and WRITER.
           var maxRole = ControlledResourceIamRole.READER;
-          if (role == ControlledResourceIamRole.WRITER) {
-            if (maxRole == ControlledResourceIamRole.READER) {
-              maxRole = role;
+          for (ControlledResourceIamRole role : roles) {
+            if (role == ControlledResourceIamRole.WRITER) {
+              if (maxRole == ControlledResourceIamRole.READER) {
+                maxRole = role;
+              }
+            } else if (role != ControlledResourceIamRole.READER) {
+              throw new ValidationException(
+                  "For application private controlled resources, only READER and WRITER roles are allowed. Found "
+                      + role.toApiModel());
             }
-          } else if (role != ControlledResourceIamRole.READER) {
-            throw new ValidationException(
-                "For application private controlled resources, only READER and WRITER roles are allowed. Found "
-                    + role.toApiModel());
           }
 
           return new PrivateUserRole.Builder()

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
@@ -16,6 +16,8 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateUserRole;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -143,12 +145,11 @@ public class ControllerBase {
                       userRequest),
               "validate private user is workspace member");
 
-          // Translate the incoming role list into our internal model form
+          // Translate the incoming role into our internal model form
           // This also validates that the incoming API model values are correct.
-          List<ControlledResourceIamRole> roles =
-              commonFields.getPrivateResourceUser().getPrivateResourceIamRoles().stream()
-                  .map(ControlledResourceIamRole::fromApiModel)
-                  .collect(Collectors.toList());
+          List<ControlledResourceIamRole> roles = new ArrayList<ControlledResourceIamRole>();
+          roles.add(ControlledResourceIamRole.fromApiModel(commonFields.getPrivateResourceUser().getPrivateResourceIamRole()));
+
           if (roles.isEmpty()) {
             throw new ValidationException(
                 "You must specify at least one role when you specify PrivateResourceIamRoles");

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
@@ -17,8 +17,6 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateUserRole;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
@@ -154,7 +152,8 @@ public class ControllerBase {
                 "You must specify at least one role when you specify PrivateResourceIamRoles");
           }
 
-          ControlledResourceIamRole role = ControlledResourceIamRole.fromApiModel(apiControlledResourceIamRole);
+          ControlledResourceIamRole role =
+              ControlledResourceIamRole.fromApiModel(apiControlledResourceIamRole);
 
           // The legal options for the assigned user of an application is READER
           // or WRITER. EDITOR is not allowed. We take the "max" of READER and WRITER.

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
@@ -16,11 +16,9 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateUserRole;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
@@ -148,7 +146,9 @@ public class ControllerBase {
           // Translate the incoming role into our internal model form
           // This also validates that the incoming API model values are correct.
           List<ControlledResourceIamRole> roles = new ArrayList<ControlledResourceIamRole>();
-          roles.add(ControlledResourceIamRole.fromApiModel(commonFields.getPrivateResourceUser().getPrivateResourceIamRole()));
+          roles.add(
+              ControlledResourceIamRole.fromApiModel(
+                  commonFields.getPrivateResourceUser().getPrivateResourceIamRole()));
 
           if (roles.isEmpty()) {
             throw new ValidationException(


### PR DESCRIPTION
Changes the input from a list of roles to a single role. UI and CLI should also be updated to account for this, but they aren't sending anything for this field now anyway.