### PR TITLE
Temporarily remove Azure VM tests

### DIFF
--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -23,10 +23,6 @@
     "integration/ReferencedGitRepoLifecycle.json",
     "integration/ReferencedTerraWorkspaceLifecycle.json",
     "integration/RemoveUser.json",
-    "integration/WorkspaceLifecycle.json",
-    "integration/ControlledAzureVmNoPublicIpLifecycle.json",
-    "integration/ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle.json",
-    "integration/ControlledAzureVmWithPublicIpLifecycle.json",
-    "integration/ControlledAzureVmWithWrongCredentialsLifecycle.json"
+    "integration/WorkspaceLifecycle.json"
   ]
 }


### PR DESCRIPTION
Need to temporarily remove Azure tests from WSM nightly run. The issue is not related directly to functionality but related to cleanup procedure which TestRunner runs. It looks like VM deletion procedure takes more time than expected (while deleting workspace). It causes retry operation to run clean up again and start deleting workspace again. Thanks @ddietterich for finding the root cause!