### PR TITLE
[PF-2039] Implement the higher role concept in the `WsmIamRole` enum

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -20,12 +20,12 @@ Please refer to the GitHub Action workflow use cases in the `Run a test suite` s
 
 Integration Test
 ```
-./gradlew runTest --args="configs/integration/BasicAuthenticated.json /tmp/TR"
+./gradlew :integration:runTest --args="configs/integration/BasicAuthenticated.json /tmp/TR"
 ```
 
 Perf Test
 ```
-./gradlew runTest --args="configs/perf/BasicAuthenticated.json /tmp/TR"
+./gradlew :integration:runTest --args="configs/perf/BasicAuthenticated.json /tmp/TR"
 ```
 
 #### Run a test suite
@@ -35,12 +35,12 @@ See `test-runner-integration.yml` and `test-runner-nightly-perf.yml` in `.github
 
 Integration Test
 ```
-./gradlew runTest --args="suites/FullIntegration.json /tmp/TR"
+./gradlew :integration:runTest --args="suites/FullIntegration.json /tmp/TR"
 ```
 
 Perf Test
 ```
-./gradlew runTest --args="suites/BasicPerf.json /tmp/TR"
+./gradlew :integration:runTest --args="suites/BasicPerf.json /tmp/TR"
 ```
 
 ### Running Resiliency Tests Through Test Runner Library
@@ -89,14 +89,14 @@ The bucket location is a parameter in an upload config file located in the `reso
 The Gradle `uploadResults` task below archive the test results located in `/tmp/TR` to the bucket specified in config file `CompressDirectoryToBucket.json`.
 
 ```
-./gradlew uploadResults --args="CompressDirectoryToBucket.json /tmp/TR"
+./gradlew :integration:uploadResults --args="CompressDirectoryToBucket.json /tmp/TR"
 ```
 
 The default server that the test will run against is specified in the test config file.
 To override the default server, set an environment variable as in the following example.
 ```
 export TEST_RUNNER_SERVER_SPECIFICATION_FILE="workspace-dev.json" 
-./gradlew  runTest --args="configs/integration/BasicAuthenticated.json /tmp/TR"
+./gradlew  :integration:runTest --args="configs/integration/BasicAuthenticated.json /tmp/TR"
 ```
 
 #### SA keys from Vault
@@ -137,13 +137,13 @@ The version of the Workspace Manager client JAR file is specified in the build.g
 fetched from the Broad Institute Maven repository. You can override this to use a local version of the Workspace Manager client
 JAR file by specifying a Gradle project property, either with a command line argument
 
