### PR TITLE
PF-1984: add folder properties

### DIFF
--- a/openapi/src/parts/folder.yaml
+++ b/openapi/src/parts/folder.yaml
@@ -99,6 +99,52 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/workspaces/v1/{workspaceId}/folders/{folderId}/properties:
+    parameters:
+    - $ref: '#/components/parameters/WorkspaceId'
+    - $ref: '#/components/parameters/FolderId'
+    post:
+      operationId: updateFolderProperties
+      summary: |
+        Update folder properties. Only properties with keys in request are
+        updated. Properties with keys not in request are not updated.
+      tags: [ Folder ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Properties'
+      responses:
+        '204':
+          description: Properties update sucessfully
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    patch:
+      operationId: deleteFolderProperties
+      tags: [ Folder ]
+      summary: |
+        Delete folder properties. Only properties with keys in request are
+        deleted. Properties with keys not in request are not deleted.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertyKeys'
+      responses:
+        '204':
+          description: Properties delete sucessfully
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
 components:
   schemas:
     FolderList:
@@ -123,6 +169,8 @@ components:
           type: string
         parentFolderId:
           $ref: '#/components/schemas/FolderId'
+        properties:
+          $ref: '#/components/schemas/Properties'
     CreateFolderRequestBody:
       type: object
       required: [displayName]
@@ -136,7 +184,9 @@ components:
           description: A description of the folder
           type: string
         parentFolderId:
-         $ref: '#/components/schemas/FolderId'
+          $ref: '#/components/schemas/FolderId'
+        properties:
+          $ref: '#/components/schemas/Properties'
 
     UpdateFolderRequestBody:
       type: object

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -239,7 +239,9 @@ paths:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'
     post:
-      summary: update the properties in workspace.
+      summary: |
+        Update the properties in workspace. Only properties with keys in request 
+        are updated. Properties with keys not in request are not updated.
       operationId: updateWorkspaceProperties
       tags: [ Workspace ]
       requestBody:
@@ -258,7 +260,10 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     patch:
-      summary: delete existing Workspace properties.
+      summary: |
+        delete existing Workspace properties. Only properties with keys in
+        request are deleted. Properties with keys not in request are not
+        deleted.
       operationId: deleteWorkspaceProperties
       tags: [ Workspace ]
       requestBody:

--- a/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
@@ -21,7 +21,6 @@ import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -101,10 +100,7 @@ public class FolderApiController extends ControllerBase implements FolderApi {
 
     var response =
         new ApiFolderList()
-            .folders(
-                folders.stream()
-                    .map(FolderApiController::buildFolder)
-                    .collect(Collectors.toList()));
+            .folders(folders.stream().map(FolderApiController::buildFolder).toList());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
@@ -1,9 +1,15 @@
 package bio.terra.workspace.app.controller;
 
+import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertApiPropertyToMap;
+import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
+import static bio.terra.workspace.common.utils.ControllerValidationUtils.validatePropertiesDeleteRequestBody;
+import static bio.terra.workspace.common.utils.ControllerValidationUtils.validatePropertiesUpdateRequestBody;
+
 import bio.terra.workspace.generated.controller.FolderApi;
 import bio.terra.workspace.generated.model.ApiCreateFolderRequestBody;
 import bio.terra.workspace.generated.model.ApiFolder;
 import bio.terra.workspace.generated.model.ApiFolderList;
+import bio.terra.workspace.generated.model.ApiProperty;
 import bio.terra.workspace.generated.model.ApiUpdateFolderRequestBody;
 import bio.terra.workspace.service.folder.FolderService;
 import bio.terra.workspace.service.folder.model.Folder;
@@ -53,7 +59,8 @@ public class FolderApiController extends ControllerBase implements FolderApi {
                 workspaceId,
                 body.getDisplayName(),
                 body.getDescription(),
-                body.getParentFolderId()));
+                body.getParentFolderId(),
+                convertApiPropertyToMap(body.getProperties())));
     return new ResponseEntity<>(buildFolder(folder), HttpStatus.OK);
   }
 
