### PR TITLE
PF-1965: Add properties fields on resource creation

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static scripts.utils.CommonResourceFieldsUtil.getResourceDefaultProperties;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
@@ -113,6 +114,7 @@ public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScr
             /*datasetId=*/ null,
             CloningInstructionsEnum.NOTHING);
     assertEquals(DATASET_RESOURCE_NAME, createdDataset.getAttributes().getDatasetId());
+    assertEquals(getResourceDefaultProperties(), createdDataset.getMetadata().getProperties());
     UUID resourceId = createdDataset.getMetadata().getResourceId();
 
     // Retrieve the dataset resource

--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -35,7 +35,6 @@ import bio.terra.workspace.model.CloneControlledGcpGcsBucketResult;
 import bio.terra.workspace.model.ClonedControlledGcpGcsBucket;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.CloudPlatform;
-import bio.terra.workspace.model.ControlledResourceCommonFields;
 import bio.terra.workspace.model.ControlledResourceIamRole;
 import bio.terra.workspace.model.CreateControlledGcpGcsBucketRequestBody;
 import bio.terra.workspace.model.CreatedControlledGcpGcsBucket;
@@ -75,6 +74,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
+import scripts.utils.CommonResourceFieldsUtil;
 import scripts.utils.GcpWorkspaceCloneTestScriptBase;
 import scripts.utils.GcsBucketAccessTester;
 import scripts.utils.GcsBucketUtils;
@@ -306,11 +306,12 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
             .lifecycle(new GcpGcsBucketLifecycle().rules(BUCKET_LIFECYCLE_RULES));
 
     var commonParameters =
-        new ControlledResourceCommonFields()
-            .name(resourceName)
-            .cloningInstructions(CloningInstructionsEnum.NOTHING)
-            .accessScope(AccessScope.SHARED_ACCESS)
-            .managedBy(ManagedBy.USER);
+        CommonResourceFieldsUtil.makeControlledResourceCommonFields(
+            resourceName,
+            /*privateUser=*/ null,
+            CloningInstructionsEnum.NOTHING,
+            ManagedBy.USER,
+            AccessScope.SHARED_ACCESS);
 
     var body =
         new CreateControlledGcpGcsBucketRequestBody()

--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static scripts.utils.CommonResourceFieldsUtil.getResourceDefaultProperties;
 import static scripts.utils.GcsBucketUtils.BUCKET_LIFECYCLE_RULES;
 import static scripts.utils.GcsBucketUtils.BUCKET_LIFECYCLE_RULE_1_CONDITION_AGE;
 import static scripts.utils.GcsBucketUtils.BUCKET_LIFECYCLE_RULE_1_CONDITION_LIVE;
@@ -134,6 +135,8 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
             ? expectedBucketName.substring(0, expectedBucketName.length() - 1)
             : expectedBucketName;
     assertEquals(expectedBucketName, gotBucketNoCloudName.getAttributes().getBucketName());
+    assertEquals(
+        getResourceDefaultProperties(), gotBucketNoCloudName.getMetadata().getProperties());
 
     GcsBucketUtils.deleteControlledGcsBucket(
         bucketNoCloudName.getResourceId(), getWorkspaceId(), resourceApi);

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
+import scripts.utils.CommonResourceFieldsUtil;
 import scripts.utils.MultiResourcesUtils;
 import scripts.utils.NotebookUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
@@ -100,6 +101,9 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
             /*postStartupScript=*/ null);
 
     UUID resourceId = creationResult.getAiNotebookInstance().getMetadata().getResourceId();
+    assertEquals(
+        CommonResourceFieldsUtil.getResourceDefaultProperties(),
+        creationResult.getAiNotebookInstance().getMetadata().getProperties());
 
     GcpAiNotebookInstanceResource resource =
         resourceUserApi.getAiNotebookInstance(getWorkspaceId(), resourceId);

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
+import scripts.utils.CommonResourceFieldsUtil;
 import scripts.utils.GcsBucketAccessTester;
 import scripts.utils.GcsBucketUtils;
 import scripts.utils.MultiResourcesUtils;
@@ -100,6 +101,9 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     CreatedControlledGcpGcsBucket bucket =
         ClientTestUtils.getWithRetryOnException(() -> createPrivateBucket(privateUserResourceApi));
     UUID resourceId = bucket.getResourceId();
+    assertEquals(
+        CommonResourceFieldsUtil.getResourceDefaultProperties(),
+        bucket.getGcpBucket().getMetadata().getProperties());
 
     // Retrieve the bucket resource from WSM
     logger.info("Retrieving bucket resource id {}", resourceId.toString());

--- a/integration/src/main/java/scripts/testscripts/ReferencedBigQueryResourceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedBigQueryResourceLifecycle.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import scripts.utils.BqDataTableUtils;
 import scripts.utils.BqDatasetUtils;
 import scripts.utils.ClientTestUtils;
+import scripts.utils.CommonResourceFieldsUtil;
 import scripts.utils.MultiResourcesUtils;
 import scripts.utils.ParameterUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
@@ -88,6 +89,9 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
             MultiResourcesUtils.makeName(),
             CloningInstructionsEnum.REFERENCE);
     bqDatasetResourceId = referencedDataset.getMetadata().getResourceId();
+    assertEquals(
+        CommonResourceFieldsUtil.getResourceDefaultProperties(),
+        referencedDataset.getMetadata().getProperties());
     GcpBigQueryDataTableResource referencedDataTable =
         BqDatasetUtils.makeBigQueryDataTableReference(
             referencedBqTableAttributes,
@@ -96,6 +100,9 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
             MultiResourcesUtils.makeName(),
             CloningInstructionsEnum.REFERENCE);
     bqDataTableResourceId = referencedDataTable.getMetadata().getResourceId();
+    assertEquals(
+        CommonResourceFieldsUtil.getResourceDefaultProperties(),
+        referencedDataTable.getMetadata().getProperties());
 
     // Get references
     testGetReferences(referencedDataset, referencedDataTable, referencedGcpResourceApi);

--- a/integration/src/main/java/scripts/testscripts/ReferencedDataRepoSnapshotLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedDataRepoSnapshotLifecycle.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import scripts.utils.ClientTestUtils;
+import scripts.utils.CommonResourceFieldsUtil;
 import scripts.utils.DataRepoUtils;
 import scripts.utils.MultiResourcesUtils;
 import scripts.utils.ParameterKeys;
@@ -80,6 +81,9 @@ public class ReferencedDataRepoSnapshotLifecycle extends WorkspaceAllocateTestSc
             snapshotId,
             tdrInstance);
     snapshotResourceId = snapshotResource.getMetadata().getResourceId();
+    assertEquals(
+        CommonResourceFieldsUtil.getResourceDefaultProperties(),
+        snapshotResource.getMetadata().getProperties());
 
     // Get the reference
     ResourceApi resourceApi = ClientTestUtils.getResourceClient(testUser, server);

--- a/integration/src/main/java/scripts/testscripts/ReferencedGcsResourceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedGcsResourceLifecycle.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import scripts.utils.ClientTestUtils;
+import scripts.utils.CommonResourceFieldsUtil;
 import scripts.utils.GcsBucketObjectUtils;
 import scripts.utils.GcsBucketUtils;
 import scripts.utils.MultiResourcesUtils;
@@ -92,6 +93,9 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
             MultiResourcesUtils.makeName(),
             CloningInstructionsEnum.REFERENCE);
     bucketResourceId = referencedBucket.getMetadata().getResourceId();
+    assertEquals(
+        CommonResourceFieldsUtil.getResourceDefaultProperties(),
+        referencedBucket.getMetadata().getProperties());
     GcpGcsBucketResource fineGrainedBucket =
         GcsBucketUtils.makeGcsBucketReference(
             gcsFineGrainedAccessBucketAttributes,
@@ -108,6 +112,9 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
             MultiResourcesUtils.makeName(),
             CloningInstructionsEnum.REFERENCE);
     fileResourceId = referencedGcsFile.getMetadata().getResourceId();
