### PR TITLE
Fix Debug Logs in GHA leaking vault tokens

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -81,8 +81,8 @@ jobs:
             vault write -field token \
               auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
               secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+          echo ::add-mask::$VAULT_TOKEN    
           echo ::set-output name=vault-token::$VAULT_TOKEN
-          echo ::add-mask::$VAULT_TOKEN
 
       - name: Write config
         id: config

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -84,8 +84,9 @@ jobs:
           vault write -field token \
             auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
             secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+        echo ::add-mask::$VAULT_TOKEN    
         echo ::set-output name=vault-token::$VAULT_TOKEN
-        echo ::add-mask::$VAULT_TOKEN
+        
 
     - name: Write config
       id: config

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -86,7 +86,6 @@ jobs:
             secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
         echo ::add-mask::$VAULT_TOKEN    
         echo ::set-output name=vault-token::$VAULT_TOKEN
-        
 
     - name: Write config
       id: config

--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -85,8 +85,8 @@ jobs:
             vault write -field token \
               auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
               secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+          echo ::add-mask::$VAULT_TOKEN    
           echo ::set-output name=vault-token::$VAULT_TOKEN
-          echo ::add-mask::$VAULT_TOKEN
 
       - name: Write configuration
         uses: ./.github/actions/write-config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,8 @@ jobs:
           vault write -field token \
             auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
             secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+        echo ::add-mask::$VAULT_TOKEN    
         echo ::set-output name=vault-token::$VAULT_TOKEN
-        echo ::add-mask::$VAULT_TOKEN
 
     - name: Write config
       if: matrix.gradleTask != 'unitTest' && steps.skiptest.outputs.is-bump == 'no'

--- a/.github/workflows/workflow-tester.yml
+++ b/.github/workflows/workflow-tester.yml
@@ -33,7 +33,7 @@ jobs:
             secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
         echo ::add-mask::$VAULT_TOKEN    
         echo ::set-output name=vault-token::$VAULT_TOKEN
-  
+        
     - name: Write config
       id: config
       uses: ./.github/actions/write-config

--- a/.github/workflows/workflow-tester.yml
+++ b/.github/workflows/workflow-tester.yml
@@ -31,9 +31,9 @@ jobs:
           vault write -field token \
             auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
             secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+        echo ::add-mask::$VAULT_TOKEN    
         echo ::set-output name=vault-token::$VAULT_TOKEN
-        echo ::add-mask::$VAULT_TOKEN
-
+  
     - name: Write config
       id: config
       uses: ./.github/actions/write-config


### PR DESCRIPTION
Fixes vault tokens being leaked in GHA logs when debug logging is enabled.

See [this thread](https://broadinstitute.slack.com/archives/CADU7L0SZ/p1659646210275089) for more context.