### PR TITLE
[PF-1930] Implement cloning controlled bucket to referenced

### DIFF
--- a/openapi/src/common/schemas.yaml
+++ b/openapi/src/common/schemas.yaml
@@ -45,8 +45,8 @@ components:
             and new cloud resource, with data copied over.  For example for GCS bucket,
             create new GCS bucket with same region/lifecycle rules as source bucket. Copy files
             from source bucket to new bucket.
-          * COPY_REFERENCE: Only used for referenced resources. Create new referenced resource
-            that points to same cloud resource as source referenced resource.
+          * COPY_REFERENCE: Used for controlled and referenced resources. Create new referenced resource
+            that points to same cloud resource as source resource.
       enum: ['COPY_NOTHING', 'COPY_DEFINITION', 'COPY_RESOURCE', 'COPY_REFERENCE']
   
     ControlledResourceIamRole:

--- a/openapi/src/parts/controlled_gcp_gcs_bucket.yaml
+++ b/openapi/src/parts/controlled_gcp_gcs_bucket.yaml
@@ -347,7 +347,8 @@ components:
           type: string
         bucketName:
           description: >-
-            Name of created bucket (not the resource name). This name must
+            Name of created bucket (not the resource name). Must not be set if
+            cloningInstructions is COPY_REFERENCE. This name must
             be globally unique, so it can't be a copy of the original bucket name.
             It also can't be a simple formula like copy-of-bucket-name, as that would
             fail on subsequent clone operations with bucket-name as the source bucket.
@@ -356,7 +357,8 @@ components:
         location:
           description: >-
             A valid bucket location per https://cloud.google.com/storage/docs/locations.
-            If null, will use source bucket's location.
+            Must not be set if cloningInstructions is COPY_REFERENCE. If null,
+            will use source bucket's location.
           type: string
         jobControl:
           $ref: '#/components/schemas/JobControl'
@@ -454,7 +456,9 @@ components:
             $ref: '#/components/schemas/CreatedControlledGcpGcsBucket'
 
     ClonedControlledGcpGcsBucketResponse:
-      description: Response to GCS bucket clone operation.
+      description: >-
+        Response to GCS bucket clone operation where source bucket is
+        controlled. (Destination bucket may be controlled or referenced.)
       content:
         application/json:
           schema:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.app.controller;
 
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.workspace.common.utils.ControllerValidationUtils;
 import bio.terra.workspace.generated.controller.ControlledGcpResourceApi;
 import bio.terra.workspace.generated.model.*;
