### PR TITLE
[PF-1875] Add minimumHighestRole to ListWorkspaces request 

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ListWorkspaces.java
+++ b/integration/src/main/java/scripts/testscripts/ListWorkspaces.java
@@ -62,7 +62,12 @@ public class ListWorkspaces extends WorkspaceAllocateTestScriptBase {
     // previous failures or other tests running in parallel. We therefore cannot assume they only
     // have 2 workspaces.
     List<WorkspaceDescription> workspaces =
-        firstUserApi.listWorkspaces(/*offset=*/ 0, /*limit=*/ MAX_USER_WORKSPACES).getWorkspaces();
+        firstUserApi
+            .listWorkspaces(
+                /*offset=*/ 0,
+                /*limit=*/ MAX_USER_WORKSPACES,
+                /*minimumHighestRole=*/ IamRole.READER)
+            .getWorkspaces();
     // Assert both workspaces are returned.
     List<UUID> workspaceIds =
         workspaces.stream().map(WorkspaceDescription::getId).collect(Collectors.toList());
@@ -81,14 +86,22 @@ public class ListWorkspaces extends WorkspaceAllocateTestScriptBase {
     int pageSize = MAX_USER_WORKSPACES / 3;
     List<WorkspaceDescription> callResults = new ArrayList<>();
     callResults.addAll(
-        firstUserApi.listWorkspaces(/*offset=*/ 0, /*limit=*/ pageSize).getWorkspaces());
+        firstUserApi
+            .listWorkspaces(
+                /*offset=*/ 0, /*limit=*/ pageSize, /*minimumHighestRole=*/ IamRole.READER)
+            .getWorkspaces());
     callResults.addAll(
-        firstUserApi.listWorkspaces(/*offset=*/ pageSize, /*limit=*/ pageSize).getWorkspaces());
+        firstUserApi
+            .listWorkspaces(
+                /*offset=*/ pageSize, /*limit=*/ pageSize, /*minimumHighestRole=*/ IamRole.READER)
+            .getWorkspaces());
     // pageSize may not be divisible by 3, so cover all remaining workspaces here instead.
     callResults.addAll(
         firstUserApi
             .listWorkspaces(
-                /*offset=*/ pageSize * 2, /*limit=*/ (MAX_USER_WORKSPACES - 2 * pageSize))
+                /*offset=*/ pageSize * 2,
+                /*limit=*/ (MAX_USER_WORKSPACES - 2 * pageSize),
+                /*minimumHighestRole=*/ IamRole.READER)
             .getWorkspaces());
     List<UUID> callResultIdList =
         callResults.stream().map(WorkspaceDescription::getId).collect(Collectors.toList());
@@ -96,7 +109,8 @@ public class ListWorkspaces extends WorkspaceAllocateTestScriptBase {
 
     // Validate second user only sees second workspace.
     WorkspaceDescriptionList secondUserResult =
-        secondUserApi.listWorkspaces(0, MAX_USER_WORKSPACES);
+        secondUserApi.listWorkspaces(
+            0, MAX_USER_WORKSPACES, /*minimumHighestRole=*/ IamRole.READER);
     List<UUID> secondCallResults =
         secondUserResult.getWorkspaces().stream()
             .map(WorkspaceDescription::getId)

--- a/openapi/src/common/parameters.yaml
+++ b/openapi/src/common/parameters.yaml
@@ -37,6 +37,19 @@ components:
       schema:
         type: string
 
+    MinimumHighestRole:
+      name: minimumHighestRole
+      in: query
+      description: |
+        Returned workspace's highest role must be at least this. If
+        minimumHighestRole is READER and requester only has DISCOVERER role,
+        workspace is not returned. If not set, defaults to READER.
+      required: false
+      schema:
+        $ref: '#/components/schemas/IamRole'
+        # No "default:" because OpenAPI doesn't let you specify default with
+        # $ref. See https://stackoverflow.com/a/68542868/6447189
+
     Name:
       name: name
       in: path

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -28,6 +28,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/MinimumHighestRole'
       summary: List all workspaces a user can read.
       operationId: listWorkspaces
       tags: [ Workspace ]

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
@@ -73,6 +73,22 @@ public enum WsmIamRole {
         String.format("Workspace %s has unexpected roles: %s", workspaceId.toString(), roles));
   }
 
