### PR TITLE
[WOR-502] Allow specification of SAS token expiration.

### DIFF
--- a/openapi/src/common/parameters.yaml
+++ b/openapi/src/common/parameters.yaml
@@ -10,7 +10,7 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/CloudPlatform'
-    
+
     JobId:
       name: jobId
       in: path
@@ -18,7 +18,7 @@ components:
       required: true
       schema:
         type: string
-    
+
     Limit:
       name: limit
       in: query
@@ -28,7 +28,7 @@ components:
         type: integer
         minimum: 1
         default: 10
-    
+
     MemberEmail:
       name: memberEmail
       in: path
@@ -57,7 +57,7 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/Name'
-  
+
     Offset:
       name: offset
       in: query
@@ -67,7 +67,7 @@ components:
         type: integer
         minimum: 0
         default: 0
-  
+
     ResourceId:
       name: resourceId
       in: path
@@ -76,7 +76,7 @@ components:
       schema:
         type: string
         format: uuid
-  
+
     ResourceType:
       name: resource
       in: query
@@ -84,7 +84,7 @@ components:
       required: false
       schema:
         $ref: '#/components/schemas/ResourceType'
-  
+
     Role:
       name: role
       in: path
@@ -101,6 +101,17 @@ components:
       schema:
         type: string
 
+    SasExpirationDuration:
+      name: sasExpirationDuration
+      in: query
+      description: |
+        The number of seconds until the SAS token should expire (optional). Default and maximum allowed values are
+        set in configuration.
+      required: false
+      schema:
+        type: integer
+        format: int64
+
     StewardshipType:
       name: stewardship
       in: query
@@ -108,7 +119,7 @@ components:
       required: false
       schema:
         $ref: '#/components/schemas/StewardshipType'
-  
+
     WorkspaceId:
       name: workspaceId
       in: path

--- a/openapi/src/parts/controlled_azure_storage_container.yaml
+++ b/openapi/src/parts/controlled_azure_storage_container.yaml
@@ -29,7 +29,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/WorkspaceId'
         - $ref: '#/components/parameters/ResourceId'
-      summary: Delete an Azure Storge Container
+      summary: Delete an Azure Storage Container
       operationId: deleteAzureStorageContainer
       tags: [ControlledAzureResource]
       requestBody:
@@ -53,6 +53,7 @@ paths:
       - $ref: '#/components/parameters/WorkspaceId'
       - $ref: '#/components/parameters/ResourceId'
       - $ref: '#/components/parameters/SasIpRange'
+      - $ref: '#/components/parameters/SasExpirationDuration'
     post:
       summary: Create a SAS token to access the storage container
       operationId: createAzureStorageContainerSasToken
@@ -64,6 +65,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreatedAzureStorageContainerSasToken'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '500':

--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -297,6 +297,7 @@ workspace:
     managed-app-tenant-id: ${tenantid}
     sas-token-start-time-minutes-offset: 15
     sas-token-expiry-time-minutes-offset: 60
+    sas-token-expiry-time-maximum-minutes-offset: 1440
 feature:
   tps-enabled: true
 EOF

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
@@ -45,7 +45,6 @@ public class AzureConfiguration {
     return sasTokenStartTimeMinutesOffset;
   }
 
-
   public void setSasTokenStartTimeMinutesOffset(Long sasTokenStartTimeMinutesOffset) {
     this.sasTokenStartTimeMinutesOffset = sasTokenStartTimeMinutesOffset;
   }
@@ -62,7 +61,8 @@ public class AzureConfiguration {
     return sasTokenExpiryTimeMaximumMinutesOffset;
   }
 
