### PR TITLE
PF-1218: Stop accepting a list of roles on the private resource user

### DIFF
--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -197,9 +197,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
                     ManagedBy.USER,
                     CloningInstructionsEnum.NOTHING,
                     privateUserNoEmail));
-    assertThat(
-        ex.getMessage(),
-        containsString("MethodArgumentNotValidException"));
+    assertThat(ex.getMessage(), containsString("MethodArgumentNotValidException"));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     String uniqueBucketName = String.format("terra-%s-bucket", UUID.randomUUID().toString());

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -199,8 +199,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
                     privateUserNoEmail));
     assertThat(
         ex.getMessage(),
-        containsString(
-            "Request could not be parsed or was invalid: MethodArgumentNotValidException. Ensure that all types are correct and that enums have valid values."));
+        containsString("MethodArgumentNotValidException"));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     String uniqueBucketName = String.format("terra-%s-bucket", UUID.randomUUID().toString());

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -200,7 +200,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     assertThat(
         ex.getMessage(),
         containsString(
-            "PrivateResourceUser can only be specified by applications for private resources"));
+            "Request could not be parsed or was invalid: MethodArgumentNotValidException. Ensure that all types are correct and that enums have valid values."));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     String uniqueBucketName = String.format("terra-%s-bucket", UUID.randomUUID().toString());

--- a/openapi/src/common/schemas.yaml
+++ b/openapi/src/common/schemas.yaml
@@ -154,14 +154,6 @@ components:
       type: string
       pattern: '^[a-zA-Z0-9][-_a-zA-Z0-9]{0,1023}$'
 
-    PrivateResourceIamRoles:
-      description: >-
-        List of role(s) granted to the user of a private resource. In the current permission model
-        EDITOR includes WRITER includes READER by definition. We only grant the maximum role listed.
-      type: array
-      items:
-        $ref: '#/components/schemas/ControlledResourceIamRole'
-
     PrivateResourceUser:
       description: >-
         This text describes the target state:
@@ -170,18 +162,13 @@ components:
         users will have no direct access to the associated cloud resource. If this element
         is specified both fields are required.
       type: object
-      # TODO: PF-1218 - This is disallowed for user private resources. Both the single role and role list are
-      # accepted as an interim step. Once the CLI and UI are updated, we should only accept the single role
-      # and require both fields to be present.
-      #      required: [ userName, privateResourceIamRole ]
+      required: [userName, privateResourceIamRole]
       properties:
         userName:
           description: email of the workspace user to grant access
           type: string
         privateResourceIamRole:
           $ref: '#/components/schemas/ControlledResourceIamRole'
-        privateResourceIamRoles:
-          $ref: '#/components/schemas/PrivateResourceIamRoles'
   
     PrivateResourceState:
       description: >-


### PR DESCRIPTION
This is the last phase of the API update - where we stop accepting a list of roles. We also require both the user + single role to be sent if the PrivateResourceUser is sent.