### PR TITLE
[PF-1980] Fix GrantPetUsagePermissionStep undo

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/GrantPetUsagePermissionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/GrantPetUsagePermissionStep.java
@@ -80,8 +80,8 @@ public class GrantPetUsagePermissionStep implements Step {
       return StepResult.getStepResultSuccess();
     }
     try {
-      // userRequest.email might be a pet SA, so we need to call Sam and determine the end-user's
-      // email directly.
+      // userRequest.email might be a pet SA (e.g. if the user is making this call from inside a
+      // notebook), so we need to call Sam and determine the end-user's email directly.
       // TODO(PF-1001): Having a SamUser object here (and in doStep) instead of an
       //  AuthenticatedUserRequest would save an extra call to Sam.
       String userEmail =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/GrantPetUsagePermissionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/GrantPetUsagePermissionStep.java
@@ -80,8 +80,15 @@ public class GrantPetUsagePermissionStep implements Step {
       return StepResult.getStepResultSuccess();
     }
     try {
+      // userRequest.email might be a pet SA, so we need to call Sam and determine the end-user's
+      // email directly.
+      // TODO(PF-1001): Having a SamUser object here (and in doStep) instead of an
+      //  AuthenticatedUserRequest would save an extra call to Sam.
+      String userEmail =
+          SamRethrow.onInterrupted(
+              () -> samService.getUserEmailFromSam(userRequest), "enablePetUndo");
       petSaService.disablePetServiceAccountImpersonationWithEtag(
-          workspaceUuid, userRequest.getEmail(), userRequest, expectedEtag);
+          workspaceUuid, userEmail, userRequest, expectedEtag);
     } catch (ConflictException e) {
       // There was a conflict disabling the service account. Request retry.
       // There is a possible concurrency error here: if two threads are trying to enable and


### PR DESCRIPTION
This undo step failed (causing dismal Stairway failures) if the `CreateControlledResourceFlight` creating an AI Notebook was triggered via pet SA credentials instead of end-user credentials, which frequently happened for users working from a notebook.

The root cause was that Sam's `getUserIds` endpoint throws a 404 if it's called with a pet SA email. This fix works by fetching the end-user email from Sam, similar to what we do in the `do` step. In the future (PF-1001) this would be a good spot for a `SamUser` object instead of an `AuthenticatedUserRequest` to save some extra calls to Sam.