### PR TITLE
[PF-1880] Write resource lineage when cloning referenced resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ HELP.md
 *.iml
 *.ipr
 out/
+# To ignore files in this repo:
+# git update-index --skip-worktree .run/Integration\ test.run.xml
 .run/**
 
 ### NetBeans ###

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -325,9 +325,11 @@ export spring_profiles_include=human-readable-logging
 ### Controlling Log Level
 By default logging at INFO level and above are displayed. You can change the logging level
 by setting yet another Spring property. For example, you can set all things terra to log
-at debug level by adding this to a property YAML file:
+at debug level by adding this to a property YAML file (such as application.yaml):
 ```
 logging.level.bio.terra: debug
+# Use this to print SQL queries
+logging.level.org.springframework.jdbc.core: trace
 ```
 You can be more precise by putting more of the path in. You can use YAML syntax to include
 multiple entries, something like (but I did not test this):

--- a/integration/src/main/java/scripts/testscripts/ResourceLineage.java
+++ b/integration/src/main/java/scripts/testscripts/ResourceLineage.java
@@ -1,0 +1,125 @@
+package scripts.testscripts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static scripts.utils.BqDatasetUtils.makeControlledBigQueryDatasetUserShared;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.ControlledGcpResourceApi;
+import bio.terra.workspace.api.ReferencedGcpResourceApi;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.model.CloneReferencedGcpBigQueryDatasetResourceResult;
+import bio.terra.workspace.model.CloneReferencedResourceRequestBody;
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import bio.terra.workspace.model.GcpBigQueryDatasetResource;
+import bio.terra.workspace.model.ResourceLineageEntry;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scripts.utils.BqDatasetUtils;
+import scripts.utils.ClientTestUtils;
+import scripts.utils.CloudContextMaker;
+import scripts.utils.TestUtils;
+import scripts.utils.WorkspaceAllocateTestScriptBase;
+
+public class ResourceLineage extends WorkspaceAllocateTestScriptBase {
+  private static final Logger logger = LoggerFactory.getLogger(ResourceLineage.class);
+
+  private ControlledGcpResourceApi controlledGcpResourceApi;
+  private ReferencedGcpResourceApi referencedGcpResourceApi;
+  private UUID bqDatasetWorkspace1ResourceId;
+
+  private final UUID workspaceId2 = UUID.randomUUID();
+
+  @Override
+  protected void doSetup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doSetup(testUsers, workspaceApi);
+
+    TestUserSpecification testUser = testUsers.get(0);
+    controlledGcpResourceApi = ClientTestUtils.getControlledGcpResourceClient(testUser, server);
+    referencedGcpResourceApi = ClientTestUtils.getReferencedGcpResourceClient(testUser, server);
+
+    String projectId1 = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
+    logger.info("Created project {} in workspace {}", projectId1, getWorkspaceId());
+
+    // In first workspace, create BigQuery dataset
+    GcpBigQueryDatasetResource controlledBqDataset =
+        makeControlledBigQueryDatasetUserShared(
+            controlledGcpResourceApi,
+            getWorkspaceId(),
+            TestUtils.appendRandomNumber("resource_lineage_bq_dataset"),
+            /*datasetId=*/ null,
+            CloningInstructionsEnum.DEFINITION);
+
+    // In first workspace, create BigQuery dataset referenced resource
+    GcpBigQueryDatasetResource referencedBqDataset =
+        BqDatasetUtils.makeBigQueryDatasetReference(
+            controlledBqDataset.getAttributes(),
+            referencedGcpResourceApi,
+            getWorkspaceId(),
+            TestUtils.appendRandomNumber("referenced_bigquery_dataset"));
+    bqDatasetWorkspace1ResourceId = referencedBqDataset.getMetadata().getResourceId();
+
+    // Create second workspace
+    createWorkspace(workspaceId2, getSpendProfileId(), workspaceApi);
+    logger.info("Created second workspace {}", workspaceId2);
+  }
+
+  @Override
+  protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    super.doCleanup(testUsers, workspaceApi);
+
+    workspaceApi.deleteWorkspace(workspaceId2);
+  }
+
+  @Override
+  protected void doUserJourney(
+      TestUserSpecification sourceOwnerUser, WorkspaceApi sourceOwnerWorkspaceApi)
+      throws Exception {
+    // Clone resource 1 into second workspace
+    CloneReferencedGcpBigQueryDatasetResourceResult resource2CloneResult =
+        referencedGcpResourceApi.cloneGcpBigQueryDatasetReference(
+            new CloneReferencedResourceRequestBody()
+                .cloningInstructions(CloningInstructionsEnum.REFERENCE)
+                .destinationWorkspaceId(workspaceId2),
+            getWorkspaceId(),
+            bqDatasetWorkspace1ResourceId);
+    UUID resource2Id = resource2CloneResult.getResource().getMetadata().getResourceId();
+
+    // Assert resource lineage on resource 2 in second workspace. There is one entry.
+    bio.terra.workspace.model.ResourceLineage expectedResourceLineage =
+        new bio.terra.workspace.model.ResourceLineage();
+    expectedResourceLineage.add(
+        new ResourceLineageEntry()
+            .sourceWorkspaceId(getWorkspaceId())
+            .sourceResourceId(bqDatasetWorkspace1ResourceId));
+    assertBqDatasetResourceLineage(resource2Id, expectedResourceLineage);
+
+    // Clone resource 2 to resource 3, still in second workspace.
+    CloneReferencedGcpBigQueryDatasetResourceResult resource3CloneResult =
+        referencedGcpResourceApi.cloneGcpBigQueryDatasetReference(
+            new CloneReferencedResourceRequestBody()
+                .cloningInstructions(CloningInstructionsEnum.REFERENCE)
+                .destinationWorkspaceId(workspaceId2)
+                // Resource 3 needs different name from resource 2, since they're in same workspace
+                .name(UUID.randomUUID().toString()),
+            workspaceId2,
+            resource2Id);
+    UUID resource3Id = resource3CloneResult.getResource().getMetadata().getResourceId();
+
+    // Assert resource lineage on resource 3.
+    // Now there are two entries. Add second entry for second clone.
+    expectedResourceLineage.add(
+        new ResourceLineageEntry().sourceWorkspaceId(workspaceId2).sourceResourceId(resource2Id));
+    assertBqDatasetResourceLineage(resource3Id, expectedResourceLineage);
+  }
+
+  private void assertBqDatasetResourceLineage(
+      UUID resourceToCheckId, bio.terra.workspace.model.ResourceLineage expected) throws Exception {
+    GcpBigQueryDatasetResource gotResource =
+        referencedGcpResourceApi.getBigQueryDatasetReference(workspaceId2, resourceToCheckId);
+    assertEquals(expected, gotResource.getMetadata().getResourceLineage());
+  }
+}

