### PR TITLE
[PF-1882] Handle unknown roles from Sam

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
@@ -34,11 +34,16 @@ public enum WsmIamRole {
                 "No IamRole enum found corresponding to model role " + apiModel.toString()));
   }
 
+  /**
+   * Return the WsmIamRole corresponding to the provided Sam role, or null if the Sam role does not
+   * match a Wsm role. There are valid roles on workspaces in Sam which do not map to WsmIam roles,
+   * in general WSM should ignore these roles.
+   */
   public static WsmIamRole fromSam(String samRole) {
-    Optional<WsmIamRole> result =
-        Arrays.stream(WsmIamRole.values()).filter(x -> x.samRole.equals(samRole)).findFirst();
-    return result.orElseThrow(
-        () -> new RuntimeException("No IamRole enum found corresponding to Sam role " + samRole));
+    return Arrays.stream(WsmIamRole.values())
+        .filter(x -> x.samRole.equals(samRole))
+        .findFirst()
+        .orElse(null);
   }
 
   public static WsmIamRole getHighestRole(UUID workspaceId, List<WsmIamRole> roles) {

--- a/service/src/test/java/bio/terra/workspace/service/iam/WsmIamRoleTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/WsmIamRoleTest.java
@@ -1,0 +1,16 @@
+package bio.terra.workspace.service.iam;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.service.iam.model.WsmIamRole;
+import org.junit.jupiter.api.Test;
+
+public class WsmIamRoleTest extends BaseUnitTest {
+
+  @Test
+  public void missingApiModelReturnsNull() {
+    assertNull(WsmIamRole.fromSam("FAKE_VALUE"));
+  }
+
+}

--- a/service/src/test/java/bio/terra/workspace/service/iam/WsmIamRoleTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/WsmIamRoleTest.java
@@ -8,6 +8,12 @@ import org.junit.jupiter.api.Test;
 
 public class WsmIamRoleTest extends BaseUnitTest {
 
+  /**
+   * This test looks trivial, but it enforces that WsmIamRole.fromSam must handle unknown values
+   * without throwing. Sam can sometimes return roles that WSM doesn't know about (e.g. if WSM lists
+   * the roles on a RAWLS_WORKSPACE stage workspace), and WSM should silently ignore them instead
+   * of throwing exceptions.
+   */
   @Test
   public void missingApiModelReturnsNull() {
     assertNull(WsmIamRole.fromSam("FAKE_VALUE"));

--- a/service/src/test/java/bio/terra/workspace/service/iam/WsmIamRoleTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/WsmIamRoleTest.java
@@ -11,12 +11,11 @@ public class WsmIamRoleTest extends BaseUnitTest {
   /**
    * This test looks trivial, but it enforces that WsmIamRole.fromSam must handle unknown values
    * without throwing. Sam can sometimes return roles that WSM doesn't know about (e.g. if WSM lists
-   * the roles on a RAWLS_WORKSPACE stage workspace), and WSM should silently ignore them instead
-   * of throwing exceptions.
+   * the roles on a RAWLS_WORKSPACE stage workspace), and WSM should silently ignore them instead of
+   * throwing exceptions.
    */
   @Test
   public void missingApiModelReturnsNull() {
     assertNull(WsmIamRole.fromSam("FAKE_VALUE"));
   }
-
 }


### PR DESCRIPTION
Currently when WSM encounters unknown Sam roles, it throws an exception. However, this can happen when reading the roles from a RAWLS_WORKSPACE stage workspaces, as Rawls may have set a role that WSM doesn't understand. Instead of throwing an exception WSM should silently ignore these roles.