### PR TITLE
[PF-1955] Add GOOGLE_PROJECT, OWNER_EMAIL, PET_SA_EMAIL environment variables.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -128,6 +128,9 @@ fi
 # Set variables into the .bash_profile such that they are available
 # to terminals, notebooks, and other tools
 
+# Keep in sync with terra CLI environment variables:
+# https://github.com/DataBiosphere/terra-cli/blob/main/src/main/java/bio/terra/cli/app/CommandRunner.java#L88
+
 # These are environment variables that are set by Leonardo for
 # Cloud Environments (https://github.com/DataBiosphere/leonardo)
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -127,12 +127,18 @@ fi
 
 # Set variables into the .bash_profile such that they are available
 # to terminals, notebooks, and other tools
+#
+# We have new-style variables (eg GOOGLE_CLOUD_PROJECT) which are set here
+# and CLI (terra app execute env).
+# We also support a few variables set by Leonardo (eg GOOGLE_PROJECT).
+# Those are only set here and NOT in the CLI as they are intended just
+# to make porting existing notebooks easier.
 
 # Keep in sync with terra CLI environment variables:
-# https://github.com/DataBiosphere/terra-cli/blob/main/src/main/java/bio/terra/cli/app/CommandRunner.java#L88
+# https://github.com/DataBiosphere/terra-cli/blob/14cf51dd809573c7ae9a3ef10ddd427fa057cb8f/src/main/java/bio/terra/cli/app/CommandRunner.java#L88
 
-# These are environment variables that are set by Leonardo for
-# Cloud Environments (https://github.com/DataBiosphere/leonardo)
+# *** Variables that are set by Leonardo for Cloud Environments
+# (https://github.com/DataBiosphere/leonardo)
 
 # OWNER_EMAIL is really the Terra user account email address
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -128,20 +128,43 @@ fi
 # Set variables into the .bash_profile such that they are available
 # to terminals, notebooks, and other tools
 
-readonly GOOGLE_PROJECT="$(
-  sudo -u "${JUPYTER_USER}" sh -c "terra workspace describe --format=json" | \
-  jq --raw-output ".googleProjectId")"
-echo "export GOOGLE_PROJECT='${GOOGLE_PROJECT}'" >> "/home/${JUPYTER_USER}/.bash_profile"
+# These are environment variables that are set by Leonardo for
+# Cloud Environments (https://github.com/DataBiosphere/leonardo)
+
+# OWNER_EMAIL is really the Terra user account email address
 
 readonly OWNER_EMAIL="$(
   sudo -u "${JUPYTER_USER}" sh -c "terra workspace describe --format=json" | \
   jq --raw-output ".userEmail")"
 echo "export OWNER_EMAIL='${OWNER_EMAIL}'" >> "/home/${JUPYTER_USER}/.bash_profile"
 
+# GOOGLE_PROJECT is the project id for the GCP project backing the workspace
+
+readonly GOOGLE_PROJECT="$(
+  sudo -u "${JUPYTER_USER}" sh -c "terra workspace describe --format=json" | \
+  jq --raw-output ".googleProjectId")"
+echo "export GOOGLE_PROJECT='${GOOGLE_PROJECT}'" >> "/home/${JUPYTER_USER}/.bash_profile"
+
+# PET_SA_EMAIL is the pet service account for the Terra user and
+# is specific to the GCP project backing the workspace
+
 readonly PET_SA_EMAIL="$(
   sudo -u "${JUPYTER_USER}" sh -c "terra auth status --format=json" | \
   jq --raw-output ".serviceAccountEmail")"
 echo "export PET_SA_EMAIL='${PET_SA_EMAIL}'" >> "/home/${JUPYTER_USER}/.bash_profile"
+
+# These are equivalent environment variables which are set for a
+# command when calling "terra app execute <command>".
+
+# GOOGLE_CLOUD_PROJECT is the project id for the GCP project backing the
+# workspace.
+
+echo "export GOOGLE_CLOUD_PROJECT='${GOOGLE_PROJECT}'" >> "/home/${JUPYTER_USER}/.bash_profile"
+
+# GOOGLE_SERVICE_ACCOUNT_EMAIL is the pet service account for the Terra user
+# and is specific to the GCP project backing the workspace.
+
+echo "export GOOGLE_SERVICE_ACCOUNT_EMAIL='${PET_SA_EMAIL}'" >> "/home/${JUPYTER_USER}/.bash_profile"
 
 ###############
 # git setup


### PR DESCRIPTION
Variables now show in Jupyter notebooks and terminals:

Here is the .bash_profile:

```
(base) jupyter@mbookman-20220831-223034:~$ cat ~/.bash_profile
export GOOGLE_PROJECT='terra-<stuff>'
export OWNER_EMAIL='<stuff>'
export PET_SA_EMAIL='pet-<stuff>@terra-<stuff>.iam.gserviceaccount.com'
eval "$(ssh-agent -s)"
```
Here's the relevant bits of the environment in a terminal in Jupyterlab:

```
(base) jupyter@mbookman-20220831-223034:~$ env | grep EMAIL
OWNER_EMAIL=<stuff>
PET_SA_EMAIL=pet-<stuff>@terra-<stuff>.iam.gserviceaccount.com
(base) jupyter@mbookman-20220831-223034:~$ env | grep GOOGLE
GOOGLE_PROJECT=terra-<stuff>
```

Added some small cleanup to the post_startup.sh where code was a little inconsistent.

