### PR TITLE
[PF-1954] bucket cloud names do not allow "goog" prefix; notebook cloud instance ids do not allow numbers start

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -71,7 +71,7 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
         generatedName.length() > MAX_INSTANCE_NAME_LENGTH
             ? generatedName.substring(0, MAX_INSTANCE_NAME_LENGTH)
             : generatedName;
-    generatedName = generatedName.replaceAll("[^a-zA-Z0-9-]+|^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$", "");
+    generatedName = generatedName.replaceAll("[^a-z0-9-]+|^[^a-z]+|[^a-z0-9]+$", "");
     return generatedName;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -71,6 +71,12 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
         generatedName.length() > MAX_INSTANCE_NAME_LENGTH
             ? generatedName.substring(0, MAX_INSTANCE_NAME_LENGTH)
             : generatedName;
+
+    /**
+     * The regular expression only allow legal character combinations which start with lowercase
+     * letter, lowercase letter and numbers and dash("-") in the string, and lowercase letter and
+     * number at the end of the string. It trims any other combinations.
+     */
     generatedName = generatedName.replaceAll("[^a-z0-9-]+|^[^a-z]+|[^a-z0-9]+$", "");
     return generatedName;
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
@@ -59,6 +59,13 @@ public class ControlledBigQueryDatasetHandler implements WsmResourceHandler {
     return resource;
   }
 
+  /**
+   * Generate big query dataset cloud name that meets the requirements for a valid name.
+   *
+   * <p>Big query dataset names can only contain letters, numeric characters, and underscores (_) up
+   * to 1024 characters. Spaces are not allowed. For details, see
+   * https://cloud.google.com/bigquery/docs/datasets#dataset-naming.
+   */
   public String generateCloudName(@Nullable UUID workspaceUuid, String bqDatasetName) {
     String generatedName = bqDatasetName.replace("-", "_");
     generatedName =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
@@ -72,6 +72,12 @@ public class ControlledBigQueryDatasetHandler implements WsmResourceHandler {
         generatedName.length() > MAX_DATASET_NAME_LENGTH
             ? generatedName.substring(0, MAX_DATASET_NAME_LENGTH)
             : generatedName;
+
+    /**
+     * The regular expression only allow legal character combinations which start with alphanumeric
+     * letter, alphanumeric letter and underscore ("_") in the string, and alphanumeric letter at
+     * the end of the string. It trims any other combinations.
+     */
     generatedName = generatedName.replaceAll("[^a-zA-Z0-9_]+|^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$", "");
 
     return generatedName;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -73,6 +73,12 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
         generatedName.length() > MAX_BUCKET_NAME_LENGTH
             ? generatedName.substring(0, MAX_BUCKET_NAME_LENGTH)
             : generatedName;
+
+    /**
+     * The regular expression only allow legal character combinations which start with alphanumeric
+     * letter, but not start with "google" or "goog", dash("-") in the string, and alphanumeric
+     * letter at the end of the string. It trims any other combinations.
+     */
     generatedName =
         generatedName.replaceAll("google|^goog|[^a-z0-9-.]+|^[^a-z0-9]+|[^a-z0-9]+$", "");
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -54,12 +54,15 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
   }
 
   /**
-   * Generate GCS bucket cloud name that meets the requirements for a valid name.
+   * Generate controlled GCS bucket cloud name that meets the requirements for a valid name.
    *
-   * <p>Bucket names can only contain lowercase letters, numeric characters, dashes (-), underscores
-   * (_), and dots (.). Spaces are not allowed. and bucket names must start and end with a number or
-   * letter and contain 3-63 characters. In addition, bucket names cannot begin with the "goog"
-   * prefix. For details, see https://cloud.google.com/storage/docs/naming-buckets.
+   * <p>Bucket names can only contain lowercase letters, numeric characters, dashes (-), and dots
+   * (.). underscores are prohibited for controlled GCS bucket. GCP recommends against underscores
+   * in bucket names because DNS hostnames can't have underscores. In particular, Nextflow fails if
+   * bucket name has underscore (because bucket name isn't valid DNS hostname.) Spaces are also not
+   * allowed. Bucket names must start and end with a number or letter and contain 3-63 characters.
+   * In addition, bucket names cannot begin with the "goog" prefix. For details, see
+   * https://cloud.google.com/storage/docs/naming-buckets.
    */
   public String generateCloudName(@Nullable UUID workspaceUuid, String bucketName) {
     Preconditions.checkNotNull(workspaceUuid);
@@ -71,7 +74,7 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
             ? generatedName.substring(0, MAX_BUCKET_NAME_LENGTH)
             : generatedName;
     generatedName =
-        generatedName.replaceAll("google|^goog|[^a-z0-9-_.]+|^[^a-z0-9]+|[^a-z0-9]+$", "");
+        generatedName.replaceAll("google|^goog|[^a-z0-9-.]+|^[^a-z0-9]+|[^a-z0-9]+$", "");
 
     return generatedName;
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -53,6 +53,14 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
     return resource;
   }
 
+  /**
+   * Generate GCS bucket cloud name that meets the requirements for a valid name.
+   *
+   * <p>Bucket names can only contain lowercase letters, numeric characters, dashes (-), underscores
+   * (_), and dots (.). Spaces are not allowed. and bucket names must start and end with a number or
+   * letter and contain 3-63 characters. In addition, bucket names cannot begin with the "goog"
+   * prefix. For details, see https://cloud.google.com/storage/docs/naming-buckets.
+   */
   public String generateCloudName(@Nullable UUID workspaceUuid, String bucketName) {
     Preconditions.checkNotNull(workspaceUuid);
 
@@ -62,7 +70,8 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
         generatedName.length() > MAX_BUCKET_NAME_LENGTH
             ? generatedName.substring(0, MAX_BUCKET_NAME_LENGTH)
             : generatedName;
-    generatedName = generatedName.replaceAll("[^a-zA-Z0-9-]+|^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$", "");
+    generatedName =
+        generatedName.replaceAll("google|^goog|[^a-z0-9-_.]+|^[^a-z0-9]+|[^a-z0-9]+$", "");
 
     return generatedName;
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandlerTest.java
@@ -46,6 +46,15 @@ public class ControlledAiNotebookHandlerTest extends BaseUnitTest {
   }
 
   @Test
+  public void generateInstanceId_userIdHasStartingNumbers_removeStartingNumbers() {
+    String instanceName = "1234_yuhuyoyo";
+    String instanceId =
+        ControlledAiNotebookHandler.getHandler().generateCloudName(null, instanceName);
+
+    assertTrue(instanceId.equals("yuhuyoyo"));
+  }
+
+  @Test
   public void generateInstanceId_userIdHasUppercase_toLowerCase() {
     String instanceName = "YUHUYOYO";
     String instanceId =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -44,12 +44,21 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
   }
 
   @Test
+  public void generateBucketName_bucketNameHasUnderscores_removeUnderscores() {
+    String bucketName = "yu_hu_yo_yo";
+    String generateCloudName =
+        ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
+
+    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+  }
+
+  @Test
   public void generateBucketName_bucketNameHasGoogPrefix_removeGoogPrefix() {
     String bucketName = "googyu_hu_yo_yo";
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yu_hu_yo_yo-" + FAKE_PROJECT_ID));
+    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
   }
 
   @Test
@@ -58,7 +67,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("gooyu_hu_yo_yo-" + FAKE_PROJECT_ID));
+    assertTrue(generateCloudName.equals("gooyuhuyoyo-" + FAKE_PROJECT_ID));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -44,12 +44,21 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
   }
 
   @Test