@@ -200,6 +201,14 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
   public ResponseEntity<ApiCloneControlledGcpGcsBucketResult> cloneGcsBucket(
       UUID workspaceUuid, UUID resourceId, @Valid ApiCloneControlledGcpGcsBucketRequest body) {
     logger.info("Cloning GCS bucket resourceId {} workspaceUuid {}", resourceId, workspaceUuid);
+
+    if (body.getCloningInstructions() == ApiCloningInstructionsEnum.REFERENCE
+        && (!StringUtils.isEmpty(body.getBucketName())
+            || !StringUtils.isEmpty(body.getLocation()))) {
+      throw new BadRequestException(
+          String.format(
+              "When cloning controlled bucket with COPY_REFERENCE, cannot set bucket or location in request"));
+    }
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     // This technically duplicates the first step of the flight as the clone flight is re-used for

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -477,7 +477,8 @@ public class ResourceValidationUtils {
         (StewardshipType.CONTROLLED == stewardshipType
                 && (CloningInstructions.COPY_NOTHING == cloningInstructions
                     || CloningInstructions.COPY_DEFINITION == cloningInstructions
-                    || CloningInstructions.COPY_RESOURCE == cloningInstructions))
+                    || CloningInstructions.COPY_RESOURCE == cloningInstructions
+                    || CloningInstructions.COPY_REFERENCE == cloningInstructions))
             || (StewardshipType.REFERENCED == stewardshipType
                 && (CloningInstructions.COPY_NOTHING == cloningInstructions
                     || CloningInstructions.COPY_REFERENCE == cloningInstructions));

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetReferencedDestinationGcsBucketInWorkingMapStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetReferencedDestinationGcsBucketInWorkingMapStep.java
@@ -1,0 +1,92 @@
+package bio.terra.workspace.service.resource.controlled.flight.clone.bucket;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
+import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.WorkspaceCloneUtils;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResourceService;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
+import com.google.common.base.Preconditions;
+import java.util.UUID;
+
+/**
+ * Adds ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE and ResourceKeys.RESOURCE_TYPE to
+ * working map, for CreateReferenceMetadataStep to use.
+ */
+public class SetReferencedDestinationGcsBucketInWorkingMapStep implements Step {
+
+  private final AuthenticatedUserRequest userRequest;
+  private final ControlledGcsBucketResource sourceBucket;
+  private final ReferencedResourceService referencedResourceService;
+  private final CloningInstructions resolvedCloningInstructions;
+
+  public SetReferencedDestinationGcsBucketInWorkingMapStep(
+      AuthenticatedUserRequest userRequest,
+      ControlledGcsBucketResource sourceBucket,
+      ReferencedResourceService referencedResourceService,
+      CloningInstructions resolvedCloningInstructions) {
+    this.userRequest = userRequest;
+    this.sourceBucket = sourceBucket;
+    this.referencedResourceService = referencedResourceService;
+    this.resolvedCloningInstructions = resolvedCloningInstructions;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    final FlightMap inputParameters = flightContext.getInputParameters();
+    final FlightMap workingMap = flightContext.getWorkingMap();
+    FlightUtils.validateRequiredEntries(
+        inputParameters,
+        ControlledResourceKeys.DESTINATION_WORKSPACE_ID,
+        ControlledResourceKeys.DESTINATION_RESOURCE_ID);
+    Preconditions.checkState(
+        resolvedCloningInstructions == CloningInstructions.COPY_REFERENCE,
+        "CloningInstructions must be COPY_REFERENCE");
+    final String resourceName =
+        FlightUtils.getInputParameterOrWorkingValue(
+            flightContext,
+            ResourceKeys.RESOURCE_NAME,
+            ResourceKeys.PREVIOUS_RESOURCE_NAME,
+            String.class);
+    final String description =
+        FlightUtils.getInputParameterOrWorkingValue(
+            flightContext,
+            ResourceKeys.RESOURCE_DESCRIPTION,
+            ResourceKeys.PREVIOUS_RESOURCE_DESCRIPTION,
+            String.class);
+    final UUID destinationWorkspaceId =
+        inputParameters.get(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, UUID.class);
+    final var destinationResourceId =
+        inputParameters.get(ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class);
+
+    ReferencedGcsBucketResource destinationBucketResource =
+        WorkspaceCloneUtils.buildDestinationReferencedGcsBucketFromControlled(
+            sourceBucket,
+            destinationWorkspaceId,
+            destinationResourceId,
+            resourceName,
+            description,
+            sourceBucket.getBucketName());
+
+    workingMap.put(
+        ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE, destinationBucketResource);
+    workingMap.put(ResourceKeys.RESOURCE_TYPE, destinationBucketResource.getResourceType());
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    // Nothing to undo
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetReferencedDestinationGcsBucketResponseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetReferencedDestinationGcsBucketResponseStep.java
@@ -1,0 +1,60 @@
+package bio.terra.workspace.service.resource.controlled.flight.clone.bucket;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.generated.model.ApiClonedControlledGcpGcsBucket;
+import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
+import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Sets flight response to destination bucket.
+ *
+ * <p>Note - This can't be done in SetReferencedDestinationGcsBucketInWorkingMapStep, because
+ * CreateReferenceMetadataStep sets flight response to dest resource ID. So this must be done after
+ * CreateReferenceMetadataStep.
+ */
+public class SetReferencedDestinationGcsBucketResponseStep implements Step {
+
+  public SetReferencedDestinationGcsBucketResponseStep() {}
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    ControlledResource sourceBucket =
+        context.getInputParameters().get(ResourceKeys.RESOURCE, ControlledResource.class);
+    ReferencedGcsBucketResource destBucket =
+        context
+            .getWorkingMap()
+            .get(
+                ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE,
+                ReferencedGcsBucketResource.class);
+
+    ApiCreatedControlledGcpGcsBucket apiCreatedBucket =
+        new ApiCreatedControlledGcpGcsBucket()
+            .gcpBucket(destBucket.toApiResource())
+            .resourceId(destBucket.getResourceId());
+
+    final ApiClonedControlledGcpGcsBucket apiClonedBucket =
+        new ApiClonedControlledGcpGcsBucket()
+            .effectiveCloningInstructions(ApiCloningInstructionsEnum.REFERENCE)
+            .bucket(apiCreatedBucket)
+            .sourceWorkspaceId(sourceBucket.getWorkspaceId())
+            .sourceResourceId(sourceBucket.getResourceId());
+    FlightUtils.setResponse(context, apiClonedBucket, HttpStatus.OK);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  // No side effects to undo.
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
@@ -67,37 +67,37 @@ public class WorkspaceCloneUtils {
     // ReferenceResource doesn't have Builder, only leaf resources like ReferencedGcsBucketResource
     // have Builder. So each resource type must be built separately.
     return switch (sourceReferencedResource.getResourceType()) {
-      case REFERENCED_GCP_GCS_BUCKET -> buildDestinationGcsBucketReference(
+      case REFERENCED_GCP_GCS_BUCKET -> buildDestinationReferencedGcsBucket(
           sourceReferencedResource.castByEnum(WsmResourceType.REFERENCED_GCP_GCS_BUCKET),
           destinationWorkspaceId,
           destinationResourceId,
           name,
           description);
-      case REFERENCED_GCP_GCS_OBJECT -> buildDestinationGcsObjectReference(
+      case REFERENCED_GCP_GCS_OBJECT -> buildDestinationReferencedGcsObject(
           sourceReferencedResource.castByEnum(WsmResourceType.REFERENCED_GCP_GCS_OBJECT),
           destinationWorkspaceId,
           destinationResourceId,
           name,
           description);
-      case REFERENCED_ANY_DATA_REPO_SNAPSHOT -> buildDestinationDataRepoSnapshotReference(
+      case REFERENCED_ANY_DATA_REPO_SNAPSHOT -> buildDestinationReferencedDataRepoSnapshot(
           sourceReferencedResource.castByEnum(WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT),
           destinationWorkspaceId,
           destinationResourceId,
           name,
           description);
-      case REFERENCED_GCP_BIG_QUERY_DATASET -> buildDestinationBigQueryDatasetReference(
+      case REFERENCED_GCP_BIG_QUERY_DATASET -> buildDestinationReferencedBigQueryDataset(
           sourceReferencedResource.castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET),
           destinationWorkspaceId,
           destinationResourceId,
           name,
           description);
-      case REFERENCED_GCP_BIG_QUERY_DATA_TABLE -> buildDestinationBigQueryDataTableReference(
+      case REFERENCED_GCP_BIG_QUERY_DATA_TABLE -> buildDestinationReferencedBigQueryDataTable(
           sourceReferencedResource.castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE),
           destinationWorkspaceId,
           destinationResourceId,
           name,
           description);
-      case REFERENCED_ANY_GIT_REPO -> buildDestinationGitHubRepoReference(
+      case REFERENCED_ANY_GIT_REPO -> buildDestinationReferencedGitHubRepo(
           sourceReferencedResource.castByEnum(WsmResourceType.REFERENCED_ANY_GIT_REPO),
           destinationWorkspaceId,
           destinationResourceId,
@@ -118,22 +118,12 @@ public class WorkspaceCloneUtils {
       @Nullable String description,
       String cloudInstanceName,
       String destinationProjectId) {
-    List<ResourceLineageEntry> destinationResourceLineage =
-        createDestinationResourceLineage(
-            sourceDataset.getResourceLineage(),
-            sourceDataset.getWorkspaceId(),
-            sourceDataset.getResourceId());
     return ControlledBigQueryDatasetResource.builder()
         .projectId(destinationProjectId)
         .datasetName(cloudInstanceName)
         .common(
             getControlledResourceCommonFields(
-                sourceDataset,
-                destinationWorkspaceId,
-                destinationResourceId,
-                name,
-                description,
-                destinationResourceLineage))
+                sourceDataset, destinationWorkspaceId, destinationResourceId, name, description))
         .build();
   }
 
@@ -144,21 +134,11 @@ public class WorkspaceCloneUtils {
       String name,
       @Nullable String description,
       String cloudInstanceName) {
-    List<ResourceLineageEntry> destinationResourceLineage =
-        createDestinationResourceLineage(
-            sourceBucket.getResourceLineage(),
-            sourceBucket.getWorkspaceId(),
-            sourceBucket.getResourceId());
     return ControlledGcsBucketResource.builder()
         .bucketName(cloudInstanceName)
         .common(
             getControlledResourceCommonFields(
-                sourceBucket,
-                destinationWorkspaceId,
-                destinationResourceId,
-                name,
-                description,
-                destinationResourceLineage))
+                sourceBucket, destinationWorkspaceId, destinationResourceId, name, description))
         .build();
   }
 
@@ -167,8 +147,12 @@ public class WorkspaceCloneUtils {
       UUID destinationWorkspaceId,
       UUID destinationResourceId,
       String name,
-      String description,
-      List<ResourceLineageEntry> destinationResourceLineage) {
+      String description) {
+    List<ResourceLineageEntry> destinationResourceLineage =
+        buildDestinationResourceLineage(
+            sourceResource.getResourceLineage(),
+            sourceResource.getWorkspaceId(),
+            sourceResource.getResourceId());
     return ControlledResourceFields.builder()
         .accessScope(sourceResource.getAccessScope())
         .assignedUser(sourceResource.getAssignedUser().orElse(null))
@@ -202,18 +186,13 @@ public class WorkspaceCloneUtils {
    * @param description - resource description for cloned reference. Uses original if left null.
    * @return referenced resource
    */
-  private static ReferencedResource buildDestinationGcsBucketReference(
+  private static ReferencedResource buildDestinationReferencedGcsBucket(
       ReferencedGcsBucketResource sourceBucketResource,
       UUID destinationWorkspaceId,
       UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
 
-    List<ResourceLineageEntry> destinationResourceLineage =
-        createDestinationResourceLineage(
-            sourceBucketResource.getResourceLineage(),
-            sourceBucketResource.getWorkspaceId(),
-            sourceBucketResource.getResourceId());
     final ReferencedGcsBucketResource.Builder resultBuilder =
         sourceBucketResource.toBuilder()
             .wsmResourceFields(
@@ -222,23 +201,49 @@ public class WorkspaceCloneUtils {
                     destinationResourceId,
                     name,
                     description,
-                    destinationResourceLineage,
                     sourceBucketResource));
 
     return resultBuilder.build();
   }
 
-  private static ReferencedResource buildDestinationGcsObjectReference(
+  public static ReferencedGcsBucketResource buildDestinationReferencedGcsBucketFromControlled(
+      ControlledGcsBucketResource sourceBucketResource,
+      UUID destinationWorkspaceId,
+      UUID destinationResourceId,
+      @Nullable String name,
+      @Nullable String description,
+      String bucketName) {
+    CloningInstructions destCloningInstructions =
+        // COPY_RESOURCE and COPY_DEFINITION aren't valid for referenced resources, so use
+        // COPY_REFERENCE instead.
+        sourceBucketResource.getCloningInstructions() == CloningInstructions.COPY_RESOURCE
+                || sourceBucketResource.getCloningInstructions()
+                    == CloningInstructions.COPY_DEFINITION
+            ? CloningInstructions.COPY_REFERENCE
+            : sourceBucketResource.getCloningInstructions();
+    WsmResourceFields wsmResourceFields =
+        buildDestinationResourceCommonFields(
+                destinationWorkspaceId,
+                destinationResourceId,
+                name,
+                description,
+                sourceBucketResource)
+            .toBuilder()
+            .cloningInstructions(destCloningInstructions)
+            .build();
+    final ReferencedGcsBucketResource.Builder resultBuilder =
+        ReferencedGcsBucketResource.builder()
+            .wsmResourceFields(wsmResourceFields)
+            .bucketName(bucketName);
+    return resultBuilder.build();
+  }
+
+  private static ReferencedResource buildDestinationReferencedGcsObject(
       ReferencedGcsObjectResource sourceBucketFileResource,
       UUID destinationWorkspaceId,
       UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
-    List<ResourceLineageEntry> destinationResourceLineage =
-        createDestinationResourceLineage(
-            sourceBucketFileResource.getResourceLineage(),
-            sourceBucketFileResource.getWorkspaceId(),
-            sourceBucketFileResource.getResourceId());
     final ReferencedGcsObjectResource.Builder resultBuilder =
         sourceBucketFileResource.toBuilder()
             .wsmResourceFields(
@@ -247,23 +252,17 @@ public class WorkspaceCloneUtils {
                     destinationResourceId,
                     name,
                     description,
-                    destinationResourceLineage,
                     sourceBucketFileResource));
     return resultBuilder.build();
   }
 
-  private static ReferencedResource buildDestinationBigQueryDatasetReference(
+  private static ReferencedResource buildDestinationReferencedBigQueryDataset(
       ReferencedBigQueryDatasetResource sourceBigQueryResource,
       UUID destinationWorkspaceId,
       UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
     // keep projectId and dataset name the same since they are for the referent
-    List<ResourceLineageEntry> destinationResourceLineage =
-        createDestinationResourceLineage(
-            sourceBigQueryResource.getResourceLineage(),
-            sourceBigQueryResource.getWorkspaceId(),
-            sourceBigQueryResource.getResourceId());
     final ReferencedBigQueryDatasetResource.Builder resultBuilder =
         sourceBigQueryResource.toBuilder()
             .wsmResourceFields(
@@ -272,23 +271,17 @@ public class WorkspaceCloneUtils {
                     destinationResourceId,
                     name,
                     description,
-                    destinationResourceLineage,
                     sourceBigQueryResource));
     return resultBuilder.build();
   }
 
-  private static ReferencedResource buildDestinationBigQueryDataTableReference(
+  private static ReferencedResource buildDestinationReferencedBigQueryDataTable(
       ReferencedBigQueryDataTableResource sourceBigQueryResource,
       UUID destinationWorkspaceId,
       UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
     // keep projectId, dataset name and data table name the same since they are for the referent
-    List<ResourceLineageEntry> destinationResourceLineage =
-        createDestinationResourceLineage(
-            sourceBigQueryResource.getResourceLineage(),
-            sourceBigQueryResource.getWorkspaceId(),
-            sourceBigQueryResource.getResourceId());
     final ReferencedBigQueryDataTableResource.Builder resultBuilder =
         sourceBigQueryResource.toBuilder()
             .wsmResourceFields(
@@ -297,22 +290,16 @@ public class WorkspaceCloneUtils {
                     destinationResourceId,
                     name,
                     description,
-                    destinationResourceLineage,
                     sourceBigQueryResource));
     return resultBuilder.build();
   }
 
-  private static ReferencedResource buildDestinationDataRepoSnapshotReference(
+  private static ReferencedResource buildDestinationReferencedDataRepoSnapshot(
       ReferencedDataRepoSnapshotResource sourceReferencedDataRepoSnapshotResource,
       UUID destinationWorkspaceId,
       UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
-    List<ResourceLineageEntry> destinationResourceLineage =
-        createDestinationResourceLineage(
-            sourceReferencedDataRepoSnapshotResource.getResourceLineage(),
-            sourceReferencedDataRepoSnapshotResource.getWorkspaceId(),
-            sourceReferencedDataRepoSnapshotResource.getResourceId());
     final ReferencedDataRepoSnapshotResource.Builder resultBuilder =
         sourceReferencedDataRepoSnapshotResource.toBuilder()
             .wsmResourceFields(
@@ -321,22 +308,16 @@ public class WorkspaceCloneUtils {
                     destinationResourceId,
                     name,
                     description,
-                    destinationResourceLineage,
                     sourceReferencedDataRepoSnapshotResource));
     return resultBuilder.build();
   }
 
-  private static ReferencedResource buildDestinationGitHubRepoReference(
+  private static ReferencedResource buildDestinationReferencedGitHubRepo(
       ReferencedGitRepoResource gitHubRepoResource,
       UUID destinationWorkspaceId,
       UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
-    List<ResourceLineageEntry> destinationResourceLineage =
-        createDestinationResourceLineage(
-            gitHubRepoResource.getResourceLineage(),
-            gitHubRepoResource.getWorkspaceId(),
-            gitHubRepoResource.getResourceId());
     ReferencedGitRepoResource.Builder resultBuilder =
         gitHubRepoResource.toBuilder()
             .wsmResourceFields(
@@ -345,7 +326,6 @@ public class WorkspaceCloneUtils {
                     destinationResourceId,
                     name,
                     description,
-                    destinationResourceLineage,
                     gitHubRepoResource));
     return resultBuilder.build();
   }
@@ -355,15 +335,19 @@ public class WorkspaceCloneUtils {
       UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description,
-      List<ResourceLineageEntry> destinationResourceLineage,
-      WsmResource wsmResource) {
+      WsmResource sourceResource) {
+    List<ResourceLineageEntry> destinationResourceLineage =
+        buildDestinationResourceLineage(
+            sourceResource.getResourceLineage(),
+            sourceResource.getWorkspaceId(),
+            sourceResource.getResourceId());
     WsmResourceFields.Builder<?> destinationResourceCommonFieldsBuilder =
-        wsmResource.getWsmResourceFields().toBuilder();
+        sourceResource.getWsmResourceFields().toBuilder();
     destinationResourceCommonFieldsBuilder
         .workspaceUuid(destinationWorkspaceId)
         .resourceId(destinationResourceId)
         .properties(
-            maybeClearSomeResourcePropertiesBeforeCloning(wsmResource, destinationWorkspaceId))
+            maybeClearSomeResourcePropertiesBeforeCloning(sourceResource, destinationWorkspaceId))
         .resourceLineage(destinationResourceLineage);
     // apply optional override variables
     Optional.ofNullable(name).ifPresent(destinationResourceCommonFieldsBuilder::name);
@@ -372,7 +356,7 @@ public class WorkspaceCloneUtils {
   }
 
   @VisibleForTesting
-  protected static List<ResourceLineageEntry> createDestinationResourceLineage(
+  protected static List<ResourceLineageEntry> buildDestinationResourceLineage(
       List<ResourceLineageEntry> sourceResourceLineage,
       UUID sourceWorkspaceId,
       UUID sourceResourceId) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/CloningInstructions.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/CloningInstructions.java
@@ -20,8 +20,8 @@ import javax.annotation.Nullable;
  * cloud resource, with data copied over. For example for GCS bucket, create new GCS bucket with
  * same region/lifecycle rules as source bucket. Copy files from source bucket to new bucket.
  *
- * <p>COPY_REFERENCE: Only used for referenced resources. Create new referenced resource that points
- * to same cloud resource as source referenced resource.
+ * <p>COPY_REFERENCE: Used for controlled and referenced resources. Create new referenced resource
+ * that points to same cloud resource as source resource.
  */
 public enum CloningInstructions {
   COPY_NOTHING,

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/ResourceLineageEntry.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/ResourceLineageEntry.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource.model;
 import bio.terra.workspace.generated.model.ApiResourceLineageEntry;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -55,7 +56,6 @@ public class ResourceLineageEntry {
 
   @Override
   public int hashCode() {
-    assert false : "hashCode not designed";
-    return 42; // any arbitrary constant will do
+    return Objects.hash(sourceWorkspaceId, sourceResourceId);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -469,6 +469,7 @@ public class ControlledResourceFixtures {
         .resourceId(UUID.randomUUID())
         .name(RandomStringUtils.randomAlphabetic(10))
         .description("how much data could a dataset set if a dataset could set data?")
+        .description(RESOURCE_DESCRIPTION)
         .cloningInstructions(CloningInstructions.COPY_DEFINITION)
         .assignedUser(null)
         .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)

--- a/service/src/test/java/bio/terra/workspace/serdes/ControlledGcsBucketResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/serdes/ControlledGcsBucketResourceTest.java
@@ -4,18 +4,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.StairwayMapper;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
-import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
-import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
-import bio.terra.workspace.service.resource.model.CloningInstructions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /** Test Stairway serialization of the ControlledGcsBucketResource class */
@@ -47,27 +42,5 @@ public class ControlledGcsBucketResourceTest extends BaseUnitTest {
         objectMapper.readValue(serialized, ControlledGcsBucketResource.class);
 
     assertThat(deserialized, equalTo(gcsBucketResource));
-  }
-
-  @Test
-  public void testCloningInstructionsValidation() {
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            ControlledGcsBucketResource.builder()
-                .bucketName(ControlledResourceFixtures.uniqueBucketName())
-                .common(
-                    ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
-                        .workspaceUuid(UUID.randomUUID())
-                        .resourceId(UUID.randomUUID())
-                        .name("controlled_bucket_1")
-                        .description(
-                            "how much data could a dataset set if a dataset could set data?")
-                        .cloningInstructions(CloningInstructions.COPY_REFERENCE) // not valid (yet!)
-                        .assignedUser(null)
-                        .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
-                        .managedBy(ManagedByType.MANAGED_BY_USER)
-                        .build())
-                .build());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -436,12 +436,5 @@ public class ValidationUtilsTest extends BaseUnitTest {
         () ->
             ResourceValidationUtils.validateCloningInstructions(
                 StewardshipType.REFERENCED, CloningInstructions.COPY_DEFINITION));
-
-    // This will be supported if we implement PF-812.
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            ResourceValidationUtils.validateCloningInstructions(
-                StewardshipType.CONTROLLED, CloningInstructions.COPY_REFERENCE));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtilsTest.java
@@ -313,7 +313,7 @@ public class WorkspaceCloneUtilsTest extends BaseUnitTest {
     var sourceResourceUuid = UUID.randomUUID();
 
     var destinationResourceLineage =
-        WorkspaceCloneUtils.createDestinationResourceLineage(
+        WorkspaceCloneUtils.buildDestinationResourceLineage(
             null, sourceWorkspaceUuid, sourceResourceUuid);
 
     List<ResourceLineageEntry> expectedLineage = new ArrayList<>();
@@ -329,7 +329,7 @@ public class WorkspaceCloneUtilsTest extends BaseUnitTest {
     var resourceLineage = new ArrayList<>(List.of(sourceResourceLineageEntry));
 
     var destinationResourceLineage =
-        WorkspaceCloneUtils.createDestinationResourceLineage(
+        WorkspaceCloneUtils.buildDestinationResourceLineage(
             resourceLineage, sourceWorkspaceUuid, sourceResourceUuid);
 
     resourceLineage.add(new ResourceLineageEntry(sourceWorkspaceUuid, sourceResourceUuid));


### PR DESCRIPTION
Manually tested:

```
{
  "resources": [
    {
      "metadata": {
        "workspaceId": "53f383ba-c91c-4b86-935f-b52f0bd1688b",
        "resourceId": "46bd7f0a-f4cb-4118-83ef-0b5be07343b6",
        "name": "dest-bucket",
        "resourceType": "GCS_BUCKET",
        "stewardshipType": "REFERENCED",
        "cloudPlatform": "GCP",
        "cloningInstructions": "COPY_REFERENCE",
        "resourceLineage": [
          {
            "sourceWorkspaceId": "53f383ba-c91c-4b86-935f-b52f0bd1688b",
            "sourceResourceId": "a7895e05-61ba-40a1-b235-28d52d6ac435"
          }
        ],
        "properties": []
      },
      "resourceAttributes": {
        "gcpGcsBucket": {
          "bucketName": "source-bucket-terra-wsm-t-rapid-walnut-999"
        }
      }
    },
    {
      "metadata": {
        "workspaceId": "53f383ba-c91c-4b86-935f-b52f0bd1688b",
        "resourceId": "a7895e05-61ba-40a1-b235-28d52d6ac435",
        "name": "source-bucket",
        "resourceType": "GCS_BUCKET",
        "stewardshipType": "CONTROLLED",
        "cloudPlatform": "GCP",
        "cloningInstructions": "COPY_DEFINITION",
        "controlledResourceMetadata": {
          "accessScope": "SHARED_ACCESS",
          "managedBy": "USER",
          "privateResourceUser": {},
          "privateResourceState": "NOT_APPLICABLE"
        },
        "resourceLineage": [],
        "properties": []
      },
      "resourceAttributes": {
        "gcpGcsBucket": {
          "bucketName": "source-bucket-terra-wsm-t-rapid-walnut-999"
        }
      }
    }
  ]
}
```

Also in `WorkspaceCloneUtils`:

- Move calling `buildDestinationResourceLineage` into `buildDestinationResourceCommonFields`, to avoid boilerplate
- Renamed `buildDestinationGcsBucketReference` -> `buildDestinationReferencedGcsBucket`, to be consistent with `buildDestinationControlledGcsBucket`

FYI @cbookg 