### PR TITLE
PF-1855: disable WRITE_DATE_AS_TIMESTAMPS so they keep the RFC3339 format.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
@@ -68,6 +68,8 @@ public class BeanConfig {
             .registerModule(new ParameterNamesModule())
             .registerModule(new Jdk8Module())
             .registerModule(new JavaTimeModule())
+            // Disable serialization Date as Timestamp so swagger shows date in the RFC3339
+            // format, see details in PF-1855.
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             .setDefaultPropertyInclusion(Include.NON_ABSENT);
     objectMapper.getFactory().setCharacterEscapes(new HTMLCharacterEscapes());

--- a/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/spring/BeanConfig.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
@@ -67,6 +68,7 @@ public class BeanConfig {
             .registerModule(new ParameterNamesModule())
             .registerModule(new Jdk8Module())
             .registerModule(new JavaTimeModule())
+            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             .setDefaultPropertyInclusion(Include.NON_ABSENT);
     objectMapper.getFactory().setCharacterEscapes(new HTMLCharacterEscapes());
     return objectMapper;

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class WorkspaceActivityLogDao {
-  
+
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   // These fields don't update workspace "Last updated" time in UI. For example,

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class WorkspaceActivityLogDao {
-
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   // These fields don't update workspace "Last updated" time in UI. For example,

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class WorkspaceActivityLogDao {
+  
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   // These fields don't update workspace "Last updated" time in UI. For example,


### PR DESCRIPTION
Does not break CLI
```
Title:			
Short description:	
Version:		
Created:		2022-07-22
Last updated:		2022-07-22
Resources:
                        NAME                            RESOURCE TYPE         DESCRIPTION     
```

swagger:
```
{
  "workspaces": [
    {
      "id": "4650baba-8a52-46c8-bb02-ba9423ad4dff",
      "userFacingId": "workspace1",
      "displayName": "",
      "description": "",
      "highestRole": "OWNER",
      "spendProfile": "wm-default-spend-profile",
      "stage": "MC_WORKSPACE",
      "gcpContext": {
        "projectId": "terra-wsm-t-clever-apple-9738"
      },
      "properties": [],
      "createdDate": "2022-07-22T19:14:42.787477Z",
      "lastUpdatedDate": "2022-07-22T19:15:07.941062Z"
    },
    {
      "id": "f9ca20a6-b845-41cf-914a-36c65aa8591a",
      "userFacingId": "gcpworkspace",
      "displayName": "",
      "description": "",
      "highestRole": "OWNER",
      "spendProfile": "wm-default-spend-profile",
      "stage": "MC_WORKSPACE",
      "gcpContext": {
        "projectId": "terra-wsm-t-frosty-date-3113"
      },
      "properties": [],
      "createdDate": "2022-07-22T19:12:50.043835Z",
      "lastUpdatedDate": "2022-07-22T19:13:29.246538Z"
    }
  ]
}
```