### PR TITLE
[PF-1987] Return resource information when updating referenced resources.

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ReferencedBigQueryResourceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedBigQueryResourceLifecycle.java
@@ -214,17 +214,16 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
     // Update BQ dataset's name and description
     String newDatasetName = "newDatasetName";
     String newDatasetDescription = "newDescription";
-    BqDatasetUtils.updateBigQueryDatasetReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqDatasetResourceId,
-        newDatasetName,
-        newDatasetDescription,
-        /*projectId=*/ null,
-        /*datasetId=*/ null,
-        CloningInstructionsEnum.NOTHING);
     GcpBigQueryDatasetResource datasetReferenceFirstUpdate =
-        fullAccessApi.getBigQueryDatasetReference(getWorkspaceId(), bqDatasetResourceId);
+        BqDatasetUtils.updateBigQueryDatasetReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqDatasetResourceId,
+            newDatasetName,
+            newDatasetDescription,
+            /*projectId=*/ null,
+            /*datasetId=*/ null,
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newDatasetName, datasetReferenceFirstUpdate.getMetadata().getName());
     assertEquals(newDatasetDescription, datasetReferenceFirstUpdate.getMetadata().getDescription());
     assertEquals(
@@ -256,17 +255,16 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
                 /*projectId=*/ null,
                 bqTableFromAlternateDatasetAttributes.getDatasetId(),
                 /*cloningInstructions=*/ null));
-    BqDatasetUtils.updateBigQueryDatasetReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqDatasetResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*projectId=*/ null,
-        bqTableFromAlternateDatasetAttributes.getDatasetId(),
-        CloningInstructionsEnum.NOTHING);
     GcpBigQueryDatasetResource datasetReferenceSecondUpdate =
-        fullAccessApi.getBigQueryDatasetReference(getWorkspaceId(), bqDatasetResourceId);
+        BqDatasetUtils.updateBigQueryDatasetReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqDatasetResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*projectId=*/ null,
+            bqTableFromAlternateDatasetAttributes.getDatasetId(),
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newDatasetName, datasetReferenceSecondUpdate.getMetadata().getName());
     assertEquals(
         newDatasetDescription, datasetReferenceSecondUpdate.getMetadata().getDescription());
@@ -287,18 +285,17 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
     // Update BQ data table's name and description.
     String newDataTableName = "newDataTableName";
     String newDataTableDescription = "a new description to the new data table reference";
-    BqDataTableUtils.updateBigQueryDataTableReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqTableResourceId,
-        newDataTableName,
-        newDataTableDescription,
-        /*projectId=*/ null,
-        /*datasetId=*/ null,
-        /*tableId=*/ null,
-        /*cloningInstructions=*/ null);
     GcpBigQueryDataTableResource dataTableReferenceFirstUpdate =
-        fullAccessApi.getBigQueryDataTableReference(getWorkspaceId(), bqTableResourceId);
+        BqDataTableUtils.updateBigQueryDataTableReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqTableResourceId,
+            newDataTableName,
+            newDataTableDescription,
+            /*projectId=*/ null,
+            /*datasetId=*/ null,
+            /*tableId=*/ null,
+            /*cloningInstructions=*/ null);
     assertEquals(newDataTableName, dataTableReferenceFirstUpdate.getMetadata().getName());
     assertEquals(
         newDataTableDescription, dataTableReferenceFirstUpdate.getMetadata().getDescription());
@@ -331,19 +328,18 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
                 /*cloningInstructions=*/ null));
     // Successfully update the referencing target because the {@code userWithFullAccess} has
     // access to the bq table 2.
-    BqDataTableUtils.updateBigQueryDataTableReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqTableResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*projectId=*/ null,
-        bqTableFromAlternateDatasetAttributes.getDatasetId(),
-        bqTableFromAlternateDatasetAttributes.getDataTableId(),
-        /*cloningInstructions=*/ null);
-
     GcpBigQueryDataTableResource dataTableReferenceSecondUpdate =
-        fullAccessApi.getBigQueryDataTableReference(getWorkspaceId(), bqTableResourceId);
+        BqDataTableUtils.updateBigQueryDataTableReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqTableResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*projectId=*/ null,
+            bqTableFromAlternateDatasetAttributes.getDatasetId(),
+            bqTableFromAlternateDatasetAttributes.getDataTableId(),
+            /*cloningInstructions=*/ null);
+
     assertEquals(newDataTableName, dataTableReferenceSecondUpdate.getMetadata().getName());
     assertEquals(
         newDataTableDescription, dataTableReferenceSecondUpdate.getMetadata().getDescription());