--- a/integration/src/main/java/scripts/utils/TestUtils.java
+++ b/integration/src/main/java/scripts/utils/TestUtils.java
@@ -6,6 +6,7 @@ public class TestUtils {
   private static final Random RANDOM = new Random();
 
   public static String appendRandomNumber(String string) {
-    return string + "-" + RANDOM.nextInt(10000);
+    // Can't be dash because BQ dataset names can't have dash
+    return string + "_" + RANDOM.nextInt(10000);
   }
 }

--- a/integration/src/main/resources/configs/integration/ResourceLineage.json
+++ b/integration/src/main/resources/configs/integration/ResourceLineage.json
@@ -1,0 +1,20 @@
+{
+  "name": "ResourceLineage",
+  "description": "Resource lineage test",
+  "serverSpecificationFile": "workspace-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ResourceLineage",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 1,
+      "expectedTimeForEach": 15,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parametersMap": {
+        "spend-profile-id": "wm-default-spend-profile"
+      }
+    }
+  ],
+  "testUserFiles": ["bella.json"]
+}

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -23,6 +23,7 @@
     "integration/ReferencedGitRepoLifecycle.json",
     "integration/ReferencedTerraWorkspaceLifecycle.json",
     "integration/RemoveUser.json",
+    "integration/ResourceLineage.json",
     "integration/WorkspaceLifecycle.json"
   ]
 }

--- a/openapi/src/common/schemas.yaml
+++ b/openapi/src/common/schemas.yaml
@@ -204,7 +204,24 @@ components:
           type: string
         cloningInstructions:
           $ref: '#/components/schemas/CloningInstructionsEnum'
-  
+
+    ResourceLineage:
+      type: array
+      items:
+        $ref: '#/components/schemas/ResourceLineageEntry'
+
+    ResourceLineageEntry:
+      type: object
+      required: [sourceWorkspaceId, sourceResourceId]
+      description: Resource lineage entry describing a single clone operation
+      properties:
+        sourceWorkspaceId:
+          type: string
+          format: uuid
+        sourceResourceId:
+          type: string
+          format: uuid
+
     # All resource objects include this resource metadata object and call it 'metadata'
     ResourceMetadata:
       type: object
@@ -230,6 +247,8 @@ components:
         controlledResourceMetadata:
           description: Present if stewardship type is CONTROLLED
           $ref: '#/components/schemas/ControlledResourceMetadata'
+        resourceLineage:
+          $ref: '#/components/schemas/ResourceLineage'
 
     StewardshipType:
       description: Enum containing valid stewardship types. Used for enumeration

--- a/openapi/src/parts/controlled_gcp_big_query_dataset.yaml
+++ b/openapi/src/parts/controlled_gcp_big_query_dataset.yaml
@@ -228,7 +228,9 @@ components:
       type: object
       properties:
         datasetId:
-          description: A valid dataset name per https://cloud.google.com/bigquery/docs/datasets#dataset-naming
+          description: >-
+            A valid dataset name per https://cloud.google.com/bigquery/docs/datasets#dataset-naming.
+            Optional. If not set, resource name is used.
           type: string
         location:
           description: A valid dataset location per https://cloud.google.com/bigquery/docs/locations.

--- a/service/src/main/java/bio/terra/workspace/db/DbSerDes.java
+++ b/service/src/main/java/bio/terra/workspace/db/DbSerDes.java
@@ -39,6 +39,18 @@ public class DbSerDes {
     }
   }
 