@@ -107,11 +114,37 @@ public class FolderApiController extends ControllerBase implements FolderApi {
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
+  @Override
+  public ResponseEntity<Void> updateFolderProperties(
+      UUID workspaceUuid, UUID folderUuid, List<ApiProperty> properties) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    workspaceService.validateWorkspaceAndAction(
+        userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+
+    validatePropertiesUpdateRequestBody(properties);
+
+    folderService.updateFolderProperties(
+        workspaceUuid, folderUuid, convertApiPropertyToMap(properties));
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteFolderProperties(
+      UUID workspaceUuid, UUID folderUuid, List<String> propertyKeys) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    validatePropertiesDeleteRequestBody(propertyKeys);
+    workspaceService.validateWorkspaceAndAction(
+        userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    folderService.deleteFolderProperties(workspaceUuid, folderUuid, propertyKeys);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
   private static ApiFolder buildFolder(Folder folder) {
     return new ApiFolder()
         .id(folder.id())
         .displayName(folder.displayName())
         .description(folder.description())
-        .parentFolderId(folder.parentFolderId());
+        .parentFolderId(folder.parentFolderId())
+        .properties(convertMapToApiProperties(folder.properties()));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
@@ -102,7 +102,9 @@ public class FolderApiController extends ControllerBase implements FolderApi {
     var response =
         new ApiFolderList()
             .folders(
-                folders.stream().map(folder -> buildFolder(folder)).collect(Collectors.toList()));
+                folders.stream()
+                    .map(FolderApiController::buildFolder)
+                    .collect(Collectors.toList()));
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 

--- a/service/src/main/java/bio/terra/workspace/db/FolderDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/FolderDao.java
@@ -130,7 +130,7 @@ public class FolderDao {
     if (displayName == null
         && description == null
         && parentFolderId == null
-        && updateParent == null) {
+        && (updateParent == null || !updateParent)) {
       throw new MissingRequiredFieldsException("Must specified fields to update");
     }
     if (parentFolderId != null) {

--- a/service/src/main/java/bio/terra/workspace/db/FolderDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/FolderDao.java
@@ -3,13 +3,17 @@ package bio.terra.workspace.db;
 import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
 import bio.terra.common.exception.BadRequestException;
-import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.db.exception.DuplicateFolderDisplayNameException;
 import bio.terra.workspace.db.exception.DuplicateFolderIdException;
 import bio.terra.workspace.db.exception.FolderNotFoundException;
 import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.service.folder.model.Folder;
+import bio.terra.workspace.service.workspace.exceptions.MissingRequiredFieldsException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -43,7 +47,8 @@ public class FolderDao {
             Objects.requireNonNull(UUID.fromString(rs.getString("workspace_id"))),
             Objects.requireNonNull(rs.getString("display_name")),
             rs.getString("description"),
-            parentFolderId);
+            parentFolderId,
+            DbSerDes.jsonToProperties(Objects.requireNonNull(rs.getString("properties"))));
       };
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
@@ -57,8 +62,8 @@ public class FolderDao {
   public Folder createFolder(Folder folder) {
     final String sql =
         """
-          INSERT INTO folder (workspace_id, id, display_name, description, parent_folder_id)
-          values (:workspace_id, :id, :display_name, :description, :parent_folder_id)
+          INSERT INTO folder (workspace_id, id, display_name, description, parent_folder_id, properties)
+          values (:workspace_id, :id, :display_name, :description, :parent_folder_id, :properties::jsonb)
         """;
     if (folder.parentFolderId() != null) {
       Optional<Folder> parentFolder =
@@ -80,7 +85,8 @@ public class FolderDao {
                 "parent_folder_id",
                 Optional.ofNullable(folder.parentFolderId())
                     .map(UUID::toString)
-                    .orElse(DEFAULT_ROOT_FOLDER_ID));
+                    .orElse(DEFAULT_ROOT_FOLDER_ID))
+            .addValue("properties", DbSerDes.propertiesToJson(folder.properties()));
 
     try {
       jdbcTemplate.update(sql, params);
@@ -125,7 +131,7 @@ public class FolderDao {
         && description == null
         && parentFolderId == null
         && updateParent == null) {
-      throw new MissingRequiredFieldException("Must specified fields to update");
+      throw new MissingRequiredFieldsException("Must specified fields to update");
     }
     if (parentFolderId != null) {
       if (getFolderIfExists(workspaceId, folderId).isEmpty()) {
@@ -187,7 +193,7 @@ public class FolderDao {
   public Optional<Folder> getFolderIfExists(UUID workspaceId, UUID folderId) {
     String sql =
         """
-           SELECT workspace_id, id, display_name, description, parent_folder_id
+           SELECT workspace_id, id, display_name, description, parent_folder_id, properties
            FROM folder
            WHERE id = :id AND workspace_id = :workspace_id
          """;
@@ -220,7 +226,7 @@ public class FolderDao {
   public ImmutableList<Folder> listFolders(UUID workspaceId, @Nullable UUID parentFolderId) {
     String sql =
         """
-         SELECT workspace_id, id, display_name, description, parent_folder_id
+         SELECT workspace_id, id, display_name, description, parent_folder_id, properties
          FROM folder
          WHERE workspace_id = :workspace_id
        """;
@@ -255,5 +261,69 @@ public class FolderDao {
       logger.info("No record found for delete folder {} in workspace {}", folderId, workspaceUuid);
     }
     return deleted;
+  }
+
+  @WriteTransaction
+  public void updateFolderProperties(
+      UUID workspaceUuid, UUID folderId, Map<String, String> properties) {
+    if (properties.isEmpty()) {
+      throw new MissingRequiredFieldsException("No folder property is specified to update");
+    }
+    Map<String, String> updatedProperties =
+        new HashMap<>(getFolderProperties(workspaceUuid, folderId));
+    updatedProperties.putAll(properties);
+    storeFolderProperties(updatedProperties, workspaceUuid, folderId);
+  }
+
+  @WriteTransaction
+  public void deleteFolderProperties(UUID workspaceUuid, UUID folderId, List<String> propertyKeys) {
+    if (propertyKeys.isEmpty()) {
+      throw new MissingRequiredFieldsException("No folder property is specified to delete");
+    }
+    Map<String, String> properties = new HashMap<>(getFolderProperties(workspaceUuid, folderId));
+    for (String key : propertyKeys) {
+      properties.remove(key);
+    }
+    storeFolderProperties(properties, workspaceUuid, folderId);
+  }
+
+  /** Update the properties column of a given folder in a given workspace. */
+  private void storeFolderProperties(
+      Map<String, String> properties, UUID workspaceUuid, UUID folderId) {
+    final String sql =
+        """
+          UPDATE folder SET properties = cast(:properties AS jsonb)
+          WHERE workspace_id = :workspace_id AND id = :folder_id
+        """;
+
+    var params = new MapSqlParameterSource();
+    params
+        .addValue("properties", DbSerDes.propertiesToJson(properties))
+        .addValue("workspace_id", workspaceUuid.toString())
+        .addValue("folder_id", folderId.toString());
+    jdbcTemplate.update(sql, params);
+  }
+
+  private ImmutableMap<String, String> getFolderProperties(UUID workspaceUuid, UUID folderId) {
+    String selectPropertiesSql =
+        """
+          SELECT properties FROM folder
+          WHERE workspace_id = :workspace_id AND id = :folder_id
+        """;
+    MapSqlParameterSource propertiesParams =
+        new MapSqlParameterSource()
+            .addValue("workspace_id", workspaceUuid.toString())
+            .addValue("folder_id", folderId.toString());
+    String result;
+
+    try {
+      result = jdbcTemplate.queryForObject(selectPropertiesSql, propertiesParams, String.class);
+    } catch (EmptyResultDataAccessException e) {
+      throw new FolderNotFoundException(
+          String.format("Cannot find resource %s in workspace %s.", folderId, workspaceUuid));
+    }
+    return result == null
+        ? ImmutableMap.of()
+        : ImmutableMap.copyOf(DbSerDes.jsonToProperties(result));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/db/FolderDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/FolderDao.java
@@ -131,7 +131,7 @@ public class FolderDao {
         && description == null
         && parentFolderId == null
         && (updateParent == null || !updateParent)) {
-      throw new MissingRequiredFieldsException("Must specified fields to update");
+      throw new MissingRequiredFieldsException("Must specify at least one field to update.");
     }
     if (parentFolderId != null) {
       if (getFolderIfExists(workspaceId, folderId).isEmpty()) {

--- a/service/src/main/java/bio/terra/workspace/service/folder/FolderService.java
+++ b/service/src/main/java/bio/terra/workspace/service/folder/FolderService.java
@@ -4,6 +4,8 @@ import bio.terra.workspace.db.FolderDao;
 import bio.terra.workspace.db.exception.FolderNotFoundException;
 import bio.terra.workspace.service.folder.model.Folder;
 import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.springframework.stereotype.Component;
@@ -50,5 +52,15 @@ public class FolderService {
               folderId, workspaceUuid));
     }
     // TODO (PF-1984): start a flight to update resource properties
+  }
+
+  public void updateFolderProperties(
+      UUID workspaceUuid, UUID folderUuid, Map<String, String> properties) {
+    folderDao.updateFolderProperties(workspaceUuid, folderUuid, properties);
+  }
+
+  public void deleteFolderProperties(
+      UUID workspaceUuid, UUID folderUuid, List<String> propertyKeys) {
+    folderDao.deleteFolderProperties(workspaceUuid, folderUuid, propertyKeys);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/folder/model/Folder.java
+++ b/service/src/main/java/bio/terra/workspace/service/folder/model/Folder.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.folder.model;
 
+import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
@@ -8,4 +9,5 @@ public record Folder(
     UUID workspaceId,
     String displayName,
     @Nullable String description,
-    @Nullable UUID parentFolderId) {}
+    @Nullable UUID parentFolderId,
+    Map<String, String> properties) {}

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -13,4 +13,5 @@
     <include file="changesets/20220810_resource_lineage.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220824_folder_table.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220907_add_resource_properties_column.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20220920_add_folder_properties_column.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20220920_add_folder_properties_column.yaml
+++ b/service/src/main/resources/db/changesets/20220920_add_folder_properties_column.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+- changeSet:
+    id: Add folder properties column
+    author: yuhuyoyo
+    changes:
+    - addColumn:
+        tableName: folder
+        columns:
+        - column:
+            name: properties
+            type: jsonb
+            remarks: |
+              Serialized key-value map of folder properties.
+            defaultValue: "{}"
+            constraints:
+              nullable: false

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/FolderApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/FolderApiControllerTest.java
@@ -92,6 +92,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     assertEquals(displayName, folder.getDisplayName());
     assertEquals(description, folder.getDescription());
     assertEquals("bar", convertApiPropertyToMap(folder.getProperties()).get("foo"));
+    assertEquals(1, folder.getProperties().size());
     assertNotNull(folder.getId());
     assertNull(folder.getParentFolderId());
   }
@@ -377,10 +378,12 @@ public class FolderApiControllerTest extends BaseUnitTest {
   }
 
   @Test
-  public void updateFolderProperties_updateSuccessfully() throws Exception {
+  public void updateFolderProperties_success() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    // create folder with foo=bar
     ApiFolder folder = createFolder(workspaceId);
 
+    // Add property cake=lava
     updateFolderPropertiesExpectCode(
         workspaceId,
         folder.getId(),
@@ -389,7 +392,22 @@ public class FolderApiControllerTest extends BaseUnitTest {
         HttpStatus.SC_NO_CONTENT);
 
     ApiFolder gotFolder = getFolder(workspaceId, folder.getId());
-    assertEquals("lava", convertApiPropertyToMap(gotFolder.getProperties()).get("cake"));
+    Map<String, String> properties = convertApiPropertyToMap(gotFolder.getProperties());
+    assertEquals("lava", properties.get("cake"));
+    assertEquals("bar", properties.get("foo"));
+
+    // update cake=lava to cake=chocolate
+    updateFolderPropertiesExpectCode(
+        workspaceId,
+        folder.getId(),
+        Map.of("cake", "chocolate"),
+        USER_REQUEST,
+        HttpStatus.SC_NO_CONTENT);
+
+    ApiFolder gotFolder2 = getFolder(workspaceId, folder.getId());
+    properties = convertApiPropertyToMap(gotFolder2.getProperties());
+    assertEquals("chocolate", properties.get("cake"));
+    assertEquals("bar", properties.get("foo"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -97,6 +97,8 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/controlled/gcp/ai-notebook-instances/generateName";
   public static final String FOLDERS_V1_PATH_FORMAT = "/api/workspaces/v1/%s/folders";
   public static final String FOLDER_V1_PATH_FORMAT = "/api/workspaces/v1/%s/folders/%s";
+  public static final String FOLDER_PROPERTIES_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/folders/%s/properties";
   public static final String RESOURCE_PROPERTIES_V1_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/%s/properties";
   public static final String CONTROLLED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT =


### PR DESCRIPTION
This is to support use case such as short descriptions. In the future, they can support version, tags, etc, similar to workspace.

on folder creation with terra-short-description -> this is a monkey
```
{
  "id": "4cca6642-fb3a-450f-8fb9-1f4299dc5a08",
  "displayName": "foo",
  "properties": [
    {
      "key": "terra-short-description",
      "value": "this is a monkey"
    }
  ]
}
```

after update properties with haha -> yoyo

```
{
  "folders": [
    {
      "id": "4cca6642-fb3a-450f-8fb9-1f4299dc5a08",
      "displayName": "foo",
      "properties": [
        {
          "key": "haha",
          "value": "yoyo"
        },
        {
          "key": "terra-short-description",
          "value": "this is a monkey"
        }
      ]
    }
  ]
}
```

after delete properties "haha"
```
{
  "folders": [
    {
      "id": "4cca6642-fb3a-450f-8fb9-1f4299dc5a08",
      "displayName": "foo",
      "properties": [
        {
          "key": "short-description",
          "value": "this is a short description"
        }
      ]
    }
  ]
}
```