@@ -357,19 +353,18 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
         bqTableFromAlternateDatasetAttributes.getDataTableId(),
         dataTableReferenceSecondUpdate.getAttributes().getDataTableId());
 
-    BqDataTableUtils.updateBigQueryDataTableReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqTableResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*projectId=*/ null,
-        table.getAttributes().getDatasetId(),
-        /*tableId=*/ null,
-        /*cloningInstructions=*/ null);
-
     GcpBigQueryDataTableResource dataTableReferenceThirdUpdate =
-        fullAccessApi.getBigQueryDataTableReference(getWorkspaceId(), bqTableResourceId);
+        BqDataTableUtils.updateBigQueryDataTableReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqTableResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*projectId=*/ null,
+            table.getAttributes().getDatasetId(),
+            /*tableId=*/ null,
+            /*cloningInstructions=*/ null);
+
     assertEquals(newDataTableName, dataTableReferenceThirdUpdate.getMetadata().getName());
     assertEquals(
         newDataTableDescription, dataTableReferenceThirdUpdate.getMetadata().getDescription());
@@ -383,18 +378,18 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
         bqTableFromAlternateDatasetAttributes.getDataTableId(),
         dataTableReferenceThirdUpdate.getAttributes().getDataTableId());
 
-    BqDataTableUtils.updateBigQueryDataTableReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqTableResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*projectId=*/ null,
-        /*datasetId=*/ null,
-        table.getAttributes().getDataTableId(),
-        /*cloningInstructions*/ null);
     GcpBigQueryDataTableResource dataTableReferenceFourthUpdate =
-        fullAccessApi.getBigQueryDataTableReference(getWorkspaceId(), bqTableResourceId);
+        BqDataTableUtils.updateBigQueryDataTableReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqTableResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*projectId=*/ null,
+            /*datasetId=*/ null,
+            table.getAttributes().getDataTableId(),
+            /*cloningInstructions*/ null);
+
     assertEquals(newDataTableName, dataTableReferenceFourthUpdate.getMetadata().getName());
     assertEquals(
         newDataTableDescription, dataTableReferenceFourthUpdate.getMetadata().getDescription());

--- a/integration/src/main/java/scripts/testscripts/ReferencedGcsResourceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedGcsResourceLifecycle.java
@@ -277,16 +277,15 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
     // Update GCS bucket's name and description
     String newBucketName = "newGcsBucket";
     String newBucketDescription = "a new description to the new bucket reference";
-    GcsBucketUtils.updateGcsBucketReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bucketResourceId,
-        newBucketName,
-        newBucketDescription,
-        null,
-        CloningInstructionsEnum.NOTHING);
     GcpGcsBucketResource bucketReferenceFirstUpdate =
-        fullAccessApi.getBucketReference(getWorkspaceId(), bucketResourceId);
+        GcsBucketUtils.updateGcsBucketReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bucketResourceId,
+            newBucketName,
+            newBucketDescription,
+            null,
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newBucketName, bucketReferenceFirstUpdate.getMetadata().getName());
     assertEquals(newBucketDescription, bucketReferenceFirstUpdate.getMetadata().getDescription());
     assertEquals(
@@ -311,16 +310,15 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
                 /*cloningInstructions=*/ null));
     // Successfully update the referencing target because the {@code userWithFullAccess} has
     // access to the bucket with fine-grained access.
-    GcsBucketUtils.updateGcsBucketReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bucketResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        fineGrainedBucket.getAttributes().getBucketName(),
-        /*cloningInstructions=*/ null);
     GcpGcsBucketResource bucketReferenceSecondUpdate =
-        fullAccessApi.getBucketReference(getWorkspaceId(), bucketResourceId);
+        GcsBucketUtils.updateGcsBucketReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bucketResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            fineGrainedBucket.getAttributes().getBucketName(),
+            /*cloningInstructions=*/ null);
     assertEquals(newBucketName, bucketReferenceSecondUpdate.getMetadata().getName());
     assertEquals(newBucketDescription, bucketReferenceSecondUpdate.getMetadata().getDescription());
     assertEquals(
@@ -330,17 +328,16 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
     // Update GCS bucket object's name and description
     String newBlobName = "newBlobName";
     String newBlobDescription = "a new description to the new bucket blob reference";
-    GcsBucketUtils.updateGcsBucketObjectReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        fileResourceId,
-        newBlobName,
-        newBlobDescription,
-        /*bucketName=*/ null,
-        /*objectName=*/ null,
-        CloningInstructionsEnum.NOTHING);
     GcpGcsObjectResource blobResource =
