### PR TITLE
[PF-1961] Clone workspace displayname follow the "[cloneWorkspace displayName]" + " (Copy)"

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -277,7 +277,7 @@ public class CloneWorkspace extends WorkspaceAllocateWithPolicyTestScriptBase {
     assertEquals(
         sourceOwnerWorkspaceApi
                 .getWorkspace(getWorkspaceId(), /*minimumHighestRole=*/ null)
-                .getDisplayName()
+                .getUserFacingId()
             + " (Copy)",
         destinationWorkspaceDescription.getDisplayName(),
         "Destination displayName matches");

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -255,7 +255,6 @@ public class CloneWorkspace extends WorkspaceAllocateWithPolicyTestScriptBase {
     final CloneWorkspaceRequest cloneWorkspaceRequest =
         new CloneWorkspaceRequest()
             .userFacingId(destinationUserFacingId)
-            .displayName("Cloned Workspace")
             .description("A clone of workspace " + getWorkspaceId().toString())
             .spendProfile(getSpendProfileId()) // TODO- use a different one if available
             .location("us-central1");
@@ -275,6 +274,13 @@ public class CloneWorkspace extends WorkspaceAllocateWithPolicyTestScriptBase {
         "Destination workspace is available in DB immediately after return from cloneWorkspace().");
     assertEquals(
         destinationWorkspaceId, destinationWorkspaceDescription.getId(), "Destination IDs match");
+    assertEquals(
+        sourceOwnerWorkspaceApi
+                .getWorkspace(getWorkspaceId(), /*minimumHighestRole=*/ null)
+                .getDisplayName()
+            + " (Copy)",
+        destinationWorkspaceDescription.getDisplayName(),
+        "Destination displayName matches");
 
     cloneResult =
         ClientTestUtils.pollWhileRunning(

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -66,6 +66,7 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import liquibase.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -572,7 +573,9 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     // name followed the sourceWorkspace's displayName, if sourceWorkspace's displayName is null, we
     // will generate the name based on the sourceWorkspace's userFacingId.
     String generatedDisplayName =
-        sourceWorkspace.getDisplayName().orElse(sourceWorkspace.getUserFacingId()) + " (Copy)";
+        (StringUtil.isEmpty(sourceWorkspace.getDisplayName().get()))
+            ? sourceWorkspace.getUserFacingId() + " (Copy)"
+            : sourceWorkspace.getDisplayName().get() + " (Copy)";
 
     // Construct the target workspace object from the inputs
     // Policies are cloned in the flight instead of here so that they get cleaned appropriately if

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -66,6 +66,7 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import liquibase.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -570,12 +571,11 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
 
     // If user does not specify the destinationWorkspace's displayName, then we will generate the
     // name followed the sourceWorkspace's displayName, if sourceWorkspace's displayName is null, we
-    // will generate the name based on the sourceWorkspace's userFacingId
+    // will generate the name based on the sourceWorkspace's userFacingId.
     String alterDisplayName =
-        (sourceWorkspace.getDisplayName().isPresent()
-                && !sourceWorkspace.getDisplayName().get().isEmpty())
-            ? sourceWorkspace.getDisplayName().get() + " (Copy)"
-            : sourceWorkspace.getUserFacingId() + " (Copy)";
+        (StringUtil.isEmpty(sourceWorkspace.getDisplayName().get()))
+            ? sourceWorkspace.getUserFacingId() + " (Copy)"
+            : sourceWorkspace.getDisplayName().get() + " (Copy)";
 
     // Construct the target workspace object from the inputs
     // Policies are cloned in the flight instead of here so that they get cleaned appropriately if

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -66,7 +66,6 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import liquibase.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -572,10 +571,8 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     // If user does not specify the destinationWorkspace's displayName, then we will generate the
     // name followed the sourceWorkspace's displayName, if sourceWorkspace's displayName is null, we
     // will generate the name based on the sourceWorkspace's userFacingId.
-    String alterDisplayName =
-        (StringUtil.isEmpty(sourceWorkspace.getDisplayName().get()))
-            ? sourceWorkspace.getUserFacingId() + " (Copy)"
-            : sourceWorkspace.getDisplayName().get() + " (Copy)";
+    String generatedDisplayName =
+        sourceWorkspace.getDisplayName().orElse(sourceWorkspace.getUserFacingId()) + " (Copy)";
 
     // Construct the target workspace object from the inputs
     // Policies are cloned in the flight instead of here so that they get cleaned appropriately if
@@ -586,7 +583,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
             .userFacingId(destinationUserFacingId)
             .spendProfileId(spendProfileId.orElse(null))
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .displayName(Optional.ofNullable(body.getDisplayName()).orElse(alterDisplayName))
+            .displayName(Optional.ofNullable(body.getDisplayName()).orElse(generatedDisplayName))
             .description(body.getDescription())
             .properties(sourceWorkspace.getProperties())
             .build();

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/WorkspaceApiControllerTest.java
@@ -280,6 +280,8 @@ public class WorkspaceApiControllerTest extends BaseUnitTest {
     ApiWorkspaceDescription destinationWorkspace = getWorkspaceDescription(destinationWorkspaceId);
 
     assertEquals(sourceWorkspace.getProperties(), destinationWorkspace.getProperties());
+    assertEquals(
+        sourceWorkspace.getDisplayName() + " (Copy)", destinationWorkspace.getDisplayName());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -448,7 +448,6 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     assertEquals(otherDescription, secondUpdatedWorkspace.getDescription().get());
 
     // Sending through empty strings and an empty map clears the values.
-    Map<String, String> propertyMap3 = new HashMap<>();
     Workspace thirdUpdatedWorkspace =
         workspaceService.updateWorkspace(workspaceUuid, userFacingId, "", "", USER_REQUEST);
 


### PR DESCRIPTION
This PR comes from the ticket [PF-1961](https://broadworkbench.atlassian.net/browse/PF-1961).

The logic follows UI logic which is 

1. if user specifies a displayName on the new workspace, we should use the user specified displayName firstly.
2.  If user does not specify, We will generate the name as the "[clonedWorkspace's displayname]" + " (Copy)"
3.  If the clonedWorkspace's displayname is null, we will use "[clonedWorkspace's userfacingId]" + " (Copy)"

These are the 3 scenarios
**Scenario 1, use user specified name** 
```
ginay-macbookpro:terra-cli ginay$ terra workspace clone --new-id=clonenew1 --name=clonenewname
Workspace successfully cloned.
Source Workspace:
ID:                913cromwell
Name:              clonenamecheck
Description:       
Google project:    terra-wsm-t-social-papaya-3341
Cloud console:     https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-social-papaya-3341
Properties:
# Resources:       0

Destination Workspace:
ID:                clonenew1
Name:              clonenewname
Description:       
Google project:    terra-wsm-t-chirpy-pepper-3155
Cloud console:     https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-chirpy-pepper-3155
Properties:
# Resources:       0
```

**Scenario 2, use clonedWorkspace's displayname** 
```
ginay-macbookpro:terra-cli ginay$ terra workspace clone --new-id=clonenew2
Workspace successfully cloned.
Source Workspace:
ID:                913clonename
Name:              clonenamecheck
Description:       
Google project:    terra-wsm-t-social-papaya-3341
Cloud console:     https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-social-papaya-3341
Properties:
# Resources:       0

Destination Workspace:
ID:                clonenew2
Name:              clonenamecheck (Copy)
Description:       
Google project:    terra-wsm-t-sunny-carrot-76
Cloud console:     https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-sunny-carrot-76
Properties:
# Resources:       0
```

**Scenario 3, use clonedWorkspace's userfacingId** 
```
ginay-macbookpro:terra-cli ginay$ terra workspace clone --new-id=clonenew3
Workspace successfully cloned.
Source Workspace:
ID:                913clonename
Name:              
Description:       
Google project:    terra-wsm-t-social-papaya-3341
Cloud console:     https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-social-papaya-3341
Properties:
# Resources:       0

Destination Workspace:
ID:                clonenew3
Name:              913clonename (Copy)
Description:       
Google project:    terra-wsm-t-sunny-carrot-76
Cloud console:     https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-sunny-carrot-76
Properties:
# Resources:       0
```

**Code explanation**
The code changes in apicontroller, and the only have the unit test for the apicontroller and the integration test.