+  /**
+   * Use this when you want to deserialize an array or list of objects. See
+   * https://stackoverflow.com/a/6349488/6447189
+   */
+  public static <T> T fromJson(String json, TypeReference<T> typeReference) {
+    try {
+      return serdesMapper.readValue(json, typeReference);
+    } catch (JsonProcessingException e) {
+      throw new SerializationException("Failed fromJson", e);
+    }
+  }
+
   // Specific mappers for key-value properties
   public static String propertiesToJson(Map<String, String> kvmap) {
     return toJson(kvmap);

--- a/service/src/main/java/bio/terra/workspace/db/model/DbResource.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/DbResource.java
@@ -4,11 +4,13 @@ import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.exceptions.MissingRequiredFieldsException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -30,6 +32,7 @@ public class DbResource {
   private WsmResourceType resourceType;
   private CloningInstructions cloningInstructions;
   private String attributes;
+  @Nullable List<ResourceLineageEntry> resourceLineage;
   // controlled resource fields
   @Nullable private AccessScopeType accessScope;
   @Nullable private ManagedByType managedBy;
@@ -172,6 +175,15 @@ public class DbResource {
 
   public DbResource privateResourceState(PrivateResourceState privateResourceState) {
     this.privateResourceState = privateResourceState;
+    return this;
+  }
+
+  public Optional<List<ResourceLineageEntry>> getResourceLineage() {
+    return Optional.ofNullable(resourceLineage);
+  }
+
+  public DbResource resourceLineage(List<ResourceLineageEntry> resourceLineage) {
+    this.resourceLineage = resourceLineage;
     return this;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -23,11 +23,13 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -51,7 +53,8 @@ public class ControlledAzureDiskResource extends ControlledResource {
       @JsonProperty("applicationId") String applicationId,
       @JsonProperty("diskName") String diskName,
       @JsonProperty("region") String region,
-      @JsonProperty("size") int size) {
+      @JsonProperty("size") int size,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
 
     super(
         workspaceId,
@@ -63,7 +66,8 @@ public class ControlledAzureDiskResource extends ControlledResource {
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.diskName = diskName;
     this.region = region;
     this.size = size;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
@@ -23,11 +23,13 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -48,7 +50,8 @@ public class ControlledAzureIpResource extends ControlledResource {
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") String applicationId,
       @JsonProperty("ipName") String ipName,
-      @JsonProperty("region") String region) {
+      @JsonProperty("region") String region,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
 
     super(
         workspaceId,
@@ -60,7 +63,8 @@ public class ControlledAzureIpResource extends ControlledResource {
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.ipName = ipName;
     this.region = region;
     validate();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
@@ -23,11 +23,13 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -54,7 +56,8 @@ public class ControlledAzureNetworkResource extends ControlledResource {
       @JsonProperty("subnetName") String subnetName,
       @JsonProperty("addressSpaceCidr") String addressSpaceCidr,
       @JsonProperty("subnetAddressCidr") String subnetAddressCidr,
-      @JsonProperty("region") String region) {
+      @JsonProperty("region") String region,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
 
     super(
         workspaceId,
@@ -66,7 +69,8 @@ public class ControlledAzureNetworkResource extends ControlledResource {
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.networkName = networkName;
     this.subnetName = subnetName;
     this.addressSpaceCidr = addressSpaceCidr;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/ControlledAzureRelayNamespaceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/ControlledAzureRelayNamespaceResource.java
@@ -23,11 +23,13 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -48,7 +50,8 @@ public class ControlledAzureRelayNamespaceResource extends ControlledResource {
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") String applicationId,
       @JsonProperty("namespaceName") String namespaceName,
-      @JsonProperty("region") String region) {
+      @JsonProperty("region") String region,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
 
     super(
         workspaceId,
@@ -60,7 +63,8 @@ public class ControlledAzureRelayNamespaceResource extends ControlledResource {
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.namespaceName = namespaceName;
     this.region = region;
     validate();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
@@ -19,11 +19,13 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.*;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
@@ -45,7 +47,8 @@ public class ControlledAzureStorageResource extends ControlledResource {
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") String applicationId,
       @JsonProperty("storageAccountName") String storageAccountName,
-      @JsonProperty("region") String region) {
+      @JsonProperty("region") String region,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
 
     super(
         workspaceId,
@@ -57,7 +60,8 @@ public class ControlledAzureStorageResource extends ControlledResource {
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.storageAccountName = storageAccountName;
     this.region = region;
     validate();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -19,11 +19,13 @@ import bio.terra.workspace.service.resource.controlled.flight.create.CreateContr
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.*;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -44,7 +46,8 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") String applicationId,
       @JsonProperty("storageAccountId") UUID storageAccountId,
-      @JsonProperty("storageContainerName") String storageContainerName) {
+      @JsonProperty("storageContainerName") String storageContainerName,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
     super(
         workspaceId,
         resourceId,
@@ -55,7 +58,8 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.storageAccountId = storageAccountId;
     this.storageContainerName = storageContainerName;
     validate();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -23,11 +23,13 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -59,7 +61,8 @@ public class ControlledAzureVmResource extends ControlledResource {
       @JsonProperty("vmImage") String vmImage,
       @JsonProperty("ipId") UUID ipId,
       @JsonProperty("networkId") UUID networkId,
-      @JsonProperty("diskId") UUID diskId) {
+      @JsonProperty("diskId") UUID diskId,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
 
     super(
         workspaceId,
@@ -71,7 +74,8 @@ public class ControlledAzureVmResource extends ControlledResource {
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.vmName = vmName;
     this.region = region;
     this.vmSize = vmSize;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -27,11 +27,13 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -74,7 +76,8 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
       @JsonProperty("application") String applicationId,
       @JsonProperty("instanceId") String instanceId,
       @JsonProperty("location") String location,
-      @JsonProperty("projectId") String projectId) {
+      @JsonProperty("projectId") String projectId,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
     super(
         workspaceId,
         resourceId,
@@ -85,7 +88,8 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.instanceId = instanceId;
     this.location = location;
     this.projectId = projectId;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -23,11 +23,13 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -50,7 +52,8 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") String applicationId,
       @JsonProperty("datasetName") String datasetName,
-      @JsonProperty("projectId") String projectId) {
+      @JsonProperty("projectId") String projectId,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
 
     super(
         workspaceId,
@@ -62,7 +65,8 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.datasetName = datasetName;
     this.projectId = projectId;
     validate();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -23,11 +23,13 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -47,7 +49,8 @@ public class ControlledGcsBucketResource extends ControlledResource {
       @JsonProperty("accessScope") AccessScopeType accessScope,
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") String applicationId,
-      @JsonProperty("bucketName") String bucketName) {
+      @JsonProperty("bucketName") String bucketName,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
 
     super(
         workspaceId,
@@ -59,7 +62,8 @@ public class ControlledGcsBucketResource extends ControlledResource {
         accessScope,
         managedBy,
         applicationId,
-        privateResourceState);
+        privateResourceState,
+        resourceLineage);
     this.bucketName = bucketName;
     validate();
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResource.java
@@ -13,8 +13,10 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceFlight;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -41,8 +43,9 @@ public abstract class ControlledResource extends WsmResource {
       AccessScopeType accessScope,
       ManagedByType managedBy,
       String applicationId,
-      PrivateResourceState privateResourceState) {
-    super(workspaceUuid, resourceId, name, description, cloningInstructions);
+      PrivateResourceState privateResourceState,
+      List<ResourceLineageEntry> resourceLineage) {
+    super(workspaceUuid, resourceId, name, description, cloningInstructions, resourceLineage);
     this.assignedUser = assignedUser;
     this.accessScope = accessScope;
     this.managedBy = managedBy;
@@ -68,7 +71,8 @@ public abstract class ControlledResource extends WsmResource {
         builder.getResourceId(),
         builder.getName(),
         builder.getDescription(),
-        builder.getCloningInstructions());
+        builder.getCloningInstructions(),
+        builder.getResourceLineage());
     this.assignedUser = builder.getAssignedUser();
     this.accessScope = builder.getAccessScope();
     this.managedBy = builder.getManagedBy();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceFields.java
@@ -4,6 +4,8 @@ import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -34,6 +36,7 @@ public class ControlledResourceFields {
   private final AccessScopeType accessScope;
   private final ManagedByType managedBy;
   @Nullable private final String applicationId;
+  @Nullable private final List<ResourceLineageEntry> resourceLineage;
 
   /** construct from database resource */
   public ControlledResourceFields(DbResource dbResource) {
@@ -49,6 +52,7 @@ public class ControlledResourceFields {
     accessScope = dbResource.getAccessScope();
     managedBy = dbResource.getManagedBy();
     applicationId = dbResource.getApplicationId().orElse(null);
+    resourceLineage = dbResource.getResourceLineage().orElse(null);
   }
 
   // constructor for the builder
@@ -63,7 +67,8 @@ public class ControlledResourceFields {
       @Nullable PrivateResourceState privateResourceState,
       AccessScopeType accessScope,
       ManagedByType managedBy,
-      @Nullable String applicationId) {
+      @Nullable String applicationId,
+      @Nullable List<ResourceLineageEntry> resourceLineage) {
     this.workspaceUuid = workspaceUuid;
     this.resourceId = resourceId;
     this.name = name;
@@ -75,6 +80,7 @@ public class ControlledResourceFields {
     this.accessScope = accessScope;
     this.managedBy = managedBy;
     this.applicationId = applicationId;
+    this.resourceLineage = resourceLineage;
   }
 
   public static Builder builder() {
@@ -135,6 +141,11 @@ public class ControlledResourceFields {
     return applicationId;
   }
 
+  @Nullable
+  public List<ResourceLineageEntry> getResourceLineage() {
+    return resourceLineage;
+  }
+
   public static class Builder {
     private UUID workspaceUuid;
     private UUID resourceId;
@@ -150,6 +161,7 @@ public class ControlledResourceFields {
     private AccessScopeType accessScope;
     private ManagedByType managedBy;
     @Nullable private String applicationId;
+    @Nullable private List<ResourceLineageEntry> resourceLineage;
 
     public ControlledResourceFields build() {
       ResourceValidationUtils.checkFieldNonNull(workspaceUuid, "workspaceId");
@@ -170,7 +182,8 @@ public class ControlledResourceFields {
           privateResourceState,
           accessScope,
           managedBy,
-          applicationId);
+          applicationId,
+          resourceLineage);
     }
 
     public Builder workspaceUuid(UUID workspaceUuid) {
@@ -229,6 +242,11 @@ public class ControlledResourceFields {
 
     public Builder applicationId(@Nullable String applicationId) {
       this.applicationId = applicationId;
+      return this;
+    }
+
+    public Builder resourceLineage(@Nullable List<ResourceLineageEntry> resourceLineage) {
+      this.resourceLineage = resourceLineage;
       return this;
     }
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/ResourceLineageEntry.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/ResourceLineageEntry.java
@@ -1,0 +1,42 @@
+package bio.terra.workspace.service.resource.model;
+
+import bio.terra.workspace.generated.model.ApiResourceLineageEntry;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+
+/**
+ * A single resource lineage entry.
+ *
+ * <p>In resource table, the resource_lineage column contains a jsonb list of ResourceLineageEntry.
+ *
+ * <p>When you have a jsonb list of Foo, you must deserialize into Foo[].class. You can't create a
+ * FooList class that contains List<Foo> and deserialize into FooList. So there is no
+ * ResourceLineage.java. See https://stackoverflow.com/a/25512128/6447189.
+ */
+public class ResourceLineageEntry {
+  private final UUID sourceWorkspaceId;
+  private final UUID sourceResourceId;
+
+  @JsonCreator
+  public ResourceLineageEntry(
+      @JsonProperty("sourceWorkspaceId") UUID sourceWorkspaceId,
+      @JsonProperty("sourceResourceId") UUID sourceResourceId) {
+    this.sourceWorkspaceId = sourceWorkspaceId;
+    this.sourceResourceId = sourceResourceId;
+  }
+
+  public UUID getSourceWorkspaceId() {
+    return sourceWorkspaceId;
+  }
+
+  public UUID getSourceResourceId() {
+    return sourceResourceId;
+  }
+
+  public ApiResourceLineageEntry toApiModel() {
+    return new ApiResourceLineageEntry()
+        .sourceWorkspaceId(sourceWorkspaceId)
+        .sourceResourceId(sourceResourceId);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
@@ -12,12 +12,14 @@ import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -33,8 +35,9 @@ public class ReferencedGitRepoResource extends ReferencedResource {
       @JsonProperty("name") String name,
       @JsonProperty("description") @Nullable String description,
       @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
-      @JsonProperty("gitRepoUrl") String gitRepoUrl) {
-    super(workspaceId, resourceId, name, description, cloningInstructions);
+      @JsonProperty("gitRepoUrl") String gitRepoUrl,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
+    super(workspaceId, resourceId, name, description, cloningInstructions, resourceLineage);
     this.gitRepoUrl = gitRepoUrl;
     validate();
   }
@@ -132,7 +135,8 @@ public class ReferencedGitRepoResource extends ReferencedResource {
         .description(getDescription())
         .name(getName())
         .resourceId(getResourceId())
-        .workspaceId(getWorkspaceId());
+        .workspaceId(getWorkspaceId())
+        .resourceLineage(getResourceLineage());
   }
 
   public static ReferencedGitRepoResource.Builder builder() {
@@ -147,6 +151,7 @@ public class ReferencedGitRepoResource extends ReferencedResource {
     private String name;
     private UUID resourceId;
     private UUID workspaceId;
+    private List<ResourceLineageEntry> resourceLineage;
 
     public ReferencedGitRepoResource.Builder workspaceId(UUID workspaceUuid) {
       this.workspaceId = workspaceUuid;
@@ -179,6 +184,11 @@ public class ReferencedGitRepoResource extends ReferencedResource {
       return this;
     }
 
+    public Builder resourceLineage(List<ResourceLineageEntry> resourceLineage) {
+      this.resourceLineage = resourceLineage;
+      return this;
+    }
+
     public ReferencedGitRepoResource build() {
       // On the create path, we can omit the resourceId and have it filled in by the builder.
       return new ReferencedGitRepoResource(
@@ -187,7 +197,8 @@ public class ReferencedGitRepoResource extends ReferencedResource {
           name,
           description,
           cloningInstructions,
-          gitRepoUrl);
+          gitRepoUrl,
+          resourceLineage);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/ReferencedResource.java
@@ -5,8 +5,10 @@ import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
@@ -16,8 +18,9 @@ public abstract class ReferencedResource extends WsmResource {
       UUID resourceId,
       String name,
       @Nullable String description,
-      CloningInstructions cloningInstructions) {
-    super(workspaceUuid, resourceId, name, description, cloningInstructions);
+      CloningInstructions cloningInstructions,
+      @Nullable List<ResourceLineageEntry> resourceLineage) {
+    super(workspaceUuid, resourceId, name, description, cloningInstructions, resourceLineage);
   }
 
   public ReferencedResource(DbResource dbResource) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
@@ -15,12 +15,14 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -47,8 +49,9 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
       @JsonProperty("description") String description,
       @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
       @JsonProperty("projectId") String projectId,
-      @JsonProperty("datasetName") String datasetName) {
-    super(workspaceId, resourceId, name, description, cloningInstructions);
+      @JsonProperty("datasetName") String datasetName,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
+    super(workspaceId, resourceId, name, description, cloningInstructions, resourceLineage);
     this.projectId = projectId;
     this.datasetName = datasetName;
     validate();
@@ -169,7 +172,8 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
         .name(getName())
         .projectId(getProjectId())
         .resourceId(getResourceId())
-        .workspaceId(getWorkspaceId());
+        .workspaceId(getWorkspaceId())
+        .resourceLineage(getResourceLineage());
   }
 
   public static class Builder {
@@ -180,6 +184,7 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
     private CloningInstructions cloningInstructions;
     private String projectId;
     private String datasetName;
+    private List<ResourceLineageEntry> resourceLineage;
 
     public ReferencedBigQueryDatasetResource.Builder workspaceId(UUID workspaceUuid) {
       this.workspaceId = workspaceUuid;
@@ -217,6 +222,11 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
       return this;
     }
 
+    public Builder resourceLineage(List<ResourceLineageEntry> resourceLineage) {
+      this.resourceLineage = resourceLineage;
+      return this;
+    }
+
     public ReferencedBigQueryDatasetResource build() {
       // On the create path, we can omit the resourceId and have it filled in by the builder.
       return new ReferencedBigQueryDatasetResource(
@@ -226,7 +236,8 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
           description,
           cloningInstructions,
           projectId,
-          datasetName);
+          datasetName,
+          resourceLineage);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
@@ -15,12 +15,14 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -34,7 +36,7 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
   /**
    * Constructor for serialized form for Stairway use
    *
-   * @param workspaceUuid workspace unique identifier
+   * @param workspaceId workspace unique identifier
    * @param resourceId resource unique identifier
    * @param name name resource name; unique within a workspace
    * @param description description - may be null
@@ -42,6 +44,7 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
    * @param projectId google project id
    * @param datasetId BigQuery dataset name
    * @param dataTableId BigQuery dataset's data table name
+   * @param resourceLineage resource lineage
    */
   @JsonCreator
   public ReferencedBigQueryDataTableResource(
@@ -52,8 +55,9 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
       @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
       @JsonProperty("projectId") String projectId,
       @JsonProperty("datasetId") String datasetId,
-      @JsonProperty("dataTableId") String dataTableId) {
-    super(workspaceId, resourceId, name, description, cloningInstructions);
+      @JsonProperty("dataTableId") String dataTableId,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
+    super(workspaceId, resourceId, name, description, cloningInstructions, resourceLineage);
     this.projectId = projectId;
     this.datasetId = datasetId;
     this.dataTableId = dataTableId;
@@ -183,7 +187,8 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
         .name(getName())
         .projectId(getProjectId())
         .resourceId(getResourceId())
-        .workspaceId(getWorkspaceId());
+        .workspaceId(getWorkspaceId())
+        .resourceLineage(getResourceLineage());
   }
 
   public static class Builder {
@@ -196,6 +201,7 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
     private String projectId;
     private String datasetId;
     private String dataTableId;
+    private List<ResourceLineageEntry> resourceLineage;
 
     public ReferencedBigQueryDataTableResource.Builder workspaceId(UUID workspaceId) {
       this.workspaceId = workspaceId;
@@ -238,6 +244,11 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
       return this;
     }
 
+    public Builder resourceLineage(List<ResourceLineageEntry> resourceLineage) {
+      this.resourceLineage = resourceLineage;
+      return this;
+    }
+
     public ReferencedBigQueryDataTableResource build() {
       // On the create path, we can omit the resourceId and have it filled in by the builder.
       return new ReferencedBigQueryDataTableResource(
@@ -248,7 +259,8 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
           cloningInstructions,
           projectId,
           datasetId,
-          dataTableId);
+          dataTableId,
+          resourceLineage);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
@@ -13,12 +13,14 @@ import bio.terra.workspace.generated.model.ApiResourceUnion;
 import bio.terra.workspace.service.datarepo.DataRepoService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -36,6 +38,7 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
    * @param cloningInstructions cloning instructions
    * @param instanceName name of the data repository instance (e.g., "terra")
    * @param snapshotId name of the snapshot
+   * @param resourceLineage resource lineage
    */
   @JsonCreator
   public ReferencedDataRepoSnapshotResource(
@@ -45,8 +48,9 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
       @JsonProperty("description") String description,
       @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
       @JsonProperty("instanceName") String instanceName,
-      @JsonProperty("snapshotId") String snapshotId) {
-    super(workspaceId, resourceId, name, description, cloningInstructions);
+      @JsonProperty("snapshotId") String snapshotId,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
+    super(workspaceId, resourceId, name, description, cloningInstructions, resourceLineage);
     this.instanceName = instanceName;
     this.snapshotId = snapshotId;
     validate();
@@ -152,7 +156,8 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
         .name(getName())
         .snapshotId(getSnapshotId())
         .resourceId(getResourceId())
-        .workspaceId(getWorkspaceId());
+        .workspaceId(getWorkspaceId())
+        .resourceLineage(getResourceLineage());
   }
 
   public static class Builder {
@@ -163,6 +168,7 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
     private String snapshotId;
     private UUID resourceId;
     private UUID workspaceId;
+    private List<ResourceLineageEntry> resourceLineage;
 
     public ReferencedDataRepoSnapshotResource.Builder workspaceId(UUID workspaceUuid) {
       this.workspaceId = workspaceUuid;
@@ -200,6 +206,11 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
       return this;
     }
 
+    public Builder resourceLineage(List<ResourceLineageEntry> resourceLineage) {
+      this.resourceLineage = resourceLineage;
+      return this;
+    }
+
     public ReferencedDataRepoSnapshotResource build() {
       // On the create path, we can omit the resourceId and have it filled in by the builder.
       return new ReferencedDataRepoSnapshotResource(
@@ -209,7 +220,8 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
           description,
           cloningInstructions,
           instanceName,
-          snapshotId);
+          snapshotId,
+          resourceLineage);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
@@ -15,12 +15,14 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -36,6 +38,7 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
    * @param description description - may be null
    * @param cloningInstructions cloning instructions
    * @param bucketName bucket name
+   * @param resourceLineage resource lineage
    */
   @JsonCreator
   public ReferencedGcsBucketResource(
@@ -44,8 +47,9 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
       @JsonProperty("name") String name,
       @JsonProperty("description") String description,
       @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
-      @JsonProperty("bucketName") String bucketName) {
-    super(workspaceId, resourceId, name, description, cloningInstructions);
+      @JsonProperty("bucketName") String bucketName,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
+    super(workspaceId, resourceId, name, description, cloningInstructions, resourceLineage);
     this.bucketName = bucketName;
     validate();
   }
@@ -151,7 +155,8 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
         .description(getDescription())
         .name(getName())
         .resourceId(getResourceId())
-        .workspaceId(getWorkspaceId());
+        .workspaceId(getWorkspaceId())
+        .resourceLineage(getResourceLineage());
   }
 
   public static Builder builder() {
@@ -165,6 +170,7 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
     private String name;
     private UUID resourceId;
     private UUID workspaceId;
+    private List<ResourceLineageEntry> resourceLineage;
 
     public Builder workspaceId(UUID workspaceId) {
       this.workspaceId = workspaceId;
@@ -196,6 +202,11 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
       return this;
     }
 
+    public Builder resourceLineage(List<ResourceLineageEntry> resourceLineage) {
+      this.resourceLineage = resourceLineage;
+      return this;
+    }
+
     public ReferencedGcsBucketResource build() {
       // On the create path, we can omit the resourceId and have it filled in by the builder.
       return new ReferencedGcsBucketResource(
@@ -204,7 +215,8 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
           name,
           description,
           cloningInstructions,
-          bucketName);
+          bucketName,
+          resourceLineage);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
@@ -15,12 +15,14 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -39,6 +41,7 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
    * @param cloningInstructions cloning instructions
    * @param bucketName bucket name
    * @param objectName name for the file in the bucket
+   * @param resourceLineage resource lineage
    */
   @JsonCreator
   public ReferencedGcsObjectResource(
@@ -48,8 +51,9 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
       @JsonProperty("description") @Nullable String description,
       @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
       @JsonProperty("bucketName") String bucketName,
-      @JsonProperty("objectName") String objectName) {
-    super(workspaceId, resourceId, name, description, cloningInstructions);
+      @JsonProperty("objectName") String objectName,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
+    super(workspaceId, resourceId, name, description, cloningInstructions, resourceLineage);
     this.bucketName = bucketName;
     this.objectName = objectName;
     validate();
@@ -162,7 +166,8 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
         .description(getDescription())
         .name(getName())
         .resourceId(getResourceId())
-        .workspaceId(getWorkspaceId());
+        .workspaceId(getWorkspaceId())
+        .resourceLineage(getResourceLineage());
   }
 
   public static Builder builder() {
@@ -177,6 +182,7 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
     private String name;
     private UUID resourceId;
     private UUID workspaceId;
+    private List<ResourceLineageEntry> resourceLineage;
 
     public Builder workspaceId(UUID workspaceId) {
       this.workspaceId = workspaceId;
@@ -213,6 +219,11 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
       return this;
     }
 
+    public Builder resourceLineage(List<ResourceLineageEntry> resourceLineage) {
+      this.resourceLineage = resourceLineage;
+      return this;
+    }
+
     public ReferencedGcsObjectResource build() {
       // On the create path, we can omit the resourceId and have it filled in by the builder.
       return new ReferencedGcsObjectResource(
@@ -222,7 +233,8 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
           description,
           cloningInstructions,
           bucketName,
-          fileName);
+          fileName,
+          resourceLineage);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/terra/workspace/ReferencedTerraWorkspaceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/terra/workspace/ReferencedTerraWorkspaceResource.java
@@ -14,12 +14,14 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResource;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -35,6 +37,7 @@ public class ReferencedTerraWorkspaceResource extends ReferencedResource {
    * @param description description - may be null
    * @param cloningInstructions cloning instructions
    * @param referencedWorkspaceId workspace uuid that this referenced resource points to
+   * @param resourceLineage resource lineage
    */
   @JsonCreator
   public ReferencedTerraWorkspaceResource(
@@ -43,8 +46,9 @@ public class ReferencedTerraWorkspaceResource extends ReferencedResource {
       @JsonProperty("name") String name,
       @JsonProperty("description") String description,
       @JsonProperty("cloningInstructions") CloningInstructions cloningInstructions,
-      @JsonProperty("referencedWorkspaceId") UUID referencedWorkspaceId) {
-    super(workspaceId, resourceId, name, description, cloningInstructions);
+      @JsonProperty("referencedWorkspaceId") UUID referencedWorkspaceId,
+      @JsonProperty("resourceLineage") List<ResourceLineageEntry> resourceLineage) {
+    super(workspaceId, resourceId, name, description, cloningInstructions, resourceLineage);
     this.referencedWorkspaceId = referencedWorkspaceId;
     validate();
   }
@@ -157,7 +161,8 @@ public class ReferencedTerraWorkspaceResource extends ReferencedResource {
         .name(getName())
         .referencedWorkspaceId(getReferencedWorkspaceId())
         .resourceId(getResourceId())
-        .workspaceId(getWorkspaceId());
+        .workspaceId(getWorkspaceId())
+        .resourceLineage(getResourceLineage());
   }
 
   public static class Builder {
@@ -167,6 +172,7 @@ public class ReferencedTerraWorkspaceResource extends ReferencedResource {
     private String description;
     private CloningInstructions cloningInstructions;
     private UUID referencedWorkspaceId;
+    private List<ResourceLineageEntry> resourceLineage;
 
     public Builder workspaceId(UUID workspaceUuid) {
       this.workspaceId = workspaceUuid;
@@ -198,6 +204,11 @@ public class ReferencedTerraWorkspaceResource extends ReferencedResource {
       return this;
     }
 
+    public Builder resourceLineage(List<ResourceLineageEntry> resourceLineage) {
+      this.resourceLineage = resourceLineage;
+      return this;
+    }
+
     public ReferencedTerraWorkspaceResource build() {
       // On the create path, we can omit the resourceId and have it filled in by the builder.
       return new ReferencedTerraWorkspaceResource(
@@ -206,7 +217,8 @@ public class ReferencedTerraWorkspaceResource extends ReferencedResource {
           name,
           description,
           cloningInstructions,
-          referencedWorkspaceId);
+          referencedWorkspaceId,
+          resourceLineage);
     }
   }
 }

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -10,4 +10,5 @@
     <include file="changesets/20220516_workspace_user_facing_id_required.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220617_workspace_activity_log_table.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220721_actor_email_and_actor_subject_id_columns.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220810_resource_lineage.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20220810_resource_lineage.yaml
+++ b/service/src/main/resources/db/changesets/20220810_resource_lineage.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+- changeSet:
+    id: Add resource_lineage column
+    author: melchang
+    changes:
+    - addColumn:
+        tableName: resource
+        columns:
+        - column:
+            name: resource_lineage
+            type: jsonb
+            remarks: |
+              Serialized list of ResourceLineageEntry. A list of
+              workspaces/resources this resource has been cloned from.

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -273,7 +273,8 @@ public class ControlledResourceFixtures {
         AccessScopeType.ACCESS_SCOPE_PRIVATE,
         ManagedByType.MANAGED_BY_USER,
         null,
-        bucketName);
+        bucketName,
+        /*resourceLineage=*/ null);
   }
 
   public static ControlledAzureIpResource getAzureIp(String ipName, String region) {
@@ -290,7 +291,8 @@ public class ControlledResourceFixtures {
         ManagedByType.MANAGED_BY_USER,
         null,
         ipName,
-        region);
+        region,
+        /*resourceLineage=*/ null);
   }
 
   public static ControlledAzureRelayNamespaceResource getAzureRelayNamespace(
@@ -307,7 +309,8 @@ public class ControlledResourceFixtures {
         ManagedByType.MANAGED_BY_APPLICATION,
         null,
         namespaceName,
-        region);
+        region,
+        /*resourceLineage=*/ null);
   }
 
   public static ControlledAzureDiskResource getAzureDisk(String diskName, String region, int size) {
@@ -325,7 +328,8 @@ public class ControlledResourceFixtures {
         null,
         diskName,
         region,
-        size);
+        size,
+        /*resourceLineage=*/ null);
   }
 
   public static ControlledAzureNetworkResource getAzureNetwork(
@@ -346,7 +350,8 @@ public class ControlledResourceFixtures {
         creationParameters.getSubnetName(),
         creationParameters.getAddressSpaceCidr(),
         creationParameters.getSubnetAddressCidr(),
-        creationParameters.getRegion());
+        creationParameters.getRegion(),
+        /*resourceLineage=*/ null);
   }
 
   public static ControlledAzureStorageResource getAzureStorage(
@@ -364,7 +369,8 @@ public class ControlledResourceFixtures {
         ManagedByType.MANAGED_BY_USER,
         null,
         storageAccountName,
-        region);
+        region,
+        /*resourceLineage=*/ null);
   }
 
   public static ControlledAzureStorageContainerResource getAzureStorageContainer(
@@ -382,7 +388,8 @@ public class ControlledResourceFixtures {
         ManagedByType.MANAGED_BY_USER,
         null,
         storageAccountId,
-        storageContainerName);
+        storageContainerName,
+        /*resourceLineage=*/ null);
   }
 
   public static ControlledAzureVmResource getAzureVm(
@@ -405,7 +412,8 @@ public class ControlledResourceFixtures {
         AzureVmUtils.getImageData(creationParameters.getVmImage()),
         creationParameters.getIpId(),
         creationParameters.getNetworkId(),
-        creationParameters.getDiskId());
+        creationParameters.getDiskId(),
+        /*resourceLineage=*/ null);
   }
 
   private ControlledResourceFixtures() {}

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
@@ -17,6 +17,7 @@ public class ReferenceResourceFixtures {
         "description of " + resourceName,
         CloningInstructions.COPY_NOTHING,
         "terra",
-        "polaroid");
+        "polaroid",
+        /*resourceLineage=*/ null);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
@@ -63,7 +63,14 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
 
     var resource =
         new ReferencedBigQueryDatasetResource(
-            workspaceUuid, resourceId, resourceName, description, cloning, projectId, datasetName);
+            workspaceUuid,
+            resourceId,
+            resourceName,
+            description,
+            cloning,
+            projectId,
+            datasetName,
+            /*resourceLineage=*/ null);
 
     ApiResourceDescription resourceDescription =
         resourceController.makeApiResourceDescription(resource);
@@ -90,7 +97,8 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
             cloning,
             projectId,
             datasetName,
-            datatableName);
+            datatableName,
+            /*resourceLineage=*/ null);
 
     ApiResourceDescription resourceDescription =
         resourceController.makeApiResourceDescription(resource);
@@ -116,7 +124,8 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
             description,
             cloning,
             instanceName,
-            snapshotId);
+            snapshotId,
+            /*resourceLineage=*/ null);
 
     ApiResourceDescription resourceDescription =
         resourceController.makeApiResourceDescription(resource);
@@ -134,7 +143,13 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
 
     var resource =
         new ReferencedGcsBucketResource(
-            workspaceUuid, resourceId, resourceName, description, cloning, bucketName);
+            workspaceUuid,
+            resourceId,
+            resourceName,
+            description,
+            cloning,
+            bucketName,
+            /*resourceLineage=*/ null);
 
     ApiResourceDescription resourceDescription =
         resourceController.makeApiResourceDescription(resource);
@@ -184,7 +199,8 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
               accessScopeType,
               managedByType,
               null,
-              bucketName);
+              bucketName,
+              /*resourceLineage=*/ null);
 
       ApiResourceDescription resourceDescription =
           resourceController.makeApiResourceDescription(resource);
@@ -213,7 +229,8 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
               managedByType,
               null,
               datasetName,
-              projectId);
+              projectId,
+              /*resourceLineage=*/ null);
 
       ApiResourceDescription resourceDescription =
           resourceController.makeApiResourceDescription(resource);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -68,7 +68,8 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
         ManagedByType.MANAGED_BY_USER,
         null,
         "fake",
-        "us-east1");
+        "us-east1",
+        /*resourceLineage=*/ null);
   }
 
   private ControlledAzureStorageContainerResource buildStorageContainerResource(
@@ -87,7 +88,8 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
         managedByType,
         null,
         UUID.randomUUID(),
-        "fake");
+        "fake",
+        /*resourceLineage=*/ null);
   }
 
   private void assertValidToken(String sas, BlobContainerSasPermission expectedPermissions) {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/FindResourcesToCloneStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/FindResourcesToCloneStepTest.java
@@ -53,7 +53,8 @@ public class FindResourcesToCloneStepTest extends BaseUnitTest {
             AccessScopeType.ACCESS_SCOPE_SHARED,
             ManagedByType.MANAGED_BY_USER,
             null,
-            "bucket-with-hole-in-it-dear-liza");
+            "bucket-with-hole-in-it-dear-liza",
+            /*resourceLineage=*/ null);
 
     findResourcesToCloneStep = new FindResourcesToCloneStep(mockResourceDao);
     doReturn(mockStairway).when(mockFlightContext).getStairway();

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -334,7 +334,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
               "some description",
               CloningInstructions.COPY_NOTHING,
               DATA_REPO_INSTANCE_NAME,
-              "polaroid");
+              "polaroid",
+              /*resourceLineage=*/ null);
       // Service methods which wait for a flight to complete will throw an
       // InvalidResultStateException when that flight fails without a cause, which occurs when a
       // flight fails via debugInfo.
@@ -364,7 +365,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   null,
                   CloningInstructions.COPY_NOTHING,
                   DATA_REPO_INSTANCE_NAME,
-                  "polaroid"));
+                  "polaroid",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -379,7 +381,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   null,
                   CloningInstructions.COPY_NOTHING,
                   DATA_REPO_INSTANCE_NAME,
-                  "polaroid"));
+                  "polaroid",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -394,7 +397,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   null,
                   null,
                   DATA_REPO_INSTANCE_NAME,
-                  "polaroid"));
+                  "polaroid",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -403,7 +407,14 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
           MissingRequiredFieldException.class,
           () ->
               new ReferencedDataRepoSnapshotResource(
-                  workspaceUuid, null, "aname", null, null, DATA_REPO_INSTANCE_NAME, "polaroid"));
+                  workspaceUuid,
+                  null,
+                  "aname",
+                  null,
+                  null,
+                  DATA_REPO_INSTANCE_NAME,
+                  "polaroid",
+                  /*resourceLineage=*/ null));
     }
   }
 
@@ -483,7 +494,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   "description of " + resourceName,
                   CloningInstructions.COPY_NOTHING,
                   null,
-                  "polaroid"));
+                  "polaroid",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -501,7 +513,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   "description of " + resourceName,
                   CloningInstructions.COPY_NOTHING,
                   DATA_REPO_INSTANCE_NAME,
-                  null));
+                  null,
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -563,7 +576,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
           "description of " + resourceName,
           CloningInstructions.COPY_REFERENCE,
           /*bucketName=*/ "theres-a-hole-in-the-bottom-of-the",
-          /*objectName=*/ "balloon");
+          /*objectName=*/ "balloon",
+          /*resourceLineage=*/ null);
     }
 
     @Test
