### PR TITLE
[PF-1747] Allow userFacingId to start with number

### DIFF
--- a/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
@@ -51,7 +51,7 @@ public class WorkspaceLifecycle extends WorkspaceApiTestScriptBase {
     assertThat(
         ex.getMessage(),
         containsString(
-            "ID must have 3-63 characters, and contain lowercase letters, numbers, dashes, or underscores"));
+            "ID must have 3-63 characters, contain lowercase letters, numbers, dashes, or underscores, and start with lowercase letter or number"));
 
     createBody.userFacingId(validUserFacingId);
     workspaceApi.createWorkspace(createBody);
@@ -75,7 +75,7 @@ public class WorkspaceLifecycle extends WorkspaceApiTestScriptBase {
     assertThat(
         ex.getMessage(),
         containsString(
-            "ID must have 3-63 characters, and contain lowercase letters, numbers, dashes, or underscores"));
+            "ID must have 3-63 characters, contain lowercase letters, numbers, dashes, or underscores, and start with lowercase letter or number"));
 
     updateBody.userFacingId(validUserFacingId2);
     WorkspaceDescription updatedDescription =

--- a/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
@@ -51,7 +51,7 @@ public class WorkspaceLifecycle extends WorkspaceApiTestScriptBase {
     assertThat(
         ex.getMessage(),
         containsString(
-            "ID must have 3-63 characters, contain lowercase letters, numbers, dashes, or underscores, and start with lowercase letter"));
+            "ID must have 3-63 characters, and contain lowercase letters, numbers, dashes, or underscores"));
 
     createBody.userFacingId(validUserFacingId);
     workspaceApi.createWorkspace(createBody);

--- a/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/WorkspaceLifecycle.java
@@ -75,7 +75,7 @@ public class WorkspaceLifecycle extends WorkspaceApiTestScriptBase {
     assertThat(
         ex.getMessage(),
         containsString(
-            "ID must have 3-63 characters, contain lowercase letters, numbers, dashes, or underscores, and start with lowercase letter"));
+            "ID must have 3-63 characters, and contain lowercase letters, numbers, dashes, or underscores"));
 
     updateBody.userFacingId(validUserFacingId2);
     WorkspaceDescription updatedDescription =

--- a/openapi/src/common/parameters.yaml
+++ b/openapi/src/common/parameters.yaml
@@ -101,8 +101,8 @@ components:
       name: workspaceUserFacingId
       in: path
       description: |
-        Human-settable, mutable id. Must have 3-63 characters, and contain lowercase letters, numbers, dashes, or
-        underscores.
+        Human-settable, mutable id. ID must have 3-63 characters, contain lowercase letters, numbers,
+        dashes, or underscores, and start with lowercase letter or number
       required: true
       schema:
         type: string

--- a/openapi/src/common/parameters.yaml
+++ b/openapi/src/common/parameters.yaml
@@ -101,8 +101,8 @@ components:
       name: workspaceUserFacingId
       in: path
       description: |
-        Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-        underscores, and start with lowercase letter.
+        Human-settable, mutable id. Must have 3-63 characters, and contain lowercase letters, numbers, dashes, or
+        underscores.
       required: true
       schema:
         type: string

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -255,8 +255,8 @@ components:
           format: uuid
         destinationUserFacingId:
           description: |
-            Human-settable, mutable id. Must have 3-63 characters, and contain lowercase letters, numbers, dashes, or
-            underscores.
+            Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers,
+            dashes, or underscores, and start with lowercase letter or number.
           type: string
         resources:
           type: array
@@ -280,8 +280,8 @@ components:
       properties:
         userFacingId:
           description: |
-            Human-settable, mutable id for cloned workspace. ID must have 3-63 characters, contain lowercase letters,
-            numbers, dashes, or underscores, and start with lowercase letter. Optional. If this isn't set, one will be
+            Human-settable, mutable id for cloned workspace. Must have 3-63 characters, contain lowercase letters, numbers,
+            dashes, or underscores, and start with lowercase letter or number. Optional. If this isn't set, one will be
             generated.
           type: string
         displayName:
@@ -363,7 +363,7 @@ components:
         userFacingId:
           description: |
             Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter. Optional. If this isn't set, one will be generated based on
+            underscores, and start with lowercase letter or number. Optional. If this isn't set, one will be generated based on
             id (uuid).
           type: string
         displayName:
@@ -443,7 +443,7 @@ components:
         userFacingId:
           description: |
             Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter.
+            underscores, and start with lowercase letter or number.
           type: string
         displayName:
           description: The human readable name of the workspace
@@ -466,7 +466,7 @@ components:
         userFacingId:
           description: |
             Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter.
