### PR TITLE
[DSEC-404] fix srcclr scans by specifying scope in srcclr.yml

### DIFF
--- a/srcclr.yml
+++ b/srcclr.yml
@@ -1,0 +1,1 @@
+scope: productionRuntimeClasspath


### PR DESCRIPTION
Veracode SCA, aka srcclr, is used to scan for vulnerable 3rd party components. In WSM, srcclr was failing to find any code with default scope. Adding a configuration file to specify the productionRuntimeClasspath scope fixes the scan. 

The scan will still be run in a separate appsec repo on a weekly basis for now. If the team wants to set up a github action or gradle configuration to scan it on every PR, we in appsec can help make that happen, but that is neither urgent nor required.