@@ -631,7 +645,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
           resourceName,
           "description of " + resourceName,
           CloningInstructions.COPY_REFERENCE,
-          "theres-a-hole-in-the-bottom-of-the");
+          "theres-a-hole-in-the-bottom-of-the",
+          /*resourceLineage=*/ null);
     }
 
     @Test
@@ -685,7 +700,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   "description of " + resourceName,
                   CloningInstructions.COPY_REFERENCE,
                   /*bucketName=*/ "spongebob",
-                  /*fileName=*/ ""));
+                  /*fileName=*/ "",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -701,7 +717,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   resourceName,
                   "description of " + resourceName,
                   CloningInstructions.COPY_REFERENCE,
-                  null));
+                  null,
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -718,7 +735,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   resourceName,
                   "description of " + resourceName,
                   CloningInstructions.COPY_REFERENCE,
-                  "Buckets don't accept * in the names, either"));
+                  "Buckets don't accept * in the names, either",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -757,7 +775,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
           "description of " + resourceName,
           CloningInstructions.COPY_REFERENCE,
           FAKE_PROJECT_ID,
-          DATASET_NAME);
+          DATASET_NAME,
+          /*resourceLineage=*/ null);
     }
 
     private ReferencedBigQueryDataTableResource makeBigQueryDataTableResource() {
@@ -771,7 +790,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
           CloningInstructions.COPY_REFERENCE,
           FAKE_PROJECT_ID,
           DATASET_NAME,
-          DATA_TABLE_NAME);
+          DATA_TABLE_NAME,
+          /*resourceLineage=*/ null);
     }
 
     @Test