+    assertEquals(
+        CommonResourceFieldsUtil.getResourceDefaultProperties(),
+        referencedGcsFile.getMetadata().getProperties());
     GcpGcsObjectResource referencedGcsFolder =
         GcsBucketObjectUtils.makeGcsObjectReference(
             gcsFolderAttributes,

--- a/integration/src/main/java/scripts/utils/BqDatasetUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDatasetUtils.java
@@ -151,9 +151,7 @@ public class BqDatasetUtils {
       throws Exception {
     var body =
         new CreateGcpBigQueryDataTableReferenceRequestBody()
-            .metadata(
-                makeReferencedResourceCommonFields(
-                    name, cloningInstructions))
+            .metadata(makeReferencedResourceCommonFields(name, cloningInstructions))
             .dataTable(dataTable);
 
     return ClientTestUtils.getWithRetryOnException(

--- a/integration/src/main/java/scripts/utils/BqDatasetUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDatasetUtils.java
@@ -3,6 +3,7 @@ package scripts.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static scripts.utils.CommonResourceFieldsUtil.makeControlledResourceCommonFields;
 import static scripts.utils.CommonResourceFieldsUtil.makeReferencedResourceCommonFields;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
@@ -11,7 +12,6 @@ import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
-import bio.terra.workspace.model.ControlledResourceCommonFields;
 import bio.terra.workspace.model.CreateControlledGcpBigQueryDatasetRequestBody;
 import bio.terra.workspace.model.CreateGcpBigQueryDataTableReferenceRequestBody;
 import bio.terra.workspace.model.CreateGcpBigQueryDatasetReferenceRequestBody;
@@ -22,7 +22,6 @@ import bio.terra.workspace.model.GcpBigQueryDatasetCreationParameters;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
 import bio.terra.workspace.model.ManagedBy;
 import bio.terra.workspace.model.PrivateResourceUser;
-import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.UpdateBigQueryDatasetReferenceRequestBody;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Field;
@@ -153,10 +152,8 @@ public class BqDatasetUtils {
     var body =
         new CreateGcpBigQueryDataTableReferenceRequestBody()
             .metadata(
-                new ReferenceResourceCommonFields()
-                    .cloningInstructions(cloningInstructions)
-                    .description("Description of " + name)
-                    .name(name))
+                CommonResourceFieldsUtil.makeReferencedResourceCommonFields(
+                    name, cloningInstructions))
             .dataTable(dataTable);
 
     return ClientTestUtils.getWithRetryOnException(
@@ -217,15 +214,13 @@ public class BqDatasetUtils {
     var body =
         new CreateControlledGcpBigQueryDatasetRequestBody()
             .common(
-                new ControlledResourceCommonFields()
-                    .accessScope(accessScope)
-                    .managedBy(managedBy)
-                    .cloningInstructions(
-                        Optional.ofNullable(cloningInstructions)
-                            .orElse(CloningInstructionsEnum.NOTHING))
-                    .description("Description of " + resourceName)
-                    .name(resourceName)
-                    .privateResourceUser(privateUser))
+                makeControlledResourceCommonFields(
+                    resourceName,
+                    privateUser,
+                    Optional.ofNullable(cloningInstructions)
+                        .orElse(CloningInstructionsEnum.NOTHING),
+                    managedBy,
+                    accessScope))
             .dataset(new GcpBigQueryDatasetCreationParameters().datasetId(datasetId));
 
     logger.info(

--- a/integration/src/main/java/scripts/utils/BqDatasetUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDatasetUtils.java
@@ -3,6 +3,7 @@ package scripts.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static scripts.utils.CommonResourceFieldsUtil.makeReferencedResourceCommonFields;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
@@ -80,11 +81,7 @@ public class BqDatasetUtils {
 
     var body =
         new CreateGcpBigQueryDatasetReferenceRequestBody()
-            .metadata(
-                new ReferenceResourceCommonFields()
-                    .cloningInstructions(cloningInstructions)
-                    .description("Description of " + name)
-                    .name(name))
+            .metadata(makeReferencedResourceCommonFields(name, cloningInstructions))
             .dataset(dataset);
 
     GcpBigQueryDatasetResource result =

--- a/integration/src/main/java/scripts/utils/BqDatasetUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDatasetUtils.java
@@ -152,7 +152,7 @@ public class BqDatasetUtils {
     var body =
         new CreateGcpBigQueryDataTableReferenceRequestBody()
             .metadata(
-                CommonResourceFieldsUtil.makeReferencedResourceCommonFields(
+                makeReferencedResourceCommonFields(
                     name, cloningInstructions))
             .dataTable(dataTable);
 

--- a/integration/src/main/java/scripts/utils/CommonResourceFieldsUtil.java
+++ b/integration/src/main/java/scripts/utils/CommonResourceFieldsUtil.java
@@ -20,22 +20,21 @@ public class CommonResourceFieldsUtil {
 
   /**
    * Makes common fields for referenced resources. Sets properties to foo -> bar.
+   *
    * @param name name of the referenced resource.
    * @param cloningInstructions when null, set to NOTHING.
    */
   public static ReferenceResourceCommonFields makeReferencedResourceCommonFields(
       String name, @Nullable CloningInstructionsEnum cloningInstructions) {
     return new ReferenceResourceCommonFields()
-        .cloningInstructions(Optional.ofNullable(cloningInstructions)
-            .orElse(CloningInstructionsEnum.NOTHING))
+        .cloningInstructions(
+            Optional.ofNullable(cloningInstructions).orElse(CloningInstructionsEnum.NOTHING))
         .description("Description of " + name)
         .name(name)
         .properties(getResourceDefaultProperties());
   }
 
-  /**
-   * Makes common fields for Controlled resource. Sets resource properties to foo->bar.
-   */
+  /** Makes common fields for Controlled resource. Sets resource properties to foo->bar. */
   public static ControlledResourceCommonFields makeControlledResourceCommonFields(
       String name,
       PrivateResourceUser privateUser,

--- a/integration/src/main/java/scripts/utils/CommonResourceFieldsUtil.java
+++ b/integration/src/main/java/scripts/utils/CommonResourceFieldsUtil.java
@@ -1,0 +1,50 @@
+package scripts.utils;
+
+import bio.terra.workspace.model.AccessScope;
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import bio.terra.workspace.model.ControlledResourceCommonFields;
+import bio.terra.workspace.model.ManagedBy;
+import bio.terra.workspace.model.PrivateResourceUser;
+import bio.terra.workspace.model.Properties;
+import bio.terra.workspace.model.Property;
+import bio.terra.workspace.model.ReferenceResourceCommonFields;
+import com.google.common.collect.ImmutableMap;
+
+/** Utils to build common resource fields for both referenced resources and controlled resources. */
+public class CommonResourceFieldsUtil {
+
+  public static ImmutableMap<String, String> DEFAULT_RESOURCE_PROPERTIES =
+      ImmutableMap.of("foo", "bar");
+
+  public static ReferenceResourceCommonFields makeReferencedResourceCommonFields(
+      String name, CloningInstructionsEnum cloningInstructions) {
+    return new ReferenceResourceCommonFields()
+        .cloningInstructions(cloningInstructions)
+        .description("Description of " + name)
+        .name(name)
+        .properties(getResourceDefaultProperties());
+  }
+
+  public static ControlledResourceCommonFields makeControlledResourceCommonFields(
+      String name,
+      PrivateResourceUser privateUser,
+      CloningInstructionsEnum cloningInstructions,
+      ManagedBy managedBy,
+      AccessScope accessScope) {
+    return new ControlledResourceCommonFields()
+        .accessScope(accessScope)
+        .managedBy(managedBy)
+        .cloningInstructions(cloningInstructions)
+        .description("Description of " + name)
+        .name(name)
+        .privateResourceUser(privateUser)
+        .properties(getResourceDefaultProperties());
+  }
+
+  public static Properties getResourceDefaultProperties() {
+    Properties properties = new Properties();
+    DEFAULT_RESOURCE_PROPERTIES.forEach(
+        (key, value) -> properties.add(new Property().key(key).value(value)));
+    return properties;
+  }
+}

--- a/integration/src/main/java/scripts/utils/CommonResourceFieldsUtil.java
+++ b/integration/src/main/java/scripts/utils/CommonResourceFieldsUtil.java
@@ -9,6 +9,8 @@ import bio.terra.workspace.model.Properties;
 import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** Utils to build common resource fields for both referenced resources and controlled resources. */
 public class CommonResourceFieldsUtil {
@@ -16,15 +18,24 @@ public class CommonResourceFieldsUtil {
   public static final ImmutableMap<String, String> DEFAULT_RESOURCE_PROPERTIES =
       ImmutableMap.of("foo", "bar");
 
+  /**
+   * Makes common fields for referenced resources. Sets properties to foo -> bar.
+   * @param name name of the referenced resource.
+   * @param cloningInstructions when null, set to NOTHING.
+   */
   public static ReferenceResourceCommonFields makeReferencedResourceCommonFields(
-      String name, CloningInstructionsEnum cloningInstructions) {
+      String name, @Nullable CloningInstructionsEnum cloningInstructions) {
     return new ReferenceResourceCommonFields()
-        .cloningInstructions(cloningInstructions)
+        .cloningInstructions(Optional.ofNullable(cloningInstructions)
+            .orElse(CloningInstructionsEnum.NOTHING))
         .description("Description of " + name)
         .name(name)
         .properties(getResourceDefaultProperties());
   }
 
+  /**
+   * Makes common fields for Controlled resource. Sets resource properties to foo->bar.
+   */
   public static ControlledResourceCommonFields makeControlledResourceCommonFields(
       String name,
       PrivateResourceUser privateUser,

--- a/integration/src/main/java/scripts/utils/CommonResourceFieldsUtil.java
+++ b/integration/src/main/java/scripts/utils/CommonResourceFieldsUtil.java
@@ -13,7 +13,7 @@ import com.google.common.collect.ImmutableMap;
 /** Utils to build common resource fields for both referenced resources and controlled resources. */
 public class CommonResourceFieldsUtil {
 
-  public static ImmutableMap<String, String> DEFAULT_RESOURCE_PROPERTIES =
+  public static final ImmutableMap<String, String> DEFAULT_RESOURCE_PROPERTIES =
       ImmutableMap.of("foo", "bar");
 
   public static ReferenceResourceCommonFields makeReferencedResourceCommonFields(

--- a/integration/src/main/java/scripts/utils/DataRepoUtils.java
+++ b/integration/src/main/java/scripts/utils/DataRepoUtils.java
@@ -25,7 +25,7 @@ public class DataRepoUtils {
 
     var body =
         new CreateDataRepoSnapshotReferenceRequestBody()
-            .metadata(makeReferencedResourceCommonFields(name, CloningInstructionsEnum.NOTHING))
+            .metadata(makeReferencedResourceCommonFields(name, null))
             .snapshot(
                 new DataRepoSnapshotAttributes()
                     .snapshot(dataRepoSnapshotId)

--- a/integration/src/main/java/scripts/utils/DataRepoUtils.java
+++ b/integration/src/main/java/scripts/utils/DataRepoUtils.java
@@ -1,12 +1,13 @@
 package scripts.utils;
 
+import static scripts.utils.CommonResourceFieldsUtil.makeReferencedResourceCommonFields;
+
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.CreateDataRepoSnapshotReferenceRequestBody;
 import bio.terra.workspace.model.DataRepoSnapshotAttributes;
 import bio.terra.workspace.model.DataRepoSnapshotResource;
-import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.UpdateDataRepoSnapshotReferenceRequestBody;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -24,11 +25,7 @@ public class DataRepoUtils {
 
     var body =
         new CreateDataRepoSnapshotReferenceRequestBody()
-            .metadata(
-                new ReferenceResourceCommonFields()
-                    .cloningInstructions(CloningInstructionsEnum.NOTHING)
-                    .description("Description of " + name)
-                    .name(name))
+            .metadata(makeReferencedResourceCommonFields(name, CloningInstructionsEnum.NOTHING))
             .snapshot(
                 new DataRepoSnapshotAttributes()
                     .snapshot(dataRepoSnapshotId)

--- a/integration/src/main/java/scripts/utils/GcsBucketObjectUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketObjectUtils.java
@@ -9,7 +9,6 @@ import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.CreateGcpGcsObjectReferenceRequestBody;
 import bio.terra.workspace.model.GcpGcsObjectAttributes;
 import bio.terra.workspace.model.GcpGcsObjectResource;
-import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
@@ -57,12 +56,10 @@ public class GcsBucketObjectUtils {
     var body =
         new CreateGcpGcsObjectReferenceRequestBody()
             .metadata(
-                new ReferenceResourceCommonFields()
-                    .cloningInstructions(
-                        Optional.ofNullable(cloningInstructionsEnum)
-                            .orElse(CloningInstructionsEnum.NOTHING))
-                    .description("Description of " + name)
-                    .name(name))
+                CommonResourceFieldsUtil.makeReferencedResourceCommonFields(
+                    name,
+                    Optional.ofNullable(cloningInstructionsEnum)
+                        .orElse(CloningInstructionsEnum.NOTHING)))
             .file(file);
 
     logger.info("Making reference to a gcs bucket file");

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -27,7 +27,6 @@ import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.ManagedBy;
 import bio.terra.workspace.model.PrivateResourceUser;
-import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.UpdateGcsBucketObjectReferenceRequestBody;
 import bio.terra.workspace.model.UpdateGcsBucketReferenceRequestBody;
 import com.google.cloud.storage.Blob;
@@ -235,12 +234,10 @@ public class GcsBucketUtils {
     var body =
         new CreateGcpGcsBucketReferenceRequestBody()
             .metadata(
-                new ReferenceResourceCommonFields()
-                    .cloningInstructions(
-                        Optional.ofNullable(cloningInstructions)
-                            .orElse(CloningInstructionsEnum.NOTHING))
-                    .description("Description of " + name)
-                    .name(name))
+                CommonResourceFieldsUtil.makeReferencedResourceCommonFields(
+                    name,
+                    Optional.ofNullable(cloningInstructions)
+                        .orElse(CloningInstructionsEnum.NOTHING)))
             .bucket(bucket);
 
     GcpGcsBucketResource result =

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -1,12 +1,13 @@
 package scripts.utils;
 
+import static scripts.utils.CommonResourceFieldsUtil.makeControlledResourceCommonFields;
+
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
-import bio.terra.workspace.model.ControlledResourceCommonFields;
 import bio.terra.workspace.model.CreateControlledGcpGcsBucketRequestBody;
 import bio.terra.workspace.model.CreateGcpGcsBucketReferenceRequestBody;
 import bio.terra.workspace.model.CreatedControlledGcpGcsBucket;
@@ -26,8 +27,6 @@ import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.ManagedBy;
 import bio.terra.workspace.model.PrivateResourceUser;
-import bio.terra.workspace.model.Properties;
-import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.UpdateGcsBucketObjectReferenceRequestBody;
 import bio.terra.workspace.model.UpdateGcsBucketReferenceRequestBody;
@@ -41,7 +40,6 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +77,6 @@ public class GcsBucketUtils {
               new GcpGcsBucketLifecycleRuleCondition()
                   .createdBefore(OffsetDateTime.parse("2007-01-03T00:00:00.00Z"))
                   .addMatchesStorageClassItem(GcpGcsBucketDefaultStorageClass.STANDARD));
-  public static Map<String, String> DEFAULT_PROPERTIES = Map.of("foo", "bar");
 
   @SuppressFBWarnings(
       value = "MS_MUTABLE_COLLECTION",
@@ -163,20 +160,12 @@ public class GcsBucketUtils {
       CloningInstructionsEnum cloningInstructions,
       @Nullable PrivateResourceUser privateUser)
       throws Exception {
-    Properties properties = new Properties();
 
     var body =
         new CreateControlledGcpGcsBucketRequestBody()
             .common(
-                new ControlledResourceCommonFields()
-                    .accessScope(accessScope)
-                    .managedBy(managedBy)
-                    .cloningInstructions(cloningInstructions)
-                    .description("Description of " + name)
-                    .name(name)
-                    .privateResourceUser(privateUser)
-                    // TODO.
-                    .properties()
+                makeControlledResourceCommonFields(
+                    name, privateUser, cloningInstructions, managedBy, accessScope))
             .gcsBucket(
                 new GcpGcsBucketCreationParameters()
                     .name(bucketName)

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -236,8 +236,7 @@ public class GcsBucketUtils {
             .metadata(
                 CommonResourceFieldsUtil.makeReferencedResourceCommonFields(
                     name,
-                    Optional.ofNullable(cloningInstructions)
-                        .orElse(CloningInstructionsEnum.NOTHING)))
+                    cloningInstructions))
             .bucket(bucket);
 
     GcpGcsBucketResource result =

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -39,7 +39,6 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -235,8 +234,7 @@ public class GcsBucketUtils {
         new CreateGcpGcsBucketReferenceRequestBody()
             .metadata(
                 CommonResourceFieldsUtil.makeReferencedResourceCommonFields(
-                    name,
-                    cloningInstructions))
+                    name, cloningInstructions))
             .bucket(bucket);
 
     GcpGcsBucketResource result =

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -26,6 +26,8 @@ import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.ManagedBy;
 import bio.terra.workspace.model.PrivateResourceUser;
+import bio.terra.workspace.model.Properties;
+import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.UpdateGcsBucketObjectReferenceRequestBody;
 import bio.terra.workspace.model.UpdateGcsBucketReferenceRequestBody;
@@ -39,6 +41,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -76,6 +79,7 @@ public class GcsBucketUtils {
               new GcpGcsBucketLifecycleRuleCondition()
                   .createdBefore(OffsetDateTime.parse("2007-01-03T00:00:00.00Z"))
                   .addMatchesStorageClassItem(GcpGcsBucketDefaultStorageClass.STANDARD));
+  public static Map<String, String> DEFAULT_PROPERTIES = Map.of("foo", "bar");
 
   @SuppressFBWarnings(
       value = "MS_MUTABLE_COLLECTION",
@@ -159,6 +163,8 @@ public class GcsBucketUtils {
       CloningInstructionsEnum cloningInstructions,
       @Nullable PrivateResourceUser privateUser)
       throws Exception {
+    Properties properties = new Properties();
+
     var body =
         new CreateControlledGcpGcsBucketRequestBody()
             .common(
@@ -168,7 +174,9 @@ public class GcsBucketUtils {
                     .cloningInstructions(cloningInstructions)
                     .description("Description of " + name)
                     .name(name)
-                    .privateResourceUser(privateUser))
+                    .privateResourceUser(privateUser)
+                    // TODO.
+                    .properties()
             .gcsBucket(
                 new GcpGcsBucketCreationParameters()
                     .name(bucketName)

--- a/integration/src/main/java/scripts/utils/GitRepoUtils.java
+++ b/integration/src/main/java/scripts/utils/GitRepoUtils.java
@@ -1,12 +1,13 @@
 package scripts.utils;
 
+import static scripts.utils.CommonResourceFieldsUtil.makeReferencedResourceCommonFields;
+
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.CreateGitRepoReferenceRequestBody;
 import bio.terra.workspace.model.GitRepoAttributes;
 import bio.terra.workspace.model.GitRepoResource;
-import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.UpdateGitRepoReferenceRequestBody;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -56,11 +57,7 @@ public class GitRepoUtils {
 
     CreateGitRepoReferenceRequestBody body =
         new CreateGitRepoReferenceRequestBody()
-            .metadata(
-                new ReferenceResourceCommonFields()
-                    .cloningInstructions(CloningInstructionsEnum.REFERENCE)
-                    .description("Description of " + name)
-                    .name(name))
+            .metadata(makeReferencedResourceCommonFields(name, CloningInstructionsEnum.REFERENCE))
             .gitrepo(new GitRepoAttributes().gitRepoUrl(attributes.getGitRepoUrl()));
     logger.info("Making git repo reference of {} with name {}", attributes.getGitRepoUrl(), name);
     return ClientTestUtils.getWithRetryOnException(

--- a/integration/src/main/java/scripts/utils/NotebookUtils.java
+++ b/integration/src/main/java/scripts/utils/NotebookUtils.java
@@ -1,13 +1,13 @@
 package scripts.utils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static scripts.utils.CommonResourceFieldsUtil.makeControlledResourceCommonFields;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
-import bio.terra.workspace.model.ControlledResourceCommonFields;
 import bio.terra.workspace.model.CreateControlledGcpAiNotebookInstanceRequestBody;
 import bio.terra.workspace.model.CreatedControlledGcpAiNotebookInstanceResult;
 import bio.terra.workspace.model.DeleteControlledGcpAiNotebookInstanceRequest;
@@ -69,12 +69,12 @@ public class NotebookUtils {
     }
 
     var commonParameters =
-        new ControlledResourceCommonFields()
-            .name(resourceName)
-            .cloningInstructions(CloningInstructionsEnum.NOTHING)
-            .accessScope(AccessScope.PRIVATE_ACCESS)
-            .managedBy(ManagedBy.USER)
-            .privateResourceUser(null);
+        makeControlledResourceCommonFields(
+            resourceName,
+            /*privateUser=*/ null,
+            CloningInstructionsEnum.NOTHING,
+            ManagedBy.USER,
+            AccessScope.PRIVATE_ACCESS);
 
     var body =
         new CreateControlledGcpAiNotebookInstanceRequestBody()

--- a/openapi/src/common/schemas.yaml
+++ b/openapi/src/common/schemas.yaml
@@ -85,6 +85,8 @@ components:
         resourceId:
           type: string
           format: uuid
+        properties:
+          $ref: '#/components/schemas/Properties'
   
     DeleteControlledAzureResourceRequest:
       type: object
@@ -202,6 +204,8 @@ components:
           $ref: "#/components/schemas/Name"
         description:
           type: string
+        properties:
+          $ref: '#/components/schemas/Properties'
         cloningInstructions:
           $ref: '#/components/schemas/CloningInstructionsEnum'
 

--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/utils/MapperUtils.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/utils/MapperUtils.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 
 public class MapperUtils {
 
-  public class LandingZoneMapper {
+  public static class LandingZoneMapper {
     private LandingZoneMapper() {}
 
     public static HashMap<String, String> landingZoneParametersFrom(
@@ -51,7 +51,7 @@ public class MapperUtils {
     }
   }
 
-  public class ErrorReportMapper {
+  public static class ErrorReportMapper {
     private ErrorReportMapper() {}
 
     public static ApiErrorReport from(ErrorReport errorReport) {
@@ -65,7 +65,7 @@ public class MapperUtils {
     }
   }
 
-  public class AzureCloudContextMapper {
+  public static class AzureCloudContextMapper {
     private AzureCloudContextMapper() {}
 
     public static LandingZoneTarget from(ApiLandingZoneTarget apiLandingZoneTarget) {

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledResourceControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledResourceControllerBase.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.app.controller;
 
+import bio.terra.workspace.app.controller.shared.PropertiesUtils;
 import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
@@ -55,6 +56,7 @@ public class ControlledResourceControllerBase extends ControllerBase {
         .accessScope(accessScopeType)
         .managedBy(managedBy)
         .applicationId(controlledResourceService.getAssociatedApp(managedBy, userRequest))
+        .properties(PropertiesUtils.convertApiPropertyToMap(apiCommonFields.getProperties()))
         .build();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -23,6 +23,7 @@ import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiGcpGcsObjectResource;
 import bio.terra.workspace.generated.model.ApiGitRepoResource;
+import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiTerraWorkspaceResource;
 import bio.terra.workspace.generated.model.ApiUpdateBigQueryDataTableReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiUpdateBigQueryDatasetReferenceRequestBody;
@@ -98,18 +99,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     // Construct a ReferenceGcsBucketResource object from the API input
     var resource =
         ReferencedGcsObjectResource.builder()
-            .wsmResourceFields(
-                WsmResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(UUID.randomUUID())
-                    .name(body.getMetadata().getName())
-                    .description(body.getMetadata().getDescription())
-                    .properties(
-                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
-                    .cloningInstructions(
-                        CloningInstructions.fromApiModel(
-                            body.getMetadata().getCloningInstructions()))
-                    .build())
+            .wsmResourceFields(getWsmResourceFields(workspaceUuid, body.getMetadata()))
             .bucketName(body.getFile().getBucketName())
             .objectName(body.getFile().getFileName())
             .build();
@@ -215,18 +205,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     // Construct a ReferenceGcsBucketResource object from the API input
     var resource =
         ReferencedGcsBucketResource.builder()
-            .wsmResourceFields(
-                WsmResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(UUID.randomUUID())
-                    .name(body.getMetadata().getName())
-                    .description(body.getMetadata().getDescription())
-                    .properties(
-                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
-                    .cloningInstructions(
-                        CloningInstructions.fromApiModel(
-                            body.getMetadata().getCloningInstructions()))
-                    .build())
+            .wsmResourceFields(getWsmResourceFields(workspaceUuid, body.getMetadata()))
             .bucketName(body.getBucket().getBucketName())
             .build();
 
@@ -322,18 +301,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
         userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
     var resource =
         ReferencedBigQueryDataTableResource.builder()
-            .wsmResourceFields(
-                WsmResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(UUID.randomUUID())
-                    .name(body.getMetadata().getName())
-                    .description(body.getMetadata().getDescription())
-                    .properties(
-                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
-                    .cloningInstructions(
-                        CloningInstructions.fromApiModel(
-                            body.getMetadata().getCloningInstructions()))
-                    .build())
+            .wsmResourceFields(getWsmResourceFields(workspaceUuid, body.getMetadata()))
             .projectId(body.getDataTable().getProjectId())
             .datasetId(body.getDataTable().getDatasetId())
             .dataTableId(body.getDataTable().getDataTableId())
@@ -446,18 +414,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     // Construct a ReferenceBigQueryResource object from the API input
     var resource =
         ReferencedBigQueryDatasetResource.builder()
-            .wsmResourceFields(
-                WsmResourceFields.builder()
-                    .workspaceUuid(uuid)
-                    .resourceId(UUID.randomUUID())
-                    .name(body.getMetadata().getName())
-                    .description(body.getMetadata().getDescription())
-                    .properties(
-                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
-                    .cloningInstructions(
-                        CloningInstructions.fromApiModel(
-                            body.getMetadata().getCloningInstructions()))
-                    .build())
+            .wsmResourceFields(getWsmResourceFields(uuid, body.getMetadata()))
             .projectId(body.getDataset().getProjectId())
             .datasetName(body.getDataset().getDatasetId())
             .build();
@@ -560,18 +517,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
 
     var resource =
         ReferencedDataRepoSnapshotResource.builder()
-            .wsmResourceFields(
-                WsmResourceFields.builder()
-                    .workspaceUuid(uuid)
-                    .resourceId(UUID.randomUUID())
-                    .name(body.getMetadata().getName())
-                    .description(body.getMetadata().getDescription())
-                    .properties(
-                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
-                    .cloningInstructions(
-                        CloningInstructions.fromApiModel(
-                            body.getMetadata().getCloningInstructions()))
-                    .build())
+            .wsmResourceFields(getWsmResourceFields(uuid, body.getMetadata()))
             .instanceName(body.getSnapshot().getInstanceName())
             .snapshotId(body.getSnapshot().getSnapshot())
             .build();
@@ -914,18 +860,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
         userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
     ReferencedGitRepoResource resource =
         ReferencedGitRepoResource.builder()
-            .wsmResourceFields(
-                WsmResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(UUID.randomUUID())
-                    .name(body.getMetadata().getName())
-                    .description(body.getMetadata().getDescription())
-                    .properties(
-                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
-                    .cloningInstructions(
-                        CloningInstructions.fromApiModel(
-                            body.getMetadata().getCloningInstructions()))
-                    .build())
+            .wsmResourceFields(getWsmResourceFields(workspaceUuid, body.getMetadata()))
             .gitRepoUrl(body.getGitrepo().getGitRepoUrl())
             .build();
 
@@ -1073,18 +1008,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     // Construct a ReferencedTerraWorkspaceResource object from the API input
     ReferencedTerraWorkspaceResource resource =
         ReferencedTerraWorkspaceResource.builder()
-            .resourceCommonFields(
-                WsmResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(UUID.randomUUID())
-                    .name(body.getMetadata().getName())
-                    .description(body.getMetadata().getDescription())
-                    .properties(
-                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
-                    .cloningInstructions(
-                        CloningInstructions.fromApiModel(
-                            body.getMetadata().getCloningInstructions()))
-                    .build())
+            .resourceCommonFields(getWsmResourceFields(workspaceUuid, body.getMetadata()))
             .referencedWorkspaceId(referencedWorkspaceId)
             .build();
 
@@ -1129,5 +1053,17 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
     referenceResourceService.deleteReferenceResourceForResourceType(
         workspaceUuid, resourceId, WsmResourceType.REFERENCED_ANY_TERRA_WORKSPACE, userRequest);
     return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  private static WsmResourceFields getWsmResourceFields(
+      UUID uuid, ApiReferenceResourceCommonFields metadata) {
+    return WsmResourceFields.builder()
+        .workspaceUuid(uuid)
+        .resourceId(UUID.randomUUID())
+        .name(metadata.getName())
+        .description(metadata.getDescription())
+        .properties(PropertiesUtils.convertApiPropertyToMap(metadata.getProperties()))
+        .cloningInstructions(CloningInstructions.fromApiModel(metadata.getCloningInstructions()))
+        .build();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -1056,9 +1056,9 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   private static WsmResourceFields getWsmResourceFields(
-      UUID uuid, ApiReferenceResourceCommonFields metadata) {
+      UUID workspaceUuid, ApiReferenceResourceCommonFields metadata) {
     return WsmResourceFields.builder()
-        .workspaceUuid(uuid)
+        .workspaceUuid(workspaceUuid)
         .resourceId(UUID.randomUUID())
         .name(metadata.getName())
         .description(metadata.getDescription())

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.app.controller;
 
+import bio.terra.workspace.app.controller.shared.PropertiesUtils;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.generated.controller.ReferencedGcpResourceApi;
 import bio.terra.workspace.generated.model.ApiCloneReferencedGcpBigQueryDataTableResourceResult;
@@ -103,6 +104,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
+                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -218,6 +220,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
+                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -323,6 +326,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
+                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -445,6 +449,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
+                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -557,6 +562,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
+                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -909,6 +915,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
+                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -1066,6 +1073,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
+                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -104,7 +104,8 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
-                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
+                    .properties(
+                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -220,7 +221,8 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
-                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
+                    .properties(
+                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -326,7 +328,8 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
-                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
+                    .properties(
+                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -449,7 +452,8 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
-                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
+                    .properties(
+                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -562,7 +566,8 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
-                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
+                    .properties(
+                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -915,7 +920,8 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
-                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
+                    .properties(
+                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))
@@ -1073,7 +1079,8 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
                     .resourceId(UUID.randomUUID())
                     .name(body.getMetadata().getName())
                     .description(body.getMetadata().getDescription())
-                    .properties(PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
+                    .properties(
+                        PropertiesUtils.convertApiPropertyToMap(body.getMetadata().getProperties()))
                     .cloningInstructions(
                         CloningInstructions.fromApiModel(
                             body.getMetadata().getCloningInstructions()))

--- a/service/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/service/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -128,8 +128,6 @@ public class JobService {
       String jobId) {
     submit(flightClass, parameterMap, jobId);
     waitForJob(jobId);
-    AuthenticatedUserRequest userRequest =
-        parameterMap.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
     JobResultOrException<T> resultOrException = retrieveJobResult(jobId, resultClass);
     if (resultOrException.getException() != null) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -8,7 +8,6 @@ import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.common.base.Preconditions;
 import java.util.UUID;
-import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,7 +63,7 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
    * In addition, bucket names cannot begin with the "goog" prefix. For details, see
    * https://cloud.google.com/storage/docs/naming-buckets.
    */
-  public String generateCloudName(@Nullable UUID workspaceUuid, String bucketName) {
+  public String generateCloudName(UUID workspaceUuid, String bucketName) {
     Preconditions.checkNotNull(workspaceUuid);
 
     String projectId = gcpCloudContextService.getRequiredGcpProject(workspaceUuid);

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/ResourceLineageEntry.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/ResourceLineageEntry.java
@@ -52,4 +52,10 @@ public class ResourceLineageEntry {
     return sourceWorkspaceId.equals(entry.sourceWorkspaceId)
         && sourceResourceId.equals(entry.sourceResourceId);
   }
+
+  @Override
+  public int hashCode() {
+    assert false : "hashCode not designed";
+    return 42; // any arbitrary constant will do
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/datareposnapshot/ReferencedDataRepoSnapshotResource.java
@@ -191,7 +191,6 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
     }
 
     public ReferencedDataRepoSnapshotResource build() {
-      // On the create path, we can omit the resourceId and have it filled in by the builder.
       return new ReferencedDataRepoSnapshotResource(this);
     }
   }

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
@@ -1,9 +1,9 @@
 package bio.terra.workspace.app.configuration.external.controller;
 
 import static bio.terra.workspace.common.utils.MockMvcUtils.createBigQueryDataset;
+import static bio.terra.workspace.common.utils.MockMvcUtils.createGcsBucket;
 import static bio.terra.workspace.common.utils.MockMvcUtils.deleteWorkspace;
 import static bio.terra.workspace.common.utils.MockMvcUtils.getBigQueryDataset;
-import static bio.terra.workspace.common.utils.MockMvcUtils.createGcsBucket;
 import static bio.terra.workspace.common.utils.MockMvcUtils.getGcsBucket;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -52,7 +52,13 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
         createBigQueryDataset(
             mockMvc, objectMapper, workspaceId, userAccessUtils.defaultUserAuthRequest());
 
-    ApiGcpBigQueryDatasetResource retrievedResource = getBigQueryDataset(mockMvc, objectMapper, workspaceId, resource.getResourceId(),  userAccessUtils.defaultUserAuthRequest());
+    ApiGcpBigQueryDatasetResource retrievedResource =
+        getBigQueryDataset(
+            mockMvc,
+            objectMapper,
+            workspaceId,
+            resource.getResourceId(),
+            userAccessUtils.defaultUserAuthRequest());
 
     assertEquals(resource.getBigQueryDataset(), retrievedResource);
   }
@@ -63,7 +69,13 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
         createGcsBucket(
             mockMvc, objectMapper, workspaceId, userAccessUtils.defaultUserAuthRequest());
 
-    ApiGcpGcsBucketResource retrievedResource = getGcsBucket(mockMvc, objectMapper, workspaceId, resource.getResourceId(),  userAccessUtils.defaultUserAuthRequest());
+    ApiGcpGcsBucketResource retrievedResource =
+        getGcsBucket(
+            mockMvc,
+            objectMapper,
+            workspaceId,
+            resource.getResourceId(),
+            userAccessUtils.defaultUserAuthRequest());
 
     assertEquals(resource.getGcpBucket(), retrievedResource);
   }

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
@@ -1,0 +1,2 @@
+package bio.terra.workspace.app.configuration.external.controller;public class ControlledGcpResourceApiControllerConnectedTest {
+}

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
@@ -24,6 +24,7 @@ import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
+import bio.terra.workspace.generated.model.ApiResourceMetadata;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -75,10 +76,18 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
         mockMvcUtils.createBigQueryDataset(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId());
 
-    ApiGcpBigQueryDatasetResource retrievedResource =
+    ApiGcpBigQueryDatasetResource actualBqDataset =
         mockMvcUtils.getBigQueryDataset(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId(), bqDataset.getResourceId());
-    assertEquals(bqDataset.getBigQueryDataset(), retrievedResource);
+    ApiGcpBigQueryDatasetResource expectedBqDataset = bqDataset.getBigQueryDataset();
+
+    assertResourceMetadata(expectedBqDataset.getMetadata(), actualBqDataset.getMetadata());
+    assertEquals(
+        expectedBqDataset.getAttributes().getDatasetId(),
+        actualBqDataset.getAttributes().getDatasetId());
+    assertEquals(
+        expectedBqDataset.getAttributes().getProjectId(),
+        actualBqDataset.getAttributes().getProjectId());
   }
 
   @Test
@@ -88,7 +97,12 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
             userAccessUtils.defaultUserAuthRequest(),
             workspace.getId(),
             originalControlledBucket.getResourceId());
-    assertEquals(originalControlledBucket.getGcpBucket(), retrievedResource);
+    ApiGcpGcsBucketResource expectedBucket = originalControlledBucket.getGcpBucket();
+
+    assertResourceMetadata(expectedBucket.getMetadata(), retrievedResource.getMetadata());
+    assertEquals(
+        expectedBucket.getAttributes().getBucketName(),
+        retrievedResource.getAttributes().getBucketName());
   }
 
   @Test
@@ -225,5 +239,16 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
       String expectedBucketName) {
     assertEquals(expectedStewardshipType, actualBucket.getMetadata().getStewardshipType());
     assertEquals(expectedBucketName, actualBucket.getAttributes().getBucketName());
+  }
+
+  private static void assertResourceMetadata(
+      ApiResourceMetadata expectedMetadata, ApiResourceMetadata actualMetadata) {
+    assertEquals(expectedMetadata.getName(), actualMetadata.getName());
+    assertEquals(expectedMetadata.getDescription(), actualMetadata.getDescription());
+    assertEquals(
+        expectedMetadata.getCloningInstructions(), actualMetadata.getCloningInstructions());
+    assertEquals(expectedMetadata.getStewardshipType(), actualMetadata.getStewardshipType());
+    assertEquals(expectedMetadata.getResourceType(), actualMetadata.getResourceType());
+    assertEquals(expectedMetadata.getProperties(), actualMetadata.getProperties());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
@@ -2,8 +2,6 @@ package bio.terra.workspace.app.configuration.external.controller;
 
 import static bio.terra.workspace.common.utils.MockMvcUtils.CLONE_CONTROLLED_GCP_GCS_BUCKET_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKET_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CONTROLLED_GCP_GCS_BUCKET_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.GET_CONTROLLED_GCP_GCS_BUCKET_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,20 +15,15 @@ import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
-import bio.terra.workspace.generated.model.ApiAccessScope;
 import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketRequest;
 import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketResult;
 import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
-import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
-import bio.terra.workspace.generated.model.ApiCreateControlledGcpGcsBucketRequestBody;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpBigQueryDataset;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
-import bio.terra.workspace.generated.model.ApiManagedBy;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -67,7 +60,8 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
   public void setup() throws Exception {
     workspace =
         mockMvcUtils.createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest());
-    originalControlledBucket = createControlledGcsBucket();
+    originalControlledBucket =
+        mockMvcUtils.createGcsBucket(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
   }
 
   @AfterAll
@@ -76,17 +70,25 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
   }
 
   @Test
-  public void createControlledBigQueryDataset() throws Exception {
+  public void createControlledBigQueryDataset_createdResourceEqualsGotResource() throws Exception {
+    ApiCreatedControlledGcpBigQueryDataset bqDataset =
+        mockMvcUtils.createBigQueryDataset(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
 
     ApiGcpBigQueryDatasetResource retrievedResource =
-        getBigQueryDataset(
-            mockMvc,
-            objectMapper,
-            workspaceId,
-            resource.getResourceId(),
-            userAccessUtils.defaultUserAuthRequest());
+        mockMvcUtils.getBigQueryDataset(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId(), bqDataset.getResourceId());
+    assertEquals(bqDataset.getBigQueryDataset(), retrievedResource);
+  }
 
-    assertEquals(originalControlledBucket.getBigQueryDataset(), retrievedResource);
+  @Test
+  public void createControlledGcsBucket_createdResourceEqualsGotResource() throws Exception {
+    ApiGcpGcsBucketResource retrievedResource =
+        mockMvcUtils.getGcsBucket(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspace.getId(),
+            originalControlledBucket.getResourceId());
+    assertEquals(originalControlledBucket.getGcpBucket(), retrievedResource);
   }
 
   @Test
@@ -118,7 +120,10 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
 
     // Assert bucket returned by calling ControlledGcpResource.getBucket
     ApiGcpGcsBucketResource gotBucket =
-        getControlledGcsBucket(workspace.getId(), cloneResultBucket.getMetadata().getResourceId());
+        mockMvcUtils.getGcsBucket(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspace.getId(),
+            cloneResultBucket.getMetadata().getResourceId());
     assertBucket(gotBucket, ApiStewardshipType.CONTROLLED, cloneBucketName);
   }
 
@@ -139,65 +144,11 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
 
     // Assert bucket returned by calling ControlledGcpResource.getBucket
     ApiGcpGcsBucketResource gotBucket =
-        getControlledGcsBucket(workspace.getId(), cloneResultBucket.getMetadata().getResourceId());
+        mockMvcUtils.getGcsBucket(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspace.getId(),
+            cloneResultBucket.getMetadata().getResourceId());
     assertBucket(gotBucket, ApiStewardshipType.REFERENCED, cloneBucketName);
-  }
-
-  private ApiCreatedControlledGcpGcsBucket createControlledGcsBucket() throws Exception {
-    ApiCreateControlledGcpGcsBucketRequestBody request =
-        new ApiCreateControlledGcpGcsBucketRequestBody()
-            .common(
-                new ApiControlledResourceCommonFields()
-                    .name("original-controlled-bucket")
-                    .cloningInstructions(ApiCloningInstructionsEnum.NOTHING)
-                    .accessScope(ApiAccessScope.PRIVATE_ACCESS)
-                    .managedBy(ApiManagedBy.USER))
-            .gcsBucket(new ApiGcpGcsBucketCreationParameters());
-    String serializedResponse =
-        mockMvc
-            .perform(
-                addJsonContentType(
-                    addAuth(
-                        post(CREATE_CONTROLLED_GCP_GCS_BUCKET_FORMAT.formatted(
-                                workspace.getId().toString()))
-                            .content(objectMapper.writeValueAsString(request)),
-                        userAccessUtils.defaultUserAuthRequest())))
-            .andExpect(status().is(HttpStatus.SC_OK))
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-    return objectMapper.readValue(serializedResponse, ApiCreatedControlledGcpGcsBucket.class);
-  }
-
-  private ApiGcpGcsBucketResource getControlledGcsBucket(UUID workspaceId, UUID resourceId)
-      throws Exception {
-    String serializedResponse =
-        mockMvc
-            .perform(
-                addJsonContentType(
-                    addAuth(
-                        get(
-                            GET_CONTROLLED_GCP_GCS_BUCKET_FORMAT.formatted(
-                                workspaceId.toString(), resourceId.toString())),
-                        userAccessUtils.defaultUserAuthRequest())))
-            .andExpect(status().is(HttpStatus.SC_OK))
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-    return objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);
-  }
-
-  private void getControlledGcsBucketExpectingError(
-      UUID workspaceId, UUID resourceId, int expectedStatusCode) throws Exception {
-    mockMvc
-        .perform(
-            addJsonContentType(
-                addAuth(
-                    get(
-                        GET_CONTROLLED_GCP_GCS_BUCKET_FORMAT.formatted(
-                            workspaceId.toString(), resourceId.toString())),
-                    userAccessUtils.defaultUserAuthRequest())))
-        .andExpect(status().is(expectedStatusCode));
   }
 
   /** Clones controlled bucket and waits for flight to finish. */

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
@@ -1,2 +1,70 @@
-package bio.terra.workspace.app.configuration.external.controller;public class ControlledGcpResourceApiControllerConnectedTest {
+package bio.terra.workspace.app.configuration.external.controller;
+
+import static bio.terra.workspace.common.utils.MockMvcUtils.createBigQueryDataset;
+import static bio.terra.workspace.common.utils.MockMvcUtils.deleteWorkspace;
+import static bio.terra.workspace.common.utils.MockMvcUtils.getBigQueryDataset;
+import static bio.terra.workspace.common.utils.MockMvcUtils.createGcsBucket;
+import static bio.terra.workspace.common.utils.MockMvcUtils.getGcsBucket;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.workspace.common.BaseConnectedTest;
+import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
+import bio.terra.workspace.generated.model.ApiCreatedControlledGcpBigQueryDataset;
+import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnectedTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired UserAccessUtils userAccessUtils;
+  @Autowired WorkspaceConnectedTestUtils connectedTestUtils;
+
+  private UUID workspaceId;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    workspaceId =
+        connectedTestUtils
+            .createWorkspaceWithGcpContext(userAccessUtils.defaultUserAuthRequest())
+            .getWorkspaceId();
+  }
+
+  @AfterEach
+  public void cleanup() throws Exception {
+    deleteWorkspace(workspaceId, mockMvc, userAccessUtils.defaultUserAuthRequest());
+  }
+
+  @Test
+  public void createControlledBigQueryDataset() throws Exception {
+    ApiCreatedControlledGcpBigQueryDataset resource =
+        createBigQueryDataset(
+            mockMvc, objectMapper, workspaceId, userAccessUtils.defaultUserAuthRequest());
+
+    ApiGcpBigQueryDatasetResource retrievedResource = getBigQueryDataset(mockMvc, objectMapper, workspaceId, resource.getResourceId(),  userAccessUtils.defaultUserAuthRequest());
+
+    assertEquals(resource.getBigQueryDataset(), retrievedResource);
+  }
+
+  @Test
+  public void createControlledGcsBucket() throws Exception {
+    ApiCreatedControlledGcpGcsBucket resource =
+        createGcsBucket(
+            mockMvc, objectMapper, workspaceId, userAccessUtils.defaultUserAuthRequest());
+
+    ApiGcpGcsBucketResource retrievedResource = getGcsBucket(mockMvc, objectMapper, workspaceId, resource.getResourceId(),  userAccessUtils.defaultUserAuthRequest());
+
+    assertEquals(resource.getGcpBucket(), retrievedResource);
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
@@ -14,7 +14,6 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_O
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GIT_REPO_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
-import static bio.terra.workspace.common.utils.MockMvcUtils.createWorkspace;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -22,6 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDataTableReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDatasetReferenceRequestBody;
@@ -37,7 +37,9 @@ import bio.terra.workspace.generated.model.ApiGitRepoResource;
 import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiResourceMetadata;
 import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
@@ -53,6 +55,7 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Autowired MockMvc mockMvc;
+  @Autowired MockMvcUtils mockMvcUtils;
   @Autowired ObjectMapper objectMapper;
 
   @MockBean SamService mockSamService;
@@ -67,144 +70,193 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
             new UserStatusInfo()
                 .userEmail(USER_REQUEST.getEmail())
                 .userSubjectId(USER_REQUEST.getSubjectId()));
+    // Needed for assertion that requester has role on workspace.
+    when(mockSamService.listRequesterRoles(any(), any(), any()))
+        .thenReturn(List.of(WsmIamRole.OWNER));
   }
 
   @Test
-  public void createDataRepoReferencedResource() throws Exception {
-    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
+  public void createReferencedDataRepoResource_commonFieldsAndAttributesCorrectlyPopulated()
+      throws Exception {
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiCreateDataRepoSnapshotReferenceRequestBody requestBody =
         makeDataRepoSnapshotReferenceRequestBody();
+
+    ApiDataRepoSnapshotResource createdResource =
+        createReferencedDataRepoSnapshotResource(workspaceId, requestBody);
+
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), createdResource.getMetadata());
+    assertEquals(
+        requestBody.getSnapshot().getSnapshot(), createdResource.getAttributes().getSnapshot());
+    assertEquals(
+        requestBody.getSnapshot().getInstanceName(),
+        createdResource.getAttributes().getInstanceName());
+  }
+
+  @Test
+  public void createReferencedGcsBucketResource_commonFieldsAndAttributesCorrectlyPopulated()
+      throws Exception {
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    ApiCreateGcpGcsBucketReferenceRequestBody requestBody = makeGcsBucketReferenceRequestBody();
+
+    ApiGcpGcsBucketResource createdResource =
+        createReferencedGcsBucketResource(workspaceId, requestBody);
+
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), createdResource.getMetadata());
+    assertEquals(
+        requestBody.getBucket().getBucketName(), createdResource.getAttributes().getBucketName());
+  }
+
+  @Test
+  public void createReferencedGcsObjectResource_commonFieldsAndAttributesCorrectlyPopulated()
+      throws Exception {
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    ApiCreateGcpGcsObjectReferenceRequestBody requestBody = makeGcsObjectReferenceRequestBody();
+
+    ApiGcpGcsObjectResource createdResource =
+        createReferencedGcsObjectResource(workspaceId, requestBody);
+
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), createdResource.getMetadata());
+    assertEquals(
+        requestBody.getFile().getBucketName(), createdResource.getAttributes().getBucketName());
+    assertEquals(
+        requestBody.getFile().getFileName(), createdResource.getAttributes().getFileName());
+  }
+
+  @Test
+  public void createReferencedBqDatasetResource_commonFieldsAndAttributesCorrectlyPopulated()
+      throws Exception {
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    ApiCreateGcpBigQueryDatasetReferenceRequestBody requestBody =
+        makeGcpBqDatasetReferenceRequestBody();
+
+    ApiGcpBigQueryDatasetResource createdResource =
+        createReferencedBigQueryDatasetResource(workspaceId, requestBody);
+
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), createdResource.getMetadata());
+    assertEquals(
+        requestBody.getDataset().getDatasetId(), createdResource.getAttributes().getDatasetId());
+    assertEquals(
+        requestBody.getDataset().getProjectId(), createdResource.getAttributes().getProjectId());
+  }
+
+  @Test
+  public void createReferencedBqDatatableResource_commonFieldsAndAttributesCorrectlyPopulated()
+      throws Exception {
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    ApiCreateGcpBigQueryDataTableReferenceRequestBody requestBody =
+        makeBqDataTableReferenceRequestBody();
+
+    ApiGcpBigQueryDataTableResource createdResource =
+        createReferencedBigQueryDataTableResource(workspaceId, requestBody);
+
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), createdResource.getMetadata());
+    assertEquals(
+        requestBody.getDataTable().getDataTableId(),
+        createdResource.getAttributes().getDataTableId());
+    assertEquals(
+        requestBody.getDataTable().getDatasetId(), createdResource.getAttributes().getDatasetId());
+    assertEquals(
+        requestBody.getDataTable().getProjectId(), createdResource.getAttributes().getProjectId());
+  }
+
+  @Test
+  public void createReferencedGitRepoResource_commonFieldsAndAttributesCorrectlyPopulated()
+      throws Exception {
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    ApiCreateGitRepoReferenceRequestBody requestBody = makeGitRepoReferenceRequestBody();
+
+    ApiGitRepoResource createdResource = createReferencedGitRepoResource(workspaceId, requestBody);
+
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), createdResource.getMetadata());
+    assertEquals(
+        requestBody.getGitrepo().getGitRepoUrl(), createdResource.getAttributes().getGitRepoUrl());
+  }
+
+  public ApiDataRepoSnapshotResource createReferencedDataRepoSnapshotResource(
+      UUID workspaceId, ApiCreateDataRepoSnapshotReferenceRequestBody requestBody)
+      throws Exception {
     var request = objectMapper.writeValueAsString(requestBody);
 
     String serializedResponse =
         createReferencedResourceAndGetSerializedResponse(
             workspaceId, request, REFERENCED_DATA_REPO_SNAPSHOTS_V1_PATH_FORMAT);
 
-    var retrievedResource =
-        objectMapper.readValue(serializedResponse, ApiDataRepoSnapshotResource.class);
-    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
-    assertEquals(
-        requestBody.getSnapshot().getSnapshot(), retrievedResource.getAttributes().getSnapshot());
-    assertEquals(
-        requestBody.getSnapshot().getInstanceName(),
-        retrievedResource.getAttributes().getInstanceName());
+    return objectMapper.readValue(serializedResponse, ApiDataRepoSnapshotResource.class);
   }
 
-  @Test
-  public void createGcsBucketReferencedResource() throws Exception {
-    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
-    ApiCreateGcpGcsBucketReferenceRequestBody requestBody = makeGcsBucketReferenceRequestBody();
+  private ApiGcpGcsBucketResource createReferencedGcsBucketResource(
+      UUID workspaceId, ApiCreateGcpGcsBucketReferenceRequestBody requestBody) throws Exception {
     var request = objectMapper.writeValueAsString(requestBody);
 
     String serializedResponse =
         createReferencedResourceAndGetSerializedResponse(
             workspaceId, request, REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT);
 
-    var retrievedResource =
-        objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);
-    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
-    assertEquals(
-        requestBody.getBucket().getBucketName(), retrievedResource.getAttributes().getBucketName());
+    return objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);
   }
 
-  @Test
-  public void createGcsObjectReferencedResource() throws Exception {
-    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
-    ApiCreateGcpGcsObjectReferenceRequestBody requestBody = makeGcsObjectReferenceRequestBody();
+  private ApiGcpGcsObjectResource createReferencedGcsObjectResource(
+      UUID workspaceId, ApiCreateGcpGcsObjectReferenceRequestBody requestBody) throws Exception {
     var request = objectMapper.writeValueAsString(requestBody);
 
     String serializedResponse =
         createReferencedResourceAndGetSerializedResponse(
             workspaceId, request, REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT);
 
-    var retrievedResource =
-        objectMapper.readValue(serializedResponse, ApiGcpGcsObjectResource.class);
-    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
-    assertEquals(
-        requestBody.getFile().getBucketName(), retrievedResource.getAttributes().getBucketName());
-    assertEquals(
-        requestBody.getFile().getFileName(), retrievedResource.getAttributes().getFileName());
+    return objectMapper.readValue(serializedResponse, ApiGcpGcsObjectResource.class);
   }
 
-  @Test
-  public void createBqDatasetReferencedResource() throws Exception {
-    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
-    ApiCreateGcpBigQueryDatasetReferenceRequestBody requestBody =
-        makeGcpBqDatasetReferenceRequestBody();
+  private ApiGcpBigQueryDatasetResource createReferencedBigQueryDatasetResource(
+      UUID workspaceId, ApiCreateGcpBigQueryDatasetReferenceRequestBody requestBody)
+      throws Exception {
     var request = objectMapper.writeValueAsString(requestBody);
 
     String serializedResponse =
         createReferencedResourceAndGetSerializedResponse(
             workspaceId, request, REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT);
 
-    var retrievedResource =
-        objectMapper.readValue(serializedResponse, ApiGcpBigQueryDatasetResource.class);
-    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
-    assertEquals(
-        requestBody.getDataset().getDatasetId(), retrievedResource.getAttributes().getDatasetId());
-    assertEquals(
-        requestBody.getDataset().getProjectId(), retrievedResource.getAttributes().getProjectId());
+    return objectMapper.readValue(serializedResponse, ApiGcpBigQueryDatasetResource.class);
   }
 
-  @Test
-  public void createBqDatatableReferencedResource() throws Exception {
-    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
-    ApiCreateGcpBigQueryDataTableReferenceRequestBody requestBody =
-        makeBqDataTableReferenceRequestBody();
+  private ApiGcpBigQueryDataTableResource createReferencedBigQueryDataTableResource(
+      UUID workspaceId, ApiCreateGcpBigQueryDataTableReferenceRequestBody requestBody)
+      throws Exception {
     var request = objectMapper.writeValueAsString(requestBody);
 
     String serializedResponse =
         createReferencedResourceAndGetSerializedResponse(
             workspaceId, request, REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT);
 
-    var retrievedResource =
-        objectMapper.readValue(serializedResponse, ApiGcpBigQueryDataTableResource.class);
-    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
-    assertEquals(
-        requestBody.getDataTable().getDataTableId(),
-        retrievedResource.getAttributes().getDataTableId());
-    assertEquals(
-        requestBody.getDataTable().getDatasetId(),
-        retrievedResource.getAttributes().getDatasetId());
-    assertEquals(
-        requestBody.getDataTable().getProjectId(),
-        retrievedResource.getAttributes().getProjectId());
+    return objectMapper.readValue(serializedResponse, ApiGcpBigQueryDataTableResource.class);
   }
 
-  @Test
-  public void createGitRepoReferencedResource() throws Exception {
-    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
-    ApiCreateGitRepoReferenceRequestBody requestBody = makeGitRepoReferenceRequestBody();
+  private ApiGitRepoResource createReferencedGitRepoResource(
+      UUID workspaceId, ApiCreateGitRepoReferenceRequestBody requestBody) throws Exception {
     var request = objectMapper.writeValueAsString(requestBody);
 
     String serializedResponse =
         createReferencedResourceAndGetSerializedResponse(
             workspaceId, request, REFERENCED_GIT_REPO_V1_PATH_FORMAT);
 
-    var retrievedResource = objectMapper.readValue(serializedResponse, ApiGitRepoResource.class);
-    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
-    assertEquals(
-        requestBody.getGitrepo().getGitRepoUrl(),
-        retrievedResource.getAttributes().getGitRepoUrl());
+    return objectMapper.readValue(serializedResponse, ApiGitRepoResource.class);
   }
 
   private String createReferencedResourceAndGetSerializedResponse(
       UUID workspaceId, String request, String apiFormat) throws Exception {
-    String serializedResponse =
-        mockMvc
-            .perform(
-                addAuth(
-                    post(String.format(apiFormat, workspaceId.toString()))
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .characterEncoding("UTF-8")
-                        .content(request),
-                    USER_REQUEST))
-            .andExpect(status().is(HttpStatus.SC_OK))
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-    return serializedResponse;
+    return mockMvc
+        .perform(
+            addAuth(
+                post(String.format(apiFormat, workspaceId.toString()))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .content(request),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK))
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
   }
 
   private void assertReferenceResourceCommonFields(

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
@@ -1,17 +1,53 @@
 package bio.terra.workspace.app.configuration.external.controller;
 
+import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeBqDataTableReferenceRequestBody;
+import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeDataRepoSnapshotReferenceRequestBody;
+import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeGcpBqDatasetReferenceRequestBody;
+import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeGcsBucketReferenceRequestBody;
+import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeGcsObjectReferenceRequestBody;
+import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeGitRepoReferenceRequestBody;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_DATA_REPO_SNAPSHOTS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GIT_REPO_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
+import static bio.terra.workspace.common.utils.MockMvcUtils.createWorkspace;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDataTableReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDatasetReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpGcsBucketReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpGcsObjectReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGitRepoReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableResource;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
+import bio.terra.workspace.generated.model.ApiGcpGcsObjectResource;
+import bio.terra.workspace.generated.model.ApiGitRepoResource;
+import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
+import bio.terra.workspace.generated.model.ApiResourceMetadata;
 import bio.terra.workspace.service.iam.SamService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
@@ -34,5 +70,150 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
                 .userSubjectId(USER_REQUEST.getSubjectId()));
   }
 
+  @Test
+  public void createDataRepoReferencedResource() throws Exception {
+    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
+    ApiCreateDataRepoSnapshotReferenceRequestBody requestBody =
+        makeDataRepoSnapshotReferenceRequestBody();
+    var request = objectMapper.writeValueAsString(requestBody);
 
+    String serializedResponse =
+        createReferencedResourceAndGetSerializedResponse(
+            workspaceId, request, REFERENCED_DATA_REPO_SNAPSHOTS_V1_PATH_FORMAT);
+
+    var retrievedResource =
+        objectMapper.readValue(serializedResponse, ApiDataRepoSnapshotResource.class);
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
+    assertEquals(
+        requestBody.getSnapshot().getSnapshot(), retrievedResource.getAttributes().getSnapshot());
+    assertEquals(
+        requestBody.getSnapshot().getInstanceName(),
+        retrievedResource.getAttributes().getInstanceName());
+  }
+
+  @Test
+  public void createGcsBucketReferencedResource() throws Exception {
+    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
+    ApiCreateGcpGcsBucketReferenceRequestBody requestBody = makeGcsBucketReferenceRequestBody();
+    var request = objectMapper.writeValueAsString(requestBody);
+
+    String serializedResponse =
+        createReferencedResourceAndGetSerializedResponse(
+            workspaceId, request, REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT);
+
+    var retrievedResource =
+        objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
+    assertEquals(
+        requestBody.getBucket().getBucketName(), retrievedResource.getAttributes().getBucketName());
+  }
+
+  @Test
+  public void createGcsObjectReferencedResource() throws Exception {
+    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
+    ApiCreateGcpGcsObjectReferenceRequestBody requestBody = makeGcsObjectReferenceRequestBody();
+    var request = objectMapper.writeValueAsString(requestBody);
+
+    String serializedResponse =
+        createReferencedResourceAndGetSerializedResponse(
+            workspaceId, request, REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT);
+
+    var retrievedResource =
+        objectMapper.readValue(serializedResponse, ApiGcpGcsObjectResource.class);
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
+    assertEquals(
+        requestBody.getFile().getBucketName(), retrievedResource.getAttributes().getBucketName());
+    assertEquals(
+        requestBody.getFile().getFileName(), retrievedResource.getAttributes().getFileName());
+  }
+
+  @Test
+  public void createBqDatasetReferencedResource() throws Exception {
+    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
+    ApiCreateGcpBigQueryDatasetReferenceRequestBody requestBody =
+        makeGcpBqDatasetReferenceRequestBody();
+    var request = objectMapper.writeValueAsString(requestBody);
+
+    String serializedResponse =
+        createReferencedResourceAndGetSerializedResponse(
+            workspaceId, request, REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT);
+
+    var retrievedResource =
+        objectMapper.readValue(serializedResponse, ApiGcpBigQueryDatasetResource.class);
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
+    assertEquals(
+        requestBody.getDataset().getDatasetId(), retrievedResource.getAttributes().getDatasetId());
+    assertEquals(
+        requestBody.getDataset().getProjectId(), retrievedResource.getAttributes().getProjectId());
+  }
+
+  @Test
+  public void createBqDatatableReferencedResource() throws Exception {
+    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
+    ApiCreateGcpBigQueryDataTableReferenceRequestBody requestBody =
+        makeBqDataTableReferenceRequestBody();
+    var request = objectMapper.writeValueAsString(requestBody);
+
+    String serializedResponse =
+        createReferencedResourceAndGetSerializedResponse(
+            workspaceId, request, REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT);
+
+    var retrievedResource =
+        objectMapper.readValue(serializedResponse, ApiGcpBigQueryDataTableResource.class);
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
+    assertEquals(
+        requestBody.getDataTable().getDataTableId(),
+        retrievedResource.getAttributes().getDataTableId());
+    assertEquals(
+        requestBody.getDataTable().getDatasetId(),
+        retrievedResource.getAttributes().getDatasetId());
+    assertEquals(
+        requestBody.getDataTable().getProjectId(),
+        retrievedResource.getAttributes().getProjectId());
+  }
+
+  @Test
+  public void createGitRepoReferencedResource() throws Exception {
+    UUID workspaceId = createWorkspace(mockMvc, objectMapper).getId();
+    ApiCreateGitRepoReferenceRequestBody requestBody = makeGitRepoReferenceRequestBody();
+    var request = objectMapper.writeValueAsString(requestBody);
+
+    String serializedResponse =
+        createReferencedResourceAndGetSerializedResponse(
+            workspaceId, request, REFERENCED_GIT_REPO_V1_PATH_FORMAT);
+
+    var retrievedResource = objectMapper.readValue(serializedResponse, ApiGitRepoResource.class);
+    assertReferenceResourceCommonFields(requestBody.getMetadata(), retrievedResource.getMetadata());
+    assertEquals(
+        requestBody.getGitrepo().getGitRepoUrl(),
+        retrievedResource.getAttributes().getGitRepoUrl());
+  }
+
+  @NotNull
+  private String createReferencedResourceAndGetSerializedResponse(
+      UUID workspaceId, String request, String apiFormat) throws Exception {
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addAuth(
+                    post(String.format(apiFormat, workspaceId.toString()))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8")
+                        .content(request),
+                    USER_REQUEST))
+            .andExpect(status().is(HttpStatus.SC_OK))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return serializedResponse;
+  }
+
+  private void assertReferenceResourceCommonFields(
+      ApiReferenceResourceCommonFields expectedFields, ApiResourceMetadata resourceFields) {
+    assertEquals(expectedFields.getName(), resourceFields.getName());
+    assertEquals(expectedFields.getDescription(), resourceFields.getDescription());
+    assertEquals(expectedFields.getCloningInstructions(), resourceFields.getCloningInstructions());
+    assertEquals(expectedFields.getProperties(), resourceFields.getProperties());
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
@@ -41,7 +41,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -189,7 +188,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
         retrievedResource.getAttributes().getGitRepoUrl());
   }
 
-  @NotNull
   private String createReferencedResourceAndGetSerializedResponse(
       UUID workspaceId, String request, String apiFormat) throws Exception {
     String serializedResponse =

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
@@ -1,0 +1,38 @@
+package bio.terra.workspace.app.configuration.external.controller;
+
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.service.iam.SamService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+
+  @MockBean SamService mockSamService;
+
+  @BeforeEach
+  public void setUp() throws InterruptedException {
+    // Needed for workspace creation as logging is triggered when a workspace is created in
+    // `WorkspaceActivityLogHook` where we extract the user request information and log it to
+    // activity log.
+    when(mockSamService.getUserStatusInfo(any()))
+        .thenReturn(
+            new UserStatusInfo()
+                .userEmail(USER_REQUEST.getEmail())
+                .userSubjectId(USER_REQUEST.getSubjectId()));
+  }
+
+
+}

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ResourceApiControllerConnectedTest.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.app.configuration.external.controller;
 
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertApiPropertyToMap;
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEFAULT_RESOURCE_PROPERTIES;
 import static bio.terra.workspace.common.utils.MockMvcUtils.RESOURCE_PROPERTIES_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
@@ -67,7 +68,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
   class UpdateResourceProperties {
     @Test
     public void updateResourceProperties_newPropertiesAdded() throws Exception {
-      // Create resource with no properties.
+      // Create resource with properties foo -> bar.
       ApiCreatedControlledGcpBigQueryDataset resource =
           createBigQueryDataset(
               mockMvc, objectMapper, workspaceId, userAccessUtils.defaultUserAuthRequest());
@@ -79,7 +80,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
               UUID.randomUUID().toString(),
               "data_type",
               "workflow_output");
-      Map<String, String> expectedProperties = new HashMap();
+      Map<String, String> expectedProperties = new HashMap<>(DEFAULT_RESOURCE_PROPERTIES);
       expectedProperties.putAll(newProperties);
 
       // Add two more properties with key terra_workspace_folder_id and data_type.

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ResourceApiControllerConnectedTest.java
@@ -29,16 +29,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
+@TestInstance(Lifecycle.PER_CLASS)
 public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;
@@ -49,7 +52,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
   private UUID workspaceId;
 
-  @BeforeEach
+  @BeforeAll
   public void setUp() throws Exception {
     workspaceId =
         connectedTestUtils
@@ -57,7 +60,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
             .getWorkspaceId();
   }
 
-  @AfterEach
+  @AfterAll
   public void cleanup() throws Exception {
     mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -255,7 +255,12 @@ public class ControlledResourceFixtures {
   }
 
   public static ApiGcpBigQueryDatasetCreationParameters defaultBigQueryDatasetCreationParameters() {
-    return new ApiGcpBigQueryDatasetCreationParameters().datasetId(uniqueDatasetId());
+    return new ApiGcpBigQueryDatasetCreationParameters()
+        .datasetId(uniqueDatasetId());
+  }
+
+  public static ApiGcpGcsBucketCreationParameters defaultGcsBucketCreationParameters() {
+    return new ApiGcpGcsBucketCreationParameters().name(uniqueBucketName());
   }
 
   public static final String RESOURCE_NAME = "my_first_bucket";

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.common.fixtures;
 
 import bio.terra.stairway.ShortUUID;
+import bio.terra.workspace.app.controller.shared.PropertiesUtils;
 import bio.terra.workspace.common.utils.AzureVmUtils;
 import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
@@ -467,7 +468,8 @@ public class ControlledResourceFixtures {
         .cloningInstructions(commonFields.getCloningInstructions().toApiModel())
         .accessScope(commonFields.getAccessScope().toApiModel())
         .managedBy(commonFields.getManagedBy().toApiModel())
-        .resourceId(commonFields.getResourceId());
+        .resourceId(commonFields.getResourceId())
+        .properties(PropertiesUtils.convertMapToApiProperties(commonFields.getProperties()));
   }
 
   /** Returns a {@link ControlledGcsBucketResource.Builder} that is ready to be built. */

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -1,7 +1,8 @@
 package bio.terra.workspace.common.fixtures;
 
+import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
+
 import bio.terra.stairway.ShortUUID;
-import bio.terra.workspace.app.controller.shared.PropertiesUtils;
 import bio.terra.workspace.common.utils.AzureVmUtils;
 import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
@@ -255,8 +256,7 @@ public class ControlledResourceFixtures {
   }
 
   public static ApiGcpBigQueryDatasetCreationParameters defaultBigQueryDatasetCreationParameters() {
-    return new ApiGcpBigQueryDatasetCreationParameters()
-        .datasetId(uniqueDatasetId());
+    return new ApiGcpBigQueryDatasetCreationParameters().datasetId(uniqueDatasetId());
   }
 
   public static ApiGcpGcsBucketCreationParameters defaultGcsBucketCreationParameters() {
@@ -474,7 +474,7 @@ public class ControlledResourceFixtures {
         .accessScope(commonFields.getAccessScope().toApiModel())
         .managedBy(commonFields.getManagedBy().toApiModel())
         .resourceId(commonFields.getResourceId())
-        .properties(PropertiesUtils.convertMapToApiProperties(commonFields.getProperties()));
+        .properties(convertMapToApiProperties(commonFields.getProperties()));
   }
 
   /** Returns a {@link ControlledGcsBucketResource.Builder} that is ready to be built. */

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.common.fixtures;
 
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
-import static bio.terra.workspace.common.utils.TestUtils.uniqueName;
+import static bio.terra.workspace.common.utils.TestUtils.appendRandomNumber;
 
 import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
@@ -65,7 +65,7 @@ public class ReferenceResourceFixtures {
     return new ApiCreateGcpGcsObjectReferenceRequestBody()
         .file(
             new ApiGcpGcsObjectAttributes()
-                .bucketName(RandomStringUtils.randomAlphabetic(10))
+                .bucketName(appendRandomNumber("gcsbucket"))
                 .fileName("foo/bar"))
         .metadata(makeDefaultReferencedResourceFieldsApi());
   }
@@ -75,8 +75,8 @@ public class ReferenceResourceFixtures {
     return new ApiCreateGcpBigQueryDatasetReferenceRequestBody()
         .dataset(
             new ApiGcpBigQueryDatasetAttributes()
-                .datasetId(RandomStringUtils.randomAlphabetic(10).toLowerCase())
-                .projectId(RandomStringUtils.randomAlphabetic(10)))
+                .datasetId(appendRandomNumber("dataset").replace("-", "_"))
+                .projectId(appendRandomNumber("my-gcp-project")))
         .metadata(makeDefaultReferencedResourceFieldsApi());
   }
 
@@ -85,9 +85,9 @@ public class ReferenceResourceFixtures {
     return new ApiCreateGcpBigQueryDataTableReferenceRequestBody()
         .dataTable(
             new ApiGcpBigQueryDataTableAttributes()
-                .dataTableId(RandomStringUtils.randomAlphabetic(10))
-                .datasetId(RandomStringUtils.randomAlphabetic(10).toLowerCase())
-                .projectId(RandomStringUtils.randomAlphabetic(10)))
+                .dataTableId(appendRandomNumber("datatable"))
+                .datasetId(appendRandomNumber("dataset").replace("-", "_"))
+                .projectId(appendRandomNumber("my-project-id")))
         .metadata(makeDefaultReferencedResourceFieldsApi());
   }
 
@@ -99,7 +99,7 @@ public class ReferenceResourceFixtures {
 
   public static ApiReferenceResourceCommonFields makeDefaultReferencedResourceFieldsApi() {
     return new ApiReferenceResourceCommonFields()
-        .name(uniqueName("test_resource").replace("-", "_"))
+        .name(appendRandomNumber("test_resource").replace("-", "_"))
         .description("This is a referenced resource")
         .cloningInstructions(ApiCloningInstructionsEnum.NOTHING)
         .properties(convertMapToApiProperties(DEFAULT_RESOURCE_PROPERTIES));

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
@@ -1,9 +1,27 @@
 package bio.terra.workspace.common.fixtures;
 
+import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
+import static bio.terra.workspace.common.utils.TestUtils.uniqueName;
+
+import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
+import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDataTableReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDatasetReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpGcsBucketReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpGcsObjectReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGitRepoReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiDataRepoSnapshotAttributes;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableAttributes;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetAttributes;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketAttributes;
+import bio.terra.workspace.generated.model.ApiGcpGcsObjectAttributes;
+import bio.terra.workspace.generated.model.ApiGitRepoAttributes;
+import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.datareposnapshot.ReferencedDataRepoSnapshotResource;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
 
 public class ReferenceResourceFixtures {
   private static final Map<String, String> DEFAULT_RESOURCE_PROPERTIES = Map.of("foo", "bar");
@@ -11,7 +29,7 @@ public class ReferenceResourceFixtures {
   public static ReferencedDataRepoSnapshotResource makeDataRepoSnapshotResource(
       UUID workspaceUuid) {
     UUID resourceId = UUID.randomUUID();
-    String resourceName = "testdatarepo-" + resourceId.toString();
+    String resourceName = "testdatarepo-" + resourceId;
 
     return new ReferencedDataRepoSnapshotResource(
         workspaceUuid,
@@ -23,5 +41,67 @@ public class ReferenceResourceFixtures {
         "polaroid",
         /*resourceLineage=*/ null,
         /*properties*/ DEFAULT_RESOURCE_PROPERTIES);
+  }
+
+  public static ApiCreateDataRepoSnapshotReferenceRequestBody
+      makeDataRepoSnapshotReferenceRequestBody() {
+    return new ApiCreateDataRepoSnapshotReferenceRequestBody()
+        .snapshot(
+            new ApiDataRepoSnapshotAttributes()
+                .snapshot("This is a snapshot")
+                .instanceName(RandomStringUtils.randomAlphabetic(10)))
+        .metadata(makeDefaultReferencedResourceFieldsApi());
+  }
+
+  public static ApiCreateGcpGcsBucketReferenceRequestBody makeGcsBucketReferenceRequestBody() {
+    return new ApiCreateGcpGcsBucketReferenceRequestBody()
+        .bucket(
+            new ApiGcpGcsBucketAttributes()
+                .bucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase()))
+        .metadata(makeDefaultReferencedResourceFieldsApi());
+  }
+
+  public static ApiCreateGcpGcsObjectReferenceRequestBody makeGcsObjectReferenceRequestBody() {
+    return new ApiCreateGcpGcsObjectReferenceRequestBody()
+        .file(
+            new ApiGcpGcsObjectAttributes()
+                .bucketName(RandomStringUtils.randomAlphabetic(10))
+                .fileName("foo/bar"))
+        .metadata(makeDefaultReferencedResourceFieldsApi());
+  }
+
+  public static ApiCreateGcpBigQueryDatasetReferenceRequestBody
+      makeGcpBqDatasetReferenceRequestBody() {
+    return new ApiCreateGcpBigQueryDatasetReferenceRequestBody()
+        .dataset(
+            new ApiGcpBigQueryDatasetAttributes()
+                .datasetId(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+                .projectId(RandomStringUtils.randomAlphabetic(10)))
+        .metadata(makeDefaultReferencedResourceFieldsApi());
+  }
+
+  public static ApiCreateGcpBigQueryDataTableReferenceRequestBody
+      makeBqDataTableReferenceRequestBody() {
+    return new ApiCreateGcpBigQueryDataTableReferenceRequestBody()
+        .dataTable(
+            new ApiGcpBigQueryDataTableAttributes()
+                .dataTableId(RandomStringUtils.randomAlphabetic(10))
+                .datasetId(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+                .projectId(RandomStringUtils.randomAlphabetic(10)))
+        .metadata(makeDefaultReferencedResourceFieldsApi());
+  }
+
+  public static ApiCreateGitRepoReferenceRequestBody makeGitRepoReferenceRequestBody() {
+    return new ApiCreateGitRepoReferenceRequestBody()
+        .gitrepo(new ApiGitRepoAttributes().gitRepoUrl("git@github.com:foo/bar"))
+        .metadata(makeDefaultReferencedResourceFieldsApi());
+  }
+
+  public static ApiReferenceResourceCommonFields makeDefaultReferencedResourceFieldsApi() {
+    return new ApiReferenceResourceCommonFields()
+        .name(uniqueName("test_resource").replace("-", "_"))
+        .description("This is a referenced resource")
+        .cloningInstructions(ApiCloningInstructionsEnum.NOTHING)
+        .properties(convertMapToApiProperties(DEFAULT_RESOURCE_PROPERTIES));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -83,6 +83,18 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/controlled/gcp/buckets";
   public static final String CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/gcp/buckets/%s";
+  public static final String REFERENCED_DATA_REPO_SNAPSHOTS_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/datarepo/snapshots";
+  public static final String REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/gcp/buckets";
+  public static final String REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/gcp/bucket/objects";
+  public static final String REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/gcp/bigquerydatasets";
+  public static final String REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/gcp/bigquerydatatables";
+  public static final String REFERENCED_GIT_REPO_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/gitrepos";
   public static final AuthenticatedUserRequest USER_REQUEST =
       new AuthenticatedUserRequest(
           "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
@@ -188,7 +200,7 @@ public class MockMvcUtils {
             .perform(
                 addAuth(
                     post(String.format(
-                        CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT, workspaceId.toString()))
+                            CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT, workspaceId.toString()))
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
@@ -199,8 +211,7 @@ public class MockMvcUtils {
             .getResponse()
             .getContentAsString();
 
-    return objectMapper.readValue(
-        serializedGetResponse, ApiCreatedControlledGcpGcsBucket.class);
+    return objectMapper.readValue(serializedGetResponse, ApiCreatedControlledGcpGcsBucket.class);
   }
 
   public static ApiGcpGcsBucketResource getGcsBucket(

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -85,11 +85,6 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/controlled/azure/network";
   public static final String CREATE_AZURE_VM_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/vm";
-
-  public static final String CREATE_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/gcp/buckets";
-  public static final String GET_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/gcp/buckets/%s";
   public static final String CLONE_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/gcp/buckets/%s/clone";
   public static final String CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKET_FORMAT =

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -10,8 +10,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpBigQueryDatasetRequestBody;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpBigQueryDataset;
+import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiGrantRoleRequestBody;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
@@ -75,6 +77,10 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/controlled/gcp/bqdatasets";
   public static final String CONTROLLED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/gcp/bqdatasets/%s";
+  public static final String CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/gcsbuckets";
+  public static final String CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/gcsbucket/%s";
   public static final AuthenticatedUserRequest USER_REQUEST =
       new AuthenticatedUserRequest(
           "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
@@ -162,6 +168,63 @@ public class MockMvcUtils {
             .getContentAsString();
 
     return objectMapper.readValue(serializedGetResponse, ApiGcpBigQueryDatasetResource.class);
+  }
+
+  public static ApiCreatedControlledGcpGcsBucket createGcsBucket(
+      MockMvc mockMvc,
+      ObjectMapper objectMapper,
+      UUID workspaceId,
+      AuthenticatedUserRequest userRequest)
+      throws Exception {
+    ApiCreateControlledGcpBigQueryDatasetRequestBody datasetCreationRequest =
+        new ApiCreateControlledGcpBigQueryDatasetRequestBody()
+            .common(makeDefaultControlledResourceFieldsApi())
+            .dataset(defaultBigQueryDatasetCreationParameters());
+
+    String serializedGetResponse =
+        mockMvc
+            .perform(
+                addAuth(
+                    post(String.format(
+                        CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT,
+                        workspaceId.toString()))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8")
+                        .content(objectMapper.writeValueAsString(datasetCreationRequest)),
+                    userRequest))
+            .andExpect(status().is(HttpStatus.SC_OK))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    return objectMapper.readValue(
+        serializedGetResponse, ApiCreatedControlledGcpGcsBucket.class);
+  }
+
+  public static ApiGcpGcsBucketResource getGcsBucket(
+      MockMvc mockMvc,
+      ObjectMapper objectMapper,
+      UUID workspaceId,
+      UUID resourceId,
+      AuthenticatedUserRequest userRequest)
+      throws Exception {
+    String serializedGetResponse =
+        mockMvc
+            .perform(
+                addAuth(
+                    get(
+                        String.format(
+                            CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT,
+                            workspaceId.toString(),
+                            resourceId.toString())),
+                    userRequest))
+            .andExpect(status().is(HttpStatus.SC_OK))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    return objectMapper.readValue(serializedGetResponse, ApiGcpGcsBucketResource.class);
   }
 
   public static void grantRole(

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.common.utils;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters;
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultGcsBucketCreationParameters;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpBigQueryDatasetRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledGcpGcsBucketRequestBody;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpBigQueryDataset;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
@@ -78,9 +80,9 @@ public class MockMvcUtils {
   public static final String CONTROLLED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/gcp/bqdatasets/%s";
   public static final String CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/gcp/gcsbuckets";
+      "/api/workspaces/v1/%s/resources/controlled/gcp/buckets";
   public static final String CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/gcp/gcsbucket/%s";
+      "/api/workspaces/v1/%s/resources/controlled/gcp/buckets/%s";
   public static final AuthenticatedUserRequest USER_REQUEST =
       new AuthenticatedUserRequest(
           "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
@@ -176,22 +178,21 @@ public class MockMvcUtils {
       UUID workspaceId,
       AuthenticatedUserRequest userRequest)
       throws Exception {
-    ApiCreateControlledGcpBigQueryDatasetRequestBody datasetCreationRequest =
-        new ApiCreateControlledGcpBigQueryDatasetRequestBody()
+    ApiCreateControlledGcpGcsBucketRequestBody gcsBucketCreationRequest =
+        new ApiCreateControlledGcpGcsBucketRequestBody()
             .common(makeDefaultControlledResourceFieldsApi())
-            .dataset(defaultBigQueryDatasetCreationParameters());
+            .gcsBucket(defaultGcsBucketCreationParameters());
 
     String serializedGetResponse =
         mockMvc
             .perform(
                 addAuth(
                     post(String.format(
-                        CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT,
-                        workspaceId.toString()))
+                        CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT, workspaceId.toString()))
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
-                        .content(objectMapper.writeValueAsString(datasetCreationRequest)),
+                        .content(objectMapper.writeValueAsString(gcsBucketCreationRequest)),
                     userRequest))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -15,8 +15,8 @@ import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiCreateCloudContextRequest;
 import bio.terra.workspace.generated.model.ApiCreateCloudContextResult;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpBigQueryDatasetRequestBody;
-import bio.terra.workspace.generated.model.ApiCreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpGcsBucketRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpBigQueryDataset;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
@@ -31,6 +31,7 @@ import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -159,7 +160,7 @@ public class MockMvcUtils {
   }
 
   public ApiWorkspaceDescription createWorkspaceWithoutCloudContext(
-      AuthenticatedUserRequest userRequest) throws Exception {
+      @Nullable AuthenticatedUserRequest userRequest) throws Exception {
     ApiCreateWorkspaceRequestBody request = WorkspaceFixtures.createWorkspaceRequestBody();
     String serializedResponse =
         mockMvc
@@ -167,7 +168,7 @@ public class MockMvcUtils {
                 addJsonContentType(
                     addAuth(
                         post(WORKSPACES_V1_PATH).content(objectMapper.writeValueAsString(request)),
-                        userRequest)))
+                        Optional.ofNullable(userRequest).orElse(USER_REQUEST))))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
             .getResponse()
@@ -296,12 +297,8 @@ public class MockMvcUtils {
     return objectMapper.readValue(serializedGetResponse, ApiGcpBigQueryDatasetResource.class);
   }
 
-  public static ApiCreatedControlledGcpGcsBucket createGcsBucket(
-      MockMvc mockMvc,
-      ObjectMapper objectMapper,
-      UUID workspaceId,
-      AuthenticatedUserRequest userRequest)
-      throws Exception {
+  public ApiCreatedControlledGcpGcsBucket createGcsBucket(
+      AuthenticatedUserRequest userRequest, UUID workspaceId) throws Exception {
     ApiCreateControlledGcpGcsBucketRequestBody gcsBucketCreationRequest =
         new ApiCreateControlledGcpGcsBucketRequestBody()
             .common(makeDefaultControlledResourceFieldsApi())
@@ -326,13 +323,8 @@ public class MockMvcUtils {
     return objectMapper.readValue(serializedGetResponse, ApiCreatedControlledGcpGcsBucket.class);
   }
 
-  public static ApiGcpGcsBucketResource getGcsBucket(
-      MockMvc mockMvc,
-      ObjectMapper objectMapper,
-      UUID workspaceId,
-      UUID resourceId,
-      AuthenticatedUserRequest userRequest)
-      throws Exception {
+  public ApiGcpGcsBucketResource getGcsBucket(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
     String serializedGetResponse =
         mockMvc
             .perform(

--- a/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
@@ -1,10 +1,11 @@
 package bio.terra.workspace.common.utils;
 
-import java.util.UUID;
+import java.util.Random;
 
 public class TestUtils {
+  private static final Random RANDOM = new Random();
 
-  public static String uniqueName(String prefix) {
-    return prefix + "-" + UUID.randomUUID();
+  public static String appendRandomNumber(String string) {
+    return string + "-" + RANDOM.nextInt(100000);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
@@ -1,0 +1,10 @@
+package bio.terra.workspace.common.utils;
+
+import java.util.UUID;
+
+public class TestUtils {
+
+  public static String uniqueName(String prefix) {
+    return prefix + "-" + UUID.randomUUID();
+  }
+}


### PR DESCRIPTION
Mostly added test coverages.

There is no unit test at the referenced resource controller level so I added referenced resource creation test for each type of resources. I also unified the commonFields construction for referenced resources; this is to eliminate risk of accidentally missing one of the referenced resources when adding new fields. 

I also added controllerConnectedTest for gcp resources creation. the code path is the same for azure and gcp so that should be somewhat sufficient. 

i didn't add much to the integration test because of the thorough test coverage on the unit test level. 

`spotbugsMain` has a couple non-blocking complains so I addresses them as well. 