### PR TITLE
Gradle retry for non-integration tests

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,6 +15,7 @@ plugins {
     id "org.springframework.boot" version "${springBootVersion}"
     id "io.spring.dependency-management" version "1.0.10.RELEASE"
     id 'ru.vyarus.quality' version '4.5.0'
+    id 'org.gradle.test-retry' version '1.4.0'
 }
 
 // constants visible to all .gradle files in this project

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -24,6 +24,24 @@ test {
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
+
+  // For GHA runs, retry failing tests. If 2nd time passes, workflow will still
+  // fail and oncall will still be notified. This way, oncall dosen't have to
+  // rerun workflow in GHA.
+  retry {
+    // This is set automatically on Github Actions runners, and never set
+    // otherwise.
+    if (System.getenv().containsKey("CI")) {
+      // Max retries per test.
+      maxRetries = 1
+      // Max total test failures.
+      // This is an estimate based on current failure rates, but if more
+      // than 5 tests fail in a run it's likely a real source of failure
+      // and we should stop retrying.
+      maxFailures = 5
+    }
+    failOnPassedAfterRetry = true
+  }
 }
 
 task unitTest(type: Test) {
@@ -41,6 +59,24 @@ task connectedTest(type: Test) {
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
+
+  // For GHA runs, retry failing tests. If 2nd time passes, workflow will still
+  // fail and oncall will still be notified. This way, oncall dosen't have to
+  // rerun workflow in GHA.
+  retry {
+    // This is set automatically on Github Actions runners, and never set
+    // otherwise.
+    if (System.getenv().containsKey("CI")) {
+      // Max retries per test.
+      maxRetries = 1
+      // Max total test failures.
+      // This is an estimate based on current failure rates, but if more
+      // than 5 tests fail in a run it's likely a real source of failure
+      // and we should stop retrying.
+      maxFailures = 5
+    }
+    failOnPassedAfterRetry = true
+  }
 }
 
 task azureTest(type: Test) {
@@ -49,4 +85,22 @@ task azureTest(type: Test) {
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
+
+  // For GHA runs, retry failing tests. If 2nd time passes, workflow will still
+  // fail and oncall will still be notified. This way, oncall dosen't have to
+  // rerun workflow in GHA.
+  retry {
+    // This is set automatically on Github Actions runners, and never set
+    // otherwise.
+    if (System.getenv().containsKey("CI")) {
+      // Max retries per test.
+      maxRetries = 1
+      // Max total test failures.
+      // This is an estimate based on current failure rates, but if more
+      // than 5 tests fail in a run it's likely a real source of failure
+      // and we should stop retrying.
+      maxFailures = 5
+    }
+    failOnPassedAfterRetry = true
+  }
 }

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -1,5 +1,9 @@
 // Testing config
 
+plugins {
+    id 'org.gradle.test-retry' version '1.4.0'
+}
+
 // The path to the default Google service account for the Workspace Manager to run as.
 // Created by scripts/write_config.sh
 def googleCredentialsFile = "${rootDir}/config/wsm-sa.json"

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -1,9 +1,5 @@
 // Testing config
 
-plugins {
-    id 'org.gradle.test-retry' version '1.4.0'
-}
-
 // The path to the default Google service account for the Workspace Manager to run as.
 // Created by scripts/write_config.sh
 def googleCredentialsFile = "${rootDir}/config/wsm-sa.json"


### PR DESCRIPTION
For GHA runs, retry failing tests. If 2nd time passes, workflow will still fail and oncall will still be notified. This way, oncall doesn't have to rerun workflow in GHA. Note that this is faster because only the tests that failed are rerun.

In CLI repo, @zloery found that adding to `test` block didn't work, he had to add to `runTestsWithTag`. So unfortunately I have to duplicate. (And this can't go in terra-gradle-plugin repo.)

I didn't do integration tests, since integration tests don't use junit (QA-1764). [Retry plugin requires junit.](https://github.com/gradle/test-retry-gradle-plugin#supported-test-frameworks)