@@ -954,7 +974,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   "description of " + resourceName,
                   CloningInstructions.COPY_NOTHING,
                   null,
-                  "testbq_datasetname"));
+                  "testbq_datasetname",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -973,7 +994,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   CloningInstructions.COPY_NOTHING,
                   "testbq-projectid",
                   "testbq-datasetname",
-                  ""));
+                  "",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -991,7 +1013,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   "description of " + resourceName,
                   CloningInstructions.COPY_NOTHING,
                   "testbq-projectid",
-                  ""));
+                  "",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -1010,7 +1033,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   CloningInstructions.COPY_NOTHING,
                   "testbq-projectid",
                   DATASET_NAME,
-                  "*&%@#"));
+                  "*&%@#",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -1028,7 +1052,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
                   "description of " + resourceName,
                   CloningInstructions.COPY_NOTHING,
                   "testbq-projectid",
-                  "Nor do datasets; neither ' nor *"));
+                  "Nor do datasets; neither ' nor *",
+                  /*resourceLineage=*/ null));
     }
 
     @Test
@@ -1061,7 +1086,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
           resourceName,
           "description of " + resourceName,
           CloningInstructions.COPY_NOTHING,
-          /*referencedWorkspaceId=*/ referencedWorkspaceId);
+          /*referencedWorkspaceId=*/ referencedWorkspaceId,
+          /*resourceLineage=*/ null);
     }
 
     @Test