-        fullAccessApi.getGcsObjectReference(getWorkspaceId(), fileResourceId);
+        GcsBucketUtils.updateGcsBucketObjectReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            fileResourceId,
+            newBlobName,
+            newBlobDescription,
+            /*bucketName=*/ null,
+            /*objectName=*/ null,
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newBlobName, blobResource.getMetadata().getName());
     assertEquals(newBlobDescription, blobResource.getMetadata().getDescription());
     assertEquals(gcsFileAttributes.getBucketName(), blobResource.getAttributes().getBucketName());
@@ -366,17 +363,16 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
                 gcsFolderAttributes.getFileName(),
                 /*cloningInstructions=*/ null));
     // User with access to foo/ can successfully update the referencing target to foo/.
-    GcsBucketUtils.updateGcsBucketObjectReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        fileResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*bucketName=*/ null,
-        gcsFolderAttributes.getFileName(),
-        /*cloningInstructions=*/ null);
     GcpGcsObjectResource blobReferenceSecondUpdate =
-        fullAccessApi.getGcsObjectReference(getWorkspaceId(), fileResourceId);
+        GcsBucketUtils.updateGcsBucketObjectReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            fileResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*bucketName=*/ null,
+            gcsFolderAttributes.getFileName(),
+            /*cloningInstructions=*/ null);
     assertEquals(
         gcsFileAttributes.getBucketName(),
         blobReferenceSecondUpdate.getAttributes().getBucketName());
@@ -386,17 +382,16 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
     assertEquals(newBlobDescription, blobReferenceSecondUpdate.getMetadata().getDescription());
 
     // update bucket only.
-    GcsBucketUtils.updateGcsBucketObjectReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        fileResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*bucketName=*/ gcsUniformAccessBucketAttributes.getBucketName(),
-        /*objectName=*/ null,
-        /*cloningInstructions=*/ null);
     GcpGcsObjectResource blobReferenceThirdUpdate =
-        fullAccessApi.getGcsObjectReference(getWorkspaceId(), fileResourceId);
+        GcsBucketUtils.updateGcsBucketObjectReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            fileResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*bucketName=*/ gcsUniformAccessBucketAttributes.getBucketName(),
+            /*objectName=*/ null,
+            /*cloningInstructions=*/ null);
     assertEquals(
         gcsUniformAccessBucketAttributes.getBucketName(),
         blobReferenceThirdUpdate.getAttributes().getBucketName());
@@ -406,17 +401,16 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
     assertEquals(newBlobDescription, blobReferenceThirdUpdate.getMetadata().getDescription());
 
     // Update both bucket and object path.
-    GcsBucketUtils.updateGcsBucketObjectReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        fileResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*bucketName=*/ gcsFileAttributes.getBucketName(),
-        gcsFileAttributes.getFileName(),
-        /*cloningInstructions=*/ null);
     GcpGcsObjectResource blobReferenceFourthUpdate =
-        fullAccessApi.getGcsObjectReference(getWorkspaceId(), fileResourceId);
+        GcsBucketUtils.updateGcsBucketObjectReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            fileResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*bucketName=*/ gcsFileAttributes.getBucketName(),
+            gcsFileAttributes.getFileName(),
+            /*cloningInstructions=*/ null);
     assertEquals(
         gcsFileAttributes.getBucketName(),
         blobReferenceFourthUpdate.getAttributes().getBucketName());

