### PR TITLE
[PF-1904] Retry GCP errors in GrantWsmRoleAdminStep

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/GrantWsmRoleAdminStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/GrantWsmRoleAdminStep.java
@@ -54,7 +54,8 @@ public class GrantWsmRoleAdminStep implements Step {
           .setIamPolicy(projectId, iamPolicyRequest)
           .execute();
     } catch (IOException e) {
-      throw new InternalServerErrorException("Error while granting WSM SA the Role Admin role", e);
+      // Errors here are unexpected and likely transient, WSM should always retry.
+      throw new RetryException("Error while granting WSM SA the Role Admin role", e);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/GrantWsmRoleAdminStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/GrantWsmRoleAdminStep.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.workspace.flight;
 
-import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;


### PR DESCRIPTION
Not retrying a timeout here failed the nightly tests on 8/12. This step already has an associated retry rule in the flight, so no changes are required there.