@@ -1165,7 +1191,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
               null,
               CloningInstructions.COPY_NOTHING,
               DATA_REPO_INSTANCE_NAME,
-              "polaroid");
+              "polaroid",
+              /*resourceLineage=*/ null);
 
       assertThrows(
           DuplicateResourceException.class,

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -675,7 +675,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
             null,
             CloningInstructions.COPY_NOTHING,
             "fakeinstance",
-            "fakesnapshot");
+            "fakesnapshot",
+            /*resourceLineage=*/ null);
     referenceResourceService.createReferenceResource(snapshot, USER_REQUEST);
 
     // Validate that the reference exists.


### PR DESCRIPTION
This PR writes resource lineage (on destination resource) when cloning referenced resource. Future PRs will handle:

- Workspace clone
- Controlled resource clone

Apologies for the large PR. I wasn't sure how postgres jsonb-that's-a-list/DbSerDes worked, so I got e2e working to make sure things work. I wrote an integration test that:

- Clones resource 1 to resource 2
- Clones resource 2 to resource 3

After 1st clone:

```
wsm_db=> select resource_lineage from resource where resource_id = 'bc1cf4e9-b3d0-49db-ba17-bd54c6a21614';
                                                      resource_lineage
-----------------------------------------------------------------------------------------------------------------------------
 [{"sourceResourceId": "1a5affca-6798-4a2b-8e91-2aa0f146288f", "sourceWorkspaceId": "eb519b10-537b-4a4c-af50-07e146363d9d"}]
```

![image](https://user-images.githubusercontent.com/10929390/186782492-3146b326-b617-4d05-b843-7190baf686ae.png)

After 2nd clone:

```
wsm_db=> select resource_lineage from resource where resource_id = '535d4c61-5e6a-4d07-8c2f-34a61a655bb9';
                                                                                                                    resource_lineage
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [{"sourceResourceId": "1a5affca-6798-4a2b-8e91-2aa0f146288f", "sourceWorkspaceId": "eb519b10-537b-4a4c-af50-07e146363d9d"}, {"sourceResourceId": "bc1cf4e9-b3d0-49db-ba17-bd54c6a21614", "sourceWorkspaceId": "b8ae6574-1670-4a05-9e05-5b90f8b65c2d"}]
```

![image](https://user-images.githubusercontent.com/10929390/186782516-26b029f3-b18b-407b-88c4-16979f6b5c1c.png)