--- a/integration/src/main/java/scripts/testscripts/ReferencedGitRepoLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedGitRepoLifecycle.java
@@ -113,16 +113,15 @@ public class ReferencedGitRepoLifecycle extends WorkspaceAllocateTestScriptBase 
       throws Exception {
     String newGitRepoReferenceName = "newGitRepoReferenceName";
     String newGitRepoReferenceDescription = "a new description for git repo reference";
-    GitRepoUtils.updateGitRepoReferenceResource(
-        referencedGcpResourceApi,
-        getWorkspaceId(),
-        gitResourceId,
-        newGitRepoReferenceName,
-        newGitRepoReferenceDescription,
-        /*gitCloneUrl=*/ null,
-        CloningInstructionsEnum.NOTHING);
     GitRepoResource updatedResource =
-        referencedGcpResourceApi.getGitRepoReference(getWorkspaceId(), gitResourceId);
+        GitRepoUtils.updateGitRepoReferenceResource(
+            referencedGcpResourceApi,
+            getWorkspaceId(),
+            gitResourceId,
+            newGitRepoReferenceName,
+            newGitRepoReferenceDescription,
+            /*gitCloneUrl=*/ null,
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newGitRepoReferenceName, updatedResource.getMetadata().getName());
     assertEquals(newGitRepoReferenceDescription, updatedResource.getMetadata().getDescription());
     assertEquals(

--- a/integration/src/main/java/scripts/utils/BqDataTableUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDataTableUtils.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.GcpBigQueryDataTableAttributes;
+import bio.terra.workspace.model.GcpBigQueryDataTableResource;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
 import bio.terra.workspace.model.UpdateBigQueryDataTableReferenceRequestBody;
 import com.google.cloud.bigquery.BigQuery;
@@ -29,7 +30,7 @@ public class BqDataTableUtils {
       Pattern.compile("^projects/([^/]+)/datasets/([^/]+)/tables/(.+)$");
 
   /** Updates name, description and/or referencing target of BigQuery data table reference. */
-  public static void updateBigQueryDataTableReference(
+  public static GcpBigQueryDataTableResource updateBigQueryDataTableReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceUuid,
       UUID resourceId,
@@ -60,7 +61,7 @@ public class BqDataTableUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateBigQueryDataTableReferenceResource(body, workspaceUuid, resourceId);
+    return resourceApi.updateBigQueryDataTableReferenceResource(body, workspaceUuid, resourceId);
   }
 
   /**

--- a/integration/src/main/java/scripts/utils/BqDatasetUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDatasetUtils.java
@@ -100,7 +100,7 @@ public class BqDatasetUtils {
   }
 
   /** Updates the name, description or referencing target of a BQ dataset reference. */
-  public static void updateBigQueryDatasetReference(
+  public static GcpBigQueryDatasetResource updateBigQueryDatasetReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspace,
       UUID resourceId,
@@ -127,7 +127,7 @@ public class BqDatasetUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateBigQueryDatasetReferenceResource(body, workspace, resourceId);
+    return resourceApi.updateBigQueryDatasetReferenceResource(body, workspace, resourceId);
   }
 
   /**

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.model.GcpGcsBucketLifecycleRuleActionType;
 import bio.terra.workspace.model.GcpGcsBucketLifecycleRuleCondition;
 import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.GcpGcsBucketUpdateParameters;
+import bio.terra.workspace.model.GcpGcsObjectResource;
 import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.ManagedBy;
@@ -123,7 +124,7 @@ public class GcsBucketUtils {
   private static final Pattern GCS_BUCKET_PATTERN = Pattern.compile("^gs://([^/]+)$");
 
   /** Updates name, description, and/or referencing target for GCS bucket reference. */
-  public static void updateGcsBucketReference(
+  public static GcpGcsBucketResource updateGcsBucketReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceUuid,
       UUID resourceId,
@@ -145,7 +146,7 @@ public class GcsBucketUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateBucketReferenceResource(body, workspaceUuid, resourceId);
+    return resourceApi.updateBucketReferenceResource(body, workspaceUuid, resourceId);
   }
 
   // Fully parameterized version; category-specific versions below
@@ -309,7 +310,7 @@ public class GcsBucketUtils {
   }
 
   /** Updates name, description, and/or referencing target for GCS bucket object reference. */
-  public static void updateGcsBucketObjectReference(
+  public static GcpGcsObjectResource updateGcsBucketObjectReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceUuid,
       UUID resourceId,
@@ -336,7 +337,7 @@ public class GcsBucketUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateBucketObjectReferenceResource(body, workspaceUuid, resourceId);
+    return resourceApi.updateBucketObjectReferenceResource(body, workspaceUuid, resourceId);
   }
 
   /**

--- a/integration/src/main/java/scripts/utils/GitRepoUtils.java
+++ b/integration/src/main/java/scripts/utils/GitRepoUtils.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 public class GitRepoUtils {
   private static final Logger logger = LoggerFactory.getLogger(GitRepoUtils.class);
 
-  public static void updateGitRepoReferenceResource(
+  public static GitRepoResource updateGitRepoReferenceResource(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceUuid,
       UUID resourceId,
@@ -38,7 +38,7 @@ public class GitRepoUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateGitRepoReference(body, workspaceUuid, resourceId);
+    return resourceApi.updateGitRepoReference(body, workspaceUuid, resourceId);
   }
 
   /**

--- a/openapi/src/parts/referenced_gcp_big_query_data_table.yaml
+++ b/openapi/src/parts/referenced_gcp_big_query_data_table.yaml
@@ -55,8 +55,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateBigQueryDataTableReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GcpBigQueryDataTableReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/openapi/src/parts/referenced_gcp_big_query_dataset.yaml
+++ b/openapi/src/parts/referenced_gcp_big_query_dataset.yaml
@@ -52,8 +52,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateBigQueryDatasetReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GcpBigQueryDatasetReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/openapi/src/parts/referenced_gcp_gcs_bucket.yaml
+++ b/openapi/src/parts/referenced_gcp_gcs_bucket.yaml
@@ -52,8 +52,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateGcsBucketReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GcpGcsBucketReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/openapi/src/parts/referenced_gcp_gcs_bucket_object.yaml
+++ b/openapi/src/parts/referenced_gcp_gcs_bucket_object.yaml
@@ -53,8 +53,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateGcsBucketObjectReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GcpGcsObjectReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/openapi/src/parts/referenced_git_repo.yaml
+++ b/openapi/src/parts/referenced_git_repo.yaml
@@ -52,8 +52,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateGitRepoReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GitRepoReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -143,7 +143,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateBucketObjectReferenceResource(
+  public ResponseEntity<ApiGcpGcsObjectResource> updateBucketObjectReferenceResource(
       UUID workspaceUuid, UUID referenceId, ApiUpdateGcsBucketObjectReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -189,7 +189,12 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           null, // included in resource arg
           userRequest);
     }
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+
+    final ReferencedGcsObjectResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, referenceId)
+            .castByEnum(WsmResourceType.REFERENCED_GCP_GCS_OBJECT);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override
@@ -255,7 +260,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateBucketReferenceResource(
+  public ResponseEntity<ApiGcpGcsBucketResource> updateBucketReferenceResource(
       UUID workspaceUuid, UUID referenceId, ApiUpdateGcsBucketReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -295,7 +300,12 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           null, // passed in via resource argument
           userRequest);
     }
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+
+    final ReferencedGcsBucketResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, referenceId)
+            .castByEnum(WsmResourceType.REFERENCED_GCP_GCS_BUCKET);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override
@@ -363,7 +373,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateBigQueryDataTableReferenceResource(
+  public ResponseEntity<ApiGcpBigQueryDataTableResource> updateBigQueryDataTableReferenceResource(
       UUID workspaceUuid, UUID referenceId, ApiUpdateBigQueryDataTableReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -410,7 +420,11 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           userRequest);
     }
 
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    final ReferencedBigQueryDataTableResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, referenceId)
+            .castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override
@@ -485,7 +499,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateBigQueryDatasetReferenceResource(
+  public ResponseEntity<ApiGcpBigQueryDatasetResource> updateBigQueryDatasetReferenceResource(
       UUID workspaceUuid, UUID resourceId, ApiUpdateBigQueryDatasetReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -527,7 +541,12 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           cloningInstructions,
           userRequest);
     }
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+
+    final ReferencedBigQueryDatasetResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, resourceId)
+            .castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override
@@ -950,7 +969,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateGitRepoReference(
+  public ResponseEntity<ApiGitRepoResource> updateGitRepoReference(
       UUID workspaceUuid, UUID referenceId, ApiUpdateGitRepoReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -984,7 +1003,12 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           CloningInstructions.fromApiModel(body.getCloningInstructions()),
           userRequest);
     }
-    return new ResponseEntity<>(HttpStatus.OK);
+
+    final ReferencedGitRepoResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, referenceId)
+            .castByEnum(WsmResourceType.REFERENCED_ANY_GIT_REPO);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override


### PR DESCRIPTION
Since the controlled (gcp) resources have the same behavior, it avoids having to manually retrieve the updated information when dealing with referenced resources.