### PR TITLE
[PF-1930] Add tests for cloning controlled GCS bucket with different cloning instructions

### DIFF
--- a/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
@@ -31,13 +31,11 @@ import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-@AutoConfigureMockMvc
 public class LandingZoneApiControllerTest extends BaseUnitTest {
   private static final String AZURE_LANDING_ZONE_PATH = "/api/landingzones/v1/azure";
   private static final String GET_CREATE_AZURE_LANDING_ZONE_RESULT =

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
@@ -1,0 +1,257 @@
+package bio.terra.workspace.app.configuration.external.controller;
+
+import static bio.terra.workspace.common.utils.MockMvcUtils.CLONE_CONTROLLED_GCP_GCS_BUCKET_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKET_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CONTROLLED_GCP_GCS_BUCKET_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.GET_CONTROLLED_GCP_GCS_BUCKET_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.workspace.common.BaseConnectedTest;
+import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.common.utils.TestUtils;
+import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.generated.model.ApiAccessScope;
+import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketRequest;
+import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketResult;
+import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
+import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
+import bio.terra.workspace.generated.model.ApiCreateControlledGcpGcsBucketRequestBody;
+import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
+import bio.terra.workspace.generated.model.ApiJobControl;
+import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
+import bio.terra.workspace.generated.model.ApiManagedBy;
+import bio.terra.workspace.generated.model.ApiStewardshipType;
+import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** Use this instead of ControlledGcpResourceApiTest, if you want to talk to real GCP. */
+public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnectedTest {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ControlledGcpResourceApiControllerConnectedTest.class);
+
+  @Autowired MockMvc mockMvc;
+  @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired UserAccessUtils userAccessUtils;
+
+  private ApiWorkspaceDescription workspace;
+  private ApiCreatedControlledGcpGcsBucket originalControlledBucket;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    workspace =
+        mockMvcUtils.createWorkspaceAndCloudContext(userAccessUtils.defaultUserAuthRequest());
+    originalControlledBucket = createControlledGcsBucket();
+  }
+
+  @AfterEach
+  public void cleanup() throws Exception {
+    mockMvcUtils.deleteWorkspace(workspace.getId());
+  }
+
+  @Test
+  public void cloneControlledGcsBucket_copyNothing() throws Exception {
+    ApiCloneControlledGcpGcsBucketResult cloneResult =
+        cloneControlledGcsBucket(
+            /*sourceWorkspaceId=*/ workspace.getId(),
+            originalControlledBucket.getResourceId(),
+            /*destWorkspaceId=*/ workspace.getId(),
+            ApiCloningInstructionsEnum.NOTHING);
+
+    // Assert clone result has no CreatedControlledGcpGcsBucket
+    assertNull(cloneResult.getBucket().getBucket());
+  }
+
+  @Test
+  public void cloneControlledGcsBucket_copyDefinition() throws Exception {
+    ApiCloneControlledGcpGcsBucketResult cloneResult =
+        cloneControlledGcsBucket(
+            /*sourceWorkspaceId=*/ workspace.getId(),
+            originalControlledBucket.getResourceId(),
+            /*destWorkspaceId=*/ workspace.getId(),
+            ApiCloningInstructionsEnum.DEFINITION);
+
+    // Assert bucket in clone result
+    ApiGcpGcsBucketResource cloneResultBucket = cloneResult.getBucket().getBucket().getGcpBucket();
+    String cloneBucketName = cloneResultBucket.getAttributes().getBucketName();
+    assertBucket(cloneResultBucket, ApiStewardshipType.CONTROLLED, cloneBucketName);
+
+    // Assert bucket returned by calling ControlledGcpResource.getBucket
+    ApiGcpGcsBucketResource gotBucket =
+        getControlledGcsBucket(workspace.getId(), cloneResultBucket.getMetadata().getResourceId());
+    assertBucket(gotBucket, ApiStewardshipType.CONTROLLED, cloneBucketName);
+  }
+
+  // TODO(PF-1930): Implement feature and uncomment test
+  // @Test
+  // public void cloneControlledGcsBucket_copyReference() throws Exception {
+  //   ApiCloneControlledGcpGcsBucketResult cloneResult =
+  //       cloneControlledGcsBucket(
+  //           /*sourceWorkspaceId=*/ workspace.getId(),
+  //           originalControlledBucket.getResourceId(),
+  //           /*destWorkspaceId=*/ workspace.getId(),
+  //           ApiCloningInstructionsEnum.REFERENCE);
+  //
+  //   // Assert bucket in clone result
+  //   ApiGcpGcsBucketResource cloneResultBucket =
+  // cloneResult.getBucket().getBucket().getGcpBucket();
+  //   String cloneBucketName = cloneResultBucket.getAttributes().getBucketName();
+  //   assertBucket(cloneResultBucket, ApiStewardshipType.REFERENCED, cloneBucketName);
+  //
+  //   // Assert bucket returned by calling ControlledGcpResource.getBucket
+  //   ApiGcpGcsBucketResource gotBucket =
+  //       getControlledGcsBucket(workspace.getId(),
+  // cloneResultBucket.getMetadata().getResourceId());
+  //   assertBucket(gotBucket, ApiStewardshipType.REFERENCED, cloneBucketName);
+  // }
+
+  private ApiCreatedControlledGcpGcsBucket createControlledGcsBucket() throws Exception {
+    ApiCreateControlledGcpGcsBucketRequestBody request =
+        new ApiCreateControlledGcpGcsBucketRequestBody()
+            .common(
+                new ApiControlledResourceCommonFields()
+                    .name("original-controlled-bucket")
+                    .cloningInstructions(ApiCloningInstructionsEnum.NOTHING)
+                    .accessScope(ApiAccessScope.PRIVATE_ACCESS)
+                    .managedBy(ApiManagedBy.USER))
+            .gcsBucket(new ApiGcpGcsBucketCreationParameters());
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addJsonContentType(
+                    addAuth(
+                        post(CREATE_CONTROLLED_GCP_GCS_BUCKET_FORMAT.formatted(
+                                workspace.getId().toString()))
+                            .content(objectMapper.writeValueAsString(request)),
+                        userAccessUtils.defaultUserAuthRequest())))
+            .andExpect(status().is(HttpStatus.SC_OK))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return objectMapper.readValue(serializedResponse, ApiCreatedControlledGcpGcsBucket.class);
+  }
+
+  private ApiGcpGcsBucketResource getControlledGcsBucket(UUID workspaceId, UUID resourceId)
+      throws Exception {
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addJsonContentType(
+                    addAuth(
+                        get(
+                            GET_CONTROLLED_GCP_GCS_BUCKET_FORMAT.formatted(
+                                workspaceId.toString(), resourceId.toString())),
+                        userAccessUtils.defaultUserAuthRequest())))
+            .andExpect(status().is(HttpStatus.SC_OK))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);
+  }
+
+  private void getControlledGcsBucketExpectingError(
+      UUID workspaceId, UUID resourceId, int expectedStatusCode) throws Exception {
+    mockMvc
+        .perform(
+            addJsonContentType(
+                addAuth(
+                    get(
+                        GET_CONTROLLED_GCP_GCS_BUCKET_FORMAT.formatted(
+                            workspaceId.toString(), resourceId.toString())),
+                    userAccessUtils.defaultUserAuthRequest())))
+        .andExpect(status().is(expectedStatusCode));
+  }
+
+  /** Clones controlled bucket and waits for flight to finish. */
+  private ApiCloneControlledGcpGcsBucketResult cloneControlledGcsBucket(
+      UUID sourceWorkspaceId,
+      UUID sourceResourceId,
+      UUID destWorkspaceId,
+      ApiCloningInstructionsEnum cloningInstructions)
+      throws Exception {
+    ApiCloneControlledGcpGcsBucketResult result =
+        cloneControlledGcsBucket_inner(
+            sourceWorkspaceId, sourceResourceId, destWorkspaceId, cloningInstructions);
+    UUID jobId = UUID.fromString(result.getJobReport().getId());
+    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
+      Thread.sleep(/*millis=*/ 5000);
+      result = getCloneControlledGcsBucketResult(destWorkspaceId, jobId);
+    }
+    assertEquals(StatusEnum.SUCCEEDED, result.getJobReport().getStatus());
+    logger.info(
+        "Controlled GCS bucket clone of resource %s completed. ".formatted(sourceResourceId));
+    return result;
+  }
+
+  private ApiCloneControlledGcpGcsBucketResult cloneControlledGcsBucket_inner(
+      UUID sourceWorkspaceId,
+      UUID sourceResourceId,
+      UUID destWorkspaceId,
+      ApiCloningInstructionsEnum cloningInstructions)
+      throws Exception {
+    ApiCloneControlledGcpGcsBucketRequest request =
+        new ApiCloneControlledGcpGcsBucketRequest()
+            .destinationWorkspaceId(destWorkspaceId)
+            .cloningInstructions(cloningInstructions)
+            .name(TestUtils.appendRandomNumber("bucket-clone"))
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addJsonContentType(
+                    addAuth(
+                        post(CLONE_CONTROLLED_GCP_GCS_BUCKET_FORMAT.formatted(
+                                sourceWorkspaceId, sourceResourceId))
+                            .content(objectMapper.writeValueAsString(request)),
+                        userAccessUtils.defaultUserAuthRequest())))
+            .andExpect(status().is(HttpStatus.SC_ACCEPTED))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return objectMapper.readValue(serializedResponse, ApiCloneControlledGcpGcsBucketResult.class);
+  }
+
+  private ApiCloneControlledGcpGcsBucketResult getCloneControlledGcsBucketResult(
+      UUID workspaceId, UUID jobId) throws Exception {
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addJsonContentType(
+                    addAuth(
+                        get(
+                            CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKET_FORMAT.formatted(
+                                workspaceId.toString(), jobId.toString())),
+                        userAccessUtils.defaultUserAuthRequest())))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return objectMapper.readValue(serializedResponse, ApiCloneControlledGcpGcsBucketResult.class);
+  }
+
+  private static void assertBucket(
+      ApiGcpGcsBucketResource actualBucket,
+      ApiStewardshipType expectedStewardshipType,
+      String expectedBucketName) {
+    assertEquals(expectedStewardshipType, actualBucket.getMetadata().getStewardshipType());
+    assertEquals(expectedBucketName, actualBucket.getAttributes().getBucketName());
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
@@ -38,12 +38,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 
 /** Use this instead of ControlledGcpResourceApiTest, if you want to talk to real GCP. */
+// Per-class lifecycle on this test to allow a shared workspace object across tests, which saves
+// time creating and deleting GCP contexts.
+@TestInstance(Lifecycle.PER_CLASS)
 public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnectedTest {
   private static final Logger logger =
       LoggerFactory.getLogger(ControlledGcpResourceApiControllerConnectedTest.class);
@@ -59,7 +64,7 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
   @BeforeEach
   public void setup() throws Exception {
     workspace =
-        mockMvcUtils.createWorkspaceAndCloudContext(userAccessUtils.defaultUserAuthRequest());
+        mockMvcUtils.createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest());
     originalControlledBucket = createControlledGcsBucket();
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
@@ -64,7 +64,7 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
 
   @AfterEach
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(workspace.getId());
+    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -214,7 +214,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     List<ApiWorkspaceDescription> listedWorkspaces =
         listWorkspaces(userAccessUtils.defaultUserAuthRequest());
 
-    assertThat(listedWorkspaces, hasSize(1));
+    assertThat(
+        String.format(
+            "Expected 1 workspace. Got %s: %s", listedWorkspaces.size(), listedWorkspaces),
+        listedWorkspaces.stream().map(ApiWorkspaceDescription::getId).toList(),
+        hasSize(1));
     assertFullWorkspace(listedWorkspaces.get(0));
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -214,12 +214,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     List<ApiWorkspaceDescription> listedWorkspaces =
         listWorkspaces(userAccessUtils.defaultUserAuthRequest());
 
-    assertThat(
-        String.format(
-            "Expected 1 workspace. Instead of %s: ",
-            listedWorkspaces.size(), listedWorkspaces.stream().map(ApiWorkspaceDescription::getId)),
-        listedWorkspaces,
-        hasSize(1));
+    assertThat(listedWorkspaces, hasSize(1));
     assertFullWorkspace(listedWorkspaces.get(0));
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -9,7 +9,6 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UUI
 import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_PATH;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
-import static bio.terra.workspace.common.utils.MockMvcUtils.grantRole;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyString;
@@ -88,13 +87,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Test
   public void getWorkspace_requesterIsDiscoverer_requestMinHighestRoleNotSet_throws()
       throws Exception {
-    grantRole(
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
-        userAccessUtils.getSecondUserEmail(),
-        mockMvc,
-        objectMapper,
-        userAccessUtils.defaultUserAuthRequest());
+        userAccessUtils.getSecondUserEmail());
 
     getWorkspaceExpectingError(
         userAccessUtils.secondUserAuthRequest(),
@@ -106,13 +103,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Test
   public void getWorkspace_requesterIsDiscoverer_requestMinHighestRoleSetToReader_throws()
       throws Exception {
-    grantRole(
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
-        userAccessUtils.getSecondUserEmail(),
-        mockMvc,
-        objectMapper,
-        userAccessUtils.defaultUserAuthRequest());
+        userAccessUtils.getSecondUserEmail());
 
     getWorkspaceExpectingError(
         userAccessUtils.secondUserAuthRequest(),
@@ -125,13 +120,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       getWorkspace_requesterIsDiscoverer_requestMinHighestRoleSetToDiscoverer_returnsStrippedWorkspace()
           throws Exception {
-    grantRole(
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
-        userAccessUtils.getSecondUserEmail(),
-        mockMvc,
-        objectMapper,
-        userAccessUtils.defaultUserAuthRequest());
+        userAccessUtils.getSecondUserEmail());
 
     ApiWorkspaceDescription gotWorkspace =
         getWorkspace(
@@ -154,13 +147,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Test
   public void getWorkspaceByUserFacingId_requesterIsDiscoverer_requestMinHighestRoleNotSet_throws()
       throws Exception {
-    grantRole(
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
-        userAccessUtils.getSecondUserEmail(),
-        mockMvc,
-        objectMapper,
-        userAccessUtils.defaultUserAuthRequest());
+        userAccessUtils.getSecondUserEmail());
 
     getWorkspaceByUserFacingIdExpectingError(
         userAccessUtils.secondUserAuthRequest(),
@@ -173,13 +164,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       getWorkspaceByUserFacingId_requesterIsDiscoverer_requestMinHighestRoleSetToReader_throws()
           throws Exception {
-    grantRole(
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
-        userAccessUtils.getSecondUserEmail(),
-        mockMvc,
-        objectMapper,
-        userAccessUtils.defaultUserAuthRequest());
+        userAccessUtils.getSecondUserEmail());
 
     getWorkspaceByUserFacingIdExpectingError(
         userAccessUtils.secondUserAuthRequest(),
@@ -192,13 +181,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       getWorkspaceByUserFacingId_requesterIsDiscoverer_requestMinHighestRoleSetToDiscoverer_returnsStrippedWorkspace()
           throws Exception {
-    grantRole(
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
-        userAccessUtils.getSecondUserEmail(),
-        mockMvc,
-        objectMapper,
-        userAccessUtils.defaultUserAuthRequest());
+        userAccessUtils.getSecondUserEmail());
 
     ApiWorkspaceDescription gotWorkspace =
         getWorkspaceByUserFacingId(
@@ -225,13 +212,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Test
   public void listWorkspaces_requesterIsDiscoverer_requestMinHighestRoleNotSet_returnsNoWorkspaces()
       throws Exception {
-    grantRole(
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
-        userAccessUtils.getSecondUserEmail(),
-        mockMvc,
-        objectMapper,
-        userAccessUtils.defaultUserAuthRequest());
+        userAccessUtils.getSecondUserEmail());
 
     List<ApiWorkspaceDescription> listedWorkspaces =
         listWorkspaces(userAccessUtils.secondUserAuthRequest());
@@ -242,13 +227,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       listWorkspaces_requesterIsDiscoverer_requestMinHighestRoleSetToReader_returnsNoWorkspaces()
           throws Exception {
-    grantRole(
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
-        userAccessUtils.getSecondUserEmail(),
-        mockMvc,
-        objectMapper,
-        userAccessUtils.defaultUserAuthRequest());
+        userAccessUtils.getSecondUserEmail());
 
     List<ApiWorkspaceDescription> listedWorkspaces =
         listWorkspaces(userAccessUtils.secondUserAuthRequest(), Optional.of(ApiIamRole.READER));
@@ -260,13 +243,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       listWorkspaces_requesterIsDiscoverer_requestMinHighestRoleSetToDiscoverer_returnsStrippedWorkspace()
           throws Exception {
-    grantRole(
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
-        userAccessUtils.getSecondUserEmail(),
-        mockMvc,
-        objectMapper,
-        userAccessUtils.defaultUserAuthRequest());
+        userAccessUtils.getSecondUserEmail());
 
     List<ApiWorkspaceDescription> listedWorkspaces =
         listWorkspaces(userAccessUtils.secondUserAuthRequest(), Optional.of(ApiIamRole.DISCOVERER));

--- a/service/src/test/java/bio/terra/workspace/common/BaseTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseTest.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.common;
 
 import bio.terra.workspace.app.Main;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -11,4 +12,5 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ContextConfiguration(classes = Main.class)
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {"spring.cloud.gcp.credentials.location="})
+@AutoConfigureMockMvc
 public class BaseTest {}

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTest.java
@@ -1,10 +1,8 @@
 package bio.terra.workspace.common;
 
 import org.junit.jupiter.api.Tag;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.context.ActiveProfiles;
 
 @Tag("unit")
-@AutoConfigureMockMvc
 @ActiveProfiles("unit-test")
 public class BaseUnitTest extends BaseTest {}

--- a/service/src/test/java/bio/terra/workspace/common/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/StairwayTestUtils.java
@@ -12,6 +12,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.DuplicateFlightIdException;
 import bio.terra.stairway.exception.StairwayExecutionException;
+import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.workspace.Alpha1Service;
@@ -107,5 +108,9 @@ public class StairwayTestUtils {
     public StepResult undoStep(FlightContext flightContext) {
       return StepResult.getStepResultSuccess();
     }
+  }
+
+  public static boolean jobIsRunning(ApiJobReport jobReport) {
+    return jobReport.getStatus().equals(ApiJobReport.StatusEnum.RUNNING);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.common.fixtures;
 
 import bio.terra.stairway.ShortUUID;
 import bio.terra.workspace.common.utils.AzureVmUtils;
+import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpResource;
@@ -83,7 +84,7 @@ public class ControlledResourceFixtures {
 
   public static final ApiGcpGcsBucketCreationParameters GOOGLE_BUCKET_CREATION_PARAMETERS_MINIMAL =
       new ApiGcpGcsBucketCreationParameters()
-          .name(uniqueName(BUCKET_NAME_PREFIX))
+          .name(TestUtils.appendRandomNumber(BUCKET_NAME_PREFIX))
           .location(GcpResourceConstant.DEFAULT_REGION);
 
   /** Construct a parameter object with a unique bucket name to avoid unintended clashes. */
@@ -248,11 +249,11 @@ public class ControlledResourceFixtures {
   }
 
   public static String uniqueBucketName() {
-    return uniqueName(BUCKET_NAME_PREFIX);
+    return TestUtils.appendRandomNumber(BUCKET_NAME_PREFIX);
   }
 
   public static String uniqueAzureName(String resourcePrefix) {
-    return uniqueName(AZURE_NAME_PREFIX + "-" + resourcePrefix);
+    return TestUtils.appendRandomNumber(AZURE_NAME_PREFIX + "-" + resourcePrefix);
   }
 
   public static String uniqueStorageAccountName() {
@@ -450,7 +451,7 @@ public class ControlledResourceFixtures {
     return ControlledResourceFields.builder()
         .workspaceUuid(UUID.randomUUID())
         .resourceId(UUID.randomUUID())
-        .name(uniqueName("test_resource").replace("-", "_"))
+        .name(TestUtils.appendRandomNumber("test_resource").replace("-", "_"))
         .description("how much data could a dataset set if a dataset could set data?")
         .cloningInstructions(CloningInstructions.COPY_DEFINITION)
         .assignedUser(null)
@@ -520,10 +521,6 @@ public class ControlledResourceFixtures {
       new Dataset().setDefaultTableExpirationMs(5900000L).setDefaultPartitionExpirationMs(5901000L);
   public static final Dataset BQ_DATASET_WITHOUT_EXPIRATION = new Dataset();
 
-  public static String uniqueName(String prefix) {
-    return prefix + "-" + UUID.randomUUID();
-  }
-
   public static String uniqueDatasetId() {
     return "my_test_dataset_" + ShortUUID.get().replace("-", "_");
   }
@@ -538,7 +535,7 @@ public class ControlledResourceFixtures {
     return ControlledResourceFields.builder()
         .workspaceUuid(UUID.randomUUID())
         .resourceId(UUID.randomUUID())
-        .name(uniqueName("my-instance"))
+        .name(TestUtils.appendRandomNumber("my-instance"))
         .description("my notebook description")
         .cloningInstructions(CloningInstructions.COPY_NOTHING)
         .assignedUser("myusername@mydomain.mine")
@@ -549,7 +546,7 @@ public class ControlledResourceFixtures {
   public static ControlledAiNotebookInstanceResource.Builder makeDefaultAiNotebookInstance() {
     return ControlledAiNotebookInstanceResource.builder()
         .common(makeNotebookCommonFieldsBuilder().build())
-        .instanceId(uniqueName("my-cloud-id"))
+        .instanceId(TestUtils.appendRandomNumber("my-cloud-id"))
         .location("us-east1-b")
         .projectId("my-project-id");
   }

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -5,7 +5,6 @@ import bio.terra.workspace.generated.model.ApiCreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiProperties;
 import bio.terra.workspace.generated.model.ApiProperty;
 import bio.terra.workspace.generated.model.ApiWorkspaceStageModel;
-import bio.terra.workspace.service.iam.model.SamConstants.SamResource;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.WorkspaceConstants.Properties;
@@ -57,7 +56,7 @@ public class WorkspaceFixtures {
         .description("A test workspace created by createWorkspaceRequestBody")
         .userFacingId(getUserFacingId(workspaceId))
         .stage(ApiWorkspaceStageModel.MC_WORKSPACE)
-        .spendProfile(SamResource.SPEND_PROFILE)
+        .spendProfile("wm-default-spend-profile")
         .properties(properties);
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -2,24 +2,38 @@ package bio.terra.workspace.common.utils;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.generated.model.ApiCloudPlatform;
+import bio.terra.workspace.generated.model.ApiCreateCloudContextRequest;
+import bio.terra.workspace.generated.model.ApiCreateCloudContextResult;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpBigQueryDatasetRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpBigQueryDataset;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiGrantRoleRequestBody;
+import bio.terra.workspace.generated.model.ApiJobControl;
+import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
+import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
+import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -31,7 +45,15 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * <p>TODO: it's probably worth looking into whether we can automatically pull routes from the
  * generated swagger, instead of manually wrapping them here.
  */
+@Component
 public class MockMvcUtils {
+  private static final Logger logger = LoggerFactory.getLogger(MockMvcUtils.class);
+
+  // Do not Autowire UserAccessUtils. UserAccessUtils are for connected tests and not unit tests
+  // (since unit tests don't use real SAM). Instead, each method must take in userRequest.
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private SpendConnectedTestUtils spendUtils;
 
   public static final String AUTH_HEADER = "Authorization";
 
@@ -61,6 +83,14 @@ public class MockMvcUtils {
   public static final String CREATE_AZURE_VM_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/vm";
 
+  public static final String CREATE_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/buckets";
+  public static final String GET_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/buckets/%s";
+  public static final String CLONE_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/buckets/%s/clone";
+  public static final String CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/buckets/clone-result/%s";
   public static final String GENERATE_GCP_GCS_BUCKET_NAME_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/gcp/buckets/generateName";
   public static final String GENERATE_GCP_BQ_DATASET_NAME_PATH_FORMAT =
@@ -89,22 +119,110 @@ public class MockMvcUtils {
     return request.contentType("application/json");
   }
 
-  public static ApiCreatedWorkspace createWorkspace(MockMvc mockMvc, ObjectMapper objectMapper)
+  public ApiWorkspaceDescription getWorkspace(AuthenticatedUserRequest userRequest, UUID id)
       throws Exception {
-    var createRequest = WorkspaceFixtures.createWorkspaceRequestBody();
+    MockHttpServletRequestBuilder requestBuilder =
+        get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, id));
+    String serializedResponse =
+        mockMvc
+            .perform(addAuth(requestBuilder, userRequest))
+            .andExpect(status().is(HttpStatus.SC_OK))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return objectMapper.readValue(serializedResponse, ApiWorkspaceDescription.class);
+  }
+
+  public ApiWorkspaceDescription createWorkspaceAndCloudContext(
+      AuthenticatedUserRequest userRequest) throws Exception {
+    ApiWorkspaceDescription createdWorkspace = createWorkspaceWithoutCloudContext(userRequest);
+    createGcpCloudContextAndWait(userRequest, createdWorkspace.getId());
+    return createdWorkspace;
+  }
+
+  public ApiWorkspaceDescription createWorkspaceWithoutCloudContext(
+      AuthenticatedUserRequest userRequest) throws Exception {
+    ApiCreateWorkspaceRequestBody request = WorkspaceFixtures.createWorkspaceRequestBody();
     String serializedResponse =
         mockMvc
             .perform(
                 addJsonContentType(
                     addAuth(
-                        post(WORKSPACES_V1_PATH)
-                            .content(objectMapper.writeValueAsString(createRequest)),
-                        USER_REQUEST)))
+                        post(WORKSPACES_V1_PATH).content(objectMapper.writeValueAsString(request)),
+                        userRequest)))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
             .getResponse()
             .getContentAsString();
-    return objectMapper.readValue(serializedResponse, ApiCreatedWorkspace.class);
+
+    // Return ApiWorkspaceDescription instead of ApiCreatedWorkspace, since former has
+    // getUserFacingId().
+    UUID workspaceId =
+        objectMapper.readValue(serializedResponse, ApiCreatedWorkspace.class).getId();
+    return getWorkspace(userRequest, workspaceId);
+  }
+
+  private void createGcpCloudContextAndWait(AuthenticatedUserRequest userRequest, UUID workspaceId)
+      throws Exception {
+    ApiCreateCloudContextResult result = createGcpCloudContext(userRequest, workspaceId);
+    UUID jobId = UUID.fromString(result.getJobReport().getId());
+    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
+      Thread.sleep(/*millis=*/ 5000);
+      result = getCreateCloudContextResult(userRequest, workspaceId, jobId);
+    }
+    assertEquals(StatusEnum.SUCCEEDED, result.getJobReport().getStatus());
+    logger.info(
+        "Created project %s for workspace %s"
+            .formatted(result.getGcpContext().getProjectId(), workspaceId));
+  }
+
+  private ApiCreateCloudContextResult createGcpCloudContext(
+      AuthenticatedUserRequest userRequest, UUID workspaceId) throws Exception {
+    String jobId = UUID.randomUUID().toString();
+    ApiCreateCloudContextRequest request =
+        new ApiCreateCloudContextRequest()
+            .cloudPlatform(ApiCloudPlatform.GCP)
+            .jobControl(new ApiJobControl().id(jobId));
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addJsonContentType(
+                    addAuth(
+                        post(CREATE_CLOUD_CONTEXT_PATH_FORMAT.formatted(workspaceId.toString()))
+                            .content(objectMapper.writeValueAsString(request)),
+                        userRequest)))
+            .andExpect(status().is(HttpStatus.SC_ACCEPTED))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return objectMapper.readValue(serializedResponse, ApiCreateCloudContextResult.class);
+  }
+
+  private ApiCreateCloudContextResult getCreateCloudContextResult(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID jobId) throws Exception {
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addJsonContentType(
+                    addAuth(
+                        get(
+                            GET_CLOUD_CONTEXT_PATH_FORMAT.formatted(
+                                workspaceId.toString(), jobId.toString())),
+                        userRequest)))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return objectMapper.readValue(serializedResponse, ApiCreateCloudContextResult.class);
+  }
+
+  public void deleteWorkspace(AuthenticatedUserRequest userRequest, UUID workspaceId)
+      throws Exception {
+    mockMvc
+        .perform(
+            addAuth(
+                delete(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceId)), userRequest))
+        .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
   }
 
   public static ApiCreatedControlledGcpBigQueryDataset createBigQueryDataset(

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -221,14 +221,15 @@ public class MockMvcUtils {
             addAuth(
                 delete(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceId)), userRequest))
         .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
+    mockMvc
+        .perform(
+            addAuth(
+                get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceId)), userRequest))
+        .andExpect(status().is(HttpStatus.SC_NOT_FOUND));
   }
 
-  public static ApiCreatedControlledGcpBigQueryDataset createBigQueryDataset(
-      MockMvc mockMvc,
-      ObjectMapper objectMapper,
-      UUID workspaceId,
-      AuthenticatedUserRequest userRequest)
-      throws Exception {
+  public ApiCreatedControlledGcpBigQueryDataset createBigQueryDataset(
+      AuthenticatedUserRequest userRequest, UUID workspaceId) throws Exception {
     ApiCreateControlledGcpBigQueryDatasetRequestBody datasetCreationRequest =
         new ApiCreateControlledGcpBigQueryDatasetRequestBody()
             .common(makeDefaultControlledResourceFieldsApi())
@@ -255,13 +256,8 @@ public class MockMvcUtils {
         serializedGetResponse, ApiCreatedControlledGcpBigQueryDataset.class);
   }
 
-  public static ApiGcpBigQueryDatasetResource getBigQueryDataset(
-      MockMvc mockMvc,
-      ObjectMapper objectMapper,
-      UUID workspaceId,
-      UUID resourceId,
-      AuthenticatedUserRequest userRequest)
-      throws Exception {
+  public ApiGcpBigQueryDatasetResource getBigQueryDataset(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
     String serializedGetResponse =
         mockMvc
             .perform(
@@ -280,13 +276,8 @@ public class MockMvcUtils {
     return objectMapper.readValue(serializedGetResponse, ApiGcpBigQueryDatasetResource.class);
   }
 
-  public static void grantRole(
-      UUID workspaceId,
-      WsmIamRole role,
-      String memberEmail,
-      MockMvc mockMvc,
-      ObjectMapper objectMapper,
-      AuthenticatedUserRequest userRequest)
+  public void grantRole(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, WsmIamRole role, String memberEmail)
       throws Exception {
     var requestBody = new ApiGrantRoleRequestBody().memberEmail(memberEmail);
     mockMvc
@@ -297,19 +288,5 @@ public class MockMvcUtils {
                         .content(objectMapper.writeValueAsString(requestBody)),
                     userRequest)))
         .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
-  }
-
-  public static void deleteWorkspace(
-      UUID workspaceId, MockMvc mockMvc, AuthenticatedUserRequest userRequest) throws Exception {
-    mockMvc
-        .perform(
-            addAuth(
-                delete(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceId)), userRequest))
-        .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
-    mockMvc
-        .perform(
-            addAuth(
-                get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceId)), userRequest))
-        .andExpect(status().is(HttpStatus.SC_NOT_FOUND));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -24,7 +24,6 @@ import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
-import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 import java.util.UUID;
@@ -53,7 +52,6 @@ public class MockMvcUtils {
   // (since unit tests don't use real SAM). Instead, each method must take in userRequest.
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;
-  @Autowired private SpendConnectedTestUtils spendUtils;
 
   public static final String AUTH_HEADER = "Authorization";
 

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -131,7 +131,7 @@ public class MockMvcUtils {
     return objectMapper.readValue(serializedResponse, ApiWorkspaceDescription.class);
   }
 
-  public ApiWorkspaceDescription createWorkspaceAndCloudContext(
+  public ApiWorkspaceDescription createWorkspaceWithCloudContext(
       AuthenticatedUserRequest userRequest) throws Exception {
     ApiWorkspaceDescription createdWorkspace = createWorkspaceWithoutCloudContext(userRequest);
     createGcpCloudContextAndWait(userRequest, createdWorkspace.getId());

--- a/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
@@ -1,0 +1,11 @@
+package bio.terra.workspace.common.utils;
+
+import java.util.Random;
+
+public class TestUtils {
+  private static final Random RANDOM = new Random();
+
+  public static String appendRandomNumber(String string) {
+    return string + "-" + RANDOM.nextInt(100000);
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
@@ -164,7 +165,7 @@ public class ResourceDaoTest extends BaseUnitTest {
   @Test
   public void
       createAiNotebook_duplicateCloudInstanceId_rejectedWhenInSameCloudProjectAndLocation() {
-    var cloudInstanceId = ControlledResourceFixtures.uniqueName("my-cloud-instance-id");
+    var cloudInstanceId = TestUtils.appendRandomNumber("my-cloud-instance-id");
     ControlledResourceFields commonFields1 =
         ControlledResourceFixtures.makeNotebookCommonFieldsBuilder()
             .workspaceUuid(workspaceUuid)

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -56,16 +56,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@AutoConfigureMockMvc
 class SamServiceTest extends BaseConnectedTest {
-
-  // Populated because this test is annotated with @AutoConfigureMockMvc
   @Autowired private MockMvc mockMvc;
-
   @Autowired private SamService samService;
   @Autowired private WorkspaceService workspaceService;
   @Autowired private UserAccessUtils userAccessUtils;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -36,12 +36,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 // Test to make sure things properly do not work when Azure feature is not enabled
-@AutoConfigureMockMvc
 // We are modifying application context here. Need to clean up once tests are done.
 @Disabled("Until we get the postgres connection leaks addressed")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/CreateGcsBucketStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/CreateGcsBucketStepTest.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.getGoogleBucketCreationParameters;
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.uniqueName;
 import static bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstant.DEFAULT_REGION;
 import static bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.GcsApiConversions.toGoogleDateTime;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,6 +25,7 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
@@ -140,7 +140,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
 
   @Test
   public void testCreatesBucketWithoutAllParameters() throws RetryException, InterruptedException {
-    final String bucketName = uniqueName("pedro");
+    final String bucketName = TestUtils.appendRandomNumber("pedro");
     final CreateGcsBucketStep createGcsBucketStep =
         new CreateGcsBucketStep(
             mockCrlService,
@@ -171,7 +171,7 @@ public class CreateGcsBucketStepTest extends BaseUnitTest {
         .create(bucketInfoCaptor.capture());
 
     // A bad bucket name that fails to be caught by the WSM validation.
-    final String bucketName = uniqueName("bad-bucket-name");
+    final String bucketName = TestUtils.appendRandomNumber("bad-bucket-name");
 
     final CreateGcsBucketStep createGcsBucketStep =
         new CreateGcsBucketStep(

--- a/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationConfigurationTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationConfigurationTest.java
@@ -12,14 +12,12 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.context.ActiveProfiles;
 
 // This is a special test to make sure the application configuration works.
 // We use a special profile to pick up a test application configuration.
 @Disabled
 @Tag("unit")
-@AutoConfigureMockMvc
 @ActiveProfiles({"unit-test", "configuration-test"})
 public class ApplicationConfigurationTest extends BaseTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -99,7 +99,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -107,7 +106,6 @@ import org.springframework.test.web.servlet.MockMvc;
 // Use application configuration profile in addition to the standard connected test profile
 // inherited from the base class.
 @ActiveProfiles({"app-test"})
-@AutoConfigureMockMvc
 class WorkspaceServiceTest extends BaseConnectedTest {
 
   /** A fake authenticated user request. */
@@ -136,9 +134,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   @MockBean private TpsApiDispatch mockTpsApiDispatch;
   @MockBean private FeatureConfiguration mockFeatureConfiguration;
 
-  // Populated because this test is annotated with @AutoConfigureMockMvc
   @Autowired private MockMvc mockMvc;
-
   @Autowired private ControlledResourceService controlledResourceService;
   @Autowired private CrlService crl;
   @Autowired private GcpCloudContextService gcpCloudContextService;


### PR DESCRIPTION
Existing "Clone controlled GCS bucket" connected/integration tests use `CloningInstructions.COPY_RESOURCE`. In `ControlledGcpResourceApiControllerConnectedTest.java`, add tests for other `CloningInstructions` enum values, in preparation for implementing `CloningInstructions.COPY_REFERENCE`.

Also make `MockMvcUtils` a spring Component. This way, users don't have to pass in `mockMvc`, `objectMapper`. In order to make `MovkMvcUtils` a spring Component, I had to add `@AutoConfigureMockMvc` to `BaseTest`. I also removed `@AutoConfigureMockMvc` from individual tests.