### PR TITLE
[PF-2025] Add azure-unit-test; remove unusaed 'azure' profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradleTask: [unitTest, connectedTest, azureTest]
+        gradleTask: [unitTest, connectedTest, azureUnitTest, azureTest]
 
     services:
       postgres:

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -105,3 +105,29 @@ task azureTest(type: Test) {
     failOnPassedAfterRetry = true
   }
 }
+
+task azureUnitTest(type: Test) {
+  useJUnitPlatform {
+    includeTags "azure-unit"
+  }
+  outputs.upToDateWhen { false }
+  finalizedBy tasks.combinedJaCoCoReport
+
+  // For GHA runs, retry failing tests. If 2nd time passes, workflow will still
+  // fail and oncall will still be notified. This way, oncall dosen't have to
+  // rerun workflow in GHA.
+  retry {
+    // This is set automatically on Github Actions runners, and never set
+    // otherwise.
+    if (System.getenv().containsKey("CI")) {
+      // Max retries per test.
+      maxRetries = 1
+      // Max total test failures.
+      // This is an estimate based on current failure rates, but if more
+      // than 5 tests fail in a run it's likely a real source of failure
+      // and we should stop retrying.
+      maxFailures = 5
+    }
+    failOnPassedAfterRetry = true
+  }
+}

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -112,22 +112,4 @@ task azureUnitTest(type: Test) {
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
-
-  // For GHA runs, retry failing tests. If 2nd time passes, workflow will still
-  // fail and oncall will still be notified. This way, oncall dosen't have to
-  // rerun workflow in GHA.
-  retry {
-    // This is set automatically on Github Actions runners, and never set
-    // otherwise.
-    if (System.getenv().containsKey("CI")) {
-      // Max retries per test.
-      maxRetries = 1
-      // Max total test failures.
-      // This is an estimate based on current failure rates, but if more
-      // than 5 tests fail in a run it's likely a real source of failure
-      // and we should stop retrying.
-      maxFailures = 5
-    }
-    failOnPassedAfterRetry = true
-  }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
@@ -1,5 +1,14 @@
 package bio.terra.workspace.app.controller;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
@@ -12,24 +21,14 @@ import bio.terra.workspace.service.resource.controlled.ControlledResourceService
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Optional;
-import java.util.UUID;
-
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
-import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest {
   AuthenticatedUserRequest USER_REQUEST =

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
@@ -1,23 +1,17 @@
 package bio.terra.workspace.app.controller;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
-import bio.terra.workspace.generated.model.*;
+import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
+import bio.terra.workspace.generated.model.ApiCreateControlledAzureVmRequestBody;
+import bio.terra.workspace.generated.model.ApiJobControl;
+import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Optional;
-import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +19,19 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-public class ControlledAzureResourceApiControllerTest extends BaseUnitTest {
+import java.util.Optional;
+import java.util.UUID;
+
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest {
   AuthenticatedUserRequest USER_REQUEST =
       new AuthenticatedUserRequest(
           "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
@@ -1,0 +1,10 @@
+package bio.terra.workspace.common;
+
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+
+@Tag("azure-unit")
+@AutoConfigureMockMvc
+@ActiveProfiles({"azure-unit-test", "unit-test"})
+public class BaseAzureUnitTest extends BaseTest {}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class CreateAzureDiskStepTest extends BaseAzureTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
@@ -33,7 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class CreateAzureDiskStepTest extends BaseAzureTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class GetAzureDiskStepTest extends BaseAzureTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
@@ -25,8 +25,6 @@ import com.azure.resourcemanager.compute.models.Disks;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class GetAzureDiskStepTest extends BaseAzureTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
 
 public class CreateAzureIpStepTest extends BaseAzureTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
@@ -35,7 +35,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
 public class CreateAzureIpStepTest extends BaseAzureTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
@@ -26,8 +26,6 @@ import com.azure.resourcemanager.network.models.PublicIpAddresses;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class GetAzureIpStepTest extends BaseAzureTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class GetAzureIpStepTest extends BaseAzureTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
@@ -39,7 +39,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class CreateAzureNetworkStepTest extends BaseAzureTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
@@ -37,8 +37,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class CreateAzureNetworkStepTest extends BaseAzureTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class GetAzureNetworkStepTest extends BaseAzureTest {
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
@@ -26,8 +26,6 @@ import com.azure.resourcemanager.network.models.Networks;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class GetAzureNetworkStepTest extends BaseAzureTest {
   private static final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStepTest.java
@@ -34,7 +34,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class CreateAzureRelayNamespaceStepTest extends BaseAzureTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStepTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class CreateAzureRelayNamespaceStepTest extends BaseAzureTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStepTest.java
@@ -27,8 +27,6 @@ import com.azure.resourcemanager.relay.models.RelayNamespace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class GetAzureRelayNamespaceStepTest extends BaseAzureTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStepTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class GetAzureRelayNamespaceStepTest extends BaseAzureTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -20,7 +20,7 @@ import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
 /** Base class for storage account and storage container tests. */
-@ActiveProfiles("azure")
+
 public class BaseStorageStepTest extends BaseAzureTest {
 
   protected final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -17,10 +17,8 @@ import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.resourcemanager.storage.models.StorageAccounts;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
 
 /** Base class for storage account and storage container tests. */
-
 public class BaseStorageStepTest extends BaseAzureTest {
 
   protected final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class CreateAzureStorageStepTest extends BaseStorageStepTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/CreateAzureStorageStepTest.java
@@ -20,7 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class CreateAzureStorageStepTest extends BaseStorageStepTest {
 
   @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class GetAzureStorageStepTest extends BaseStorageStepTest {
 
   @Mock private CheckNameAvailabilityResult mockNameAvailabilityResult;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/GetAzureStorageStepTest.java
@@ -13,8 +13,6 @@ import bio.terra.workspace.service.resource.exception.DuplicateResourceException
 import com.azure.resourcemanager.storage.models.CheckNameAvailabilityResult;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class GetAzureStorageStepTest extends BaseStorageStepTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStepTest.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class CreateAzureStorageContainerStepTest extends BaseStorageStepTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStepTest.java
@@ -26,7 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class CreateAzureStorageContainerStepTest extends BaseStorageStepTest {
 
   @Mock private BlobContainers mockBlobContainers;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
@@ -23,8 +23,6 @@ import com.azure.resourcemanager.storage.models.BlobContainers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorageStepTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorageStepTest {
 
   @Mock private BlobContainers mockBlobContainers;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -54,8 +54,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-
 
 public class CreateAzureVmStepTest extends BaseAzureTest {
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -56,7 +56,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("azure")
+
 public class CreateAzureVmStepTest extends BaseAzureTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";

--- a/service/src/test/resources/application-azure-unit-test.yml
+++ b/service/src/test/resources/application-azure-unit-test.yml
@@ -1,0 +1,3 @@
+feature:
+  # Enable azure support when running azure tests
+  azure-enabled: true


### PR DESCRIPTION
The new controller test Doug added showed up a problem with the test categories. The new test needs the MockMvc to test the REST API interface. The `azure` tag is set up for a _connected_ test, so it does not support the MockMvc.

The default for `azure-enabled` is true, but we still need support for `azure-enabled` as false. So we still need to segregate the Azure tests.

My solution in this PR is:
1. Add a new tag `azure-unit`
2. Add a new profile `azure-unit-test`
3. Add a new property file that sets `azure-enabled`:  `application-azure-unit-test`
4. Added a fourth entry to the test matrix so these tests run as part of PR qualification as well as overnight.

I removed all of the `@ActiveProfiles("azure")` from a bunch of Azure tests. There is no profile-based code or configuration. The tests run fine without it.


