### PR TITLE
PF-1966: Unable to clone pre-policy workspace

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ClonePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ClonePolicyAttributesStep.java
@@ -8,7 +8,11 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.amalgam.tps.TpsApiDispatch;
 import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.generated.model.ApiTpsComponent;
+import bio.terra.workspace.generated.model.ApiTpsObjectType;
+import bio.terra.workspace.generated.model.ApiTpsPaoCreateRequest;
 import bio.terra.workspace.generated.model.ApiTpsPaoGetResult;
+import bio.terra.workspace.generated.model.ApiTpsPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
@@ -41,11 +45,26 @@ public class ClonePolicyAttributesStep implements Step {
             .getInputParameters()
             .get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
-    Optional<ApiTpsPaoGetResult> workspacePao =
+    Optional<ApiTpsPaoGetResult> sourcePao =
         tpsApiDispatch.getPaoIfExists(
             new BearerToken(userRequest.getRequiredToken()), sourceWorkspaceId);
 
-    if (workspacePao.isPresent()) {
+    if (!sourcePao.isPresent()) {
+      // Source workspace doesn't have a PAO, so create one for it.
+      ApiTpsPaoCreateRequest request =
+          new ApiTpsPaoCreateRequest()
+              .objectId(sourceWorkspaceId)
+              .component(ApiTpsComponent.WSM)
+              .objectType(ApiTpsObjectType.WORKSPACE)
+              .attributes(new ApiTpsPolicyInputs());
+      tpsApiDispatch.createPao(new BearerToken(userRequest.getRequiredToken()), request);
+    }
+
+    Optional<ApiTpsPaoGetResult> destinationPao =
+        tpsApiDispatch.getPaoIfExists(
+            new BearerToken(userRequest.getRequiredToken()), destinationWorkspace.getWorkspaceId());
+
+    if (destinationPao.isPresent()) {
       // If this is our first attempt, a default PAO would have been created with the workspace.
       // If this is a retry, then our previous attempt at saving a PAO might exist.
       // In either case, remove the existing PAO so we can clone from the source.

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ClonePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/ClonePolicyAttributesStep.java
@@ -5,6 +5,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.amalgam.tps.TpsApiDispatch;
 import bio.terra.workspace.common.utils.FlightUtils;
@@ -19,8 +20,11 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.Contr
 import bio.terra.workspace.service.workspace.model.Workspace;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ClonePolicyAttributesStep implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(ClonePolicyAttributesStep.class);
   TpsApiDispatch tpsApiDispatch;
 
   public ClonePolicyAttributesStep(TpsApiDispatch tpsApiDispatch) {
@@ -57,7 +61,12 @@ public class ClonePolicyAttributesStep implements Step {
               .component(ApiTpsComponent.WSM)
               .objectType(ApiTpsObjectType.WORKSPACE)
               .attributes(new ApiTpsPolicyInputs());
-      tpsApiDispatch.createPao(new BearerToken(userRequest.getRequiredToken()), request);
+      try {
+        tpsApiDispatch.createPao(new BearerToken(userRequest.getRequiredToken()), request);
+      } catch (Exception ex) {
+        logger.info("Attempt to create a default PAO for source failed: " + sourceWorkspaceId, ex);
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+      }
     }
 
     Optional<ApiTpsPaoGetResult> destinationPao =
@@ -68,8 +77,16 @@ public class ClonePolicyAttributesStep implements Step {
       // If this is our first attempt, a default PAO would have been created with the workspace.
       // If this is a retry, then our previous attempt at saving a PAO might exist.
       // In either case, remove the existing PAO so we can clone from the source.
-      tpsApiDispatch.deletePao(
-          new BearerToken(userRequest.getRequiredToken()), destinationWorkspace.getWorkspaceId());
+      try {
+        tpsApiDispatch.deletePao(
+            new BearerToken(userRequest.getRequiredToken()), destinationWorkspace.getWorkspaceId());
+      } catch (Exception ex) {
+        logger.info(
+            "Attempt to remove PAO for cloned workspace failed: "
+                + destinationWorkspace.getWorkspaceId(),
+            ex);
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+      }
     }
 
     tpsApiDispatch.clonePao(


### PR DESCRIPTION
If we're cloning a workspace that doesn't have a policy attached - IE it was created before TPS was turned on - then create an empty policy on the source workspace before cloning it.