### PR TITLE
[PF-2013] Add log based alert for stale status

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/status/BaseStatusService.java
+++ b/service/src/main/java/bio/terra/workspace/service/status/BaseStatusService.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.status;
 
+import bio.terra.common.logging.LoggingUtils;
 import bio.terra.workspace.app.configuration.external.StatusCheckConfiguration;
 import java.time.Instant;
 import java.util.concurrent.ConcurrentHashMap;
@@ -93,7 +94,11 @@ public class BaseStatusService {
       if (lastStatusUpdate
           .plusSeconds(configuration.getStalenessThresholdSeconds())
           .isBefore(Instant.now())) {
-        logger.warn("Status has not been updated since {}", lastStatusUpdate);
+        LoggingUtils.logAlert(
+            logger,
+            String.format(
+                "Status has not been updated since %s. This might mean that the status cronjob has failed, or that requests to downstream services are timing out.",
+                lastStatusUpdate));
         statusOk.set(false);
       }
       return statusOk.get();


### PR DESCRIPTION
This upgrades the log message for stale status to fire an alert in any environment with log-based alerting configured, instead of just logging a warning. This should also be a more informative message for oncall engineers.

