### PR TITLE
[PF-1930] Fix dismal failure with CreateStorageTransferServiceJobStep undo

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -371,3 +371,5 @@ Spring auto-magically searches for properties files for the active profiles.
       reloading, you still have to refresh the browser, but at least you don't have to
       restart the server.
 ![Main Run Configuration Dialog](docs/images/main_run_config.png)
+- For local development of connected tests, [comment out these lines](https://cs.github.com/DataBiosphere/terra-workspace-manager/blob/05dba30e7f597690c46c95a974d31bde532bcbbd/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java?q=startupinitializer#L33-L37)
+  to preserve workspace/cloud context between runs.

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/StorageTransferServiceUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/StorageTransferServiceUtils.java
@@ -31,7 +31,7 @@ public final class StorageTransferServiceUtils {
       throws IOException {
     // If there's no job  to delete, return early
     final TransferJob existingTransferJob =
-        storageTransferService.transferJobs().get(transferJobName, controlPlaneProjectId).execute();
+        getTransferJob(storageTransferService, transferJobName, controlPlaneProjectId);
     if (existingTransferJob == null) {
       logger.info(
           "Transfer Job {} in project {} was not found when trying to delete it.",
@@ -75,6 +75,15 @@ public final class StorageTransferServiceUtils {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
     }
     return StepResult.getStepResultSuccess();
+  }
+
+  public static TransferJob getTransferJob(
+      Storagetransfer storageTransferService, String transferJobName, String controlPlaneProjectId)
+      throws IOException {
+    return storageTransferService
+        .transferJobs()
+        .get(transferJobName, controlPlaneProjectId)
+        .execute();
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ControlledGcpResourceApiControllerConnectedTest.java
@@ -71,7 +71,7 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
   }
 
   @Test
-  public void createControlledBigQueryDataset_createdResourceEqualsGotResource() throws Exception {
+  public void createBigQueryDataset_createdResourceEqualsGotResource() throws Exception {
     ApiCreatedControlledGcpBigQueryDataset bqDataset =
         mockMvcUtils.createBigQueryDataset(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId());
@@ -91,7 +91,7 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
   }
 
   @Test
-  public void createControlledGcsBucket_createdResourceEqualsGotResource() throws Exception {
+  public void createBucket_createdResourceEqualsGotResource() throws Exception {
     ApiGcpGcsBucketResource retrievedResource =
         mockMvcUtils.getGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
@@ -106,7 +106,7 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
   }
 
   @Test
-  public void cloneControlledGcsBucket_copyNothing() throws Exception {
+  public void cloneBucket_copyNothing() throws Exception {
     ApiCloneControlledGcpGcsBucketResult cloneResult =
         cloneControlledGcsBucket(
             /*sourceWorkspaceId=*/ workspace.getId(),
@@ -119,7 +119,7 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
   }
 
   @Test
-  public void cloneControlledGcsBucket_copyDefinition() throws Exception {
+  public void cloneBucket_copyDefinition() throws Exception {
     ApiCloneControlledGcpGcsBucketResult cloneResult =
         cloneControlledGcsBucket(
             /*sourceWorkspaceId=*/ workspace.getId(),
@@ -143,7 +143,7 @@ public class ControlledGcpResourceApiControllerConnectedTest extends BaseConnect
 
   @Disabled("PF-1930: Enable when feature is implemented")
   @Test
-  public void cloneControlledGcsBucket_copyReference() throws Exception {
+  public void cloneBucket_copyReference() throws Exception {
     ApiCloneControlledGcpGcsBucketResult cloneResult =
         cloneControlledGcsBucket(
             /*sourceWorkspaceId=*/ workspace.getId(),

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -457,7 +457,7 @@ public class ControlledResourceFixtures {
     return ControlledResourceFields.builder()
         .workspaceUuid(UUID.randomUUID())
         .resourceId(UUID.randomUUID())
-        .name(TestUtils.appendRandomNumber("test_resource").replace("-", "_"))
+        .name(TestUtils.appendRandomNumber("test_resource"))
         .description("how much data could a dataset set if a dataset could set data?")
         .cloningInstructions(CloningInstructions.COPY_DEFINITION)
         .assignedUser(null)

--- a/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
@@ -6,6 +6,9 @@ public class TestUtils {
   private static final Random RANDOM = new Random();
 
   public static String appendRandomNumber(String string) {
-    return string + "-" + RANDOM.nextInt(100000);
+    // Can't have dash because BQ dataset names can't have dash.
+    // Can't have underscore because for controlled buckets, GCP recommends not having underscore
+    // in bucket name.
+    return string + RANDOM.nextInt(100000);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/connected/ResourceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/ResourceConnectedTestUtils.java
@@ -1,0 +1,29 @@
+package bio.terra.workspace.connected;
+
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/** Utilities for working with resources in connected tests. */
+@Component
+public class ResourceConnectedTestUtils {
+
+  @Autowired ControlledResourceService controlledResourceService;
+
+  public ControlledResource createControlledBucket(
+      AuthenticatedUserRequest userRequest, UUID workspaceId) {
+    ControlledResource bucketResource =
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceId).build();
+    return controlledResourceService.createControlledResourceSync(
+        bucketResource,
+        ControlledResourceIamRole.OWNER,
+        userRequest,
+        new ApiGcpGcsBucketCreationParameters());
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -19,7 +19,12 @@ public class WorkspaceConnectedTestUtils {
   private @Autowired JobService jobService;
   private @Autowired SpendConnectedTestUtils spendUtils;
 
-  /** Creates a workspace with a GCP cloud context. */
+  /**
+   * Creates a workspace with a GCP cloud context.
+   *
+   * <p>Note: To delete workspace and cloud context, call workspaceService.deleteWorkspace(). This
+   * automatically deletes cloud context.
+   */
   public Workspace createWorkspaceWithGcpContext(AuthenticatedUserRequest userRequest) {
     UUID workspaceUuid = UUID.randomUUID();
     Workspace workspace =
@@ -36,16 +41,5 @@ public class WorkspaceConnectedTestUtils {
     jobService.waitForJob(gcpContextJobId);
     assertNull(jobService.retrieveJobResult(gcpContextJobId, Object.class).getException());
     return workspaceService.getWorkspace(workspaceUuid);
-  }
-
-  public void deleteWorkspaceAndGcpContext(AuthenticatedUserRequest userRequest, UUID workspaceId) {
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
-    workspaceService.deleteGcpCloudContext(workspace, userRequest);
-
-    workspaceService.deleteWorkspace(workspace, userRequest);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -37,4 +37,17 @@ public class WorkspaceConnectedTestUtils {
     assertNull(jobService.retrieveJobResult(gcpContextJobId, Object.class).getException());
     return workspaceService.getWorkspace(workspaceUuid);
   }
+
+  public void deleteWorkspaceAndGcpContext(AuthenticatedUserRequest userRequest, UUID workspaceId) {
+    String jobId = UUID.randomUUID().toString();
+    Workspace workspace =
+        Workspace.builder()
+            .workspaceId(workspaceId)
+            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+            .build();
+    workspaceService.deleteGcpCloudContext(workspace, userRequest);
+    jobService.waitForJob(jobId);
+
+    workspaceService.deleteWorkspace(workspace, userRequest);
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -39,14 +39,12 @@ public class WorkspaceConnectedTestUtils {
   }
 
   public void deleteWorkspaceAndGcpContext(AuthenticatedUserRequest userRequest, UUID workspaceId) {
-    String jobId = UUID.randomUUID().toString();
     Workspace workspace =
         Workspace.builder()
             .workspaceId(workspaceId)
             .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
     workspaceService.deleteGcpCloudContext(workspace, userRequest);
-    jobService.waitForJob(jobId);
 
     workspaceService.deleteWorkspace(workspace, userRequest);
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlightTest.java
@@ -18,8 +18,10 @@ import bio.terra.workspace.service.resource.controlled.ControlledResourceService
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
+import bio.terra.workspace.service.workspace.model.Workspace;
 import java.time.Duration;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
@@ -43,6 +45,7 @@ public class CloneControlledGcsBucketResourceFlightTest extends BaseConnectedTes
 
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired JobService jobService;
+  @Autowired WorkspaceService workspaceService;
   @Autowired WorkspaceConnectedTestUtils workspaceUtils;
   @Autowired ResourceConnectedTestUtils resourceUtils;
   @Autowired ControlledResourceService controlledResourceService;
@@ -66,8 +69,8 @@ public class CloneControlledGcsBucketResourceFlightTest extends BaseConnectedTes
 
   @AfterAll
   public void cleanup() throws Exception {
-    workspaceUtils.deleteWorkspaceAndGcpContext(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    Workspace workspace = workspaceService.getWorkspace(workspaceId);
+    workspaceService.deleteWorkspace(workspace, userAccessUtils.defaultUserAuthRequest());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlightTest.java
@@ -22,8 +22,8 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.Contr
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import java.time.Duration;
 import java.util.UUID;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -51,7 +51,7 @@ public class CloneControlledGcsBucketResourceFlightTest extends BaseConnectedTes
   private ControlledResource sourceResource;
   private UUID destResourceId;
 
-  @BeforeEach
+  @BeforeAll
   public void setup() throws Exception {
     workspaceId =
         workspaceUtils
@@ -64,7 +64,7 @@ public class CloneControlledGcsBucketResourceFlightTest extends BaseConnectedTes
     destResourceId = UUID.randomUUID();
   }
 
-  @AfterEach
+  @AfterAll
   public void cleanup() throws Exception {
     workspaceUtils.deleteWorkspaceAndGcpContext(
         userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlightTest.java
@@ -1,0 +1,110 @@
+package bio.terra.workspace.service.resource.controlled.flight.clone.bucket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.stairway.FlightDebugInfo;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.FlightState;
+import bio.terra.stairway.FlightStatus;
+import bio.terra.workspace.common.BaseConnectedTest;
+import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.connected.ResourceConnectedTestUtils;
+import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
+import bio.terra.workspace.service.job.JobMapKeys;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+/**
+ * ControlledGcpResourceApiControllerConnectedTest tests that cloning succeeds. This file just tests
+ * undo.
+ */
+// Per-class lifecycle on this test to allow a shared workspace object across tests, which saves
+// time creating and deleting GCP contexts.
+@TestInstance(Lifecycle.PER_CLASS)
+public class CloneControlledGcsBucketResourceFlightTest extends BaseConnectedTest {
+  /** How long to wait for a Stairway flight to complete before timing out the test. */
+  private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(2);
+
+  @Autowired UserAccessUtils userAccessUtils;
+  @Autowired JobService jobService;
+  @Autowired WorkspaceConnectedTestUtils workspaceUtils;
+  @Autowired ResourceConnectedTestUtils resourceUtils;
+  @Autowired ControlledResourceService controlledResourceService;
+
+  private UUID workspaceId;
+  private ControlledResource sourceResource;
+  private UUID destResourceId;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    workspaceId =
+        workspaceUtils
+            .createWorkspaceWithGcpContext(userAccessUtils.defaultUserAuthRequest())
+            .getWorkspaceId();
+
+    sourceResource =
+        resourceUtils.createControlledBucket(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+
+    destResourceId = UUID.randomUUID();
+  }
+
+  @AfterEach
+  public void cleanup() throws Exception {
+    workspaceUtils.deleteWorkspaceAndGcpContext(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId);
+  }
+
+  @Test
+  void cloneBucket_copyResource_undo() throws Exception {
+    testCloneBucket_undo(CloningInstructions.COPY_RESOURCE);
+  }
+
+  /**
+   *
+   * <li>Runs CloneControlledGcsBucketResourceFlight, with last step set to fail
+   * <li>Confirms destination bucket resource no longer exists
+   */
+  private void testCloneBucket_undo(CloningInstructions cloningInstructions) throws Exception {
+    FlightMap inputs = new FlightMap();
+    inputs.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), userAccessUtils.defaultUserAuthRequest());
+    inputs.put(ResourceKeys.RESOURCE, sourceResource);
+    inputs.put(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, workspaceId);
+    inputs.put(ControlledResourceKeys.DESTINATION_RESOURCE_ID, destResourceId);
+    // Set destination resource name
+    inputs.put(ResourceKeys.RESOURCE_NAME, sourceResource.getName() + "-clone");
+    inputs.put(ControlledResourceKeys.CLONING_INSTRUCTIONS, cloningInstructions);
+
+    FlightDebugInfo debugInfo = FlightDebugInfo.newBuilder().lastStepFailure(true).build();
+    FlightState flightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CloneControlledGcsBucketResourceFlight.class,
+            inputs,
+            STAIRWAY_FLIGHT_TIMEOUT,
+            debugInfo);
+    assertEquals(FlightStatus.ERROR, flightState.getFlightStatus());
+
+    // Assert destination bucket resource doesn't exist
+    ResourceNotFoundException exception =
+        assertThrows(
+            ResourceNotFoundException.class,
+            () -> controlledResourceService.getControlledResource(workspaceId, destResourceId));
+    assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlightTest.java
@@ -88,6 +88,9 @@ public class CloneControlledGcsBucketResourceFlightTest extends BaseConnectedTes
     inputs.put(ControlledResourceKeys.DESTINATION_RESOURCE_ID, destResourceId);
     // Set destination resource name
     inputs.put(ResourceKeys.RESOURCE_NAME, sourceResource.getName() + "-clone");
+    inputs.put(
+        ControlledResourceKeys.DESTINATION_BUCKET_NAME,
+        sourceResource.getName() + "-clone-bucket-name");
     inputs.put(ControlledResourceKeys.CLONING_INSTRUCTIONS, cloningInstructions);
 
     FlightDebugInfo debugInfo = FlightDebugInfo.newBuilder().lastStepFailure(true).build();


### PR DESCRIPTION
While working on implementing cloning controlled bucket -> referenced, I wrote a test for CloneControlledGcsBucketResourceFlight undo. (There is no existing test for undo.) It turns out that existing undo fails with dismal exception:

```
2022-09-21 13:33:20.472  ERROR 87902 --- [pool-8-thread-2] bio.terra.stairway.StepResult            : Step Result exception

com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
POST https://storagetransfer.googleapis.com/v1/transferJobs/wsm-owfmSCImSDe8CFS3Aai_8w
{
  "code": 400,
  "errors": [
    {
      "domain": "global",
      "message": "Updating a deleted transfer job is not allowed.",
      "reason": "failedPrecondition"
    }
  ],
  "message": "Updating a deleted transfer job is not allowed.",
  "status": "FAILED_PRECONDITION"
}

DISMAL FAILURE: non-retry-able error during undo. Flight: owfmSCImSDe8CFS3Aai_8w(bio.terra.workspace.service.resource.controlled.flight.clone.bucket.CloneControlledGcsBucketResourceFlight) Step: 5(bio.terra.workspace.service.resource.controlled.flight.clone.bucket.CreateStorageTransferServiceJobStep)
```
Updated CloneControlledGcsBucketResourceFlight undo to 1) prevent dismal failure 2) be idempotent.