-  public void generateBucketName_bucketNameHasUnderscores_removeUnderscores() {
-    String bucketName = "yu_hu_yo_yo";
+  public void generateBucketName_bucketNameHasGoogPrefix_removeGoogPrefix() {
+    String bucketName = "googyu_hu_yo_yo";
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertTrue(generateCloudName.equals("yu_hu_yo_yo-" + FAKE_PROJECT_ID));
+  }
+
+  @Test
+  public void generateBucketName_bucketNameHasGoogle_removeGoogle() {
+    String bucketName = "gooyu_hu_googleyo_yo";
+    String generateCloudName =
+        ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
+
+    assertTrue(generateCloudName.equals("gooyu_hu_yo_yo-" + FAKE_PROJECT_ID));
   }
 
   @Test


### PR DESCRIPTION
In this ticket, we are focusing correcting 2 bugs on the previous ticket for [autogeneration the cloud name](https://github.com/DataBiosphere/terra-workspace-manager/pull/764). 

For the AI notebook cloud instance id, we do not have the official document in gcp like the old code mentioned. I just add a corner case which not allow the cloud instance id starts with numbers, if it does, we strip the numbers until it satisfied the requirement.

For the controlled gcs bucket, the official doc is [here](https://cloud.google.com/storage/docs/naming-buckets). In order to improve the suggestion name, I add the bad case start with `goog` prefix, then, strip it. 

Also add the comments on bq dataset to make consistence. 