### PR TITLE
[PF-1871] Stop sending policy information for most integration tests

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -58,9 +58,9 @@ import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
 import scripts.utils.GcsBucketObjectUtils;
 import scripts.utils.GcsBucketUtils;
-import scripts.utils.WorkspaceAllocateTestScriptBase;
+import scripts.utils.WorkspaceAllocateWithPolicyTestScriptBase;
 
-public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
+public class CloneWorkspace extends WorkspaceAllocateWithPolicyTestScriptBase {
   private static final Logger logger = LoggerFactory.getLogger(CloneWorkspace.class);
   private ControlledGcpResourceApi cloningUserResourceApi;
   private CreatedControlledGcpGcsBucket copyDefinitionSourceBucket;

--- a/integration/src/main/java/scripts/utils/WorkspaceAllocateTestScriptBase.java
+++ b/integration/src/main/java/scripts/utils/WorkspaceAllocateTestScriptBase.java
@@ -10,9 +10,6 @@ import bio.terra.workspace.model.CreateWorkspaceRequestBody;
 import bio.terra.workspace.model.CreatedWorkspace;
 import bio.terra.workspace.model.Properties;
 import bio.terra.workspace.model.Property;
-import bio.terra.workspace.model.TpsPolicyInput;
-import bio.terra.workspace.model.TpsPolicyInputs;
-import bio.terra.workspace.model.TpsPolicyPair;
 import bio.terra.workspace.model.WorkspaceStageModel;
 import java.util.List;
 import java.util.Map;
@@ -83,22 +80,12 @@ public abstract class WorkspaceAllocateTestScriptBase extends WorkspaceApiTestSc
     properties.add(property1);
     properties.add(property2);
 
-    TpsPolicyInputs policies =
-        new TpsPolicyInputs()
-            .addInputsItem(
-                new TpsPolicyInput()
-                    .name("region-constraint")
-                    .namespace("terra")
-                    .addAdditionalDataItem(
-                        new TpsPolicyPair().key("region-name").value("us-central1")));
-
     final var requestBody =
         new CreateWorkspaceRequestBody()
             .id(workspaceUuid)
             .spendProfile(spendProfileId)
             .stage(getStageModel())
-            .properties(properties)
-            .policies(policies);
+            .properties(properties);
     final CreatedWorkspace workspace = workspaceApi.createWorkspace(requestBody);
     assertThat(workspace.getId(), equalTo(workspaceUuid));
     return workspace;

--- a/integration/src/main/java/scripts/utils/WorkspaceAllocateWithPolicyTestScriptBase.java
+++ b/integration/src/main/java/scripts/utils/WorkspaceAllocateWithPolicyTestScriptBase.java
@@ -1,0 +1,51 @@
+package scripts.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.model.CreateWorkspaceRequestBody;
+import bio.terra.workspace.model.CreatedWorkspace;
+import bio.terra.workspace.model.Properties;
+import bio.terra.workspace.model.Property;
+import bio.terra.workspace.model.TpsPolicyInput;
+import bio.terra.workspace.model.TpsPolicyInputs;
+import bio.terra.workspace.model.TpsPolicyPair;
+import java.util.UUID;
+
+// TODO: This script only exists because environments above dev do not support policies being
+//   included on workspaces yet. Once these environments support TPS, this class should be deleted
+//   and its policy functionality should be merged into WorkspaceAllocateTestScriptBase.
+public abstract class WorkspaceAllocateWithPolicyTestScriptBase
+    extends WorkspaceAllocateTestScriptBase {
+
+  @Override
+  protected CreatedWorkspace createWorkspace(
+      UUID workspaceUuid, String spendProfileId, WorkspaceApi workspaceApi) throws Exception {
+    Properties properties = new Properties();
+    Property property1 = new Property().key("foo").value("bar");
+    Property property2 = new Property().key("xyzzy").value("plohg");
+    properties.add(property1);
+    properties.add(property2);
+
+    TpsPolicyInputs policies =
+        new TpsPolicyInputs()
+            .addInputsItem(
+                new TpsPolicyInput()
+                    .name("region-constraint")
+                    .namespace("terra")
+                    .addAdditionalDataItem(
+                        new TpsPolicyPair().key("region-name").value("us-central1")));
+
+    final var requestBody =
+        new CreateWorkspaceRequestBody()
+            .id(workspaceUuid)
+            .spendProfile(spendProfileId)
+            .stage(getStageModel())
+            .properties(properties)
+            .policies(policies);
+    final CreatedWorkspace workspace = workspaceApi.createWorkspace(requestBody);
+    assertThat(workspace.getId(), equalTo(workspaceUuid));
+    return workspace;
+  }
+}

--- a/integration/src/main/java/scripts/utils/WorkspaceAllocateWithPolicyTestScriptBase.java
+++ b/integration/src/main/java/scripts/utils/WorkspaceAllocateWithPolicyTestScriptBase.java
@@ -13,9 +13,9 @@ import bio.terra.workspace.model.TpsPolicyInputs;
 import bio.terra.workspace.model.TpsPolicyPair;
 import java.util.UUID;
 
-// TODO: This script only exists because environments above dev do not support policies being
-//   included on workspaces yet. Once these environments support TPS, this class should be deleted
-//   and its policy functionality should be merged into WorkspaceAllocateTestScriptBase.
+// TODO(PF-1948): This script only exists because environments above dev do not support policies
+//  being included on workspaces yet. Once these environments support TPS, this class should be
+//  deleted and its policy functionality should be merged into WorkspaceAllocateTestScriptBase.
 public abstract class WorkspaceAllocateWithPolicyTestScriptBase
     extends WorkspaceAllocateTestScriptBase {
 


### PR DESCRIPTION
Part of #766 modified `WorkspaceAllocateTestScriptBase` to include policy information, but I forgot that several tests using this base run in environments which don't have TPS enabled. As a result, the basic integration tests are broken when they run against environments > dev (as WSM rejects requests including policy information if TPS is disabled). However, the service itself is fine, so I don't think we need to roll #766 back entirely.

This splits the policy into a separate base class for now, with the expectation that we'll delete this class once TPS is enabled in all environments.