-  public void setSasTokenExpiryTimeMaximumMinutesOffset(Long sasTokenExpiryTimeMaximumMinutesOffset) {
+  public void setSasTokenExpiryTimeMaximumMinutesOffset(
+      Long sasTokenExpiryTimeMaximumMinutesOffset) {
     this.sasTokenExpiryTimeMaximumMinutesOffset = sasTokenExpiryTimeMaximumMinutesOffset;
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
@@ -14,6 +14,7 @@ public class AzureConfiguration {
   private String managedAppTenantId;
   private Long sasTokenStartTimeMinutesOffset;
   private Long sasTokenExpiryTimeMinutesOffset;
+  private Long sasTokenExpiryTimeMaximumMinutesOffset;
   private String corsAllowedOrigins;
 
   public String getManagedAppClientId() {
@@ -44,6 +45,7 @@ public class AzureConfiguration {
     return sasTokenStartTimeMinutesOffset;
   }
 
+
   public void setSasTokenStartTimeMinutesOffset(Long sasTokenStartTimeMinutesOffset) {
     this.sasTokenStartTimeMinutesOffset = sasTokenStartTimeMinutesOffset;
   }
@@ -54,6 +56,14 @@ public class AzureConfiguration {
 
   public void setSasTokenExpiryTimeMinutesOffset(Long sasTokenExpiryTimeMinutesOffset) {
     this.sasTokenExpiryTimeMinutesOffset = sasTokenExpiryTimeMinutesOffset;
+  }
+
+  public Long getSasTokenExpiryTimeMaximumMinutesOffset() {
+    return sasTokenExpiryTimeMaximumMinutesOffset;
+  }
+
+  public void setSasTokenExpiryTimeMaximumMinutesOffset(Long sasTokenExpiryTimeMaximumMinutesOffset) {
+    this.sasTokenExpiryTimeMaximumMinutesOffset = sasTokenExpiryTimeMaximumMinutesOffset;
   }
 
   public String getCorsAllowedOrigins() {

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -253,8 +253,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     long secondDuration =
         sasExpirationDuration != null
             ? sasExpirationDuration
-            : azureConfiguration.getSasTokenExpiryTimeMinutesOffset()
-                * 40; // TODO: should be 60, trying to discover where tests live
+            : azureConfiguration.getSasTokenExpiryTimeMinutesOffset() * 60;
     OffsetDateTime expiryTime = OffsetDateTime.now().plusSeconds(secondDuration);
 
     var sasBundle =

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -211,11 +211,11 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
       createAzureStorageContainerSasToken(
           UUID workspaceUuid,
           UUID storageContainerUuid,
-          String sasIPRange,
+          String sasIpRange,
           Long sasExpirationDuration) {
     features.azureEnabledCheck();
 
-    ControllerValidationUtils.validateIpAddressRange(sasIPRange);
+    ControllerValidationUtils.validateIpAddressRange(sasIpRange);
     ControllerValidationUtils.validateSasExpirationDuration(
         sasExpirationDuration, azureConfiguration.getSasTokenExpiryTimeMaximumMinutesOffset());
 
@@ -264,7 +264,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             startTime,
             expiryTime,
             userRequest,
-            sasIPRange);
+            sasIpRange);
 
     logger.info(
         "SAS token with expiry time of {} generated for user {} on container {} in workspace {}",

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -209,11 +209,15 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
   @Override
   public ResponseEntity<ApiCreatedAzureStorageContainerSasToken>
       createAzureStorageContainerSasToken(
-          UUID workspaceUuid, UUID storageContainerUuid, String sasIPRange, Long sasExpirationDuration) {
+          UUID workspaceUuid,
+          UUID storageContainerUuid,
+          String sasIPRange,
+          Long sasExpirationDuration) {
     features.azureEnabledCheck();
 
     ControllerValidationUtils.validateIpAddressRange(sasIPRange);
-    ControllerValidationUtils.validateSasExpirationDuration(sasExpirationDuration, azureConfiguration.getSasTokenExpiryTimeMaximumMinutesOffset());
+    ControllerValidationUtils.validateSasExpirationDuration(
+        sasExpirationDuration, azureConfiguration.getSasTokenExpiryTimeMaximumMinutesOffset());
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     // Creating an AzureStorageContainerSasToken requires checking the user's access to both the
@@ -246,7 +250,11 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
 
     OffsetDateTime startTime =
         OffsetDateTime.now().minusMinutes(azureConfiguration.getSasTokenStartTimeMinutesOffset());
-    long secondDuration = sasExpirationDuration != null ? sasExpirationDuration : azureConfiguration.getSasTokenExpiryTimeMinutesOffset() * 40; // TODO: should be 60, trying to discover where tests live
+    long secondDuration =
+        sasExpirationDuration != null
+            ? sasExpirationDuration
+            : azureConfiguration.getSasTokenExpiryTimeMinutesOffset()
+                * 40; // TODO: should be 60, trying to discover where tests live
     OffsetDateTime expiryTime = OffsetDateTime.now().plusSeconds(secondDuration);
 
     var sasBundle =

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -139,16 +139,21 @@ public final class ControllerValidationUtils {
     }
   }
 
-  public static void validateSasExpirationDuration(@Nullable Long sasExpirationDuration, Long maxDurationMinutes) {
+  public static void validateSasExpirationDuration(
+      @Nullable Long sasExpirationDuration, Long maxDurationMinutes) {
     if (sasExpirationDuration == null) {
       return;
     }
     if (sasExpirationDuration <= 0) {
-      throw new ValidationException("sasExpirationDuration must be positive: " + sasExpirationDuration);
+      throw new ValidationException(
+          "sasExpirationDuration must be positive: " + sasExpirationDuration);
     }
     long maxDurationSeconds = 60 * maxDurationMinutes;
     if (sasExpirationDuration > maxDurationSeconds) {
-      throw new ValidationException(String.format("sasExpirationDuration must cannot be greater than allowed maximum (%d): %d", maxDurationSeconds, sasExpirationDuration));
+      throw new ValidationException(
+          String.format(
+              "sasExpirationDuration must cannot be greater than allowed maximum (%d): %d",
+              maxDurationSeconds, sasExpirationDuration));
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -139,6 +139,15 @@ public final class ControllerValidationUtils {
     }
   }
 
+  /**
+   * Validate that the expiration duration (in seconds) is between 1 and the maximum allowed
+   * duration (in minutes).
+   *
+   * @param sasExpirationDuration user-specified duration in seconds (note that null is allowed)
+   * @param maxDurationMinutes maximum allowed duration in minutes
+   * @throws ValidationException if sasExpiration is not positive or is greater than maximum allowed
+   *     duration. Does not throw an exception if sasExpiration is null.
+   */
   public static void validateSasExpirationDuration(
       @Nullable Long sasExpirationDuration, Long maxDurationMinutes) {
     if (sasExpirationDuration == null) {

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -161,7 +161,7 @@ public final class ControllerValidationUtils {
     if (sasExpirationDuration > maxDurationSeconds) {
       throw new ValidationException(
           String.format(
-              "sasExpirationDuration must cannot be greater than allowed maximum (%d): %d",
+              "sasExpirationDuration cannot be greater than allowed maximum (%d): %d",
               maxDurationSeconds, sasExpirationDuration));
     }
   }

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -139,6 +139,19 @@ public final class ControllerValidationUtils {
     }
   }
 
+  public static void validateSasExpirationDuration(@Nullable Long sasExpirationDuration, Long maxDurationMinutes) {
+    if (sasExpirationDuration == null) {
+      return;
+    }
+    if (sasExpirationDuration <= 0) {
+      throw new ValidationException("sasExpirationDuration must be positive: " + sasExpirationDuration);
+    }
+    long maxDurationSeconds = 60 * maxDurationMinutes;
+    if (sasExpirationDuration > maxDurationSeconds) {
+      throw new ValidationException(String.format("sasExpirationDuration must cannot be greater than allowed maximum (%d): %d", maxDurationSeconds, sasExpirationDuration));
+    }
+  }
+
   public static void validatePropertiesUpdateRequestBody(List<ApiProperty> properties) {
     if (properties.isEmpty()) {
       throw new ValidationException("Must specify at least one property to update");

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -87,7 +87,7 @@ public class AzureStorageAccessService {
    * @param startTime Time at which the SAS will become functional
    * @param expiryTime Time at which the SAS will expire
    * @param userRequest The authenticated user's request
-   * @param sasIPRange (optional) IP address or range of IPs from which the Azure APIs will accept
+   * @param sasIpRange (optional) IP address or range of IPs from which the Azure APIs will accept
    *     requests for the token being minted.
    * @return A bundle of 1) a full Azure SAS URL, including the storage account hostname and 2) the
    *     token query param fragment
@@ -99,7 +99,7 @@ public class AzureStorageAccessService {
       OffsetDateTime startTime,
       OffsetDateTime expiryTime,
       AuthenticatedUserRequest userRequest,
-      String sasIPRange) {
+      String sasIpRange) {
     features.azureEnabledCheck();
 
     BlobContainerSasPermission blobContainerSasPermission =
@@ -125,8 +125,8 @@ public class AzureStorageAccessService {
             .setStartTime(startTime)
             .setProtocol(SasProtocol.HTTPS_ONLY);
 
-    if (sasIPRange != null) {
-      sasValues.setSasIpRange(SasIpRange.parse(sasIPRange));
+    if (sasIpRange != null) {
+      sasValues.setSasIpRange(SasIpRange.parse(sasIpRange));
     }
 
     final var token = blobContainerClient.generateSas(sasValues);

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -125,6 +125,7 @@ workspace:
   azure:
     sas-token-start-time-minutes-offset: 15
     sas-token-expiry-time-minutes-offset: 60
+    sas-token-expiry-time-maximum-minutes-offset: 1440
     cors-allowed-origins:
 
 terra.common:

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
@@ -1,14 +1,18 @@
 package bio.terra.workspace.app.controller;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_SAS_TOKEN_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
@@ -16,15 +20,24 @@ import bio.terra.workspace.generated.model.ApiCreateControlledAzureVmRequestBody
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -91,5 +104,154 @@ public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest 
                         .content(objectMapper.writeValueAsString(vmRequest)),
                     USER_REQUEST)))
         .andExpect(status().is(HttpStatus.SC_OK));
+  }
+}
+
+class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
+  AuthenticatedUserRequest USER_REQUEST =
+      new AuthenticatedUserRequest(
+          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
+
+  @Autowired MockMvc mockMvc;
+  @Autowired AzureConfiguration azureConfiguration;
+  @MockBean ControlledResourceMetadataManager controlledResourceMetadataManager;
+  @MockBean SamService samService;
+  @MockBean AzureStorageAccessService azureStorageAccessService;
+
+  @Test
+  void createSASToken400BadDuration() throws Exception {
+    UUID workspaceId = UUID.randomUUID();
+    UUID resourceId = UUID.randomUUID();
+
+    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
+        240L); // maximum of 240 minutes (4 hours)
+
+    // expiration duration must be positive
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, resourceId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasExpirationDuration", "-1"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+
+    // expiration can't exceed 4 hours = 14400 seconds
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, resourceId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasExpirationDuration", "14401"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  void createSASTokenSuccess() throws Exception {
+    UUID workspaceId = UUID.randomUUID();
+    UUID storageAccountId = UUID.randomUUID();
+    UUID storageContainerId = UUID.randomUUID();
+
+    azureConfiguration.setSasTokenStartTimeMinutesOffset(5L); // 5 minutes before
+    azureConfiguration.setSasTokenExpiryTimeMinutesOffset(10L); // 10 minutes after
+    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
+        240L); // maximum of 240 minutes (4 hours)
+
+    ControlledAzureStorageContainerResource containerResource =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(storageContainerId)
+                    .build())
+            .storageAccountId(storageAccountId)
+            .storageContainerName("testcontainer")
+            .build();
+
+    when(controlledResourceMetadataManager.validateControlledResourceAndAction(
+            any(), eq(workspaceId), eq(storageContainerId), any()))
+        .thenReturn(containerResource);
+
+    ControlledAzureStorageResource accountResource =
+        ControlledAzureStorageResource.builder()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(storageAccountId)
+                    .build())
+            .storageAccountName("testaccount")
+            .region("eastus")
+            .build();
+
+    when(controlledResourceMetadataManager.validateControlledResourceAndAction(
+            any(), eq(workspaceId), eq(storageAccountId), any()))
+        .thenReturn(accountResource);
+
+    when(samService.getUserEmailFromSam(any())).thenReturn(USER_REQUEST.getEmail());
+
+    when(azureStorageAccessService.createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            any(),
+            any(),
+            any(),
+            any()))
+        .thenReturn(new AzureStorageAccessService.AzureSasBundle("sasToken", "sasUrl"));
+
+    // Specify custom expiration duration of 2 hours.
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasExpirationDuration", "7200"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    // Use expiration time as set in configuration.
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    ArgumentCaptor<OffsetDateTime> startTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+    ArgumentCaptor<OffsetDateTime> endTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+
+    Mockito.verify(azureStorageAccessService, times(2))
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            startTimeCaptor.capture(),
+            endTimeCaptor.capture(),
+            any(),
+            any());
+
+    // First call uses custom time of 2 hours (plus 5 minutes before) = 7500 seconds.
+    assertEquals(
+        7500,
+        endTimeCaptor.getAllValues().get(0).toEpochSecond()
+            - startTimeCaptor.getAllValues().get(0).toEpochSecond());
+
+    // Second call based on configuration, difference should be 15 minutes = 900 seconds.
+    assertEquals(
+        900,
+        endTimeCaptor.getAllValues().get(1).toEpochSecond()
+            - startTimeCaptor.getAllValues().get(1).toEpochSecond());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
@@ -30,7 +30,6 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContai
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;

--- a/service/src/test/java/bio/terra/workspace/common/utils/ControllerValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/ControllerValidationUtilsTest.java
@@ -60,7 +60,27 @@ public class ControllerValidationUtilsTest extends BaseUnitTest {
   }
 
   @Test
-  void userFacingIdCanStartWithNumber() throws Exception {
+  void userFacingIdCanStartWithNumber() {
     ControllerValidationUtils.validateUserFacingId("1000-genomes");
+  }
+
+  @Test
+  void validatingValidSasExpirationDurations() {
+    ControllerValidationUtils.validateSasExpirationDuration(1L, 10L);
+    ControllerValidationUtils.validateSasExpirationDuration(3600L, 60L);
+    ControllerValidationUtils.validateSasExpirationDuration(null, 60L);
+  }
+
+  @Test
+  void validatingInvalidSasExpirationDurations() {
+    assertThrows(
+        ValidationException.class,
+        () -> ControllerValidationUtils.validateSasExpirationDuration(0L, 10L));
+    assertThrows(
+        ValidationException.class,
+        () -> ControllerValidationUtils.validateSasExpirationDuration(-5L, 10L));
+    assertThrows(
+        ValidationException.class,
+        () -> ControllerValidationUtils.validateSasExpirationDuration(3601L, 60L));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -85,6 +85,8 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/controlled/azure/network";
   public static final String CREATE_AZURE_VM_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/vm";
+  public static final String CREATE_AZURE_SAS_TOKEN_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/getSasToken";
   public static final String CLONE_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/gcp/buckets/%s/clone";
   public static final String CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKET_FORMAT =


### PR DESCRIPTION
Allows specification of the SAS token duration (not including the padding we add to the beginning of the time to account for clock drift) in seconds. Maximum allowable value is set in configuration, currently 24 hours per devsecops recommendation.