+            underscores, and start with lowercase letter or number.
           type: string
         displayName:
           description: The human readable name of the workspace

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -255,8 +255,8 @@ components:
           format: uuid
         destinationUserFacingId:
           description: |
-            Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter.
+            Human-settable, mutable id. Must have 3-63 characters, and contain lowercase letters, numbers, dashes, or
+            underscores.
           type: string
         resources:
           type: array

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -118,9 +118,8 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
         Optional.ofNullable(body.getSpendProfile()).map(SpendProfileId::new);
 
     // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't
-    // pass userFacingId in request, so use id. Prefix with "a" because userFacingId must start with
-    // a letter.
-    String userFacingId = Optional.ofNullable(body.getUserFacingId()).orElse("a-" + body.getId());
+    // pass userFacingId in request, so use id.
+    String userFacingId = Optional.ofNullable(body.getUserFacingId()).orElse(body.getId().toString());
     ControllerValidationUtils.validateUserFacingId(userFacingId);
 
     Workspace workspace =
@@ -449,10 +448,9 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     final UUID destinationWorkspaceId = UUID.randomUUID();
 
     // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't
-    // pass userFacingId in request, so use id. Prefix with "a" because userFacingId must start with
-    // letter.
+    // pass userFacingId in request, so use id.
     String destinationUserFacingId =
-        Optional.ofNullable(body.getUserFacingId()).orElse("a-" + destinationWorkspaceId);
+        Optional.ofNullable(body.getUserFacingId()).orElse(destinationWorkspaceId.toString());
     ControllerValidationUtils.validateUserFacingId(destinationUserFacingId);
 
     // Construct the target workspace object from the inputs

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -119,7 +119,8 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
 
     // ET uses userFacingId; CWB doesn't. Schema enforces that userFacingId must be set. CWB doesn't
     // pass userFacingId in request, so use id.
