### PR TITLE
In post-startup script, use pip instead of conda

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -2,6 +2,13 @@
 #
 # Default post startup script for GCP notebooks.
 # GCP Notebook post startup scrips are run only when the instance is first created.
+#
+# How to test changes to this file:
+# - gsutil cp service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh gs://MYBUCKET
+# - terra resource create gcp-notebook --post-startup-script=gs://MYBUCKET/post-startup.sh --name="test_post_startup"
+#
+# To test a single line, run with "sudo" in notebook. Post-startup script runs
+# as root.
 
 set -o errexit
 set -o nounset
@@ -36,8 +43,8 @@ function get_metadata_value() {
     "http://metadata/computeMetadata/v1/$1"
 }
 
-# Install common packages in conda environment
-/opt/conda/bin/conda install -y pre-commit nbdime nbstripout pylint pytest dsub pandas_gbq
+# Install common packages. Use pip instead of conda because conda is slow.
+/opt/conda/bin/pip install pre-commit nbdime nbstripout pylint pytest dsub pandas_gbq
 
 # Install nbstripout for the jupyter user in all git repositories.
 sudo -u "${JUPYTER_USER}" sh -c "/opt/conda/bin/nbstripout --install --global"


### PR DESCRIPTION
[Previous PR](https://github.com/DataBiosphere/terra-workspace-manager/pull/733) broke startup script:

![image](https://user-images.githubusercontent.com/10929390/181603927-b449435c-3b84-4e35-b186-0f130c43b33f.png)


With conda, must be `pandas-gbq` (this is why [previous PR](https://github.com/DataBiosphere/terra-workspace-manager/pull/733) broke). With pip, can be `pandas-gbq` or `pandas_gbq`.

conda took 17 minutes (!!). pip takes less than 1 minute, so changed to pip.