### PR TITLE
[DC-534] Handle updated TDR forbidden response

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/datarepo/DataRepoService.java
+++ b/service/src/main/java/bio/terra/workspace/service/datarepo/DataRepoService.java
@@ -69,14 +69,12 @@ public class DataRepoService {
       logger.info("Retrieved snapshotId {} on Data Repo instance {}", snapshotId, instanceName);
       return true;
     } catch (ApiException e) {
-      // TDR uses 401 (rather than 403) to indicate "user does not have permission", so we check for
-      // UNAUTHORIZED here instead of FORBIDDEN.
       if (e.getCode() == HttpStatus.NOT_FOUND.value()
-          || e.getCode() == HttpStatus.UNAUTHORIZED.value()) {
+          || e.getCode() == HttpStatus.FORBIDDEN.value()) {
         return false;
       } else {
         throw new DataRepoInternalServerErrorException(
-            "Data Repo returned the following error: " + e.getMessage(), e.getCause());
+            "Data Repo returned the following unexpected error: " + e.getMessage(), e.getCause());
       }
     }
   }


### PR DESCRIPTION
In https://github.com/DataBiosphere/jade-data-repo/pull/1343, TDR began returning 403 responses when a user does not have permission, rather than 401, so WSM needs to handle the new response. This broke the `ReferencedDataRepoSnapshotLifecycle` integration test.

This is the only spot WSM calls TDR, so I don't think we need to update anywhere else