-    String userFacingId = Optional.ofNullable(body.getUserFacingId()).orElse(body.getId().toString());
+    String userFacingId =
+        Optional.ofNullable(body.getUserFacingId()).orElse(body.getId().toString());
     ControllerValidationUtils.validateUserFacingId(userFacingId);
 
     Workspace workspace =

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -29,10 +29,10 @@ public final class ControllerValidationUtils {
 
   /**
    * userFacingId must be 3-63 characters, use lower-case letters, numbers, dashes, or underscores
-   * and must start with a letter.
+   * and must start with a lower-case letter or number.
    */
   public static final Pattern USER_FACING_ID_VALIDATION_PATTERN =
-      Pattern.compile("^[-_a-z0-9]{3,63}$");
+      Pattern.compile("^[a-z0-9][-_a-z0-9]{2,62}$");
 
   /**
    * Utility to validate limit/offset parameters used in pagination.
@@ -105,7 +105,7 @@ public final class ControllerValidationUtils {
       logger.warn("User provided invalid userFacingId: " + userFacingId);
       // "ID" instead of "userFacingId" because user sees this.
       throw new ValidationException(
-          "ID must have 3-63 characters, and contain lowercase letters, numbers, dashes, or underscores");
+          "ID must have 3-63 characters, contain lowercase letters, numbers, dashes, or underscores, and start with lowercase letter or number");
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -32,7 +32,7 @@ public final class ControllerValidationUtils {
    * and must start with a letter.
    */
   public static final Pattern USER_FACING_ID_VALIDATION_PATTERN =
-      Pattern.compile("^[a-z][-_a-z0-9]{2,62}$");
+      Pattern.compile("^[-_a-z0-9]{3,63}$");
 
   /**
    * Utility to validate limit/offset parameters used in pagination.
@@ -105,7 +105,7 @@ public final class ControllerValidationUtils {
       logger.warn("User provided invalid userFacingId: " + userFacingId);
       // "ID" instead of "userFacingId" because user sees this.
       throw new ValidationException(
-          "ID must have 3-63 characters, contain lowercase letters, numbers, dashes, or underscores, and start with lowercase letter");
+          "ID must have 3-63 characters, and contain lowercase letters, numbers, dashes, or underscores");
     }
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -142,7 +142,7 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     workspaceDao.createWorkspace(
         Workspace.builder()
             .workspaceId(workspaceUuid)
-            .userFacingId("a" + workspaceUuid)
+            .userFacingId(workspaceUuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build());
     FlightMap inputParams = new FlightMap();
@@ -184,7 +184,7 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     workspaceDao.createWorkspace(
         Workspace.builder()
             .workspaceId(workspaceUuid)
-            .userFacingId("a" + workspaceUuid)
+            .userFacingId(workspaceUuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build());
     var flightId = UUID.randomUUID().toString();
@@ -252,7 +252,7 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     workspaceDao.createWorkspace(
         Workspace.builder()
             .workspaceId(workspaceUuid)
-            .userFacingId("a" + workspaceUuid)
+            .userFacingId(workspaceUuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build());
     var flightId = UUID.randomUUID().toString();

--- a/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
@@ -45,7 +45,7 @@ public class AzureTestUtils {
     Workspace workspace =
         Workspace.builder()
             .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
+            .userFacingId(uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     workspaceService.createWorkspace(workspace, userAccessUtils.defaultUserAuthRequest());

--- a/service/src/test/java/bio/terra/workspace/common/utils/ControllerValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/ControllerValidationUtilsTest.java
@@ -1,0 +1,12 @@
+package bio.terra.workspace.common.utils;
+
+import bio.terra.workspace.common.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+
+class ControllerValidationUtilsTest extends BaseUnitTest {
+
+  @Test
+  void userFacingIdCanStartWithNumber() throws Exception {
+    ControllerValidationUtils.validateUserFacingId("1000-genomes");
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -25,7 +25,7 @@ public class WorkspaceConnectedTestUtils {
     Workspace workspace =
         Workspace.builder()
             .workspaceId(workspaceUuid)
-            .userFacingId("a" + UUID.randomUUID().toString())
+            .userFacingId(UUID.randomUUID().toString())
             .spendProfileId(spendUtils.defaultSpendId())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -43,7 +43,7 @@ public class ResourceDaoTest extends BaseUnitTest {
     Workspace workspace =
         Workspace.builder()
             .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
+            .userFacingId(uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     workspaceDao.createWorkspace(workspace);

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -68,7 +68,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
     Workspace workspace =
         Workspace.builder()
             .workspaceId(workspaceUuid)
-            .userFacingId("a" + workspaceUuid)
+            .userFacingId(workspaceUuid.toString())
             .spendProfileId(spendProfileId)
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .build();
@@ -139,7 +139,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
     Workspace secondWorkspace =
         Workspace.builder()
             .workspaceId(uuid)
-            .userFacingId("a" + uuid)
+            .userFacingId(uuid.toString())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .build();
     workspaceDao.createWorkspace(secondWorkspace);
@@ -160,7 +160,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
     Workspace secondWorkspace =
         Workspace.builder()
             .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
+            .userFacingId(uuid.toString())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .build();
     workspaceDao.createWorkspace(secondWorkspace);
@@ -185,7 +185,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
       mcWorkspace =
           Workspace.builder()
               .workspaceId(mcWorkspaceId)
-              .userFacingId("a" + mcWorkspaceId)
+              .userFacingId(mcWorkspaceId.toString())
               .workspaceStage(WorkspaceStage.MC_WORKSPACE)
               .build();
       workspaceDao.createWorkspace(mcWorkspace);
@@ -292,7 +292,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
   private Workspace defaultWorkspace() {
     return Workspace.builder()
         .workspaceId(workspaceUuid)
-        .userFacingId("a" + workspaceUuid)
+        .userFacingId(workspaceUuid.toString())
         .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
         .build();
   }

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -232,7 +232,7 @@ class SamServiceTest extends BaseConnectedTest {
     Workspace rawlsWorkspace =
         Workspace.builder()
             .workspaceId(workspaceUuid)
-            .userFacingId("a" + workspaceUuid.toString())
+            .userFacingId(workspaceUuid.toString())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .build();
     workspaceService.createWorkspace(rawlsWorkspace, defaultUserRequest());
@@ -461,7 +461,7 @@ class SamServiceTest extends BaseConnectedTest {
     Workspace workspace =
         Workspace.builder()
             .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
+            .userFacingId(uuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     workspaceService.createWorkspace(workspace, userRequest);

--- a/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -200,7 +200,7 @@ class JobServiceTest extends BaseUnitTest {
     Workspace workspace =
         Workspace.builder()
             .workspaceId(workspaceUuid)
-            .userFacingId("a" + workspaceUuid)
+            .userFacingId(workspaceUuid.toString())
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .description("Workspace for runFlight: " + description)
             .build();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureControlledStorageResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureControlledStorageResourceServiceTest.java
@@ -95,7 +95,7 @@ public class AzureControlledStorageResourceServiceTest extends BaseAzureTest {
         workspaceService.createWorkspace(
             Workspace.builder()
                 .workspaceId(UUID.randomUUID())
-                .userFacingId("a" + UUID.randomUUID().toString())
+                .userFacingId(UUID.randomUUID().toString())
                 .spendProfileId(spendUtils.defaultSpendId())
                 .workspaceStage(WorkspaceStage.MC_WORKSPACE)
                 .build(),


### PR DESCRIPTION
For the 1000 Genomes workspaces, I'd like userFacing id to be 1000-genomes instead of a-1000-genomes.

@cbookg I can take a stab at corresponding UI PR.