+  public static boolean roleAtLeastAsHighAs(WsmIamRole minimumRole, WsmIamRole roleToCheck) {
+    return switch (minimumRole) {
+      case APPLICATION -> roleToCheck == WsmIamRole.APPLICATION;
+      case OWNER -> roleToCheck == WsmIamRole.APPLICATION || roleToCheck == WsmIamRole.OWNER;
+      case WRITER -> roleToCheck == WsmIamRole.APPLICATION
+          || roleToCheck == WsmIamRole.OWNER
+          || roleToCheck == WsmIamRole.WRITER;
+      case READER -> roleToCheck == WsmIamRole.APPLICATION
+          || roleToCheck == WsmIamRole.OWNER
+          || roleToCheck == WsmIamRole.WRITER
+          || roleToCheck == WsmIamRole.READER;
+      case DISCOVERER -> true;
+      case MANAGER -> throw new InternalServerErrorException("Unexpected workspace MANAGER role");
+    };
+  }
+
   public ApiIamRole toApiModel() {
     return apiRole;
   }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceConstants.java
@@ -4,5 +4,8 @@ public class WorkspaceConstants {
 
   public static class Properties {
     public static final String DEFAULT_RESOURCE_LOCATION = "terra-default-location";
+    public static final String TYPE = "terra-type";
+    public static final String SHORT_DESCRIPTION = "terra-workspace-short-description";
+    public static final String VERSION = "terra-workspace-version";
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/WorkspaceApiControllerTest.java
@@ -402,7 +402,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTest {
     // No need to actually pass policy inputs because TPS is mocked.
     ApiCreatedWorkspace workspace = createDefaultWorkspace();
     ApiCreatedWorkspace noPolicyWorkspace = createDefaultWorkspace();
-    when(mockSamService.listWorkspaceIdsAndHighestRoles(any()))
+    when(mockSamService.listWorkspaceIdsAndHighestRoles(any(), any()))
         .thenReturn(
             ImmutableMap.of(
                 workspace.getId(), WsmIamRole.OWNER, noPolicyWorkspace.getId(), WsmIamRole.OWNER));
@@ -435,7 +435,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTest {
   public void tpsDisabledListWorkspaceExcludesPolicy() throws Exception {
     when(mockFeatureConfiguration.isTpsEnabled()).thenReturn(false);
     ApiCreatedWorkspace workspace = createDefaultWorkspace();
-    when(mockSamService.listWorkspaceIdsAndHighestRoles(any()))
+    when(mockSamService.listWorkspaceIdsAndHighestRoles(any(), any()))
         .thenReturn(ImmutableMap.of(workspace.getId(), WsmIamRole.OWNER));
 
     ApiWorkspaceDescription gotWorkspace = getWorkspaceDescriptionFromList(workspace.getId());

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -8,9 +8,21 @@ import bio.terra.workspace.generated.model.ApiWorkspaceStageModel;
 import bio.terra.workspace.service.iam.model.SamConstants.SamResource;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import bio.terra.workspace.service.workspace.model.WorkspaceConstants.Properties;
+import com.google.common.collect.ImmutableList;
 import java.util.UUID;
 
 public class WorkspaceFixtures {
+
+  public static final String WORKSPACE_NAME = "TestWorkspace";
+  public static final ApiProperty TYPE_PROPERTY =
+      new ApiProperty().key(Properties.TYPE).value("type");
+  public static final ApiProperty SHORT_DESCRIPTION_PROPERTY =
+      new ApiProperty().key(Properties.SHORT_DESCRIPTION).value("short description");
+  public static final ApiProperty VERSION_PROPERTY =
+      new ApiProperty().key(Properties.VERSION).value("version 3");
+  public static final ApiProperty USER_SET_PROPERTY =
+      new ApiProperty().key("userkey").value("uservalue");
 
   /**
    * This method creates the database artifact for a cloud context without actually creating
@@ -36,20 +48,12 @@ public class WorkspaceFixtures {
   public static ApiCreateWorkspaceRequestBody createWorkspaceRequestBody() {
     UUID workspaceId = UUID.randomUUID();
     ApiProperties properties = new ApiProperties();
-    ApiProperty property1 = new ApiProperty();
-    property1.setKey("foo");
-    property1.setValue("bar");
-
-    ApiProperty property2 = new ApiProperty();
-    property2.setKey("xyzzy");
-    property2.setValue("plohg");
-
-    properties.add(property1);
-    properties.add(property2);
-
+    properties.addAll(
+        ImmutableList.of(
+            TYPE_PROPERTY, SHORT_DESCRIPTION_PROPERTY, VERSION_PROPERTY, USER_SET_PROPERTY));
     return new ApiCreateWorkspaceRequestBody()
         .id(workspaceId)
-        .displayName("TestWorkspace")
+        .displayName(WORKSPACE_NAME)
         .description("A test workspace created by createWorkspaceRequestBody")
         .userFacingId(getUserFacingId(workspaceId))
         .stage(ApiWorkspaceStageModel.MC_WORKSPACE)

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -336,7 +336,8 @@ class SamServiceTest extends BaseConnectedTest {
   @Test
   void listWorkspaceIdsAndHighestRoles() throws Exception {
     Map<UUID, WsmIamRole> actual =
-        samService.listWorkspaceIdsAndHighestRoles(userAccessUtils.defaultUserAuthRequest());
+        samService.listWorkspaceIdsAndHighestRoles(
+            userAccessUtils.defaultUserAuthRequest(), WsmIamRole.READER);
 
     assertThat(actual, IsMapContaining.hasEntry(workspaceUuid, WsmIamRole.OWNER));
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -82,7 +82,6 @@ import bio.terra.workspace.service.workspace.flight.CreateWorkspaceAuthzStep;
 import bio.terra.workspace.service.workspace.flight.CreateWorkspacePoliciesStep;
 import bio.terra.workspace.service.workspace.flight.CreateWorkspaceStep;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceAndHighestRole;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
@@ -181,22 +180,6 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   @AfterEach
   public void resetFlightDebugInfo() {
     jobService.setFlightDebugInfoForTest(null);
-  }
-
-  @Test
-  void listWorkspacesAndHighestRoles_existing() throws Exception {
-    UUID workspaceId = UUID.randomUUID();
-    Workspace request = defaultRequestBuilder(workspaceId).build();
-    workspaceService.createWorkspace(request, null, USER_REQUEST);
-
-    when(mockSamService.listWorkspaceIdsAndHighestRoles(any()))
-        .thenReturn(Map.of(workspaceId, WsmIamRole.OWNER));
-
-    List<WorkspaceAndHighestRole> actual =
-        workspaceService.listWorkspacesAndHighestRoles(USER_REQUEST, /*offset=*/ 0, /*limit=*/ 10);
-    assertEquals(1, actual.size());
-    assertEquals(request.getWorkspaceId(), actual.get(0).workspace().getWorkspaceId());
-    assertEquals(WsmIamRole.OWNER, actual.get(0).highestRole());
   }
 
   @Test


### PR DESCRIPTION
Also delete test from WorkspaceServiceTest.listWorkspacesAndHighestRoles_existing because same functionality is now tested in WorkspaceApiControllerConnectedTest.

Manually tested
- Configured workspace where second user only has discoverer role
- Second user runs ListWorkspaces with minimumHighestRole unset, no workspace returned
- Second user runs ListWorkspaces with minimumHighestRole set to DISCOVERER, subset of workspace is returned ([screenshot](https://screenshot.googleplex.com/6xYX7V9GiFkQz3T))
- Workspace owner calls ListWorkspace with minimumHighestRole set to DISCOVERER, full workspace is returned