### PR TITLE
First cut at adding optional CORS support for azure storage accounts

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
@@ -14,6 +14,7 @@ public class AzureConfiguration {
   private String managedAppTenantId;
   private Long sasTokenStartTimeMinutesOffset;
   private Long sasTokenExpiryTimeMinutesOffset;
+  private String corsOrigins;
 
   public String getManagedAppClientId() {
     return managedAppClientId;
@@ -53,5 +54,13 @@ public class AzureConfiguration {
 
   public void setSasTokenExpiryTimeMinutesOffset(Long sasTokenExpiryTimeMinutesOffset) {
     this.sasTokenExpiryTimeMinutesOffset = sasTokenExpiryTimeMinutesOffset;
+  }
+
+  public String getCorsOrigins() {
+    return corsOrigins;
+  }
+
+  public void setCorsOrigins(String corsOrigins) {
+    this.corsOrigins = corsOrigins;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
@@ -14,7 +14,7 @@ public class AzureConfiguration {
   private String managedAppTenantId;
   private Long sasTokenStartTimeMinutesOffset;
   private Long sasTokenExpiryTimeMinutesOffset;
-  private String corsOrigins;
+  private String corsAllowedOrigins;
 
   public String getManagedAppClientId() {
     return managedAppClientId;
@@ -56,11 +56,11 @@ public class AzureConfiguration {
     this.sasTokenExpiryTimeMinutesOffset = sasTokenExpiryTimeMinutesOffset;
   }
 
-  public String getCorsOrigins() {
-    return corsOrigins;
+  public String getCorsAllowedOrigins() {
+    return corsAllowedOrigins;
   }
 
-  public void setCorsOrigins(String corsOrigins) {
-    this.corsOrigins = corsOrigins;
+  public void setCorsAllowedOrigins(String corsAllowedOrigins) {
+    this.corsAllowedOrigins = corsAllowedOrigins;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/common/utils/FlightBeanBag.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/FlightBeanBag.java
@@ -15,6 +15,7 @@ import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.StorageAccountKeyProvider;
 import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.BucketCloneRolesService;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResourceService;
 import bio.terra.workspace.service.spendprofile.SpendProfileService;
@@ -57,6 +58,7 @@ public class FlightBeanBag {
   private final WorkspaceDao workspaceDao;
   private final WorkspaceService workspaceService;
   private final VersionConfiguration versionConfiguration;
+  private final StorageAccountKeyProvider storageAccountKeyProvider;
 
   @Lazy
   @Autowired
@@ -82,7 +84,8 @@ public class FlightBeanBag {
       Storagetransfer storagetransfer,
       WorkspaceDao workspaceDao,
       WorkspaceService workspaceService,
-      VersionConfiguration versionConfiguration) {
+      VersionConfiguration versionConfiguration,
+      StorageAccountKeyProvider storageAccountKeyProvider) {
     this.applicationDao = applicationDao;
     this.azureCloudContextService = azureCloudContextService;
     this.azureConfig = azureConfig;
@@ -105,6 +108,7 @@ public class FlightBeanBag {
     this.workspaceDao = workspaceDao;
     this.workspaceService = workspaceService;
     this.versionConfiguration = versionConfiguration;
+    this.storageAccountKeyProvider = storageAccountKeyProvider;
   }
 
   public static FlightBeanBag getFromObject(Object object) {
@@ -197,5 +201,9 @@ public class FlightBeanBag {
 
   public VersionConfiguration getVersionConfiguration() {
     return versionConfiguration;
+  }
+
+  public StorageAccountKeyProvider getStorageAccountKeyProvider() {
+    return storageAccountKeyProvider;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/ControlledAzureStorageResource.java
@@ -115,7 +115,10 @@ public class ControlledAzureStorageResource extends ControlledResource {
         cloudRetry);
     flight.addStep(
         new CreateAzureStorageStep(
-            flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
+            flightBeanBag.getAzureConfig(),
+            flightBeanBag.getCrlService(),
+            this,
+            flightBeanBag.getStorageAccountKeyProvider()),
         cloudRetry);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
@@ -24,6 +24,10 @@ import org.slf4j.LoggerFactory;
 
 public class CreateAzureStorageStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(CreateAzureStorageStep.class);
+  private static final String CORS_ALLOWED_METHODS = "GET,HEAD,OPTIONS,PUT,PATCH,POST,MERGE,DELETE";
+  private static final String CORS_ALLOWED_HEADERS =
+      "authorization,content-type,x-app-id,Referer,x-ms-blob-type,x-ms-copy-source,content-length";
+
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureStorageResource resource;
@@ -138,7 +142,7 @@ public class CreateAzureStorageStep implements Step {
   private void setupCors(StorageAccount acct) {
     var allowedOrigins = azureConfig.getCorsOrigins();
     if (allowedOrigins == null || allowedOrigins.isBlank()) {
-      logger.debug("No CORS allowed origins setup, skipping adding for Azure storage account");
+      logger.info("No CORS allowed origins setup, skipping adding for Azure storage account {}", resource.getWorkspaceId());
       return;
     }
 
@@ -155,7 +159,10 @@ public class CreateAzureStorageStep implements Step {
 
     var corsRules = props.getCors();
     var corsRule =
-        new BlobCorsRule().setAllowedOrigins(azureConfig.getCorsOrigins()).setAllowedMethods("GET");
+        new BlobCorsRule()
+            .setAllowedOrigins(azureConfig.getCorsOrigins())
+            .setAllowedMethods(CORS_ALLOWED_METHODS)
+            .setAllowedHeaders(CORS_ALLOWED_HEADERS);
     corsRules.add(corsRule);
 
     props.setCors(corsRules);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
@@ -142,7 +142,9 @@ public class CreateAzureStorageStep implements Step {
   private void setupCors(StorageAccount acct) {
     var allowedOrigins = azureConfig.getCorsOrigins();
     if (allowedOrigins == null || allowedOrigins.isBlank()) {
-      logger.info("No CORS allowed origins setup, skipping adding for Azure storage account {}", resource.getWorkspaceId());
+      logger.info(
+          "No CORS allowed origins setup, skipping adding for Azure storage account [workspace_id={}]",
+          resource.getWorkspaceId());
       return;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStep.java
@@ -140,7 +140,7 @@ public class CreateAzureStorageStep implements Step {
   }
 
   private void setupCors(StorageAccount acct) {
-    var allowedOrigins = azureConfig.getCorsOrigins();
+    var allowedOrigins = azureConfig.getCorsAllowedOrigins();
     if (allowedOrigins == null || allowedOrigins.isBlank()) {
       logger.info(
           "No CORS allowed origins setup, skipping adding for Azure storage account [workspace_id={}]",
@@ -162,7 +162,7 @@ public class CreateAzureStorageStep implements Step {
     var corsRules = props.getCors();
     var corsRule =
         new BlobCorsRule()
-            .setAllowedOrigins(azureConfig.getCorsOrigins())
+            .setAllowedOrigins(azureConfig.getCorsAllowedOrigins())
             .setAllowedMethods(CORS_ALLOWED_METHODS)
             .setAllowedHeaders(CORS_ALLOWED_HEADERS);
     corsRules.add(corsRule);

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -125,7 +125,7 @@ workspace:
   azure:
     sas-token-start-time-minutes-offset: 15
     sas-token-expiry-time-minutes-offset: 60
-    cors-origins:
+    cors-allowed-origins:
 
 terra.common:
   kubernetes:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -125,7 +125,7 @@ workspace:
   azure:
     sas-token-start-time-minutes-offset: 15
     sas-token-expiry-time-minutes-offset: 60
-    cors-origins:
+    cors-origins: "*"
 
 terra.common:
   kubernetes:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -125,6 +125,7 @@ workspace:
   azure:
     sas-token-start-time-minutes-offset: 15
     sas-token-expiry-time-minutes-offset: 60
+    cors-origins:
 
 terra.common:
   kubernetes:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -125,7 +125,7 @@ workspace:
   azure:
     sas-token-start-time-minutes-offset: 15
     sas-token-expiry-time-minutes-offset: 60
-    cors-origins: "*"
+    cors-origins:
 
 terra.common:
   kubernetes:

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -27,6 +27,7 @@ public class CreateAzureStorageStepTest extends BaseStorageStepTest {
   @Mock private StorageAccount.DefinitionStages.Blank mockStorageBlankStage;
   @Mock private StorageAccount.DefinitionStages.WithGroup mockStorageGroupStage;
   @Mock private StorageAccount.DefinitionStages.WithCreate mockStorageCreateStage;
+  @Mock private StorageAccountKeyProvider mockStorageAccountKeyProvider;
 
   private ApiAzureStorageCreationParameters creationParameters;
   private ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
@@ -95,7 +96,8 @@ public class CreateAzureStorageStepTest extends BaseStorageStepTest {
             mockAzureConfig,
             mockCrlService,
             ControlledResourceFixtures.getAzureStorage(
-                creationParameters.getStorageAccountName(), creationParameters.getRegion()));
+                creationParameters.getStorageAccountName(), creationParameters.getRegion()),
+            mockStorageAccountKeyProvider);
     return createAzureStorageStep;
   }
 


### PR DESCRIPTION
## Context
[Related ticket](https://broadworkbench.atlassian.net/browse/WOR-503)
We need to set CORS allowed origins, methods and headers on Azure storage containers so calls from the browser succeed.

## This PR
* Wires up the call to Azure to set the needed values on the owning storage account at the time of creation. The allowed origins are config'ed out and default to none (these will be set via a subsequent terra-helmfile PR).