### PR TITLE
PF-1956: Clean up dead code-ish

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
@@ -82,9 +82,7 @@ public class CopyGcsBucketDefinitionStep implements Step {
             ResourceKeys.PREVIOUS_RESOURCE_DESCRIPTION,
             String.class);
     final String bucketName =
-        Optional.ofNullable(
-                inputParameters.get(ControlledResourceKeys.DESTINATION_BUCKET_NAME, String.class))
-            .orElseGet(this::randomBucketName);
+        inputParameters.get(ControlledResourceKeys.DESTINATION_BUCKET_NAME, String.class);
     final PrivateResourceState privateResourceState =
         sourceBucket.getAccessScope() == AccessScopeType.ACCESS_SCOPE_PRIVATE
             ? PrivateResourceState.INITIALIZING
@@ -187,9 +185,5 @@ public class CopyGcsBucketDefinitionStep implements Step {
     } else {
       return sourceCreationParameters;
     }
-  }
-
-  private String randomBucketName() {
-    return "terra-wsm-" + UUID.randomUUID().toString().toLowerCase();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
@@ -81,26 +81,25 @@ public class CopyGcsBucketDefinitionStep implements Step {
             ResourceKeys.RESOURCE_DESCRIPTION,
             ResourceKeys.PREVIOUS_RESOURCE_DESCRIPTION,
             String.class);
-    final String bucketName =
-        inputParameters.get(ControlledResourceKeys.DESTINATION_BUCKET_NAME, String.class);
+
     final PrivateResourceState privateResourceState =
         sourceBucket.getAccessScope() == AccessScopeType.ACCESS_SCOPE_PRIVATE
             ? PrivateResourceState.INITIALIZING
             : PrivateResourceState.NOT_APPLICABLE;
-    // Store effective bucket name for destination
-    workingMap.put(ControlledResourceKeys.DESTINATION_BUCKET_NAME, bucketName);
     final UUID destinationWorkspaceId =
         inputParameters.get(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, UUID.class);
+    final String bucketName =
+        Optional.ofNullable(inputParameters.get(ControlledResourceKeys.DESTINATION_BUCKET_NAME, String.class))
+            .orElse(ControlledGcsBucketHandler.getHandler()
+                .generateCloudName(destinationWorkspaceId, resourceName));
+    // Store effective bucket name for destination
+    workingMap.put(ControlledResourceKeys.DESTINATION_BUCKET_NAME, bucketName);
     final var destinationResourceId =
         inputParameters.get(ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class);
     // bucket resource for create flight
     ControlledGcsBucketResource destinationBucketResource =
         ControlledGcsBucketResource.builder()
-            .bucketName(
-                StringUtils.isEmpty(bucketName)
-                    ? ControlledGcsBucketHandler.getHandler()
-                        .generateCloudName(destinationWorkspaceId, resourceName)
-                    : bucketName)
+            .bucketName(bucketName)
             .common(
                 ControlledResourceFields.builder()
                     .workspaceUuid(destinationWorkspaceId)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
@@ -25,7 +25,6 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.Resou
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 
 /**
@@ -89,9 +88,11 @@ public class CopyGcsBucketDefinitionStep implements Step {
     final UUID destinationWorkspaceId =
         inputParameters.get(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, UUID.class);
     final String bucketName =
-        Optional.ofNullable(inputParameters.get(ControlledResourceKeys.DESTINATION_BUCKET_NAME, String.class))
-            .orElse(ControlledGcsBucketHandler.getHandler()
-                .generateCloudName(destinationWorkspaceId, resourceName));
+        Optional.ofNullable(
+                inputParameters.get(ControlledResourceKeys.DESTINATION_BUCKET_NAME, String.class))
+            .orElse(
+                ControlledGcsBucketHandler.getHandler()
+                    .generateCloudName(destinationWorkspaceId, resourceName));
     // Store effective bucket name for destination
     workingMap.put(ControlledResourceKeys.DESTINATION_BUCKET_NAME, bucketName);
     final var destinationResourceId =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
@@ -91,8 +91,12 @@ public class CopyGcsBucketDefinitionStep implements Step {
         Optional.ofNullable(
                 inputParameters.get(ControlledResourceKeys.DESTINATION_BUCKET_NAME, String.class))
             .orElse(
+                // If the source bucket uses the auto-generated cloud name and the destination
+                // bucket attempt to do the same, the name will crash as the bucket name must be
+                // globally unique. Thus we add cloned- as prefix to the resource name to prevent
+                // crashing.
                 ControlledGcsBucketHandler.getHandler()
-                    .generateCloudName(destinationWorkspaceId, resourceName));
+                    .generateCloudName(destinationWorkspaceId, "cloned-" + resourceName));
     // Store effective bucket name for destination
     workingMap.put(ControlledResourceKeys.DESTINATION_BUCKET_NAME, bucketName);
     final var destinationResourceId =


### PR DESCRIPTION
this bucket name generation does not follow the new standard way. So removing this. at line 100, we are also checking for bucketname null and using the right way to generate one.