### PR TITLE
[PF-1921] Install java 17 in jupyter notebooks

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -67,7 +67,7 @@ function install_java() {
 
 if [[ -n "$(which java)" ]];
 then
-  CUR_JAVA_VERSION=`java -version 2>&1 | grep 'version' 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}'`
+  readonly CUR_JAVA_VERSION=$(java -version 2>&1 | grep 'version' 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')
   if [[ "${CUR_JAVA_VERSION}" -lt 17 ]];
   then
     echo "current java version is ${CUR_JAVA_VERSION}, installing java 17"

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -55,11 +55,29 @@ export NXF_MODE=google
 
 sudo apt-get update
 
+#######################################
+# Install required JDK and set it as default (debian)
+#######################################
+function install_java() {
+  curl -Os https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.deb
+  sudo apt-get install -y ./jdk-17_linux-x64_bin.deb
+  sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk-17/bin/java 1
+  sudo update-alternatives --set java /usr/lib/jvm/jdk-17/bin/java
+}
+
 if [[ -n "$(which java)" ]];
 then
-  echo "java is installed"
+  CUR_JAVA_VERSION=`java -version 2>&1 | grep 'version' 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}'`
+  if [[ "${CUR_JAVA_VERSION}" -lt 17 ]];
+  then
+    echo "current java version is ${CUR_JAVA_VERSION}, installing java 17"
+    install_java
+  else
+    echo "java 17 is installed"
+  fi
 else
-  sudo apt-get -y install openjdk-11-jdk
+  echo "installing java 17"
+  install_java
 fi
 
 sudo -u "${JUPYTER_USER}" sh -c "curl -s https://get.nextflow.io | bash"

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -67,16 +67,17 @@ function install_java() {
 
 if [[ -n "$(which java)" ]];
 then
-  readonly CUR_JAVA_VERSION=$(java -version 2>&1 | grep 'version' 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')
+  # Get the current major version of Java: "11.0.12" => "11"
+  readonly CUR_JAVA_VERSION=$(java -version 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')
   if [[ "${CUR_JAVA_VERSION}" -lt 17 ]];
   then
-    echo "current java version is ${CUR_JAVA_VERSION}, installing java 17"
+    echo "Current Java version is ${CUR_JAVA_VERSION}, installing Java 17"
     install_java
   else
-    echo "java 17 is installed"
+    echo "Java 17 is installed"
   fi
 else
-  echo "installing java 17"
+  echo "Installing Java 17"
   install_java
 fi
 


### PR DESCRIPTION
Changes - 

Check if java 17 is installed. If not: install JDK17 and set it as the default version to be used

Verifying java upgrade on notebook 

```
(base) jupyter@dexamundsen-20220819-215419:~$ java --version
java 17.0.4.1 2022-08-18 LTS
Java(TM) SE Runtime Environment (build 17.0.4.1+1-LTS-2)
Java HotSpot(TM) 64-Bit Server VM (build 17.0.4.1+1-LTS-2, mixed mode, sharing)
(base) jupyter@dexamundsen-20220819-215419:~$ update-alternatives --list java
/usr/lib/jvm/java-11-openjdk-amd64/bin/java
/usr/lib/jvm/jdk-17/bin/java
(base) jupyter@dexamundsen-20220819-215419:~$ 
```

Logs from post_startup script 

```
(base) jupyter@dexamundsen-20220819-215419:~$ grep java  /home/jupyter/.terra/post-startup-output.txt 
++ which java
+ [[ -n /usr/bin/java ]]
++ java -version
+ echo 'current java version is 11, installing java 17'
current java version is 11, installing java 17
+ install_java
+ curl -Os https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.deb
+ sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk-17/bin/java 1
+ sudo update-alternatives --set java /usr/lib/jvm/jdk-17/bin/java
update-alternatives: using /usr/lib/jvm/jdk-17/bin/java to provide /usr/bin/java (java) in manual mode
+ java --version
java 17.0.4.1 2022-08-18 LTS
+ echo 'verifying java 17'
verifying java 17
```