### PR TITLE
[PF-2016] Stop writing test user access tokens to logs

### DIFF
--- a/service/gradle.lockfile
+++ b/service/gradle.lockfile
@@ -2,10 +2,10 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 bio.terra:datarepo-client:1.41.0-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra:stairway-gcp:0.0.67-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra:stairway:0.0.67-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:stairway-gcp:0.0.71-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:stairway:0.0.71-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:terra-cloud-resource-lib:1.2.2-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra:terra-common-lib:0.0.66-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:terra-common-lib:0.0.69-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:terra-landing-zone-service:0.0.5-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:terra-policy-service:0.2.4-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:terra-resource-buffer-client:0.4.3-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/service/gradle/dependencies.gradle
+++ b/service/gradle/dependencies.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation group: "io.opencensus", name: "opencensus-contrib-http-jaxrs", version: "0.28.3"
 
   // Get stairway via TCL
-  implementation("bio.terra:terra-common-lib:0.0.66-SNAPSHOT") {
+  implementation("bio.terra:terra-common-lib:0.0.69-SNAPSHOT") {
     exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.12"
   }
   implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "0.1-e826d4d"

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ResourceApiControllerConnectedTest.java
@@ -33,11 +33,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@AutoConfigureMockMvc
 public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
@@ -1,10 +1,8 @@
 package bio.terra.workspace.common;
 
 import org.junit.jupiter.api.Tag;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.context.ActiveProfiles;
 
 @Tag("azure-unit")
-@AutoConfigureMockMvc
 @ActiveProfiles({"azure-unit-test", "unit-test"})
 public class BaseAzureUnitTest extends BaseTest {}

--- a/service/src/test/java/bio/terra/workspace/common/BaseTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseTest.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.common;
 import bio.terra.workspace.app.Main;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcPrint;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -12,5 +13,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ContextConfiguration(classes = Main.class)
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {"spring.cloud.gcp.credentials.location="})
-@AutoConfigureMockMvc
+// Configure MockMvc not to print additional debugging information. Otherwise, this will print out
+// request headers including test user access tokens, which should not be written to test output.
+@AutoConfigureMockMvc(print = MockMvcPrint.NONE)
 public class BaseTest {}


### PR DESCRIPTION
Currently, MockMvc tests print debug information about the requests they "send", including headers with access tokens. We should stop doing this. These are short-lived access tokens for dedicated test users with no access to real data or resources so I'm not concerned about the real impact, but it's still a best practice.

Additionally, this pulls in the TCL change from https://github.com/DataBiosphere/terra-common-lib/pull/86 to stop writing access tokens to logs. This affects live environments as well as tests. Note this is for server logs (which are access controlled in live environments) unlike the above fix for Github Actions test output (which are publicly visible).

This also removes unnecessary `AutoConfigureMockMvc` annotations now that they're applied from `BaseTest`