-`./gradlew -Pworkspacemanagerclientjar=~/terra-workspace-manager/workspace-manager-client/build/libs/workspace-manager-client-0.5.0-SNAPSHOT.jar runTest --args="configs/integration/BasicAuthenticated.json"
+`./gradlew -Pworkspacemanagerclientjar=~/terra-workspace-manager/workspace-manager-client/build/libs/workspace-manager-client-0.5.0-SNAPSHOT.jar :integration:runTest --args="configs/integration/BasicAuthenticated.json"
 
 or an environment variable.
 
 ```
 export ORG_GRADLE_PROJECT_workspacemanagerclientjar=~/terra-workspace-manager/workspace-manager-client/build/libs/workspace-manager-client-0.5.0-SNAPSHOT.jar
-./gradlew runTest --args="configs/integration/BasicAuthenticated.json /tmp/TestRunnerResults"
+./gradlew :integration:runTest --args="configs/integration/BasicAuthenticated.json /tmp/TestRunnerResults"
 ```
 
 This is useful for debugging or testing local server code changes that affect the generated client library (e.g. new API
@@ -165,7 +165,7 @@ for running against a local server. Once you have a local server running separat
 you can run client tests against that server, e.g.
 ```
 export TEST_RUNNER_SERVER_SPECIFICATION_FILE="workspace-local.json" 
-./gradlew runTest --args="configs/integration/BasicAuthenticated.json /tmp/TR"
+./gradlew :integration:runTest --args="configs/integration/BasicAuthenticated.json /tmp/TR"
 ```
 
 If setting the server file to `workspace-dev.json`, `workspace-alpha.json`, `workspace-staging.json`, you are pointing the test

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -305,7 +305,7 @@ public class SamService {
           // Skip workspaces with no roles. (That means there's a role this WSM doesn't know
           // about.)
           if (highestRole.isPresent()) {
-            if (WsmIamRole.roleAtLeastAsHighAs(minimumHighestRoleFromRequest, highestRole.get())) {
+            if (minimumHighestRoleFromRequest.roleAtLeastAsHighAs(highestRole.get())) {
               workspacesAndRoles.put(workspaceId, highestRole.get());
             }
           }

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -301,14 +301,15 @@ public class SamService {
                   .map(WsmIamRole::fromSam)
                   .filter(Objects::nonNull)
                   .collect(Collectors.toList());
-          Optional<WsmIamRole> highestRole = WsmIamRole.getHighestRole(workspaceId, roles);
           // Skip workspaces with no roles. (That means there's a role this WSM doesn't know
           // about.)
-          if (highestRole.isPresent()) {
-            if (minimumHighestRoleFromRequest.roleAtLeastAsHighAs(highestRole.get())) {
-              workspacesAndRoles.put(workspaceId, highestRole.get());
-            }
-          }
+          WsmIamRole.getHighestRole(workspaceId, roles)
+              .ifPresent(
+                  highestRole -> {
+                    if (minimumHighestRoleFromRequest.roleAtLeastAsHighAs(highestRole)) {
+                      workspacesAndRoles.put(workspaceId, highestRole);
+                    }
+                  });
         } catch (IllegalArgumentException e) {
           // WSM always uses UUIDs for workspace IDs, but this is not enforced in Sam and there are
           // old workspaces that don't use UUIDs. Any workspace with a non-UUID workspace ID is

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
@@ -20,16 +20,16 @@ public enum WsmIamRole {
   READER("reader", SamWorkspaceAction.READ, ApiIamRole.READER) {
     public boolean roleAtLeastAsHighAs(WsmIamRole roleToCheck) {
       return roleToCheck == WsmIamRole.APPLICATION
-              || roleToCheck == WsmIamRole.OWNER
-              || roleToCheck == WsmIamRole.WRITER
-              || roleToCheck == WsmIamRole.READER;
+          || roleToCheck == WsmIamRole.OWNER
+          || roleToCheck == WsmIamRole.WRITER
+          || roleToCheck == WsmIamRole.READER;
     }
   },
   WRITER("writer", SamWorkspaceAction.WRITE, ApiIamRole.WRITER) {
     public boolean roleAtLeastAsHighAs(WsmIamRole roleToCheck) {
       return roleToCheck == WsmIamRole.APPLICATION
-              || roleToCheck == WsmIamRole.OWNER
-              || roleToCheck == WsmIamRole.WRITER;
+          || roleToCheck == WsmIamRole.OWNER
+          || roleToCheck == WsmIamRole.WRITER;
     }
   },
   APPLICATION("application", null, ApiIamRole.APPLICATION) {
@@ -67,8 +67,7 @@ public enum WsmIamRole {
         Arrays.stream(WsmIamRole.values()).filter(x -> x.apiRole.equals(apiModel)).findFirst();
     return result.orElseThrow(
         () ->
-            new RuntimeException(
-                "No IamRole enum found corresponding to model role " + apiModel));
+            new RuntimeException("No IamRole enum found corresponding to model role " + apiModel));
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java
@@ -12,14 +12,43 @@ import org.slf4j.LoggerFactory;
 
 /** Internal representation of IAM roles. */
 public enum WsmIamRole {
-  DISCOVERER("discoverer", SamWorkspaceAction.DISCOVER, ApiIamRole.DISCOVERER),
-  READER("reader", SamWorkspaceAction.READ, ApiIamRole.READER),
-  WRITER("writer", SamWorkspaceAction.WRITE, ApiIamRole.WRITER),
-  APPLICATION("application", null, ApiIamRole.APPLICATION),
-  OWNER("owner", SamWorkspaceAction.OWN, ApiIamRole.OWNER),
+  DISCOVERER("discoverer", SamWorkspaceAction.DISCOVER, ApiIamRole.DISCOVERER) {
+    public boolean roleAtLeastAsHighAs(WsmIamRole roleToCheck) {
+      return true;
+    }
+  },
+  READER("reader", SamWorkspaceAction.READ, ApiIamRole.READER) {
+    public boolean roleAtLeastAsHighAs(WsmIamRole roleToCheck) {
+      return roleToCheck == WsmIamRole.APPLICATION
+              || roleToCheck == WsmIamRole.OWNER
+              || roleToCheck == WsmIamRole.WRITER
+              || roleToCheck == WsmIamRole.READER;
+    }
+  },
+  WRITER("writer", SamWorkspaceAction.WRITE, ApiIamRole.WRITER) {
+    public boolean roleAtLeastAsHighAs(WsmIamRole roleToCheck) {
+      return roleToCheck == WsmIamRole.APPLICATION
+              || roleToCheck == WsmIamRole.OWNER
+              || roleToCheck == WsmIamRole.WRITER;
+    }
+  },
+  APPLICATION("application", null, ApiIamRole.APPLICATION) {
+    public boolean roleAtLeastAsHighAs(WsmIamRole roleToCheck) {
+      return roleToCheck == WsmIamRole.APPLICATION;
+    }
+  },
+  OWNER("owner", SamWorkspaceAction.OWN, ApiIamRole.OWNER) {
+    public boolean roleAtLeastAsHighAs(WsmIamRole roleToCheck) {
+      return roleToCheck == WsmIamRole.APPLICATION || roleToCheck == WsmIamRole.OWNER;
+    }
+  },
   // The manager role is given to WSM's SA on all Sam workspace objects for admin control. Users
   // are never given this role.
-  MANAGER("manager", null, null);
+  MANAGER("manager", null, null) {
+    public boolean roleAtLeastAsHighAs(WsmIamRole roleToCheck) {
+      throw new InternalServerErrorException("Unexpected workspace MANAGER role");
+    }
+  };
 
   private static final Logger logger = LoggerFactory.getLogger(WsmIamRole.class);
 
@@ -39,7 +68,7 @@ public enum WsmIamRole {
     return result.orElseThrow(
         () ->
             new RuntimeException(
-                "No IamRole enum found corresponding to model role " + apiModel.toString()));
+                "No IamRole enum found corresponding to model role " + apiModel));
   }
 
   /**
@@ -57,7 +86,7 @@ public enum WsmIamRole {
   public static Optional<WsmIamRole> getHighestRole(UUID workspaceId, List<WsmIamRole> roles) {
     if (roles.isEmpty()) {
       // This workspace had a role that this WSM doesn't know about.
-      logger.warn("Workspace %s missing roles", workspaceId.toString());
+      logger.warn("Workspace {} missing roles", workspaceId);
       return Optional.empty();
     }
 
@@ -73,24 +102,10 @@ public enum WsmIamRole {
       return Optional.of(WsmIamRole.DISCOVERER);
     }
     throw new InternalServerErrorException(
-        String.format("Workspace %s has unexpected roles: %s", workspaceId.toString(), roles));
+        String.format("Workspace %s has unexpected roles: %s", workspaceId, roles));
   }
 
-  public static boolean roleAtLeastAsHighAs(WsmIamRole minimumRole, WsmIamRole roleToCheck) {
-    return switch (minimumRole) {
-      case APPLICATION -> roleToCheck == WsmIamRole.APPLICATION;
-      case OWNER -> roleToCheck == WsmIamRole.APPLICATION || roleToCheck == WsmIamRole.OWNER;
-      case WRITER -> roleToCheck == WsmIamRole.APPLICATION
-          || roleToCheck == WsmIamRole.OWNER
-          || roleToCheck == WsmIamRole.WRITER;
-      case READER -> roleToCheck == WsmIamRole.APPLICATION
-          || roleToCheck == WsmIamRole.OWNER
-          || roleToCheck == WsmIamRole.WRITER
-          || roleToCheck == WsmIamRole.READER;
-      case DISCOVERER -> true;
-      case MANAGER -> throw new InternalServerErrorException("Unexpected workspace MANAGER role");
-    };
-  }
+  public abstract boolean roleAtLeastAsHighAs(WsmIamRole roleToCheck);
 
   public ApiIamRole toApiModel() {
     return apiRole;

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -515,7 +515,7 @@ public class WorkspaceService {
         .workspaceId(workspace.getWorkspaceId().toString())
         .operationType(OperationType.REMOVE_WORKSPACE_ROLE)
         .addParameter(WorkspaceFlightMapKeys.USER_TO_REMOVE, targetUserEmail)
-        .addParameter(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, role)
+        .addParameter(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, role.name())
         .submitAndWait(null);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
@@ -25,7 +25,8 @@ public class RemoveUserFromWorkspaceFlight extends Flight {
     String userToRemove = inputParameters.get(WorkspaceFlightMapKeys.USER_TO_REMOVE, String.class);
     Optional<WsmIamRole> roleToRemove =
         Optional.ofNullable(
-            inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, WsmIamRole.class));
+            WsmIamRole.valueOf(
+                inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class)));
 
     // Flight plan:
     // 0. (Pre-flight): Validate that the user is directly granted the specified workspace role.

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
@@ -24,9 +24,11 @@ public class RemoveUserFromWorkspaceFlight extends Flight {
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
     String userToRemove = inputParameters.get(WorkspaceFlightMapKeys.USER_TO_REMOVE, String.class);
     Optional<WsmIamRole> roleToRemove =
-        Optional.ofNullable(
-            WsmIamRole.valueOf(
-                inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class)));
+        inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class) != null
+            ? Optional.of(
+                WsmIamRole.valueOf(
+                    inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class)))
+            : Optional.empty();
 
     // Flight plan:
     // 0. (Pre-flight): Validate that the user is directly granted the specified workspace role.

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
@@ -8,7 +8,6 @@ import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobMapKeys;
-import java.util.Optional;
 import java.util.UUID;
 
 public class RemoveUserFromWorkspaceFlight extends Flight {
@@ -23,12 +22,9 @@ public class RemoveUserFromWorkspaceFlight extends Flight {
     AuthenticatedUserRequest userRequest =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
     String userToRemove = inputParameters.get(WorkspaceFlightMapKeys.USER_TO_REMOVE, String.class);
-    Optional<WsmIamRole> roleToRemove =
-        inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class) != null
-            ? Optional.of(
-                WsmIamRole.valueOf(
-                    inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class)))
-            : Optional.empty();
+    WsmIamRole roleToRemove =
+        WsmIamRole.valueOf(
+            inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class));
 
     // Flight plan:
     // 0. (Pre-flight): Validate that the user is directly granted the specified workspace role.
@@ -47,11 +43,7 @@ public class RemoveUserFromWorkspaceFlight extends Flight {
     RetryRule dbRetry = RetryRules.shortDatabase();
     addStep(
         new RemoveUserFromSamStep(
-            workspaceUuid,
-            roleToRemove.orElse(null),
-            userToRemove,
-            appContext.getSamService(),
-            userRequest),
+            workspaceUuid, roleToRemove, userToRemove, appContext.getSamService(), userRequest),
         samRetry);
     addStep(
         new CheckUserStillInWorkspaceStep(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlight.java
@@ -23,8 +23,10 @@ public class RemoveUserFromWorkspaceFlight extends Flight {
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
     String userToRemove = inputParameters.get(WorkspaceFlightMapKeys.USER_TO_REMOVE, String.class);
     WsmIamRole roleToRemove =
-        WsmIamRole.valueOf(
-            inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class));
+        inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class) != null
+            ? WsmIamRole.valueOf(
+                inputParameters.get(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, String.class))
+            : null;
 
     // Flight plan:
     // 0. (Pre-flight): Validate that the user is directly granted the specified workspace role.

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -163,8 +163,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
     inputParameters.put(WorkspaceFlightMapKeys.WORKSPACE_ID, workspaceUuid.toString());
     inputParameters.put(
         WorkspaceFlightMapKeys.USER_TO_REMOVE, userAccessUtils.getSecondUserEmail());
-    inputParameters.put(
-        WorkspaceFlightMapKeys.ROLE_TO_REMOVE, ControlledResourceIamRole.WRITER.name());
+    inputParameters.put(WorkspaceFlightMapKeys.ROLE_TO_REMOVE, WsmIamRole.WRITER.name());
     // Auth info comes from default user, as they are the ones "making this request"
     inputParameters.put(
         JobMapKeys.AUTH_USER_INFO.getKeyName(), userAccessUtils.defaultUserAuthRequest());


### PR DESCRIPTION
From the discussion https://github.com/DataBiosphere/terra-workspace-manager/pull/758#discussion_r942645004. This PR is for illustrative purposes, if it's useful then someone from the WSM should take on the task of creating a ticket for the work and fixing it up for merging. If not, feel free to close the PR and delete the branch.

You can use the lambda solution, but since the enum members aren't valid at enum declaration time, you need to use a method instead. Since there aren't unit tests for this code I'm not 100% sure I copied everything over correctly.

Also there was a bug with a `log` message using `%s` when it should use `{}`. There is an IntelliJ warning that will catch this error for you.

And there were many unnecessary calls to `toString()` which I removed.