### PR TITLE
[PF-1882] Handle roles that WSM doesn't know about yet

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -191,8 +191,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: wsm-and-testrunner-logs
-          path: |
-            wsm.log
-            ${{ steps.integration-test.outputs.results-dir }}
+          # We're not running WSM locally, so there's no wsm.log
+          name: testrunner-logs
+          path: ${{ steps.integration-test.outputs.results-dir }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ HELP.md
 *.iml
 *.ipr
 out/
-.run
+.run/**
 
 ### NetBeans ###
 /nbproject/private/

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -299,7 +299,10 @@ public class SamService {
                   .map(WsmIamRole::fromSam)
                   .filter(Objects::nonNull)
                   .collect(Collectors.toList());
-          workspacesAndRoles.put(workspaceId, WsmIamRole.getHighestRole(workspaceId, roles));
+          Optional<WsmIamRole> highestRole = WsmIamRole.getHighestRole(workspaceId, roles);
+          if (highestRole.isPresent()) {
+            workspacesAndRoles.put(workspaceId, highestRole.get());
+          }
         } catch (IllegalArgumentException e) {
           // WSM always uses UUIDs for workspace IDs, but this is not enforced in Sam and there are
           // old workspaces that don't use UUIDs. Any workspace with a non-UUID workspace ID is

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -300,8 +300,7 @@ public class SamService {
                   .filter(Objects::nonNull)
                   .collect(Collectors.toList());
           Optional<WsmIamRole> highestRole = WsmIamRole.getHighestRole(workspaceId, roles);
-          // Skip workspaces with no roles. (That means there's a role this WSM doesn't know about
-          // yet.)
+          // Skip workspaces with no roles. (That means there's a role this WSM doesn't know about.)
           if (highestRole.isPresent()) {
             workspacesAndRoles.put(workspaceId, highestRole.get());
           }

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -300,6 +300,8 @@ public class SamService {
                   .filter(Objects::nonNull)
                   .collect(Collectors.toList());
           Optional<WsmIamRole> highestRole = WsmIamRole.getHighestRole(workspaceId, roles);
+          // Skip workspaces with no roles. (That means there's a role this WSM doesn't know about
+          // yet.)
           if (highestRole.isPresent()) {
             workspacesAndRoles.put(workspaceId, highestRole.get());
           }

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
@@ -52,9 +52,7 @@ public enum WsmIamRole {
 
   public static Optional<WsmIamRole> getHighestRole(UUID workspaceId, List<WsmIamRole> roles) {
     if (roles.isEmpty()) {
-      // This should be extremely rare. This only happens when a WSM role has been added to SAM,
-      // but WSM doesn't know about it yet (eg a local WSM created a workspace with this role, but
-      // broad-dev WSM doesn't know about role yet).
+      // This workspace had a role that this WSM doesn't know about.
       logger.warn("Workspace %s missing roles", workspaceId.toString());
       return Optional.empty();
     }

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Internal representation of IAM roles. */
 public enum WsmIamRole {
@@ -16,6 +18,8 @@ public enum WsmIamRole {
   // The manager role is given to WSM's SA on all Sam workspace objects for admin control. Users
   // are never given this role.
   MANAGER("manager", null);
+
+  private static final Logger logger = LoggerFactory.getLogger(WsmIamRole.class);
 
   private final String samRole;
   private final ApiIamRole apiRole;
@@ -46,20 +50,23 @@ public enum WsmIamRole {
         .orElse(null);
   }
 
-  public static WsmIamRole getHighestRole(UUID workspaceId, List<WsmIamRole> roles) {
+  public static Optional<WsmIamRole> getHighestRole(UUID workspaceId, List<WsmIamRole> roles) {
     if (roles.isEmpty()) {
-      throw new InternalServerErrorException(
-          String.format("Workspace %s missing roles", workspaceId.toString()));
+      // This should be extremely rare. This only happens when a WSM role has been added to SAM,
+      // but WSM doesn't know about it yet (eg a local WSM created a workspace with this role, but
+      // broad-dev WSM doesn't know about role yet).
+      logger.warn("Workspace %s missing roles", workspaceId.toString());
+      return Optional.empty();
     }
 
     if (roles.contains(WsmIamRole.APPLICATION)) {
-      return WsmIamRole.APPLICATION;
+      return Optional.of(WsmIamRole.APPLICATION);
     } else if (roles.contains(WsmIamRole.OWNER)) {
-      return WsmIamRole.OWNER;
+      return Optional.of(WsmIamRole.OWNER);
     } else if (roles.contains(WsmIamRole.WRITER)) {
-      return WsmIamRole.WRITER;
+      return Optional.of(WsmIamRole.WRITER);
     } else if (roles.contains(WsmIamRole.READER)) {
-      return WsmIamRole.READER;
+      return Optional.of(WsmIamRole.READER);
     }
     throw new InternalServerErrorException(
         String.format("Workspace %s has unexpected roles: %s", workspaceId.toString(), roles));

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -29,9 +29,11 @@ import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceAndHighestRole;
+import com.google.common.base.Preconditions;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -242,7 +244,10 @@ public class WorkspaceService {
                 samService.listRequesterRoles(
                     userRequest, SamConstants.SamResource.WORKSPACE, uuid.toString()),
             "listRequesterRoles");
-    return WsmIamRole.getHighestRole(uuid, requesterRoles);
+    Optional<WsmIamRole> highestRole = WsmIamRole.getHighestRole(uuid, requesterRoles);
+    Preconditions.checkState(
+        highestRole.isPresent(), String.format("Workspace %s missing roles", uuid.toString()));
+    return highestRole.get();
   }
 
   /**


### PR DESCRIPTION
[Last night's nightly test failed.](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/2794805592)

Yesterday, with a local WSM, I added discoverer policy to some workspaces in broad-dev SAM. The test's ListWorkspaces picked those up. Nightly test WSM (`https://workspace.wsmtest.integ.envs.broadinstitute.org/`) didn't know about discoverer role. It threw an exception when a workspace didn't have any SAM permissions.

In this PR, if a workspace doesn't have any SAM permission, ListWorkspaces doesn't return it.