### PR TITLE
PF-1871 - Clone policy step will return right away if TPS is not enabled

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneGcpWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneGcpWorkspaceFlight.java
@@ -28,10 +28,9 @@ public class CloneGcpWorkspaceFlight extends Flight {
         RetryRules.cloud());
     addStep(new AwaitCreateGcpContextFlightStep(), RetryRules.cloudLongRunning());
 
-    addStep(
-        new ClonePolicyAttributesStep(
-            flightBeanBag.getTpsApiDispatch(), flightBeanBag.getFeatureConfiguration()),
-        RetryRules.cloud());
+    if (flightBeanBag.getFeatureConfiguration().isTpsEnabled()) {
+      addStep(new ClonePolicyAttributesStep(flightBeanBag.getTpsApiDispatch()), RetryRules.cloud());
+    }
 
     addStep(new LaunchCloneAllResourcesFlightStep(), RetryRules.cloud());
     addStep(new AwaitCloneAllResourcesFlightStep(), RetryRules.cloudLongRunning());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneGcpWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneGcpWorkspaceFlight.java
@@ -28,7 +28,10 @@ public class CloneGcpWorkspaceFlight extends Flight {
         RetryRules.cloud());
     addStep(new AwaitCreateGcpContextFlightStep(), RetryRules.cloudLongRunning());
 
-    addStep(new ClonePolicyAttributesStep(flightBeanBag.getTpsApiDispatch()), RetryRules.cloud());
+    addStep(
+        new ClonePolicyAttributesStep(
+            flightBeanBag.getTpsApiDispatch(), flightBeanBag.getFeatureConfiguration()),
+        RetryRules.cloud());
 
     addStep(new LaunchCloneAllResourcesFlightStep(), RetryRules.cloud());
     addStep(new AwaitCloneAllResourcesFlightStep(), RetryRules.cloudLongRunning());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ClonePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ClonePolicyAttributesStep.java
@@ -7,6 +7,7 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.amalgam.tps.TpsApiDispatch;
+import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.generated.model.ApiTpsPaoGetResult;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -18,13 +19,19 @@ import java.util.UUID;
 
 public class ClonePolicyAttributesStep implements Step {
   TpsApiDispatch tpsApiDispatch;
+  FeatureConfiguration features;
 
-  public ClonePolicyAttributesStep(TpsApiDispatch tpsApiDispatch) {
+  public ClonePolicyAttributesStep(TpsApiDispatch tpsApiDispatch, FeatureConfiguration features) {
     this.tpsApiDispatch = tpsApiDispatch;
+    this.features = features;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    if (!features.isTpsEnabled()) {
+      return StepResult.getStepResultSuccess();
+    }
+
     final FlightMap inputParameters = context.getInputParameters();
     FlightUtils.validateRequiredEntries(
         inputParameters,
@@ -63,6 +70,10 @@ public class ClonePolicyAttributesStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
+    if (!features.isTpsEnabled()) {
+      return StepResult.getStepResultSuccess();
+    }
+
     final var destinationWorkspace =
         context.getInputParameters().get(JobMapKeys.REQUEST.getKeyName(), Workspace.class);
     final var userRequest =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ClonePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ClonePolicyAttributesStep.java
@@ -7,7 +7,6 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.amalgam.tps.TpsApiDispatch;
-import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.generated.model.ApiTpsPaoGetResult;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -19,19 +18,13 @@ import java.util.UUID;
 
 public class ClonePolicyAttributesStep implements Step {
   TpsApiDispatch tpsApiDispatch;
-  FeatureConfiguration features;
 
-  public ClonePolicyAttributesStep(TpsApiDispatch tpsApiDispatch, FeatureConfiguration features) {
+  public ClonePolicyAttributesStep(TpsApiDispatch tpsApiDispatch) {
     this.tpsApiDispatch = tpsApiDispatch;
-    this.features = features;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    if (!features.isTpsEnabled()) {
-      return StepResult.getStepResultSuccess();
-    }
-
     final FlightMap inputParameters = context.getInputParameters();
     FlightUtils.validateRequiredEntries(
         inputParameters,
@@ -70,10 +63,6 @@ public class ClonePolicyAttributesStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
-    if (!features.isTpsEnabled()) {
-      return StepResult.getStepResultSuccess();
-    }
-
     final var destinationWorkspace =
         context.getInputParameters().get(JobMapKeys.REQUEST.getKeyName(), Workspace.class);
     final var userRequest =


### PR DESCRIPTION
Not all environments will have TPS enabled. We don't need to attempt to clone policies if the feature is not turned on.