### PR TITLE
Toaz 105 retrofit storage container operations in wsm with lz integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradleTask: [unitTest, connectedTest, azureUnitTest, azureTest]
+        gradleTask: [unitTest, connectedTest, azureUnitTest, azureConnectedTest]
 
     services:
       postgres:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,16 +29,27 @@ Workspace Manager's logic for handling requests is broken into several layers. F
 - Flights (`service/**/flight`): collections of [Stairway](https://github.com/DataBiosphere/stairway) individual logical steps which are performed in order as a transaction. Individual steps may call service or DAO methods.
 - Data Access Objects (DAOs) (`db/`): wrappers around the WSM database. Methods that interact with the database directly live here, and Services call DAO methods rather than the database directly.
 
+### REST API Class Usage
+In general, API class objects are converted to and from internal WSM objects in the Controller layer.
+There are two exceptions to this rule.
+
+First, we use API objects directly to pass cloud resource object parameters through create and update methods.
+There is little utility in copying the API structure into an identical internal structure, simply to make the
+cloud call and discard the object.
+
+Second, we create API response objects within flight steps. That allows the JobService to implement a generic
+job response.
+
 ## GitHub Interactions
 
 We currently have these workflows:
 
-Workflow      | Triggers         | Work
---------------|------------------|-------
-_test_ | on PR and merge to dev | runs the unit, connected and azure tests
-_pr-integration_ | on PR and merge to dev | runs the TestRunner-based integration test suite from the GHA host VM
-_nightly-tests_ | nightly at 2am | runs the TestRunner-based integration, perf, and resiliency test suites on the wsmtest personal environment
-_tag-publish_ | on merge to dev | tags, version bumps, publishes client to artifactory, pushes image to GCR
+| Workflow         | Triggers               | Work                                                                                                        |
+|------------------|------------------------|-------------------------------------------------------------------------------------------------------------|
+| _test_           | on PR and merge to dev | runs the unit, connected and azure tests                                                                    |
+| _pr-integration_ | on PR and merge to dev | runs the TestRunner-based integration test suite from the GHA host VM                                       |
+| _nightly-tests_  | nightly at 2am         | runs the TestRunner-based integration, perf, and resiliency test suites on the wsmtest personal environment |
+| _tag-publish_    | on merge to dev        | tags, version bumps, publishes client to artifactory, pushes image to GCR                                   |
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -289,8 +289,29 @@ There are three groups of tests.
 
 #### Unit Tests
 The unit tests are written using JUnit. The implementations are in
-`src/test/java/bio/terra/workspace/`. Unit tests derive from `common/BaseUnitTest.java`.
+`src/test/java/bio/terra/workspace/`.
 Some unit tests depend on the availability of a running Postgresql server.
+
+Every combination of `@MockBean` creates a distinct Spring application context. Each context holds several
+database connection pools: (WSM db, WSM Stairway db, and any amalgam connection pools). We have run out of
+database connections due to cached application contexts.
+
+To reduce the number of unique combinations, we have put **ALL** `@MockBean` into test base classes. That helps
+limit the unique combinations. You should **NEVER** code a naked `@MockBean` in a test. They should always be
+specified in these bases. That helps us control the number of unique combinations we have.
+
+The test base classes can be found in `src/test/java/bio/terra/workspace/common/`.
+
+The current inheritance for unit test base classes looks like this:
+- `BaseTest` - the base class for unit and connected tests
+    - `BaseUnitTestMocks` - the base set of mocks shared by all unit tests
+        - `BaseUnitTest` - enables the right test tags and profiles for unit testing
+            - `BaseUnitTestMockDataRepoService` - adds one more mock; used in one unit test
+            - `BaseUnitTestMockGcpCloudContextService` - adds one more mock; used by several tests
+        - `BaseAzureUnitTest` - adds mocks shared by azure unit tests and enables the right test tags and profiles
+
+We keep the Azure tests separated from the general tests, because the Azure feature is not live in all environments.
+Those tests will not successfully run in those environments.
 
 #### Connected Tests
 The connected tests are also written using JUnit.

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -157,6 +157,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
             resource.getAttributes().getInstanceId());
     AIPlatformNotebooks userNotebooks = ClientTestUtils.getAIPlatformNotebooksClient(resourceUser);
 
+    NotebookUtils.assertInstanceHasProxyUrl(userNotebooks, instanceName);
     assertTrue(
         NotebookUtils.userHasProxyAccess(
             creationResult, resourceUser, resource.getAttributes().getProjectId()),

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstancePostStartup.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstancePostStartup.java
@@ -1,7 +1,6 @@
 package scripts.testscripts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
@@ -12,7 +11,6 @@ import bio.terra.workspace.model.GcpAiNotebookInstanceResource;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import com.google.api.services.notebooks.v1.AIPlatformNotebooks;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -63,28 +61,7 @@ public class PrivateControlledAiNotebookInstancePostStartup
     AIPlatformNotebooks userNotebooks = ClientTestUtils.getAIPlatformNotebooksClient(resourceUser);
     GcpAiNotebookInstanceResource resource = getNotebookResource(resourceUserApi, creationResult);
     var instanceName = composeInstanceName(resource);
-    String proxyUrl =
-        ClientTestUtils.getWithRetryOnException(
-            () -> {
-              try {
-                String p =
-                    userNotebooks
-                        .projects()
-                        .locations()
-                        .instances()
-                        .get(instanceName)
-                        .execute()
-                        .getProxyUri();
-                if (p == null) {
-                  throw new NullPointerException();
-                }
-                return p;
-                // Do not retry if it's an IO exception.
-              } catch (IOException ignored) {
-              }
-              return null;
-            });
-    assertNotNull(proxyUrl);
+    NotebookUtils.assertInstanceHasProxyUrl(userNotebooks, instanceName);
     Map<String, String> metadata =
         userNotebooks.projects().locations().instances().get(instanceName).execute().getMetadata();
     assertEquals(testValue, metadata.get("terra-test-value"));

--- a/integration/src/main/java/scripts/testscripts/ReferencedBigQueryResourceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedBigQueryResourceLifecycle.java
@@ -221,17 +221,16 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
     // Update BQ dataset's name and description
     String newDatasetName = "newDatasetName";
     String newDatasetDescription = "newDescription";
-    BqDatasetUtils.updateBigQueryDatasetReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqDatasetResourceId,
-        newDatasetName,
-        newDatasetDescription,
-        /*projectId=*/ null,
-        /*datasetId=*/ null,
-        CloningInstructionsEnum.NOTHING);
     GcpBigQueryDatasetResource datasetReferenceFirstUpdate =
-        fullAccessApi.getBigQueryDatasetReference(getWorkspaceId(), bqDatasetResourceId);
+        BqDatasetUtils.updateBigQueryDatasetReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqDatasetResourceId,
+            newDatasetName,
+            newDatasetDescription,
+            /*projectId=*/ null,
+            /*datasetId=*/ null,
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newDatasetName, datasetReferenceFirstUpdate.getMetadata().getName());
     assertEquals(newDatasetDescription, datasetReferenceFirstUpdate.getMetadata().getDescription());
     assertEquals(
@@ -263,17 +262,16 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
                 /*projectId=*/ null,
                 bqTableFromAlternateDatasetAttributes.getDatasetId(),
                 /*cloningInstructions=*/ null));
-    BqDatasetUtils.updateBigQueryDatasetReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqDatasetResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*projectId=*/ null,
-        bqTableFromAlternateDatasetAttributes.getDatasetId(),
-        CloningInstructionsEnum.NOTHING);
     GcpBigQueryDatasetResource datasetReferenceSecondUpdate =
-        fullAccessApi.getBigQueryDatasetReference(getWorkspaceId(), bqDatasetResourceId);
+        BqDatasetUtils.updateBigQueryDatasetReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqDatasetResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*projectId=*/ null,
+            bqTableFromAlternateDatasetAttributes.getDatasetId(),
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newDatasetName, datasetReferenceSecondUpdate.getMetadata().getName());
     assertEquals(
         newDatasetDescription, datasetReferenceSecondUpdate.getMetadata().getDescription());
@@ -294,18 +292,17 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
     // Update BQ data table's name and description.
     String newDataTableName = "newDataTableName";
     String newDataTableDescription = "a new description to the new data table reference";
-    BqDataTableUtils.updateBigQueryDataTableReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqTableResourceId,
-        newDataTableName,
-        newDataTableDescription,
-        /*projectId=*/ null,
-        /*datasetId=*/ null,
-        /*tableId=*/ null,
-        /*cloningInstructions=*/ null);
     GcpBigQueryDataTableResource dataTableReferenceFirstUpdate =
-        fullAccessApi.getBigQueryDataTableReference(getWorkspaceId(), bqTableResourceId);
+        BqDataTableUtils.updateBigQueryDataTableReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqTableResourceId,
+            newDataTableName,
+            newDataTableDescription,
+            /*projectId=*/ null,
+            /*datasetId=*/ null,
+            /*tableId=*/ null,
+            /*cloningInstructions=*/ null);
     assertEquals(newDataTableName, dataTableReferenceFirstUpdate.getMetadata().getName());
     assertEquals(
         newDataTableDescription, dataTableReferenceFirstUpdate.getMetadata().getDescription());
@@ -338,19 +335,18 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
                 /*cloningInstructions=*/ null));
     // Successfully update the referencing target because the {@code userWithFullAccess} has
     // access to the bq table 2.
-    BqDataTableUtils.updateBigQueryDataTableReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqTableResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*projectId=*/ null,
-        bqTableFromAlternateDatasetAttributes.getDatasetId(),
-        bqTableFromAlternateDatasetAttributes.getDataTableId(),
-        /*cloningInstructions=*/ null);
-
     GcpBigQueryDataTableResource dataTableReferenceSecondUpdate =
-        fullAccessApi.getBigQueryDataTableReference(getWorkspaceId(), bqTableResourceId);
+        BqDataTableUtils.updateBigQueryDataTableReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqTableResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*projectId=*/ null,
+            bqTableFromAlternateDatasetAttributes.getDatasetId(),
+            bqTableFromAlternateDatasetAttributes.getDataTableId(),
+            /*cloningInstructions=*/ null);
+
     assertEquals(newDataTableName, dataTableReferenceSecondUpdate.getMetadata().getName());
     assertEquals(
         newDataTableDescription, dataTableReferenceSecondUpdate.getMetadata().getDescription());
@@ -364,19 +360,18 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
         bqTableFromAlternateDatasetAttributes.getDataTableId(),
         dataTableReferenceSecondUpdate.getAttributes().getDataTableId());
 
-    BqDataTableUtils.updateBigQueryDataTableReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqTableResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*projectId=*/ null,
-        table.getAttributes().getDatasetId(),
-        /*tableId=*/ null,
-        /*cloningInstructions=*/ null);
-
     GcpBigQueryDataTableResource dataTableReferenceThirdUpdate =
-        fullAccessApi.getBigQueryDataTableReference(getWorkspaceId(), bqTableResourceId);
+        BqDataTableUtils.updateBigQueryDataTableReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqTableResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*projectId=*/ null,
+            table.getAttributes().getDatasetId(),
+            /*tableId=*/ null,
+            /*cloningInstructions=*/ null);
+
     assertEquals(newDataTableName, dataTableReferenceThirdUpdate.getMetadata().getName());
     assertEquals(
         newDataTableDescription, dataTableReferenceThirdUpdate.getMetadata().getDescription());
@@ -390,18 +385,18 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
         bqTableFromAlternateDatasetAttributes.getDataTableId(),
         dataTableReferenceThirdUpdate.getAttributes().getDataTableId());
 
-    BqDataTableUtils.updateBigQueryDataTableReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bqTableResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*projectId=*/ null,
-        /*datasetId=*/ null,
-        table.getAttributes().getDataTableId(),
-        /*cloningInstructions*/ null);
     GcpBigQueryDataTableResource dataTableReferenceFourthUpdate =
-        fullAccessApi.getBigQueryDataTableReference(getWorkspaceId(), bqTableResourceId);
+        BqDataTableUtils.updateBigQueryDataTableReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bqTableResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*projectId=*/ null,
+            /*datasetId=*/ null,
+            table.getAttributes().getDataTableId(),
+            /*cloningInstructions*/ null);
+
     assertEquals(newDataTableName, dataTableReferenceFourthUpdate.getMetadata().getName());
     assertEquals(
         newDataTableDescription, dataTableReferenceFourthUpdate.getMetadata().getDescription());

--- a/integration/src/main/java/scripts/testscripts/ReferencedGcsResourceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedGcsResourceLifecycle.java
@@ -284,16 +284,15 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
     // Update GCS bucket's name and description
     String newBucketName = "newGcsBucket";
     String newBucketDescription = "a new description to the new bucket reference";
-    GcsBucketUtils.updateGcsBucketReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bucketResourceId,
-        newBucketName,
-        newBucketDescription,
-        null,
-        CloningInstructionsEnum.NOTHING);
     GcpGcsBucketResource bucketReferenceFirstUpdate =
-        fullAccessApi.getBucketReference(getWorkspaceId(), bucketResourceId);
+        GcsBucketUtils.updateGcsBucketReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bucketResourceId,
+            newBucketName,
+            newBucketDescription,
+            null,
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newBucketName, bucketReferenceFirstUpdate.getMetadata().getName());
     assertEquals(newBucketDescription, bucketReferenceFirstUpdate.getMetadata().getDescription());
     assertEquals(
@@ -318,16 +317,15 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
                 /*cloningInstructions=*/ null));
     // Successfully update the referencing target because the {@code userWithFullAccess} has
     // access to the bucket with fine-grained access.
-    GcsBucketUtils.updateGcsBucketReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        bucketResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        fineGrainedBucket.getAttributes().getBucketName(),
-        /*cloningInstructions=*/ null);
     GcpGcsBucketResource bucketReferenceSecondUpdate =
-        fullAccessApi.getBucketReference(getWorkspaceId(), bucketResourceId);
+        GcsBucketUtils.updateGcsBucketReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            bucketResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            fineGrainedBucket.getAttributes().getBucketName(),
+            /*cloningInstructions=*/ null);
     assertEquals(newBucketName, bucketReferenceSecondUpdate.getMetadata().getName());
     assertEquals(newBucketDescription, bucketReferenceSecondUpdate.getMetadata().getDescription());
     assertEquals(
@@ -337,17 +335,16 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
     // Update GCS bucket object's name and description
     String newBlobName = "newBlobName";
     String newBlobDescription = "a new description to the new bucket blob reference";
-    GcsBucketUtils.updateGcsBucketObjectReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        fileResourceId,
-        newBlobName,
-        newBlobDescription,
-        /*bucketName=*/ null,
-        /*objectName=*/ null,
-        CloningInstructionsEnum.NOTHING);
     GcpGcsObjectResource blobResource =
-        fullAccessApi.getGcsObjectReference(getWorkspaceId(), fileResourceId);
+        GcsBucketUtils.updateGcsBucketObjectReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            fileResourceId,
+            newBlobName,
+            newBlobDescription,
+            /*bucketName=*/ null,
+            /*objectName=*/ null,
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newBlobName, blobResource.getMetadata().getName());
     assertEquals(newBlobDescription, blobResource.getMetadata().getDescription());
     assertEquals(gcsFileAttributes.getBucketName(), blobResource.getAttributes().getBucketName());
@@ -373,17 +370,16 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
                 gcsFolderAttributes.getFileName(),
                 /*cloningInstructions=*/ null));
     // User with access to foo/ can successfully update the referencing target to foo/.
-    GcsBucketUtils.updateGcsBucketObjectReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        fileResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*bucketName=*/ null,
-        gcsFolderAttributes.getFileName(),
-        /*cloningInstructions=*/ null);
     GcpGcsObjectResource blobReferenceSecondUpdate =
-        fullAccessApi.getGcsObjectReference(getWorkspaceId(), fileResourceId);
+        GcsBucketUtils.updateGcsBucketObjectReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            fileResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*bucketName=*/ null,
+            gcsFolderAttributes.getFileName(),
+            /*cloningInstructions=*/ null);
     assertEquals(
         gcsFileAttributes.getBucketName(),
         blobReferenceSecondUpdate.getAttributes().getBucketName());
@@ -393,17 +389,16 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
     assertEquals(newBlobDescription, blobReferenceSecondUpdate.getMetadata().getDescription());
 
     // update bucket only.
-    GcsBucketUtils.updateGcsBucketObjectReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        fileResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*bucketName=*/ gcsUniformAccessBucketAttributes.getBucketName(),
-        /*objectName=*/ null,
-        /*cloningInstructions=*/ null);
     GcpGcsObjectResource blobReferenceThirdUpdate =
-        fullAccessApi.getGcsObjectReference(getWorkspaceId(), fileResourceId);
+        GcsBucketUtils.updateGcsBucketObjectReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            fileResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*bucketName=*/ gcsUniformAccessBucketAttributes.getBucketName(),
+            /*objectName=*/ null,
+            /*cloningInstructions=*/ null);
     assertEquals(
         gcsUniformAccessBucketAttributes.getBucketName(),
         blobReferenceThirdUpdate.getAttributes().getBucketName());
@@ -413,17 +408,16 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
     assertEquals(newBlobDescription, blobReferenceThirdUpdate.getMetadata().getDescription());
 
     // Update both bucket and object path.
-    GcsBucketUtils.updateGcsBucketObjectReference(
-        fullAccessApi,
-        getWorkspaceId(),
-        fileResourceId,
-        /*name=*/ null,
-        /*description=*/ null,
-        /*bucketName=*/ gcsFileAttributes.getBucketName(),
-        gcsFileAttributes.getFileName(),
-        /*cloningInstructions=*/ null);
     GcpGcsObjectResource blobReferenceFourthUpdate =
-        fullAccessApi.getGcsObjectReference(getWorkspaceId(), fileResourceId);
+        GcsBucketUtils.updateGcsBucketObjectReference(
+            fullAccessApi,
+            getWorkspaceId(),
+            fileResourceId,
+            /*name=*/ null,
+            /*description=*/ null,
+            /*bucketName=*/ gcsFileAttributes.getBucketName(),
+            gcsFileAttributes.getFileName(),
+            /*cloningInstructions=*/ null);
     assertEquals(
         gcsFileAttributes.getBucketName(),
         blobReferenceFourthUpdate.getAttributes().getBucketName());

--- a/integration/src/main/java/scripts/testscripts/ReferencedGitRepoLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedGitRepoLifecycle.java
@@ -113,16 +113,15 @@ public class ReferencedGitRepoLifecycle extends WorkspaceAllocateTestScriptBase 
       throws Exception {
     String newGitRepoReferenceName = "newGitRepoReferenceName";
     String newGitRepoReferenceDescription = "a new description for git repo reference";
-    GitRepoUtils.updateGitRepoReferenceResource(
-        referencedGcpResourceApi,
-        getWorkspaceId(),
-        gitResourceId,
-        newGitRepoReferenceName,
-        newGitRepoReferenceDescription,
-        /*gitCloneUrl=*/ null,
-        CloningInstructionsEnum.NOTHING);
     GitRepoResource updatedResource =
-        referencedGcpResourceApi.getGitRepoReference(getWorkspaceId(), gitResourceId);
+        GitRepoUtils.updateGitRepoReferenceResource(
+            referencedGcpResourceApi,
+            getWorkspaceId(),
+            gitResourceId,
+            newGitRepoReferenceName,
+            newGitRepoReferenceDescription,
+            /*gitCloneUrl=*/ null,
+            CloningInstructionsEnum.NOTHING);
     assertEquals(newGitRepoReferenceName, updatedResource.getMetadata().getName());
     assertEquals(newGitRepoReferenceDescription, updatedResource.getMetadata().getDescription());
     assertEquals(

--- a/integration/src/main/java/scripts/utils/BqDataTableUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDataTableUtils.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.GcpBigQueryDataTableAttributes;
+import bio.terra.workspace.model.GcpBigQueryDataTableResource;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
 import bio.terra.workspace.model.UpdateBigQueryDataTableReferenceRequestBody;
 import com.google.cloud.bigquery.BigQuery;
@@ -29,7 +30,7 @@ public class BqDataTableUtils {
       Pattern.compile("^projects/([^/]+)/datasets/([^/]+)/tables/(.+)$");
 
   /** Updates name, description and/or referencing target of BigQuery data table reference. */
-  public static void updateBigQueryDataTableReference(
+  public static GcpBigQueryDataTableResource updateBigQueryDataTableReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceUuid,
       UUID resourceId,
@@ -60,7 +61,7 @@ public class BqDataTableUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateBigQueryDataTableReferenceResource(body, workspaceUuid, resourceId);
+    return resourceApi.updateBigQueryDataTableReferenceResource(body, workspaceUuid, resourceId);
   }
 
   /**

--- a/integration/src/main/java/scripts/utils/BqDatasetUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDatasetUtils.java
@@ -96,7 +96,7 @@ public class BqDatasetUtils {
   }
 
   /** Updates the name, description or referencing target of a BQ dataset reference. */
-  public static void updateBigQueryDatasetReference(
+  public static GcpBigQueryDatasetResource updateBigQueryDatasetReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspace,
       UUID resourceId,
@@ -123,7 +123,7 @@ public class BqDatasetUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateBigQueryDatasetReferenceResource(body, workspace, resourceId);
+    return resourceApi.updateBigQueryDatasetReferenceResource(body, workspace, resourceId);
   }
 
   /**

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -23,6 +23,7 @@ import bio.terra.workspace.model.GcpGcsBucketLifecycleRuleActionType;
 import bio.terra.workspace.model.GcpGcsBucketLifecycleRuleCondition;
 import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.GcpGcsBucketUpdateParameters;
+import bio.terra.workspace.model.GcpGcsObjectResource;
 import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.ManagedBy;
@@ -122,7 +123,7 @@ public class GcsBucketUtils {
   private static final Pattern GCS_BUCKET_PATTERN = Pattern.compile("^gs://([^/]+)$");
 
   /** Updates name, description, and/or referencing target for GCS bucket reference. */
-  public static void updateGcsBucketReference(
+  public static GcpGcsBucketResource updateGcsBucketReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceUuid,
       UUID resourceId,
@@ -144,7 +145,7 @@ public class GcsBucketUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateBucketReferenceResource(body, workspaceUuid, resourceId);
+    return resourceApi.updateBucketReferenceResource(body, workspaceUuid, resourceId);
   }
 
   // Fully parameterized version; category-specific versions below
@@ -300,7 +301,7 @@ public class GcsBucketUtils {
   }
 
   /** Updates name, description, and/or referencing target for GCS bucket object reference. */
-  public static void updateGcsBucketObjectReference(
+  public static GcpGcsObjectResource updateGcsBucketObjectReference(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceUuid,
       UUID resourceId,
@@ -327,7 +328,7 @@ public class GcsBucketUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateBucketObjectReferenceResource(body, workspaceUuid, resourceId);
+    return resourceApi.updateBucketObjectReferenceResource(body, workspaceUuid, resourceId);
   }
 
   /**

--- a/integration/src/main/java/scripts/utils/GitRepoUtils.java
+++ b/integration/src/main/java/scripts/utils/GitRepoUtils.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 public class GitRepoUtils {
   private static final Logger logger = LoggerFactory.getLogger(GitRepoUtils.class);
 
-  public static void updateGitRepoReferenceResource(
+  public static GitRepoResource updateGitRepoReferenceResource(
       ReferencedGcpResourceApi resourceApi,
       UUID workspaceUuid,
       UUID resourceId,
@@ -39,7 +39,7 @@ public class GitRepoUtils {
     if (cloningInstructions != null) {
       body.setCloningInstructions(cloningInstructions);
     }
-    resourceApi.updateGitRepoReference(body, workspaceUuid, resourceId);
+    return resourceApi.updateGitRepoReference(body, workspaceUuid, resourceId);
   }
 
   /**

--- a/integration/src/main/java/scripts/utils/NotebookUtils.java
+++ b/integration/src/main/java/scripts/utils/NotebookUtils.java
@@ -1,6 +1,7 @@
 package scripts.utils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static scripts.utils.CommonResourceFieldsUtil.makeControlledResourceCommonFields;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
@@ -174,5 +175,35 @@ public class NotebookUtils {
     return Optional.ofNullable(maybePermissionsList)
         .map(list -> list.contains(actAsPermission))
         .orElse(false);
+  }
+
+  /**
+   * Asserts that the notebook instance contains proxy url. It usually takes 1-2 min for the proxy
+   * url to be set.
+   */
+  public static void assertInstanceHasProxyUrl(
+      AIPlatformNotebooks userNotebooks, String instanceName) throws Exception {
+    String proxyUrl =
+        ClientTestUtils.getWithRetryOnException(
+            () -> {
+              try {
+                String p =
+                    userNotebooks
+                        .projects()
+                        .locations()
+                        .instances()
+                        .get(instanceName)
+                        .execute()
+                        .getProxyUri();
+                if (p == null) {
+                  throw new NullPointerException();
+                }
+                return p;
+                // Do not retry if it's an IO exception.
+              } catch (IOException ignored) {
+              }
+              return null;
+            });
+    assertNotNull(proxyUrl);
   }
 }

--- a/openapi/src/common/parameters.yaml
+++ b/openapi/src/common/parameters.yaml
@@ -112,6 +112,43 @@ components:
         type: integer
         format: int64
 
+    SasPermissions:
+      name: sasPermissions
+      in: query
+      required: false
+      description: |
+        Permissions associated with the SAS indicating what operations a client may perform on the resource. Must be a 
+        string consisting of some combination following available permissions:
+
+        | Permission | Description |
+        |------------|-------------|
+        |`r`         | Read        |
+        |`a`         | Add         |
+        |`c`         | Create      |
+        |`w`         | Write       |
+        |`d`         | Delete      |
+        |`l`         | List        |
+
+
+        For example:
+          * To construct a SAS with permissions limited to read, write and list the caller would supply the string
+        `rwl`.
+          * To construct a SAS with permissions limited to add, create, write and delete, the caller would supply the 
+        string `acwd`.
+
+        If the calling user does not have the requisite role against the workspace for the requested permissions, this
+        operation will return a 403 Forbidden error.
+      schema:
+        type: string
+
+    SasBlobName:
+      name: sasBlobName
+      in: query
+      description:  Requests access to a single blob in a container
+      required: false
+      schema:
+        type: string
+
     StewardshipType:
       name: stewardship
       in: query

--- a/openapi/src/parts/azure_landing_zone.yaml
+++ b/openapi/src/parts/azure_landing_zone.yaml
@@ -98,7 +98,7 @@ components:
     CreateAzureLandingZoneRequestBody:
       description: Payload for requesting a new Azure landing zone.
       type: object
-      required: [definition, landingZoneTarget]
+      required: [definition, billingProfileId]
       properties:
         definition:
           description: A definition to create an Azure landing zone from
@@ -118,8 +118,10 @@ components:
               Here is a list of some parameters - POSTGRES_SERVER_SKU, POSTGRESQL_SUBNET, VNET_ADDRESS_SPACE.
               These are example of assigned values - POSTGRES_SERVER_SKU=GP_Gen5_2, POSTGRESQL_SUBNET=10.1.0.16/29
             $ref: '#/components/schemas/AzureLandingZoneParameter'
-        landingZoneTarget:
-          $ref: '#/components/schemas/LandingZoneTarget'
+        billingProfileId:
+          description: Identifier for the billing profile to be used for this landing zone.
+          type: string
+          format: uuid
         jobControl:
           $ref: '#/components/schemas/JobControl'
 
@@ -141,6 +143,7 @@ components:
         id:
           description: An identifier of created Azure landing zone.
           type: string
+          format: uuid
         resources:
           description: List of Azure landing zone deployed resources.
           type: array
@@ -208,23 +211,6 @@ components:
           description: Value of the parameter
           type: string
 
-    LandingZoneTarget:
-      description: |
-        The azure configuration associated with a landing zone deployment.
-        This configuration defines where landing zone would be deployed.
-      type: object
-      required: [tenantId, subscriptionId, resourceGroupId]
-      properties:
-        tenantId:
-          description: The ID of Azure tenant associated with the landing zone.
-          type: string
-        subscriptionId:
-          description: The ID of Azure subscription associated with the landing zone.
-          type: string
-        resourceGroupId:
-          description: The ID of Azure resource group associated with the landing zone.
-          type: string
-
     AzureLandingZoneResourcesList:
       type: object
       required: [resources]
@@ -232,6 +218,7 @@ components:
         id:
           description: An identifier of a Azure landing zone.
           type: string
+          format: uuid
         resources:
           description: A list of deployed resources in a landing zone, grouped by purpose.
           type: array
@@ -240,7 +227,7 @@ components:
 
     AzureLandingZoneResourcesPurposeGroup:
       description: |
-        The structure contains one landing zone purpose and a list of Azure deployed resources that 
+        The structure contains one landing zone purpose and a list of Azure deployed resources that
         are tagged with this purpose.
       type: object
       required: [purpose,deployedResources]
@@ -270,3 +257,4 @@ components:
       required: true
       schema:
         type: string
+        format: uuid

--- a/openapi/src/parts/controlled_azure_storage_container.yaml
+++ b/openapi/src/parts/controlled_azure_storage_container.yaml
@@ -54,6 +54,8 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       - $ref: '#/components/parameters/SasIpRange'
       - $ref: '#/components/parameters/SasExpirationDuration'
+      - $ref: '#/components/parameters/SasPermissions'
+      - $ref: '#/components/parameters/SasBlobName'
     post:
       summary: Create a SAS token to access the storage container
       operationId: createAzureStorageContainerSasToken

--- a/openapi/src/parts/controlled_azure_storage_container.yaml
+++ b/openapi/src/parts/controlled_azure_storage_container.yaml
@@ -81,7 +81,7 @@ components:
         Storage container-specific properties to be set on creation. These are a subset of the values
         accepted by the azure resource API (note that public access is disabled).
       type: object
-      required: [ storageAccountId, storageContainerName ]
+      required: [ storageContainerName ]
       properties:
         storageAccountId:
           description: The resource ID of the storage account in which the container will be created.

--- a/openapi/src/parts/referenced_gcp_big_query_data_table.yaml
+++ b/openapi/src/parts/referenced_gcp_big_query_data_table.yaml
@@ -55,8 +55,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateBigQueryDataTableReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GcpBigQueryDataTableReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/openapi/src/parts/referenced_gcp_big_query_dataset.yaml
+++ b/openapi/src/parts/referenced_gcp_big_query_dataset.yaml
@@ -52,8 +52,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateBigQueryDatasetReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GcpBigQueryDatasetReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/openapi/src/parts/referenced_gcp_gcs_bucket.yaml
+++ b/openapi/src/parts/referenced_gcp_gcs_bucket.yaml
@@ -52,8 +52,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateGcsBucketReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GcpGcsBucketReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/openapi/src/parts/referenced_gcp_gcs_bucket_object.yaml
+++ b/openapi/src/parts/referenced_gcp_gcs_bucket_object.yaml
@@ -53,8 +53,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateGcsBucketObjectReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GcpGcsObjectReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/openapi/src/parts/referenced_git_repo.yaml
+++ b/openapi/src/parts/referenced_git_repo.yaml
@@ -52,8 +52,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateGitRepoReferenceRequestBody'
       responses:
-        '204':
-          description: OK
+        '200':
+          $ref: '#/components/responses/GitRepoReferenceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -171,6 +171,37 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/workspaces/v1/{workspaceId}/policies:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+    patch:
+      summary: Update policies for a workspace
+      operationId: updatePolicies
+      tags: [Workspace]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TpsPaoUpdateRequest'
+      responses:
+        '200':
+          description: Update successfully processed. The update itself may or may not have succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TpsPaoUpdateResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/workspaces/v1/{workspaceId}/roles:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'

--- a/service/gradle.lockfile
+++ b/service/gradle.lockfile
@@ -1,12 +1,13 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+bio.terra:billing-profile-manager-client:0.1.29-SNAPSHOT=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 bio.terra:datarepo-client:1.41.0-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:stairway-gcp:0.0.71-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:stairway:0.0.71-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:terra-cloud-resource-lib:1.2.2-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:terra-common-lib:0.0.69-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra:terra-landing-zone-service:0.0.8-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:terra-landing-zone-service:0.0.10-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:terra-policy-service:0.2.11-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:terra-resource-buffer-client:0.4.3-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra:terra-resource-janitor-client:0.114.0-SNAPSHOT=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath

--- a/service/gradle/dependencies.gradle
+++ b/service/gradle/dependencies.gradle
@@ -38,7 +38,7 @@ dependencies {
   }
 
   //Terra Landing Zone Service
-  implementation ('bio.terra:terra-landing-zone-service:0.0.8-SNAPSHOT') {
+  implementation ('bio.terra:terra-landing-zone-service:0.0.10-SNAPSHOT') {
     exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.12"
   }
 

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -80,7 +80,7 @@ task connectedTest(type: Test) {
   }
 }
 
-task azureTest(type: Test) {
+task azureConnectedTest(type: Test) {
   useJUnitPlatform {
     includeTags "azure"
   }

--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiController.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiController.java
@@ -1,14 +1,15 @@
 package bio.terra.workspace.amalgam.landingzone.azure;
 
+import static bio.terra.workspace.app.controller.ControllerBase.getAsyncResponseCode;
+
+import bio.terra.common.iam.BearerTokenFactory;
 import bio.terra.landingzone.service.landingzone.azure.exception.LandingZoneDeleteNotImplemented;
-import bio.terra.workspace.app.controller.ControllerBase;
 import bio.terra.workspace.generated.controller.LandingZonesApi;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneDefinitionList;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneResourcesList;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneResult;
 import bio.terra.workspace.generated.model.ApiCreateAzureLandingZoneRequestBody;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
-import bio.terra.workspace.service.iam.SamService;
+import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,56 +21,63 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Controller
-public class LandingZoneApiController extends ControllerBase implements LandingZonesApi {
+public class LandingZoneApiController implements LandingZonesApi {
   private static final Logger logger = LoggerFactory.getLogger(LandingZoneApiController.class);
+  private final HttpServletRequest request;
+  private final BearerTokenFactory bearerTokenFactory;
   private final LandingZoneApiDispatch landingZoneApiDispatch;
 
   @Autowired
   public LandingZoneApiController(
-      AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
       HttpServletRequest request,
-      SamService samService,
+      BearerTokenFactory bearerTokenFactory,
       LandingZoneApiDispatch landingZoneApiDispatch) {
-    super(authenticatedUserRequestFactory, request, samService);
+    this.request = request;
+    this.bearerTokenFactory = bearerTokenFactory;
     this.landingZoneApiDispatch = landingZoneApiDispatch;
   }
 
   @Override
   public ResponseEntity<ApiAzureLandingZoneResult> createAzureLandingZone(
       @RequestBody ApiCreateAzureLandingZoneRequestBody body) {
+    String resultEndpoint =
+        String.format(
+            "%s/%s/%s", request.getServletPath(), "create-result", body.getJobControl().getId());
     ApiAzureLandingZoneResult result =
         landingZoneApiDispatch.createAzureLandingZone(
-            body, getAsyncResultEndpoint(body.getJobControl().getId(), "create-result"));
+            bearerTokenFactory.from(request), body, resultEndpoint);
     return new ResponseEntity<>(result, getAsyncResponseCode(result.getJobReport()));
   }
 
   @Override
   public ResponseEntity<ApiAzureLandingZoneResult> getCreateAzureLandingZoneResult(String jobId) {
     ApiAzureLandingZoneResult response =
-        landingZoneApiDispatch.getCreateAzureLandingZoneResult(jobId);
+        landingZoneApiDispatch.getCreateAzureLandingZoneResult(
+            bearerTokenFactory.from(request), jobId);
     return new ResponseEntity<>(response, getAsyncResponseCode(response.getJobReport()));
   }
 
   @Override
   public ResponseEntity<ApiAzureLandingZoneDefinitionList> listAzureLandingZonesDefinitions() {
     ApiAzureLandingZoneDefinitionList result =
-        landingZoneApiDispatch.listAzureLandingZonesDefinitions();
+        landingZoneApiDispatch.listAzureLandingZonesDefinitions(bearerTokenFactory.from(request));
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
   @Override
   public ResponseEntity<ApiAzureLandingZoneResourcesList> listAzureLandingZoneResources(
-      @PathVariable("landingZoneId") String landingZoneId) {
+      @PathVariable("landingZoneId") UUID landingZoneId) {
     ApiAzureLandingZoneResourcesList result =
-        landingZoneApiDispatch.listAzureLandingZoneResources(landingZoneId);
+        landingZoneApiDispatch.listAzureLandingZoneResources(
+            bearerTokenFactory.from(request), landingZoneId);
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
   @Override
   public ResponseEntity<Void> deleteAzureLandingZone(
-      @PathVariable("landingZoneId") String landingZoneId) {
+      @PathVariable("landingZoneId") UUID landingZoneId) {
     try {
-      landingZoneApiDispatch.deleteLandingZone(landingZoneId);
+      landingZoneApiDispatch.deleteLandingZone(bearerTokenFactory.from(request), landingZoneId);
     } catch (LandingZoneDeleteNotImplemented ex) {
       logger.info("Request to delete landing zone. Operation is not supported.");
       return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);

--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -129,10 +130,10 @@ public class LandingZoneApiDispatch {
   }
 
   public Optional<ApiAzureLandingZoneDeployedResource> getSharedStorageAccount(
-      String landingZoneId) {
+      BearerToken bearerToken, UUID landingZoneId) {
     features.azureEnabledCheck();
     String azureStorageAccountResourceType = "Microsoft.Storage/storageAccounts";
-    return listAzureLandingZoneResources(landingZoneId).getResources().stream()
+    return listAzureLandingZoneResources(bearerToken, landingZoneId).getResources().stream()
         .filter(rpg -> rpg.getPurpose().equals(ResourcePurpose.SHARED_RESOURCE.toString()))
         .flatMap(r -> r.getDeployedResources().stream())
         .filter(

--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
@@ -128,6 +128,18 @@ public class LandingZoneApiDispatch {
     return result;
   }
 
+  public Optional<ApiAzureLandingZoneDeployedResource> getSharedStorageAccount(
+      String landingZoneId) {
+    features.azureEnabledCheck();
+    String azureStorageAccountResourceType = "Microsoft.Storage/storageAccounts";
+    return listAzureLandingZoneResources(landingZoneId).getResources().stream()
+        .filter(rpg -> rpg.getPurpose().equals(ResourcePurpose.SHARED_RESOURCE.toString()))
+        .flatMap(r -> r.getDeployedResources().stream())
+        .filter(
+            r -> StringUtils.equalsIgnoreCase(r.getResourceType(), azureStorageAccountResourceType))
+        .findFirst();
+  }
+
   public List<ApiAzureLandingZoneDeployedResource> listSubnetsWithParentVNetByPurpose(
       BearerToken bearerToken, UUID landingZoneId, LandingZonePurpose purpose) {
 
@@ -142,6 +154,7 @@ public class LandingZoneApiDispatch {
     if (purpose.getClass().equals(ResourcePurpose.class)) {
       return new ApiAzureLandingZoneDeployedResource()
           .resourceId(resource.resourceId())
+          .resourceName(resource.resourceName().orElse(null))
           .resourceType(resource.resourceType())
           .region(resource.region());
     }

--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
@@ -154,7 +154,6 @@ public class LandingZoneApiDispatch {
     if (purpose.getClass().equals(ResourcePurpose.class)) {
       return new ApiAzureLandingZoneDeployedResource()
           .resourceId(resource.resourceId())
-          .resourceName(resource.resourceName().orElse(null))
           .resourceType(resource.resourceType())
           .region(resource.region());
     }

--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/utils/MapperUtils.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/utils/MapperUtils.java
@@ -6,7 +6,6 @@ import bio.terra.landingzone.model.LandingZoneTarget;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneParameter;
 import bio.terra.workspace.generated.model.ApiErrorReport;
 import bio.terra.workspace.generated.model.ApiJobReport;
-import bio.terra.workspace.generated.model.ApiLandingZoneTarget;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import java.util.Collection;
 import java.util.HashMap;
@@ -68,13 +67,6 @@ public class MapperUtils {
 
   public static class LandingZoneTargetMapper {
     private LandingZoneTargetMapper() {}
-
-    public static LandingZoneTarget from(ApiLandingZoneTarget apiLandingZoneTarget) {
-      return new LandingZoneTarget(
-          apiLandingZoneTarget.getTenantId(),
-          apiLandingZoneTarget.getSubscriptionId(),
-          apiLandingZoneTarget.getResourceGroupId());
-    }
 
     public static LandingZoneTarget from(AzureCloudContext azureCloudContext) {
       return new LandingZoneTarget(

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -54,7 +54,6 @@ import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.OffsetDateTime;
-import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -332,7 +331,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     ControlledAzureStorageContainerResource resource =
         ControlledAzureStorageContainerResource.builder()
             .common(commonFields)
-            .storageAccountId(Optional.ofNullable(body.getAzureStorageContainer().getStorageAccountId()).orElse(null))
+            .storageAccountId(body.getAzureStorageContainer().getStorageAccountId())
             .storageContainerName(body.getAzureStorageContainer().getStorageContainerName())
             .build();
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -54,6 +54,7 @@ import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -331,7 +332,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     ControlledAzureStorageContainerResource resource =
         ControlledAzureStorageContainerResource.builder()
             .common(commonFields)
-            .storageAccountId(body.getAzureStorageContainer().getStorageAccountId())
+            .storageAccountId(Optional.ofNullable(body.getAzureStorageContainer().getStorageAccountId()).orElse(null))
             .storageContainerName(body.getAzureStorageContainer().getStorageContainerName())
             .build();
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -41,6 +41,7 @@ import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.SasPermissionsHelper;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
@@ -212,12 +213,16 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
           UUID workspaceUuid,
           UUID storageContainerUuid,
           String sasIpRange,
-          Long sasExpirationDuration) {
+          Long sasExpirationDuration,
+          String sasPermissions,
+          String sasBlobName) {
     features.azureEnabledCheck();
 
     ControllerValidationUtils.validateIpAddressRange(sasIpRange);
     ControllerValidationUtils.validateSasExpirationDuration(
         sasExpirationDuration, azureConfiguration.getSasTokenExpiryTimeMaximumMinutesOffset());
+    ControllerValidationUtils.validateSasBlobName(sasBlobName);
+    SasPermissionsHelper.validateSasPermissionString(sasPermissions);
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     // Creating an AzureStorageContainerSasToken requires checking the user's access to both the
@@ -264,7 +269,9 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             startTime,
             expiryTime,
             userRequest,
-            sasIpRange);
+            sasIpRange,
+            sasBlobName,
+            sasPermissions);
 
     logger.info(
         "SAS token with expiry time of {} generated for user {} on container {} in workspace {}",

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -136,7 +136,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateBucketObjectReferenceResource(
+  public ResponseEntity<ApiGcpGcsObjectResource> updateBucketObjectReferenceResource(
       UUID workspaceUuid, UUID referenceId, ApiUpdateGcsBucketObjectReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -182,7 +182,12 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           null, // included in resource arg
           userRequest);
     }
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+
+    final ReferencedGcsObjectResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, referenceId)
+            .castByEnum(WsmResourceType.REFERENCED_GCP_GCS_OBJECT);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override
@@ -239,7 +244,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateBucketReferenceResource(
+  public ResponseEntity<ApiGcpGcsBucketResource> updateBucketReferenceResource(
       UUID workspaceUuid, UUID referenceId, ApiUpdateGcsBucketReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -279,7 +284,12 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           null, // passed in via resource argument
           userRequest);
     }
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+
+    final ReferencedGcsBucketResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, referenceId)
+            .castByEnum(WsmResourceType.REFERENCED_GCP_GCS_BUCKET);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override
@@ -338,7 +348,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateBigQueryDataTableReferenceResource(
+  public ResponseEntity<ApiGcpBigQueryDataTableResource> updateBigQueryDataTableReferenceResource(
       UUID workspaceUuid, UUID referenceId, ApiUpdateBigQueryDataTableReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -385,7 +395,11 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           userRequest);
     }
 
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    final ReferencedBigQueryDataTableResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, referenceId)
+            .castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATA_TABLE);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override
@@ -451,7 +465,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateBigQueryDatasetReferenceResource(
+  public ResponseEntity<ApiGcpBigQueryDatasetResource> updateBigQueryDatasetReferenceResource(
       UUID workspaceUuid, UUID resourceId, ApiUpdateBigQueryDatasetReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -493,7 +507,12 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           cloningInstructions,
           userRequest);
     }
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+
+    final ReferencedBigQueryDatasetResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, resourceId)
+            .castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override
@@ -898,7 +917,7 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
   }
 
   @Override
-  public ResponseEntity<Void> updateGitRepoReference(
+  public ResponseEntity<ApiGitRepoResource> updateGitRepoReference(
       UUID workspaceUuid, UUID referenceId, ApiUpdateGitRepoReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(
@@ -932,7 +951,12 @@ public class ReferencedGcpResourceController implements ReferencedGcpResourceApi
           CloningInstructions.fromApiModel(body.getCloningInstructions()),
           userRequest);
     }
-    return new ResponseEntity<>(HttpStatus.OK);
+
+    final ReferencedGitRepoResource updatedResource =
+        referenceResourceService
+            .getReferenceResource(workspaceUuid, referenceId)
+            .castByEnum(WsmResourceType.REFERENCED_ANY_GIT_REPO);
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -32,6 +32,8 @@ import bio.terra.workspace.generated.model.ApiProperty;
 import bio.terra.workspace.generated.model.ApiRoleBinding;
 import bio.terra.workspace.generated.model.ApiRoleBindingList;
 import bio.terra.workspace.generated.model.ApiTpsPaoGetResult;
+import bio.terra.workspace.generated.model.ApiTpsPaoUpdateRequest;
+import bio.terra.workspace.generated.model.ApiTpsPaoUpdateResult;
 import bio.terra.workspace.generated.model.ApiTpsPolicyInput;
 import bio.terra.workspace.generated.model.ApiTpsPolicyInputs;
 import bio.terra.workspace.generated.model.ApiUpdateWorkspaceRequestBody;
@@ -332,6 +334,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     }
     workspaceService.validateWorkspaceAndAction(
         userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+
     Workspace workspace =
         workspaceService.updateWorkspace(
             workspaceUuid,
@@ -344,6 +347,28 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     logger.info("Updated workspace {} for {}", desc, userRequest.getEmail());
 
     return new ResponseEntity<>(desc, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ApiTpsPaoUpdateResult> updatePolicies(
+      @PathVariable("workspaceId") UUID workspaceId, @RequestBody ApiTpsPaoUpdateRequest body) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    logger.info("Updating workspace policies {} for {}", workspaceId, userRequest.getEmail());
+
+    workspaceService.validateWorkspaceAndAction(
+        userRequest, workspaceId, SamConstants.SamWorkspaceAction.WRITE);
+
+    if (!featureConfiguration.isTpsEnabled()) {
+      throw new FeatureNotSupportedException(
+          "TPS is not enabled on this instance of Workspace Manager, cannot update policies for workspace.");
+    }
+
+    ApiTpsPaoUpdateResult result =
+        tpsApiDispatch.updatePao(
+            new BearerToken(userRequest.getRequiredToken()), workspaceId, body);
+    logger.info(
+        "Finished updating workspace policies {} for {}", workspaceId, userRequest.getEmail());
+    return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -166,6 +166,24 @@ public final class ControllerValidationUtils {
     }
   }
 
+  /**
+   * Validate an azure blob name. Blob name may be a string or null, and must be > 1 char and < 1024
+   * chars in length.
+   *
+   * @param blobName Blob name to validate, or null.
+   */
+  public static void validateSasBlobName(@Nullable String blobName) {
+    if (blobName == null) {
+      return;
+    }
+    if (blobName.isEmpty()) {
+      throw new ValidationException("Blob name may not be empty");
+    }
+    if (blobName.length() > 1024) {
+      throw new ValidationException("Blob name must be <= 1024 chars");
+    }
+  }
+
   public static void validatePropertiesUpdateRequestBody(List<ApiProperty> properties) {
     if (properties.isEmpty()) {
       throw new ValidationException("Must specify at least one property to update");

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/SasPermissionsHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/SasPermissionsHelper.java
@@ -1,0 +1,25 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure;
+
+import bio.terra.common.exception.ValidationException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SasPermissionsHelper {
+  private static final Set<Character> ALLOWED_SAS_PERMISSIONS =
+      Set.of('r', 'l', 'a', 'c', 'w', 'd');
+
+  public static Set<Character> permissionStringToCharSet(String permissions) {
+    return permissions.chars().mapToObj(c -> (char) c).collect(Collectors.toSet());
+  }
+
+  public static void validateSasPermissionString(String permissions) {
+    if (permissions == null) {
+      return;
+    }
+
+    var userPermissionsSet = permissionStringToCharSet(permissions);
+    if (!ALLOWED_SAS_PERMISSIONS.containsAll(userPermissionsSet)) {
+      throw new ValidationException("Invalid permissions");
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/AzureStorageAccountCacheKey.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/AzureStorageAccountCacheKey.java
@@ -1,0 +1,4 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storage;
+
+public record AzureStorageAccountCacheKey(
+    String subscriptionId, String managedResourceGroupId, String storageAccountName) {}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/StorageAccountKeyProvider.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/StorageAccountKeyProvider.java
@@ -6,9 +6,12 @@ import bio.terra.workspace.service.workspace.AzureCloudContextService;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.resourcemanager.storage.StorageManager;
 import com.azure.resourcemanager.storage.models.StorageAccount;
-import com.azure.resourcemanager.storage.models.StorageAccountKey;
 import com.azure.storage.common.StorageSharedKeyCredential;
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import liquibase.repackaged.org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +20,7 @@ public class StorageAccountKeyProvider {
   private final AzureCloudContextService azureCloudContextService;
   private final CrlService crlService;
   private final AzureConfiguration azureConfiguration;
+  private final Map<AzureStorageAccountCacheKey, String> storageAccountKeyCache;
 
   @Autowired
   public StorageAccountKeyProvider(
@@ -26,20 +30,36 @@ public class StorageAccountKeyProvider {
     this.azureCloudContextService = azureCloudContextService1;
     this.crlService = crlService;
     this.azureConfiguration = azureConfiguration;
+    this.storageAccountKeyCache =
+        Collections.synchronizedMap(new PassiveExpiringMap<>(24, TimeUnit.HOURS));
   }
 
   public StorageSharedKeyCredential getStorageAccountKey(
       UUID workspaceUuid, String storageAccountName) {
     AzureCloudContext azureCloudContext =
         azureCloudContextService.getRequiredAzureCloudContext(workspaceUuid);
-    StorageManager storageManager =
-        crlService.getStorageManager(azureCloudContext, azureConfiguration);
-    StorageAccount storageAccount =
-        storageManager
-            .storageAccounts()
-            .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), storageAccountName);
 
-    StorageAccountKey key = storageAccount.getKeys().get(0);
-    return new StorageSharedKeyCredential(storageAccountName, key.value());
+    // cache storage account keys to avoid reaching out to azure for every request for a sas
+    var storageAccountCacheKey =
+        new AzureStorageAccountCacheKey(
+            azureCloudContext.getAzureSubscriptionId(),
+            azureCloudContext.getAzureResourceGroupId(),
+            storageAccountName);
+
+    var key =
+        storageAccountKeyCache.computeIfAbsent(
+            storageAccountCacheKey,
+            v -> {
+              StorageManager storageManager =
+                  crlService.getStorageManager(azureCloudContext, azureConfiguration);
+              StorageAccount storageAccount =
+                  storageManager
+                      .storageAccounts()
+                      .getByResourceGroup(
+                          azureCloudContext.getAzureResourceGroupId(), storageAccountName);
+
+              return storageAccount.getKeys().get(0).value();
+            });
+    return new StorageSharedKeyCredential(storageAccountName, key);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -213,7 +213,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
 
     ControlledAzureStorageContainerResource that = (ControlledAzureStorageContainerResource) o;
 
-    return storageAccountId.equals(that.getStorageAccountId())
+    return (storageAccountId == null || storageAccountId.equals(that.getStorageAccountId()))
         && storageContainerName.equals(that.getStorageContainerName());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -113,6 +113,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
             flightBeanBag.getAzureConfig(),
             flightBeanBag.getCrlService(),
             flightBeanBag.getResourceDao(),
+            flightBeanBag.getLandingZoneApiDispatch(),
             this),
         cloudRetry);
     flight.addStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -29,10 +29,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import javax.annotation.Nullable;
 
 public class ControlledAzureStorageContainerResource extends ControlledResource {
-  @Nullable private final UUID storageAccountId;
+  private final UUID storageAccountId;
   private final String storageContainerName;
 
   @JsonCreator
@@ -97,7 +96,9 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
     return Optional.of(
         new UniquenessCheckAttributes()
             .uniquenessScope(UniquenessScope.WORKSPACE)
-            // .addParameter("storageAccountId", getStorageAccountId().toString())
+            .addParameter(
+                "storageAccountId",
+                Optional.ofNullable(getStorageAccountId()).map(UUID::toString).orElse(null))
             .addParameter("storageContainerName", getStorageContainerName()));
   }
 
@@ -212,14 +213,16 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
 
     ControlledAzureStorageContainerResource that = (ControlledAzureStorageContainerResource) o;
 
-    return /*storageAccountId.equals(that.getStorageAccountId())
-           &&*/ storageContainerName.equals(that.getStorageContainerName());
+    return storageAccountId.equals(that.getStorageAccountId())
+        && storageContainerName.equals(that.getStorageContainerName());
   }
 
   @Override
   public int hashCode() {
     int result = super.hashCode();
-    // result = 31 * result + storageAccountId.hashCode();
+    if (storageAccountId != null) {
+      result = 31 * result + storageAccountId.hashCode();
+    }
     result = 31 * result + storageContainerName.hashCode();
     return result;
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -116,6 +116,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
             flightBeanBag.getCrlService(),
             flightBeanBag.getResourceDao(),
             flightBeanBag.getLandingZoneApiDispatch(),
+            userRequest,
             this),
         cloudRetry);
     flight.addStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -29,9 +29,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 public class ControlledAzureStorageContainerResource extends ControlledResource {
-  private final UUID storageAccountId;
+  @Nullable private final UUID storageAccountId;
   private final String storageContainerName;
 
   @JsonCreator
@@ -96,7 +97,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
     return Optional.of(
         new UniquenessCheckAttributes()
             .uniquenessScope(UniquenessScope.WORKSPACE)
-            .addParameter("storageAccountId", getStorageAccountId().toString())
+            // .addParameter("storageAccountId", getStorageAccountId().toString())
             .addParameter("storageContainerName", getStorageContainerName()));
   }
 
@@ -130,6 +131,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
             flightBeanBag.getAzureConfig(),
             flightBeanBag.getCrlService(),
             flightBeanBag.getResourceDao(),
+            flightBeanBag.getLandingZoneApiDispatch(),
             this),
         RetryRules.cloud());
   }
@@ -194,11 +196,6 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
       throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_STORAGE_CONTAINER");
     }
 
-    if (getStorageAccountId() == null) {
-      throw new MissingRequiredFieldException(
-          "Missing required storage account ID field for ControlledAzureStorageContainer.");
-    }
-
     if (getStorageContainerName() == null) {
       throw new MissingRequiredFieldException(
           "Missing required storage container name field for ControlledAzureStorageContainer.");
@@ -215,14 +212,14 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
 
     ControlledAzureStorageContainerResource that = (ControlledAzureStorageContainerResource) o;
 
-    return storageAccountId.equals(that.getStorageAccountId())
-        && storageContainerName.equals(that.getStorageContainerName());
+    return /*storageAccountId.equals(that.getStorageAccountId())
+           &&*/ storageContainerName.equals(that.getStorageContainerName());
   }
 
   @Override
   public int hashCode() {
     int result = super.hashCode();
-    result = 31 * result + storageAccountId.hashCode();
+    // result = 31 * result + storageAccountId.hashCode();
     result = 31 * result + storageContainerName.hashCode();
     return result;
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -44,6 +44,7 @@ public class CreateAzureStorageContainerStep implements Step {
         crlService.getStorageManager(azureCloudContext, azureConfig);
 
     // The storage account name is stored by VerifyAzureStorageContainerCanBeCreated.
+    // It can be workspace managed storage account or landing zone shared storage account
     final String storageAccountName =
         context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
     if (storageAccountName == null) {
@@ -62,7 +63,6 @@ public class CreateAzureStorageContainerStep implements Step {
           .withPublicAccess(PublicAccess.NONE)
           .withMetadata("workspaceId", resource.getWorkspaceId().toString())
           .withMetadata("resourceId", resource.getResourceId().toString())
-              //TODO: should we add WLZ-ID/PURPOSE?
           .create(
               Defaults.buildContext(
                   CreateStorageContainerRequestData.builder()
@@ -70,7 +70,6 @@ public class CreateAzureStorageContainerStep implements Step {
                       .setStorageContainerName(resource.getStorageContainerName())
                       .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
                       .build()));
-
     } catch (ManagementException e) {
       logger.error(
           "Failed to create the Azure storage container '{}' with storage account with the ID '{}'. Error Code: {}",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -62,6 +62,7 @@ public class CreateAzureStorageContainerStep implements Step {
           .withPublicAccess(PublicAccess.NONE)
           .withMetadata("workspaceId", resource.getWorkspaceId().toString())
           .withMetadata("resourceId", resource.getResourceId().toString())
+              //TODO: should we add WLZ-ID/PURPOSE?
           .create(
               Defaults.buildContext(
                   CreateStorageContainerRequestData.builder()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.storageConta
 import bio.terra.cloudres.azure.resourcemanager.common.ResourceManagerRequestData;
 import com.google.gson.JsonObject;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 /**
  * Extends {@link ResourceManagerRequestData} to add common fields for working with the Storage
@@ -22,6 +23,7 @@ public abstract class BaseStorageContainerRequestData implements ResourceManager
   public abstract String resourceGroupName();
 
   /** The storage account resource ID. */
+  @Nullable
   public abstract UUID storageAccountId();
 
   /**
@@ -32,7 +34,9 @@ public abstract class BaseStorageContainerRequestData implements ResourceManager
     JsonObject requestData = new JsonObject();
     requestData.addProperty("resourceGroupName", resourceGroupName());
     requestData.addProperty("storageContainerName", storageContainerName());
-    requestData.addProperty("storageAccountId", storageAccountId().toString());
+    if (storageAccountId() != null) {
+      requestData.addProperty("storageAccountId", storageAccountId().toString());
+    }
     return requestData;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -145,7 +145,8 @@ public class ControlledAzureVmResource extends ControlledResource {
             flightBeanBag.getCrlService(),
             this,
             flightBeanBag.getResourceDao(),
-            flightBeanBag.getLandingZoneApiDispatch()),
+            flightBeanBag.getLandingZoneApiDispatch(),
+            userRequest),
         cloudRetry);
     flight.addStep(
         new CreateAzureVmStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ControlledGcsBucketHandler implements WsmResourceHandler {
-
   protected static final int MAX_BUCKET_NAME_LENGTH = 63;
   private static ControlledGcsBucketHandler theHandler;
   private final GcpCloudContextService gcpCloudContextService;

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -71,6 +71,7 @@ public class CloudSyncRoleMapping {
               "artifactregistry.tags.update",
               "cloudbuild.builds.create",
               "cloudbuild.builds.update",
+              "compute.instances.get",
               "iam.serviceAccounts.get",
               "iam.serviceAccounts.list",
               "lifesciences.operations.cancel",

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -107,12 +107,4 @@ public final class WorkspaceFlightMapKeys {
 
     private WsmApplicationKeys() {}
   }
-
-  public static class LandingZoneKeys {
-    public static final String LANDING_ZONE_ID = "landingZoneId";
-    public static final String LANDING_ZONE_SHARED_STORAGE_ACCOUNT_NAME =
-        "landingZoneSharedStorageAccountName";
-
-    private LandingZoneKeys() {}
-  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -107,4 +107,12 @@ public final class WorkspaceFlightMapKeys {
 
     private WsmApplicationKeys() {}
   }
+
+  public static class LandingZoneKeys {
+    public static final String LANDING_ZONE_ID = "landingZoneId";
+    public static final String LANDING_ZONE_SHARED_STORAGE_ACCOUNT_NAME =
+        "landingZoneSharedStorageAccountName";
+
+    private LandingZoneKeys() {}
+  }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -30,6 +30,7 @@ env:
   urls: # While we've traditionally thought of these as env specific and ok to hardcode, with kubernetes they may change
     sam: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org/}
     terra-datarepo: ${TERRA_DATAREPO_URL:https://jade.datarepo-dev.broadinstitute.org}
+    bpm: ${BPM_ADDRESS:https://bpm.dsde-dev.broadinstitute.org/}
 
 # Below here is non-deployment-specific
 
@@ -179,7 +180,8 @@ landingzone:
     tracing-enabled: true
     retention-check-interval: 1d
     completed-flight-retention: 7d
-
+  sam.base-path: ${env.urls.sam}
+  bpm.base-path: ${env.urls.bpm}
 
 # Feature flags
 # The general rule is that feature flags should be set here in their production setting

--- a/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
@@ -15,13 +15,11 @@ import bio.terra.landingzone.job.LandingZoneJobService;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZonePurpose;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
-import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
 import bio.terra.landingzone.service.landingzone.azure.exception.LandingZoneDeleteNotImplemented;
 import bio.terra.landingzone.service.landingzone.azure.model.DeployedLandingZone;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneDefinition;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResourcesByPurpose;
-import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.common.fixtures.AzureLandingZoneFixtures;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,7 +31,6 @@ import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -50,18 +47,15 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
   @Autowired private MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;
 
-  @MockBean private LandingZoneService landingZoneService;
-  @MockBean private FeatureConfiguration featureConfiguration;
-
   @Test
   public void createAzureLandingZoneJobRunning() throws Exception {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithRunningState(JOB_ID);
 
-    when(landingZoneService.startLandingZoneCreationJob(any(), any(), any(), any()))
+    when(mockLandingZoneService().startLandingZoneCreationJob(any(), any(), any(), any()))
         .thenReturn(asyncJobResult);
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     var requestBody = AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequest(JOB_ID);
 
@@ -84,10 +78,10 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithSucceededState(JOB_ID, LANDING_ZONE_ID);
 
-    when(landingZoneService.startLandingZoneCreationJob(any(), any(), any(), any()))
+    when(mockLandingZoneService().startLandingZoneCreationJob(any(), any(), any(), any()))
         .thenReturn(asyncJobResult);
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     // TODO SG: check if we need name and description??
     var requestBody = AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequest(JOB_ID);
@@ -114,10 +108,10 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithSucceededState(JOB_ID, LANDING_ZONE_ID);
 
-    when(landingZoneService.startLandingZoneCreationJob(any(), any(), any(), any()))
+    when(mockLandingZoneService().startLandingZoneCreationJob(any(), any(), any(), any()))
         .thenReturn(asyncJobResult);
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     var requestBody =
         AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequestWithoutDefinition(JOB_ID);
@@ -137,10 +131,10 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithSucceededState(JOB_ID, LANDING_ZONE_ID);
 
-    when(landingZoneService.startLandingZoneCreationJob(any(), any(), any(), any()))
+    when(mockLandingZoneService().startLandingZoneCreationJob(any(), any(), any(), any()))
         .thenReturn(asyncJobResult);
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     var requestBody =
         AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequestWithoutTarget(JOB_ID);
@@ -160,7 +154,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithRunningState(JOB_ID);
 
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
 
     mockMvc
         .perform(
@@ -178,7 +172,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithSucceededState(JOB_ID, LANDING_ZONE_ID);
 
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
 
     mockMvc
         .perform(
@@ -216,8 +210,8 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
                 .description("barDescription")
                 .version("v1")
                 .build());
-    when(landingZoneService.listLandingZoneDefinitions(any())).thenReturn(definitions);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().listLandingZoneDefinitions(any())).thenReturn(definitions);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     mockMvc
         .perform(
@@ -230,7 +224,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
 
   @Test
   public void deleteAzureLandingZoneSuccess() throws Exception {
-    doNothing().when(landingZoneService).deleteLandingZone(any(), any());
+    doNothing().when(mockLandingZoneService()).deleteLandingZone(any(), any());
     mockMvc
         .perform(
             delete(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}", LANDING_ZONE_ID)
@@ -241,7 +235,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
   @Test
   public void deleteAzureLandingZoneNotImplemented() throws Exception {
     doThrow(LandingZoneDeleteNotImplemented.class)
-        .when(landingZoneService)
+        .when(mockLandingZoneService())
         .deleteLandingZone(any(), any());
     mockMvc
         .perform(
@@ -320,9 +314,9 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
                 purposeSubnets2,
                 listSubnets2));
 
-    when(landingZoneService.listResourcesWithPurposes(any(), any())).thenReturn(groupedResources);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
-
+    when(mockLandingZoneService().listResourcesWithPurposes(any(), any()))
+        .thenReturn(groupedResources);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
             get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/resources", LANDING_ZONE_ID)
@@ -348,9 +342,9 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneResourcesByPurpose groupedResources =
         new LandingZoneResourcesByPurpose(Collections.emptyMap());
 
-    when(landingZoneService.listResourcesWithPurposes(any(), any())).thenReturn(groupedResources);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
-
+    when(mockLandingZoneService().listResourcesWithPurposes(any(), any()))
+        .thenReturn(groupedResources);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
             get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/resources", LANDING_ZONE_ID)

--- a/service/src/test/java/bio/terra/workspace/amalgam/tps/TpsBasicPaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/amalgam/tps/TpsBasicPaoTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.amalgam.tps;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,9 +26,7 @@ import bio.terra.workspace.generated.model.ApiTpsPolicyInput;
 import bio.terra.workspace.generated.model.ApiTpsPolicyInputs;
 import bio.terra.workspace.generated.model.ApiTpsPolicyPair;
 import bio.terra.workspace.generated.model.ApiTpsUpdateMode;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,9 +43,7 @@ public class TpsBasicPaoTest extends BaseUnitTest {
   private static final String REGION = "region";
   private static final String DDGROUP = "ddgroup";
   private static final String US_REGION = "US";
-  AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
+
   @Autowired private ObjectMapper objectMapper;
   @Autowired private FeatureConfiguration features;
   @Autowired private MockMvc mockMvc;

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/FolderApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/FolderApiControllerTest.java
@@ -5,6 +5,7 @@ import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertM
 import static bio.terra.workspace.common.utils.MockMvcUtils.FOLDERS_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.FOLDER_PROPERTIES_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.FOLDER_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,7 +34,6 @@ import bio.terra.workspace.generated.model.ApiProperties;
 import bio.terra.workspace.generated.model.ApiPropertyKeys;
 import bio.terra.workspace.generated.model.ApiUpdateFolderRequestBody;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
@@ -41,7 +41,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.http.HttpStatus;
@@ -49,35 +48,28 @@ import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 public class FolderApiControllerTest extends BaseUnitTest {
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
-
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
   @Autowired ObjectMapper objectMapper;
-
-  @MockBean SamService mockSamService;
 
   @BeforeEach
   public void setUp() throws InterruptedException {
     // Needed for workspace creation as logging is triggered when a workspace is created in
     // `WorkspaceActivityLogHook` where we extract the user request information and log it to
     // activity log.
-    when(mockSamService.getUserStatusInfo(any()))
+    when(mockSamService().getUserStatusInfo(any()))
         .thenReturn(
             new UserStatusInfo()
                 .userEmail(USER_REQUEST.getEmail())
                 .userSubjectId(USER_REQUEST.getSubjectId()));
 
     // Needed for assertion that requester has role on workspace.
-    when(mockSamService.listRequesterRoles(any(), any(), any()))
+    when(mockSamService().listRequesterRoles(any(), any(), any()))
         .thenReturn(List.of(WsmIamRole.OWNER));
   }
 
@@ -102,7 +94,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
   public void createFolder_doesNotHaveWriteAccess_throws403() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -193,7 +185,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -239,7 +231,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     createFolderExpectCode(workspaceId, HttpStatus.SC_OK);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -259,7 +251,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -344,7 +336,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -416,7 +408,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -465,7 +457,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
@@ -36,7 +36,6 @@ import bio.terra.workspace.generated.model.ApiGcpGcsObjectResource;
 import bio.terra.workspace.generated.model.ApiGitRepoResource;
 import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiResourceMetadata;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -47,7 +46,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -58,20 +56,18 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Autowired MockMvcUtils mockMvcUtils;
   @Autowired ObjectMapper objectMapper;
 
-  @MockBean SamService mockSamService;
-
   @BeforeEach
   public void setUp() throws InterruptedException {
     // Needed for workspace creation as logging is triggered when a workspace is created in
     // `WorkspaceActivityLogHook` where we extract the user request information and log it to
     // activity log.
-    when(mockSamService.getUserStatusInfo(any()))
+    when(mockSamService().getUserStatusInfo(any()))
         .thenReturn(
             new UserStatusInfo()
                 .userEmail(USER_REQUEST.getEmail())
                 .userSubjectId(USER_REQUEST.getSubjectId()));
     // Needed for assertion that requester has role on workspace.
-    when(mockSamService.listRequesterRoles(any(), any(), any()))
+    when(mockSamService().listRequesterRoles(any(), any(), any()))
         .thenReturn(List.of(WsmIamRole.OWNER));
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
@@ -169,6 +169,8 @@ class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
             any(),
             any(),
             any(),
+            any(),
+            any(),
             any()))
         .thenReturn(new AzureStorageAccessService.AzureSasBundle("sasToken", "sasUrl"));
   }
@@ -248,6 +250,8 @@ class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
             startTimeCaptor.capture(),
             endTimeCaptor.capture(),
             any(),
+            any(),
+            any(),
             any());
 
     // First call uses custom time of 2 hours (plus 5 minutes before) = 7500 seconds.
@@ -301,6 +305,96 @@ class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
             any(),
             any(),
             any(),
-            eq(ipRange));
+            eq(ipRange),
+            any(),
+            any());
+  }
+
+  @Test
+  void createSASTokenBlobNameSuccess() throws Exception {
+    String blobName = "testing/foo/bar";
+
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasBlobName", blobName),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    Mockito.verify(azureStorageAccessService)
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(blobName),
+            any());
+  }
+
+  @Test
+  void createSASTokenBlobNameInvalidName() throws Exception {
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasBlobName", ""),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  void createSASTokenBlobPermissionsSuccess() throws Exception {
+    String permissions = "rwcd";
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasPermissions", permissions),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    Mockito.verify(azureStorageAccessService)
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(permissions));
+  }
+
+  @Test
+  void createSASTokenBlobPermissionsInvalidPerms() throws Exception {
+    String permissions = "tfi";
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasPermissions", permissions),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
@@ -1,61 +1,35 @@
 package bio.terra.workspace.app.controller;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_SAS_TOKEN_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiCreateControlledAzureVmRequestBody;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
-import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.OffsetDateTime;
-import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest {
-  AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
-
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;
-
   @Autowired ControlledAzureResourceApiController controller;
-
-  @MockBean ControlledResourceService controlledResourceServiceMock;
-  @MockBean WorkspaceService workspaceServiceMock;
-  @MockBean JobService jobServiceMock;
 
   @Test
   public void createAzureVm400WithNoParameters() throws Exception {
@@ -90,7 +64,7 @@ public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest 
         controller.buildControlledAzureVmResource(
             creationParameters, controller.toCommonFields(workspaceId, commonFields, USER_REQUEST));
 
-    when(jobServiceMock.retrieveAsyncJobResult(any(), eq(ControlledAzureVmResource.class)))
+    when(mockJobService().retrieveAsyncJobResult(any(), eq(ControlledAzureVmResource.class)))
         .thenReturn(
             new JobService.AsyncJobResult<ControlledAzureVmResource>()
                 .result(resource)
@@ -104,297 +78,5 @@ public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest 
                         .content(objectMapper.writeValueAsString(vmRequest)),
                     USER_REQUEST)))
         .andExpect(status().is(HttpStatus.SC_OK));
-  }
-}
-
-class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
-  AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
-
-  @Autowired MockMvc mockMvc;
-  @Autowired AzureConfiguration azureConfiguration;
-  @MockBean ControlledResourceMetadataManager controlledResourceMetadataManager;
-  @MockBean SamService samService;
-  @MockBean AzureStorageAccessService azureStorageAccessService;
-
-  private UUID workspaceId;
-  private UUID storageContainerId;
-
-  private ControlledAzureStorageResource accountResource;
-  private ControlledAzureStorageContainerResource containerResource;
-
-  @BeforeEach
-  public void setup() throws Exception {
-    workspaceId = UUID.randomUUID();
-    storageContainerId = UUID.randomUUID();
-    UUID storageAccountId = UUID.randomUUID();
-
-    containerResource =
-        ControlledAzureStorageContainerResource.builder()
-            .common(
-                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
-                    .workspaceUuid(workspaceId)
-                    .resourceId(storageContainerId)
-                    .build())
-            .storageAccountId(storageAccountId)
-            .storageContainerName("testcontainer")
-            .build();
-
-    when(controlledResourceMetadataManager.validateControlledResourceAndAction(
-            any(), eq(workspaceId), eq(storageContainerId), any()))
-        .thenReturn(containerResource);
-
-    accountResource =
-        ControlledAzureStorageResource.builder()
-            .common(
-                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
-                    .workspaceUuid(workspaceId)
-                    .resourceId(storageAccountId)
-                    .build())
-            .storageAccountName("testaccount")
-            .region("eastus")
-            .build();
-
-    when(controlledResourceMetadataManager.validateControlledResourceAndAction(
-            any(), eq(workspaceId), eq(storageAccountId), any()))
-        .thenReturn(accountResource);
-
-    when(samService.getUserEmailFromSam(eq(USER_REQUEST))).thenReturn(USER_REQUEST.getEmail());
-
-    when(azureStorageAccessService.createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any()))
-        .thenReturn(new AzureStorageAccessService.AzureSasBundle("sasToken", "sasUrl"));
-  }
-
-  @Test
-  void createSASToken400BadDuration() throws Exception {
-    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
-        240L); // maximum of 240 minutes (4 hours)
-
-    // expiration duration must be positive
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasExpirationDuration", "-1"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
-
-    // expiration can't exceed 4 hours = 14400 seconds
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasExpirationDuration", "14401"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
-  }
-
-  @Test
-  void createSASTokenCustomExpirationSuccess() throws Exception {
-    azureConfiguration.setSasTokenStartTimeMinutesOffset(5L); // 5 minutes before
-    azureConfiguration.setSasTokenExpiryTimeMinutesOffset(10L); // 10 minutes after
-    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
-        240L); // maximum of 240 minutes (4 hours)
-
-    // Specify custom expiration duration of 2 hours.
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasExpirationDuration", "7200"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    // Use expiration time as set in configuration.
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    ArgumentCaptor<OffsetDateTime> startTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
-    ArgumentCaptor<OffsetDateTime> endTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
-
-    Mockito.verify(azureStorageAccessService, times(2))
-        .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            startTimeCaptor.capture(),
-            endTimeCaptor.capture(),
-            any(),
-            any(),
-            any(),
-            any());
-
-    // First call uses custom time of 2 hours (plus 5 minutes before) = 7500 seconds.
-    assertEquals(
-        7500,
-        endTimeCaptor.getAllValues().get(0).toEpochSecond()
-            - startTimeCaptor.getAllValues().get(0).toEpochSecond());
-
-    // Second call based on configuration, difference should be 15 minutes = 900 seconds.
-    assertEquals(
-        900,
-        endTimeCaptor.getAllValues().get(1).toEpochSecond()
-            - startTimeCaptor.getAllValues().get(1).toEpochSecond());
-  }
-
-  @Test
-  void createSASToken400BadIPRange() throws Exception {
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasIpRange", "not_an_IP"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
-  }
-
-  @Test
-  void createSASTokenIpRangeSuccess() throws Exception {
-    String ipRange = "168.1.5.60-168.1.5.70";
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasIpRange", ipRange),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    Mockito.verify(azureStorageAccessService)
-        .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            eq(ipRange),
-            any(),
-            any());
-  }
-
-  @Test
-  void createSASTokenBlobNameSuccess() throws Exception {
-    String blobName = "testing/foo/bar";
-
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasBlobName", blobName),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    Mockito.verify(azureStorageAccessService)
-        .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            any(),
-            eq(blobName),
-            any());
-  }
-
-  @Test
-  void createSASTokenBlobNameInvalidName() throws Exception {
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasBlobName", ""),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
-  }
-
-  @Test
-  void createSASTokenBlobPermissionsSuccess() throws Exception {
-    String permissions = "rwcd";
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasPermissions", permissions),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    Mockito.verify(azureStorageAccessService)
-        .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            eq(permissions));
-  }
-
-  @Test
-  void createSASTokenBlobPermissionsInvalidPerms() throws Exception {
-    String permissions = "tfi";
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasPermissions", permissions),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.app.controller;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_AI_NOTEBOOK_NAME_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_BQ_DATASET_NAME_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_GCS_BUCKET_NAME_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -10,7 +11,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiAiNotebookCloudId;
 import bio.terra.workspace.generated.model.ApiBqDatasetCloudId;
@@ -18,19 +19,14 @@ import bio.terra.workspace.generated.model.ApiGcsBucketCloudName;
 import bio.terra.workspace.generated.model.ApiGenerateGcpAiNotebookCloudIdRequestBody;
 import bio.terra.workspace.generated.model.ApiGenerateGcpBigQueryDatasetCloudIDRequestBody;
 import bio.terra.workspace.generated.model.ApiGenerateGcpGcsBucketCloudNameRequestBody;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
-import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -38,25 +34,17 @@ import org.springframework.test.web.servlet.MockMvc;
  * Use this instead of ControlledGcpResourceApiControllerConnectedTest if you don't want to talk to
  * real GCP.
  */
-public class ControlledGcpResourceApiControllerTest extends BaseUnitTest {
-
-  AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
-
+public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpCloudContextService {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
   @Autowired ObjectMapper objectMapper;
 
-  @MockBean GcpCloudContextService mockGcpCloudContextService;
-  @MockBean SamService mockSamService;
-
   @BeforeEach
   public void setup() throws InterruptedException {
-    when(mockGcpCloudContextService.getRequiredGcpProject(any())).thenReturn("fake-project-id");
+    when(mockGcpCloudContextService().getRequiredGcpProject(any())).thenReturn("fake-project-id");
 
     // Needed for assertion that requester has role on workspace.
-    when(mockSamService.listRequesterRoles(any(), any(), any()))
+    when(mockSamService().listRequesterRoles(any(), any(), any()))
         .thenReturn(List.of(WsmIamRole.OWNER));
   }
 
@@ -84,7 +72,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTest {
     ApiGcsBucketCloudName generatedGcsBucketName =
         objectMapper.readValue(serializedGetResponse, ApiGcsBucketCloudName.class);
 
-    String projectId = mockGcpCloudContextService.getRequiredGcpProject(workspaceId);
+    String projectId = mockGcpCloudContextService().getRequiredGcpProject(workspaceId);
     assertEquals(
         generatedGcsBucketName.getGeneratedBucketCloudName(),
         bucketNameRequest.getGcsBucketName() + "-" + projectId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
@@ -1,0 +1,318 @@
+package bio.terra.workspace.app.controller;
+
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_SAS_TOKEN_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.BaseAzureUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
+  @Autowired MockMvc mockMvc;
+  @Autowired AzureConfiguration azureConfiguration;
+
+  private UUID workspaceId;
+  private UUID storageContainerId;
+
+  private ControlledAzureStorageResource accountResource;
+  private ControlledAzureStorageContainerResource containerResource;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    workspaceId = UUID.randomUUID();
+    storageContainerId = UUID.randomUUID();
+    UUID storageAccountId = UUID.randomUUID();
+
+    containerResource =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(storageContainerId)
+                    .build())
+            .storageAccountId(storageAccountId)
+            .storageContainerName("testcontainer")
+            .build();
+
+    when(mockControlledResourceMetadataManager()
+            .validateControlledResourceAndAction(
+                any(), eq(workspaceId), eq(storageContainerId), any()))
+        .thenReturn(containerResource);
+
+    accountResource =
+        ControlledAzureStorageResource.builder()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(storageAccountId)
+                    .build())
+            .storageAccountName("testaccount")
+            .region("eastus")
+            .build();
+
+    when(mockControlledResourceMetadataManager()
+            .validateControlledResourceAndAction(
+                any(), eq(workspaceId), eq(storageAccountId), any()))
+        .thenReturn(accountResource);
+
+    when(mockSamService().getUserEmailFromSam(eq(USER_REQUEST)))
+        .thenReturn(USER_REQUEST.getEmail());
+
+    when(mockAzureStorageAccessService()
+            .createAzureStorageContainerSasToken(
+                eq(workspaceId),
+                eq(containerResource),
+                eq(accountResource),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()))
+        .thenReturn(new AzureStorageAccessService.AzureSasBundle("sasToken", "sasUrl"));
+  }
+
+  @Test
+  void createSASToken400BadDuration() throws Exception {
+    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
+        240L); // maximum of 240 minutes (4 hours)
+
+    // expiration duration must be positive
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasExpirationDuration", "-1"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+
+    // expiration can't exceed 4 hours = 14400 seconds
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasExpirationDuration", "14401"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  void createSASTokenCustomExpirationSuccess() throws Exception {
+    azureConfiguration.setSasTokenStartTimeMinutesOffset(5L); // 5 minutes before
+    azureConfiguration.setSasTokenExpiryTimeMinutesOffset(10L); // 10 minutes after
+    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
+        240L); // maximum of 240 minutes (4 hours)
+
+    // Specify custom expiration duration of 2 hours.
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasExpirationDuration", "7200"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    // Use expiration time as set in configuration.
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    ArgumentCaptor<OffsetDateTime> startTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+    ArgumentCaptor<OffsetDateTime> endTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+
+    Mockito.verify(mockAzureStorageAccessService(), times(2))
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            startTimeCaptor.capture(),
+            endTimeCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any());
+
+    // First call uses custom time of 2 hours (plus 5 minutes before) = 7500 seconds.
+    assertEquals(
+        7500,
+        endTimeCaptor.getAllValues().get(0).toEpochSecond()
+            - startTimeCaptor.getAllValues().get(0).toEpochSecond());
+
+    // Second call based on configuration, difference should be 15 minutes = 900 seconds.
+    assertEquals(
+        900,
+        endTimeCaptor.getAllValues().get(1).toEpochSecond()
+            - startTimeCaptor.getAllValues().get(1).toEpochSecond());
+  }
+
+  @Test
+  void createSASToken400BadIPRange() throws Exception {
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasIpRange", "not_an_IP"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  void createSASTokenIpRangeSuccess() throws Exception {
+    String ipRange = "168.1.5.60-168.1.5.70";
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasIpRange", ipRange),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    Mockito.verify(mockAzureStorageAccessService())
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            any(),
+            any(),
+            any(),
+            eq(ipRange),
+            any(),
+            any());
+  }
+
+  @Test
+  void createSASTokenBlobNameSuccess() throws Exception {
+    String blobName = "testing/foo/bar";
+
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasBlobName", blobName),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    Mockito.verify(mockAzureStorageAccessService())
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(blobName),
+            any());
+  }
+
+  @Test
+  void createSASTokenBlobNameInvalidName() throws Exception {
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasBlobName", ""),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  void createSASTokenBlobPermissionsSuccess() throws Exception {
+    String permissions = "rwcd";
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasPermissions", permissions),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    Mockito.verify(mockAzureStorageAccessService())
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(permissions));
+  }
+
+  @Test
+  void createSASTokenBlobPermissionsInvalidPerms() throws Exception {
+    String permissions = "tfi";
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasPermissions", permissions),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
@@ -6,4 +6,4 @@ import org.springframework.test.context.ActiveProfiles;
 /** Base class for azure tests. Treat these as connected tests: connected to Azure */
 @Tag("azure")
 @ActiveProfiles({"azure-test", "connected-test"})
-public class BaseAzureTest extends BaseTest {}
+public class BaseAzureConnectedTest extends BaseTest {}

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
@@ -1,8 +1,34 @@
 package bio.terra.workspace.common;
 
+import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
+import bio.terra.workspace.service.workspace.WorkspaceService;
 import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 @Tag("azure-unit")
 @ActiveProfiles({"azure-unit-test", "unit-test"})
-public class BaseAzureUnitTest extends BaseTest {}
+public class BaseAzureUnitTest extends BaseUnitTestMocks {
+  @MockBean private AzureStorageAccessService mockAzureStorageAccessService;
+  @MockBean private JobService mockJobService;
+  @MockBean private LandingZoneService mockLandingZoneService;
+  @MockBean private WorkspaceService mockWorkspaceService;
+
+  public AzureStorageAccessService mockAzureStorageAccessService() {
+    return mockAzureStorageAccessService;
+  }
+
+  public JobService mockJobService() {
+    return mockJobService;
+  }
+
+  public LandingZoneService mockLandingZoneService() {
+    return mockLandingZoneService;
+  }
+
+  public WorkspaceService mockWorkspaceService() {
+    return mockWorkspaceService;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTest.java
@@ -5,4 +5,4 @@ import org.springframework.test.context.ActiveProfiles;
 
 @Tag("unit")
 @ActiveProfiles("unit-test")
-public class BaseUnitTest extends BaseTest {}
+public class BaseUnitTest extends BaseUnitTestMocks {}

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockDataRepoService.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockDataRepoService.java
@@ -1,0 +1,13 @@
+package bio.terra.workspace.common;
+
+import bio.terra.workspace.service.datarepo.DataRepoService;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+/** Mock out the DataRepoService where needed */
+public class BaseUnitTestMockDataRepoService extends BaseUnitTest {
+  @MockBean private DataRepoService mockDataRepoService;
+
+  public DataRepoService mockDataRepoService() {
+    return mockDataRepoService;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockGcpCloudContextService.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockGcpCloudContextService.java
@@ -1,0 +1,13 @@
+package bio.terra.workspace.common;
+
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+/** Mock out the GcpCloudContextService where needed */
+public class BaseUnitTestMockGcpCloudContextService extends BaseUnitTest {
+  @MockBean private GcpCloudContextService gcpCloudContextService;
+
+  public GcpCloudContextService mockGcpCloudContextService() {
+    return gcpCloudContextService;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMocks.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMocks.java
@@ -1,0 +1,45 @@
+package bio.terra.workspace.common;
+
+import bio.terra.workspace.amalgam.tps.TpsApiDispatch;
+import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+/*
+ * Mock beans used by (or not conflicting with) all unit tests
+ */
+public class BaseUnitTestMocks extends BaseTest {
+  @MockBean private ControlledResourceMetadataManager mockControlledResourceMetadataManager;
+  @MockBean private ControlledResourceService mockControlledResourceService;
+  @MockBean private CrlService mockCrlService;
+  @MockBean private FeatureConfiguration mockFeatureConfiguration;
+  @MockBean private SamService mockSamService;
+  @MockBean private TpsApiDispatch mockTpsApiDispatch;
+
+  public ControlledResourceMetadataManager mockControlledResourceMetadataManager() {
+    return mockControlledResourceMetadataManager;
+  }
+
+  public ControlledResourceService mockControlledResourceService() {
+    return mockControlledResourceService;
+  }
+
+  public CrlService mockCrlService() {
+    return mockCrlService;
+  }
+
+  public FeatureConfiguration mockFeatureConfiguration() {
+    return mockFeatureConfiguration;
+  }
+
+  public SamService mockSamService() {
+    return mockSamService;
+  }
+
+  public TpsApiDispatch mockTpsApiDispatch() {
+    return mockTpsApiDispatch;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/AzureLandingZoneFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/AzureLandingZoneFixtures.java
@@ -6,10 +6,10 @@ import bio.terra.landingzone.service.landingzone.azure.model.DeployedLandingZone
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.workspace.generated.model.ApiCreateAzureLandingZoneRequestBody;
 import bio.terra.workspace.generated.model.ApiJobControl;
-import bio.terra.workspace.generated.model.ApiLandingZoneTarget;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.UUID;
 import org.apache.http.HttpStatus;
 
 public class AzureLandingZoneFixtures {
@@ -29,7 +29,7 @@ public class AzureLandingZoneFixtures {
   }
 
   public static LandingZoneJobService.AsyncJobResult<DeployedLandingZone>
-      createJobResultWithSucceededState(String jobId, String landingZoneId) {
+      createJobResultWithSucceededState(String jobId, UUID landingZoneId) {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         new LandingZoneJobService.AsyncJobResult<>();
     asyncJobResult.jobReport(
@@ -58,11 +58,7 @@ public class AzureLandingZoneFixtures {
   public static ApiCreateAzureLandingZoneRequestBody buildCreateAzureLandingZoneRequest(
       String jobId) {
     return new ApiCreateAzureLandingZoneRequestBody()
-        .landingZoneTarget(
-            new ApiLandingZoneTarget()
-                .resourceGroupId("resourceGroup")
-                .subscriptionId("subscriptionId")
-                .tenantId("tenantId"))
+        .billingProfileId(UUID.randomUUID())
         .jobControl(new ApiJobControl().id(jobId))
         .definition("azureLandingZoneDefinition")
         .version("v1");
@@ -71,11 +67,7 @@ public class AzureLandingZoneFixtures {
   public static ApiCreateAzureLandingZoneRequestBody
       buildCreateAzureLandingZoneRequestWithoutDefinition(String jobId) {
     return new ApiCreateAzureLandingZoneRequestBody()
-        .landingZoneTarget(
-            new ApiLandingZoneTarget()
-                .resourceGroupId("resourceGroup")
-                .subscriptionId("subscriptionId")
-                .tenantId("tenantId"))
+        .billingProfileId(UUID.randomUUID())
         .jobControl(new ApiJobControl().id(jobId))
         .version("v1");
   }

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.common.logging;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys.CONTROLLED_RESOURCES_TO_DELETE;
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.FOLDER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,8 +26,6 @@ import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.folder.flights.DeleteFolderFlight;
 import bio.terra.workspace.service.folder.model.Folder;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
@@ -54,17 +53,8 @@ import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class WorkspaceActivityLogHookTest extends BaseUnitTest {
-
-  /** A fake authenticated user request. */
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest()
-          .token(Optional.of("fake-token"))
-          .email("fake@email.com")
-          .subjectId("fakeID123");
-
   private static final UserStatusInfo USER_STATUS_INFO =
       new UserStatusInfo()
           .userEmail(USER_REQUEST.getEmail())
@@ -74,11 +64,10 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
   @Autowired private ResourceDao resourceDao;
   @Autowired private WorkspaceActivityLogHook hook;
   @Autowired private FolderDao folderDao;
-  @MockBean private SamService mockSamService;
 
   @BeforeEach
   void setUpOnce() throws InterruptedException {
-    when(mockSamService.getUserStatusInfo(any())).thenReturn(USER_STATUS_INFO);
+    when(mockSamService().getUserStatusInfo(any())).thenReturn(USER_STATUS_INFO);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/common/utils/ControllerValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/ControllerValidationUtilsTest.java
@@ -83,4 +83,16 @@ public class ControllerValidationUtilsTest extends BaseUnitTest {
         ValidationException.class,
         () -> ControllerValidationUtils.validateSasExpirationDuration(3601L, 60L));
   }
+
+  @Test
+  void validateSasBlobName() {
+    ControllerValidationUtils.validateSasBlobName(null);
+    ControllerValidationUtils.validateSasBlobName("hello");
+    assertThrows(
+        ValidationException.class, () -> ControllerValidationUtils.validateSasBlobName(""));
+    String largeString = "a".repeat(1025);
+    assertThrows(
+        ValidationException.class,
+        () -> ControllerValidationUtils.validateSasBlobName(largeString));
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
@@ -1,14 +1,13 @@
 package bio.terra.workspace.common.utils;
 
-import java.util.Random;
+import java.util.UUID;
 
 public class TestUtils {
-  private static final Random RANDOM = new Random();
-
-  public static String appendRandomNumber(String string) {
+  public static String appendRandomNumber(String prefix) {
     // Can't have dash because BQ dataset names can't have dash.
     // Can't have underscore because for controlled buckets, GCP recommends not having underscore
     // in bucket name.
-    return string + RANDOM.nextInt(100000);
+    String randomString = prefix + UUID.randomUUID();
+    return randomString.replaceAll("[-_]", "");
   }
 }

--- a/service/src/test/java/bio/terra/workspace/connected/LandingZoneTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/LandingZoneTestUtils.java
@@ -1,0 +1,16 @@
+package bio.terra.workspace.connected;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("connected-test")
+public class LandingZoneTestUtils {
+  @Value("${workspace.connected-test.default-landing-zone-id}")
+  private String defaultLandingZoneId;
+
+  public String getDefaultLandingZoneId() {
+    return defaultLandingZoneId;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/folder/FolderServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/folder/FolderServiceTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.folder;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,6 +43,7 @@ import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.Refer
 import bio.terra.workspace.service.workspace.model.WorkspaceConstants.ResourceProperties;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -98,7 +100,7 @@ public class FolderServiceTest extends BaseConnectedTest {
     controlledBucketInFoo =
         ControlledGcsBucketResource.builder()
             .common(createControlledResourceCommonFieldWithFolderId(workspaceId, fooFolder.id()))
-            .bucketName(TestUtils.appendRandomNumber("my-gcs-bucket"))
+            .bucketName(randomAlphabetic(10).toLowerCase(Locale.ROOT))
             .build();
     controlledResourceService.createControlledResourceSync(
         controlledBucketInFoo,
@@ -109,7 +111,7 @@ public class FolderServiceTest extends BaseConnectedTest {
     controlledBucket2InFooFoo =
         ControlledGcsBucketResource.builder()
             .common(createControlledResourceCommonFieldWithFolderId(workspaceId, fooFooFolder.id()))
-            .bucketName(TestUtils.appendRandomNumber("my-gcs-bucket-2"))
+            .bucketName(randomAlphabetic(10).toLowerCase(Locale.ROOT))
             .build();
     controlledResourceService.createControlledResourceSync(
         controlledBucket2InFooFoo,

--- a/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -12,7 +12,6 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.exception.InvalidJobIdException;
 import bio.terra.workspace.service.job.exception.InvalidResultStateException;
 import bio.terra.workspace.service.job.exception.JobNotFoundException;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.MethodMode;
@@ -41,7 +39,6 @@ class JobServiceTest extends BaseUnitTest {
 
   @Autowired private JobService jobService;
   @Autowired private WorkspaceDao workspaceDao;
-  @MockBean private SamService mockSamService;
 
   /**
    * Reset the {@link JobService} {@link FlightDebugInfo} after each test so that future submissions

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -95,7 +95,8 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
         /*properties*/ Map.of());
   }
 
-  private void assertValidToken(String sas, BlobContainerSasPermission expectedPermissions) {
+  private void assertValidToken(
+      String sas, BlobContainerSasPermission expectedPermissions, boolean blobToken) {
     Pattern protocolRegex = Pattern.compile("spr=https&");
     // SAS tokens start and expiry times are UTC
     Pattern startTimeRegex =
@@ -110,13 +111,19 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
                 + expiryTime
                     .atZoneSameInstant(ZoneOffset.UTC)
                     .format(DateTimeFormatter.ISO_LOCAL_DATE));
-    Pattern signedResourceRegex = Pattern.compile("sr=c&");
+    Pattern signedContainerResourceRegex = Pattern.compile("sr=c&");
+    Pattern signedBlobResourceRegex = Pattern.compile("sr=b&");
     Pattern permissionsRegex = Pattern.compile("sp=" + expectedPermissions.toString() + "&");
 
     assertThat("SAS is https", protocolRegex.matcher(sas).find());
     assertThat("SAS validity starts today", startTimeRegex.matcher(sas).find());
     assertThat("SAS validity ends today", expiryTimeRegex.matcher(sas).find());
-    assertThat("SAS is for a container resource", signedResourceRegex.matcher(sas).find());
+    if (blobToken) {
+      assertThat("SAS is for a blob resource", signedBlobResourceRegex.matcher(sas).find());
+    } else {
+      assertThat(
+          "SAS is for a container resource", signedContainerResourceRegex.matcher(sas).find());
+    }
     assertThat("SAS grants correct permissions", permissionsRegex.matcher(sas).find());
   }
 
@@ -144,9 +151,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             startTime,
             expiryTime,
             userRequest,
-            ipRange);
+            ipRange,
+            null,
+            null);
 
-    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("rl"));
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("rl"), false);
     assertTrue(
         result.sasToken().contains("sip=" + ipRange),
         "the SignedIP was added to the query parameters");
@@ -178,9 +187,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             startTime,
             expiryTime,
             userRequest,
+            null,
+            null,
             null);
 
-    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"));
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), false);
     verify(samService)
         .listResourceActions(
             ArgumentMatchers.eq(userRequest),
@@ -212,6 +223,8 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
                 startTime,
                 expiryTime,
                 userRequest,
+                null,
+                null,
                 null));
 
     verify(samService)
@@ -247,14 +260,175 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             startTime,
             expiryTime,
             userRequest,
+            null,
+            null,
             null);
 
-    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"));
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), false);
 
     verify(samService)
         .listResourceActions(
             ArgumentMatchers.eq(userRequest),
             ArgumentMatchers.eq(SamConstants.SamResource.CONTROLLED_APPLICATION_PRIVATE),
             ArgumentMatchers.eq(storageContainerResource.getResourceId().toString()));
+  }
+
+  @Test
+  void createAzureStorageContainerSasToken_blobPath() throws InterruptedException {
+    var storageAccountResource = buildStorageAccount();
+    var storageContainerResource =
+        buildStorageContainerResource(
+            PrivateResourceState.ACTIVE,
+            AccessScopeType.ACCESS_SCOPE_PRIVATE,
+            ManagedByType.MANAGED_BY_APPLICATION);
+    when(samService.listResourceActions(
+            ArgumentMatchers.eq(userRequest),
+            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+        .thenReturn(
+            List.of(
+                SamConstants.SamControlledResourceActions.WRITE_ACTION,
+                SamConstants.SamControlledResourceActions.READ_ACTION));
+
+    var result =
+        azureStorageAccessService.createAzureStorageContainerSasToken(
+            UUID.randomUUID(),
+            storageContainerResource,
+            storageAccountResource,
+            startTime,
+            expiryTime,
+            userRequest,
+            null,
+            "testing/blob-path",
+            null);
+
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), true);
+  }
+
+  @Test
+  void createAzureStorageContainerSasToken_permissions() throws InterruptedException {
+    var storageAccountResource = buildStorageAccount();
+    var storageContainerResource =
+        buildStorageContainerResource(
+            PrivateResourceState.ACTIVE,
+            AccessScopeType.ACCESS_SCOPE_PRIVATE,
+            ManagedByType.MANAGED_BY_APPLICATION);
+    when(samService.listResourceActions(
+            ArgumentMatchers.eq(userRequest),
+            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+        .thenReturn(
+            List.of(
+                SamConstants.SamControlledResourceActions.WRITE_ACTION,
+                SamConstants.SamControlledResourceActions.READ_ACTION));
+
+    var result =
+        azureStorageAccessService.createAzureStorageContainerSasToken(
+            UUID.randomUUID(),
+            storageContainerResource,
+            storageAccountResource,
+            startTime,
+            expiryTime,
+            userRequest,
+            null,
+            "testing/blob-path",
+            "ld");
+
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("dl"), true);
+  }
+
+  @Test
+  void createAzureStorageContainerSasToken_forbiddenPermissions() throws InterruptedException {
+    var storageAccountResource = buildStorageAccount();
+    var storageContainerResource =
+        buildStorageContainerResource(
+            PrivateResourceState.ACTIVE,
+            AccessScopeType.ACCESS_SCOPE_PRIVATE,
+            ManagedByType.MANAGED_BY_APPLICATION);
+    when(samService.listResourceActions(
+            ArgumentMatchers.eq(userRequest),
+            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+        .thenReturn(List.of(SamConstants.SamControlledResourceActions.READ_ACTION));
+
+    assertThrows(
+        ForbiddenException.class,
+        () ->
+            azureStorageAccessService.createAzureStorageContainerSasToken(
+                UUID.randomUUID(),
+                storageContainerResource,
+                storageAccountResource,
+                startTime,
+                expiryTime,
+                userRequest,
+                null,
+                null,
+                "rwdl"),
+        "Asking for delete + write when we should only have READ_ACTION should result in an exception ");
+  }
+
+  @Test
+  void createAzureStorageContainerSasToken_invalidPermissions() throws InterruptedException {
+    var storageAccountResource = buildStorageAccount();
+    var storageContainerResource =
+        buildStorageContainerResource(
+            PrivateResourceState.ACTIVE,
+            AccessScopeType.ACCESS_SCOPE_PRIVATE,
+            ManagedByType.MANAGED_BY_APPLICATION);
+    when(samService.listResourceActions(
+            ArgumentMatchers.eq(userRequest),
+            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+        .thenReturn(
+            List.of(
+                SamConstants.SamControlledResourceActions.READ_ACTION,
+                SamConstants.SamControlledResourceActions.WRITE_ACTION));
+
+    assertThrows(
+        ForbiddenException.class,
+        () ->
+            azureStorageAccessService.createAzureStorageContainerSasToken(
+                UUID.randomUUID(),
+                storageContainerResource,
+                storageAccountResource,
+                startTime,
+                expiryTime,
+                userRequest,
+                null,
+                null,
+                "!@#"),
+        "Nonsense characters should result in an exception ");
+  }
+
+  @Test
+  void createAzureStorageContainerSasToken_blobName() throws InterruptedException {
+    var storageAccountResource = buildStorageAccount();
+    var storageContainerResource =
+        buildStorageContainerResource(
+            PrivateResourceState.ACTIVE,
+            AccessScopeType.ACCESS_SCOPE_PRIVATE,
+            ManagedByType.MANAGED_BY_APPLICATION);
+    when(samService.listResourceActions(
+            ArgumentMatchers.eq(userRequest),
+            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+        .thenReturn(
+            List.of(
+                SamConstants.SamControlledResourceActions.READ_ACTION,
+                SamConstants.SamControlledResourceActions.WRITE_ACTION));
+
+    var result =
+        azureStorageAccessService.createAzureStorageContainerSasToken(
+            UUID.randomUUID(),
+            storageContainerResource,
+            storageAccountResource,
+            startTime,
+            expiryTime,
+            userRequest,
+            null,
+            "foo/the/bar.baz",
+            null);
+
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), true);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -9,10 +9,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.exception.ForbiddenException;
-import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
-import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.StorageAccountKeyProvider;
@@ -34,17 +32,14 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
+public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
 
   private final OffsetDateTime startTime = OffsetDateTime.now().minusMinutes(15);
   private final OffsetDateTime expiryTime = OffsetDateTime.now().plusMinutes(60);
   private final AuthenticatedUserRequest userRequest =
       new AuthenticatedUserRequest("foo@example.com", "sub", Optional.of("token"));
 
-  @MockBean private SamService samService;
-  @MockBean private FeatureConfiguration featureConfig;
   private AzureStorageAccessService azureStorageAccessService;
 
   @BeforeEach
@@ -53,7 +48,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
     var cred = new StorageSharedKeyCredential("fake", "fake");
     when(keyProvider.getStorageAccountKey(any(), any())).thenReturn(cred);
     azureStorageAccessService =
-        new AzureStorageAccessService(samService, keyProvider, featureConfig);
+        new AzureStorageAccessService(mockSamService(), keyProvider, mockFeatureConfiguration());
   }
 
   private ControlledAzureStorageResource buildStorageAccount() {
@@ -137,10 +132,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             ManagedByType.MANAGED_BY_USER);
 
     var ipRange = "168.1.5.60-168.1.5.70";
-    when(samService.listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageAccountResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageAccountResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(List.of(SamConstants.SamControlledResourceActions.READ_ACTION));
 
     var result =
@@ -170,10 +166,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             AccessScopeType.ACCESS_SCOPE_SHARED,
             ManagedByType.MANAGED_BY_USER);
 
-    when(samService.listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.WRITE_ACTION,
@@ -192,7 +189,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             null);
 
     assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), false);
-    verify(samService)
+    verify(mockSamService())
         .listResourceActions(
             ArgumentMatchers.eq(userRequest),
             ArgumentMatchers.eq(SamConstants.SamResource.CONTROLLED_USER_SHARED),
@@ -207,10 +204,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             PrivateResourceState.NOT_APPLICABLE,
             AccessScopeType.ACCESS_SCOPE_SHARED,
             ManagedByType.MANAGED_BY_USER);
-    when(samService.listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(List.of());
 
     assertThrows(
@@ -227,7 +225,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
                 null,
                 null));
 
-    verify(samService)
+    verify(mockSamService())
         .listResourceActions(
             ArgumentMatchers.eq(userRequest),
             ArgumentMatchers.eq(SamConstants.SamResource.CONTROLLED_USER_SHARED),
@@ -243,10 +241,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(samService.listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.WRITE_ACTION,
@@ -266,7 +265,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
 
     assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), false);
 
-    verify(samService)
+    verify(mockSamService())
         .listResourceActions(
             ArgumentMatchers.eq(userRequest),
             ArgumentMatchers.eq(SamConstants.SamResource.CONTROLLED_APPLICATION_PRIVATE),
@@ -281,10 +280,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(samService.listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.WRITE_ACTION,
@@ -313,10 +313,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(samService.listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.WRITE_ACTION,
@@ -345,10 +346,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(samService.listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(List.of(SamConstants.SamControlledResourceActions.READ_ACTION));
 
     assertThrows(
@@ -375,10 +377,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(samService.listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.READ_ACTION,
@@ -408,10 +411,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(samService.listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.READ_ACTION,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -333,7 +333,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     testLandingZoneManager.createLandingZoneWithSharedStorageAccount(
         landingZoneId, storageAccountName, "eastus");
 
-    Thread.sleep(30000);
+    Thread.sleep(60000);
 
     // Submit a storage container creation flight and then verify the resource exists in the
     // workspace.
@@ -362,7 +362,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
         containerResource,
         WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
 
-    Thread.sleep(30000);
+    Thread.sleep(60000);
 
     // clean up resources - delete storage container resource
     submitControlledResourceDeletionFlight(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureTestUtils;
@@ -48,7 +48,7 @@ import java.util.function.BiFunction;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureTest {
+public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureConnectedTest {
   private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(15);
 
   @Autowired private WorkspaceService workspaceService;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureTestUtils;
 import bio.terra.workspace.common.utils.AzureVmUtils;
+import bio.terra.workspace.connected.LandingZoneTestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.service.crl.CrlService;
@@ -60,6 +61,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
   @Autowired private JobService jobService;
   @Autowired private AzureTestUtils azureTestUtils;
   @Autowired private UserAccessUtils userAccessUtils;
+  @Autowired private LandingZoneTestUtils landingZoneTestUtils;
   @Autowired private ControlledResourceService controlledResourceService;
   @Autowired private WsmResourceService wsmResourceService;
   @Autowired private AzureCloudContextService azureCloudContextService;
@@ -324,7 +326,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     createCloudContext(workspaceUuid, userRequest);
 
     // create quasi landing zone with a single resource - shared storage account
-    UUID landingZoneId = UUID.randomUUID();
+    UUID landingZoneId = UUID.fromString(landingZoneTestUtils.getDefaultLandingZoneId());
 
     TestLandingZoneManager testLandingZoneManager =
         new TestLandingZoneManager(
@@ -437,7 +439,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     createCloudContext(workspaceUuid, userRequest);
 
     // create quasi landing zone without resources
-    UUID landingZoneId = UUID.randomUUID();
+    UUID landingZoneId = UUID.fromString(landingZoneTestUtils.getDefaultLandingZoneId());
 
     TestLandingZoneManager testLandingZoneManager =
         new TestLandingZoneManager(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
@@ -23,9 +23,12 @@ import java.util.UUID;
  * <p>We are cheating here when creating landing zone. One of the main reason is that LZ service API
  * doesn't support deletion of landing zone. This functionality is under construction. In this
  * particular case we don't need real landing zone, because everything we need is shared storage
- * account as part of landing zone. So, here we use LZ low-level api to create landing zone: -
- * register landing zone in LZ database - create shared storage account It will allow us to clean up
- * created resource and test functionality with quasi landing zone.
+ * account as part of landing zone. Here we use LZ low-level api to create landing zone:
+ *
+ * <p>-register landing zone in LZ database
+ *
+ * <p>-create shared storage account with appropriate tags It will allow us to clean up created
+ * resource and test functionality with landing zone.
  *
  * <p>This class should go once delete landing zone operation is available
  */
@@ -51,7 +54,7 @@ public class TestLandingZoneManager {
     this.workspaceUuid = workspaceUuid;
 
     azureCloudContext = azureCloudContextService.getAzureCloudContext(workspaceUuid).orElse(null);
-    assertNotNull(azureCloudContext, "Azure cloud context should exist. Check configuration.");
+    assertNotNull(azureCloudContext, "Azure cloud context should exist. Make sure it was created.");
 
     storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
@@ -18,19 +18,20 @@ import com.azure.resourcemanager.storage.models.StorageAccount;
 import java.util.UUID;
 
 /**
- * Create quasi landing zone for testing.
+ * This class allows creating 2 different landing zones. It is created for integration test purposes
+ * only. It simplifies process of creation/deletion of a landing zone with custom resources without
+ * using high-level LZ API. This class might be improved/refactored in future if we need to handle
+ * wide range of different LZs. Currently, it has 2 sets of symmetrical create/delete operations for
+ * 2 different LZs.
  *
- * <p>We are cheating here when creating landing zone. One of the main reason is that LZ service API
- * doesn't support deletion of landing zone. This functionality is under construction. In this
- * particular case we don't need real landing zone, because everything we need is shared storage
- * account as part of landing zone. Here we use LZ low-level api to create landing zone:
+ * <p>We are cheating here when creating landing zone. One of the main reason is that LZ service has
+ * limited number of available landing zones for creation and also LZ service doesn't have LZ delete
+ * operation implemented yet. In this particular case we don't need to use high-level LZ service
+ * API. Here we mimic landing zone creation/deletion process by using LZ low-level api:
  *
  * <p>-register landing zone in LZ database
  *
- * <p>-create shared storage account with appropriate tags It will allow us to clean up created
- * resource and test functionality with landing zone.
- *
- * <p>This class should go once delete landing zone operation is available
+ * <p>-create shared storage account with appropriate tags
  */
 public class TestLandingZoneManager {
   private final AzureCloudContextService azureCloudContextService;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
@@ -1,0 +1,121 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import bio.terra.cloudres.azure.resourcemanager.common.Defaults;
+import bio.terra.landingzone.db.LandingZoneDao;
+import bio.terra.landingzone.db.model.LandingZone;
+import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
+import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resourcemanager.data.CreateStorageAccountRequestData;
+import bio.terra.workspace.service.workspace.AzureCloudContextService;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.Region;
+import com.azure.resourcemanager.storage.StorageManager;
+import com.azure.resourcemanager.storage.models.StorageAccount;
+import java.util.UUID;
+
+/**
+ * Create quasi landing zone for testing.
+ *
+ * <p>We are cheating here when creating landing zone. One of the main reason is that LZ service API
+ * doesn't support deletion of landing zone. This functionality is under construction. In this
+ * particular case we don't need real landing zone, because everything we need is shared storage
+ * account as part of landing zone. So, here we use LZ low-level api to create landing zone: -
+ * register landing zone in LZ database - create shared storage account It will allow us to clean up
+ * created resource and test functionality with quasi landing zone.
+ *
+ * <p>This class should go once delete landing zone operation is available
+ */
+public class TestLandingZoneManager {
+  private final AzureCloudContextService azureCloudContextService;
+  private final LandingZoneDao landingZoneDao;
+  private final CrlService crlService;
+  private final AzureConfiguration azureConfig;
+  private final UUID workspaceUuid;
+  private final AzureCloudContext azureCloudContext;
+  private final StorageManager storageManager;
+
+  public TestLandingZoneManager(
+      AzureCloudContextService azureCloudContextService,
+      LandingZoneDao landingZoneDao,
+      CrlService crlService,
+      AzureConfiguration azureConfig,
+      UUID workspaceUuid) {
+    this.azureCloudContextService = azureCloudContextService;
+    this.landingZoneDao = landingZoneDao;
+    this.crlService = crlService;
+    this.azureConfig = azureConfig;
+    this.workspaceUuid = workspaceUuid;
+
+    azureCloudContext = azureCloudContextService.getAzureCloudContext(workspaceUuid).orElse(null);
+    assertNotNull(azureCloudContext, "Azure cloud context should exist. Check configuration.");
+
+    storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
+  }
+
+  public void createLandingZoneWithSharedStorageAccount(
+      UUID landingZoneId, String storageAccountName, String region) {
+    createLandingZoneDbRecord(landingZoneId);
+    createStorageAccount(storageAccountName, region, landingZoneId);
+  }
+
+  public void deleteLandingZoneWithSharedStorageAccount(
+      UUID landingZoneId, String azureResourceGroup, String storageAccountName) {
+    landingZoneDao.deleteLandingZone(landingZoneId);
+
+    storageManager.storageAccounts().deleteByResourceGroup(azureResourceGroup, storageAccountName);
+  }
+
+  public void createLandingZoneWithoutResources(UUID landingZoneId) {
+    createLandingZoneDbRecord(landingZoneId);
+  }
+
+  public void deleteLandingZoneWithoutResources(UUID landingZoneId) {
+    landingZoneDao.deleteLandingZone(landingZoneId);
+  }
+
+  private void createLandingZoneDbRecord(UUID landingZoneId) {
+    String definition = "QuasiLandingZoneWithSharedStorageAccount";
+    String version = "v1";
+    // create record in LZ database
+    landingZoneDao.createLandingZone(
+        LandingZone.builder()
+            .landingZoneId(landingZoneId)
+            .definition(definition)
+            .version(version)
+            .description(String.format("Definition:%s Version:%s", definition, version))
+            .displayName(definition)
+            .properties(null)
+            .resourceGroupId(azureCloudContext.getAzureResourceGroupId())
+            .subscriptionId(azureCloudContext.getAzureSubscriptionId())
+            .tenantId(azureCloudContext.getAzureTenantId())
+            .build());
+  }
+
+  private StorageAccount createStorageAccount(
+      String storageAccountName, String region, UUID landingZoneId) {
+    StorageAccount storageAccount =
+        storageManager
+            .storageAccounts()
+            .define(storageAccountName)
+            .withRegion(region)
+            .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
+            .withHnsEnabled(true)
+            .withTag("workspaceId", workspaceUuid.toString())
+            .withTag(LandingZoneTagKeys.LANDING_ZONE_ID.toString(), landingZoneId.toString())
+            .withTag(
+                LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString(),
+                ResourcePurpose.SHARED_RESOURCE.toString())
+            .create(
+                Defaults.buildContext(
+                    CreateStorageAccountRequestData.builder()
+                        .setName(storageAccountName)
+                        .setRegion(Region.fromName(region))
+                        .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
+                        .build()));
+    return storageAccount;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
@@ -13,7 +13,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureDiskStepTest extends BaseAzureTest {
+public class CreateAzureDiskStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
@@ -10,7 +10,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class GetAzureDiskStepTest extends BaseAzureTest {
+public class GetAzureDiskStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
@@ -13,7 +13,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureIpStepTest extends BaseAzureTest {
+public class CreateAzureIpStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
@@ -10,7 +10,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class GetAzureIpStepTest extends BaseAzureTest {
+public class GetAzureIpStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
@@ -13,7 +13,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureNetworkStepTest extends BaseAzureTest {
+public class CreateAzureNetworkStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
@@ -10,7 +10,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class GetAzureNetworkStepTest extends BaseAzureTest {
+public class GetAzureNetworkStepTest extends BaseAzureConnectedTest {
   private static final String STUB_STRING_RETURN = "stubbed-return";
 
   @Mock private FlightContext mockFlightContext;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStepTest.java
@@ -13,7 +13,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureRelayNamespaceCreationParameters;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureRelayNamespaceStepTest extends BaseAzureTest {
+public class CreateAzureRelayNamespaceStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStepTest.java
@@ -12,7 +12,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureRelayNamespaceCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class GetAzureRelayNamespaceStepTest extends BaseAzureTest {
+public class GetAzureRelayNamespaceStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 
 /** Base class for storage account and storage container tests. */
-public class BaseStorageStepTest extends BaseAzureTest {
+public class BaseStorageStepTest extends BaseAzureConnectedTest {
 
   protected final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStepTest.java
@@ -1,0 +1,171 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.db.exception.LandingZoneNotFoundException;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
+import bio.terra.workspace.generated.model.ApiAzureStorageContainerCreationParameters;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.BaseStorageStepTest;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.resourcemanager.storage.models.BlobContainers;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+public class DeleteAzureStorageContainerStepTest extends BaseStorageStepTest {
+  @Mock private BlobContainers mockBlobContainers;
+  @Mock private ResourceDao mockResourceDao;
+  @Mock private LandingZoneApiDispatch mockLandingZoneApiDispatch;
+
+  @Captor ArgumentCaptor<String> resourceGroupNameCaptor;
+  @Captor ArgumentCaptor<String> accountNameCaptor;
+  @Captor ArgumentCaptor<String> containerNameCaptor;
+
+  private final ApiAzureStorageContainerCreationParameters creationParameters =
+      ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+  private final String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
+  private final ControlledAzureStorageResource storageAccountResource =
+      ControlledResourceFixtures.getAzureStorage(storageAccountName, "mockRegion");
+  private ControlledAzureStorageContainerResource storageContainerResource;
+  private DeleteAzureStorageContainerStep deleteAzureStorageContainerStep;
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
+    when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
+  }
+
+  private void initDeleteValidationStep(Optional<UUID> storageAccountId) {
+    storageContainerResource =
+        ControlledResourceFixtures.getAzureStorageContainer(
+            storageAccountId.orElse(null), creationParameters.getStorageContainerName());
+
+    deleteAzureStorageContainerStep =
+        new DeleteAzureStorageContainerStep(
+            mockAzureConfig,
+            mockCrlService,
+            mockResourceDao,
+            mockLandingZoneApiDispatch,
+            storageContainerResource);
+  }
+
+  @Test
+  public void deleteStorageAccountContainerControlledByWsmStorageAccountSuccess()
+      throws InterruptedException {
+    initDeleteValidationStep(Optional.of(creationParameters.getStorageAccountId()));
+    when(mockResourceDao.getResource(
+            storageContainerResource.getWorkspaceId(), creationParameters.getStorageAccountId()))
+        .thenReturn(storageAccountResource);
+
+    // act
+    final StepResult stepResult = deleteAzureStorageContainerStep.doStep(mockFlightContext);
+
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+
+    verify(mockBlobContainers, times(1))
+        .delete(
+            resourceGroupNameCaptor.capture(),
+            accountNameCaptor.capture(),
+            containerNameCaptor.capture());
+    assertThat(
+        resourceGroupNameCaptor.getValue(),
+        equalTo(mockAzureCloudContext.getAzureResourceGroupId()));
+    assertThat(
+        accountNameCaptor.getValue(), equalTo(storageAccountResource.getStorageAccountName()));
+    assertThat(
+        containerNameCaptor.getValue(),
+        equalTo(storageContainerResource.getStorageContainerName()));
+  }
+
+  @Test
+  public void deleteStorageAccountContainerControlledByLzStorageAccountSuccess()
+      throws InterruptedException {
+    UUID landingZoneId = UUID.randomUUID();
+    initDeleteValidationStep(Optional.empty());
+
+    when(mockLandingZoneApiDispatch.getLandingZoneId(any(AzureCloudContext.class)))
+        .thenReturn(landingZoneId.toString());
+    ApiAzureLandingZoneDeployedResource mockSharedStorageAccount =
+        mock(ApiAzureLandingZoneDeployedResource.class);
+    String sharedAccountId = UUID.randomUUID().toString();
+    when(mockSharedStorageAccount.getResourceId()).thenReturn(sharedAccountId);
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(landingZoneId.toString()))
+        .thenReturn(Optional.of(mockSharedStorageAccount));
+    String sharedStorageAccountName = "sharedStorageAccount";
+    when(mockStorageAccount.name()).thenReturn(sharedStorageAccountName);
+    when(mockStorageAccounts.getById(sharedAccountId)).thenReturn(mockStorageAccount);
+
+    // act
+    final StepResult stepResult = deleteAzureStorageContainerStep.doStep(mockFlightContext);
+
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+
+    verify(mockBlobContainers, times(1))
+        .delete(
+            resourceGroupNameCaptor.capture(),
+            accountNameCaptor.capture(),
+            containerNameCaptor.capture());
+    assertThat(
+        resourceGroupNameCaptor.getValue(),
+        equalTo(mockAzureCloudContext.getAzureResourceGroupId()));
+    assertThat(accountNameCaptor.getValue(), equalTo(sharedStorageAccountName));
+    assertThat(
+        containerNameCaptor.getValue(),
+        equalTo(storageContainerResource.getStorageContainerName()));
+  }
+
+  @Test
+  public void deleteStorageAccountContainerControlledByLzStorageAccountFailure_NoLandingZone()
+      throws InterruptedException {
+    initDeleteValidationStep(Optional.empty());
+
+    when(mockLandingZoneApiDispatch.getLandingZoneId(any(AzureCloudContext.class)))
+        .thenThrow(
+            new IllegalStateException(
+                "Could not find a landing zone id for the given Azure context. "
+                    + "Please check that the landing zone deployment is complete."));
+
+    // act
+    final StepResult stepResult = deleteAzureStorageContainerStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(LandingZoneNotFoundException.class));
+  }
+
+  @Test
+  public void
+      deleteStorageAccountContainerControlledByLzStorageAccountFailure_NoSharedStorageAccount()
+          throws InterruptedException {
+    UUID landingZoneId = UUID.randomUUID();
+    initDeleteValidationStep(Optional.empty());
+
+    when(mockLandingZoneApiDispatch.getLandingZoneId(any(AzureCloudContext.class)))
+        .thenReturn(landingZoneId.toString());
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(landingZoneId.toString()))
+        .thenReturn(Optional.empty());
+
+    // act
+    final StepResult stepResult = deleteAzureStorageContainerStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(ResourceNotFoundException.class));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStepTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.iam.BearerToken;
 import bio.terra.landingzone.db.exception.LandingZoneNotFoundException;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
@@ -102,12 +103,12 @@ public class DeleteAzureStorageContainerStepTest extends BaseStorageStepTest {
     initDeleteValidationStep(Optional.empty());
 
     when(mockLandingZoneApiDispatch.getLandingZoneId(any(AzureCloudContext.class)))
-        .thenReturn(landingZoneId.toString());
+        .thenReturn(landingZoneId);
     ApiAzureLandingZoneDeployedResource mockSharedStorageAccount =
         mock(ApiAzureLandingZoneDeployedResource.class);
     String sharedAccountId = UUID.randomUUID().toString();
     when(mockSharedStorageAccount.getResourceId()).thenReturn(sharedAccountId);
-    when(mockLandingZoneApiDispatch.getSharedStorageAccount(landingZoneId.toString()))
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(any(BearerToken.class), landingZoneId))
         .thenReturn(Optional.of(mockSharedStorageAccount));
     String sharedStorageAccountName = "sharedStorageAccount";
     when(mockStorageAccount.name()).thenReturn(sharedStorageAccountName);
@@ -158,8 +159,8 @@ public class DeleteAzureStorageContainerStepTest extends BaseStorageStepTest {
     initDeleteValidationStep(Optional.empty());
 
     when(mockLandingZoneApiDispatch.getLandingZoneId(any(AzureCloudContext.class)))
-        .thenReturn(landingZoneId.toString());
-    when(mockLandingZoneApiDispatch.getSharedStorageAccount(landingZoneId.toString()))
+        .thenReturn(landingZoneId);
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(any(BearerToken.class), landingZoneId))
         .thenReturn(Optional.empty());
 
     // act

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.iam.BearerToken;
 import bio.terra.landingzone.db.exception.LandingZoneNotFoundException;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.stairway.StepResult;
@@ -19,6 +20,7 @@ import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneResourcesList;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneResourcesPurposeGroup;
 import bio.terra.workspace.generated.model.ApiAzureStorageContainerCreationParameters;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.BaseStorageStepTest;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
@@ -42,8 +44,10 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
   @Mock private BlobContainer mockBlobContainer;
   @Mock private ResourceDao mockResourceDao;
   @Mock private LandingZoneApiDispatch mockLandingZoneApiDispatch;
+  @Mock private AuthenticatedUserRequest mockUserRequest;
 
-  private static final String LANDING_ZONE_ID = "b2db9b47-fd0f-4ae9-b9b4-f675550b0291";
+  private static final UUID LANDING_ZONE_ID =
+      UUID.fromString("b2db9b47-fd0f-4ae9-b9b4-f675550b0291");
 
   private final String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
   final ApiAzureStorageContainerCreationParameters creationParameters =
@@ -77,6 +81,7 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
             mockCrlService,
             mockResourceDao,
             mockLandingZoneApiDispatch,
+            mockUserRequest,
             storageContainerResource);
   }
 
@@ -119,11 +124,13 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
     when(mockLandingZoneApiDispatch.getLandingZoneId(any())).thenReturn(LANDING_ZONE_ID);
     ApiAzureLandingZoneDeployedResource mockSharedStorageAccount =
         mock(ApiAzureLandingZoneDeployedResource.class);
-    when(mockLandingZoneApiDispatch.getSharedStorageAccount(LANDING_ZONE_ID))
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(
+            any(BearerToken.class), LANDING_ZONE_ID))
         .thenReturn(Optional.of(mockSharedStorageAccount));
     String sharedAccountId = UUID.randomUUID().toString();
     when(mockSharedStorageAccount.getResourceId()).thenReturn(sharedAccountId);
-    when(mockLandingZoneApiDispatch.getSharedStorageAccount(LANDING_ZONE_ID))
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(
+            any(BearerToken.class), LANDING_ZONE_ID))
         .thenReturn(Optional.of(mockSharedStorageAccount));
     String sharedStorageAccountName = "sharedStorageAccount";
     when(mockStorageAccount.name()).thenReturn(sharedStorageAccountName);
@@ -196,7 +203,8 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
     initValidationStep(Optional.empty());
 
     when(mockLandingZoneApiDispatch.getLandingZoneId(any())).thenReturn(LANDING_ZONE_ID);
-    when(mockLandingZoneApiDispatch.getSharedStorageAccount(LANDING_ZONE_ID))
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(
+            any(BearerToken.class), LANDING_ZONE_ID))
         .thenReturn(Optional.empty());
 
     // act

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.db.ResourceDao;
@@ -29,6 +30,7 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
   @Mock private BlobContainers mockBlobContainers;
   @Mock private BlobContainer mockBlobContainer;
   @Mock private ResourceDao mockResourceDao;
+  @Mock private LandingZoneApiDispatch mockLandingZoneApiDispatch;
 
   private final String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
   final ApiAzureStorageContainerCreationParameters creationParameters =
@@ -53,7 +55,7 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
     when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
     verifyCanBeCreatedStep =
         new VerifyAzureStorageContainerCanBeCreatedStep(
-            mockAzureConfig, mockCrlService, mockResourceDao, storageContainerResource);
+            mockAzureConfig, mockCrlService, mockResourceDao, mockLandingZoneApiDispatch, storageContainerResource);
   }
 
   private void mockStorageAccountExists() {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureNetworkInterfaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureNetworkInterfaceStepTest.java
@@ -2,6 +2,8 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
@@ -11,6 +13,7 @@ import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
@@ -20,6 +23,7 @@ import com.azure.resourcemanager.network.models.Networks;
 import com.azure.resourcemanager.network.models.Subnet;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,11 +60,19 @@ public class CreateAzureNetworkInterfaceStepTest extends BaseAzureUnitTest {
 
   @Mock private Subnet armSubnet;
 
+  private final AuthenticatedUserRequest USER_REQUEST =
+      new AuthenticatedUserRequest().token(Optional.of("some-token"));
+
   @BeforeEach
   void setUp() {
     networkInterfaceStep =
         new CreateAzureNetworkInterfaceStep(
-            azureConfiguration, crlService, resource, resourceDao, landingZoneApiDispatch);
+            azureConfiguration,
+            crlService,
+            resource,
+            resourceDao,
+            landingZoneApiDispatch,
+            USER_REQUEST);
     when(networkManager.networks()).thenReturn(networks);
     var subnets = new HashMap<String, Subnet>();
     subnets.put(STUB_SUBNET, armSubnet);
@@ -109,7 +121,7 @@ public class CreateAzureNetworkInterfaceStepTest extends BaseAzureUnitTest {
   }
 
   private void setUpNetworkInLZInteractionChain(UUID networkId, UUID workspaceId) {
-    var lzId = UUID.randomUUID().toString();
+    var lzId = UUID.randomUUID();
     var resources = new ArrayList<ApiAzureLandingZoneDeployedResource>();
     resources.add(
         new ApiAzureLandingZoneDeployedResource()
@@ -119,7 +131,7 @@ public class CreateAzureNetworkInterfaceStepTest extends BaseAzureUnitTest {
     when(resource.getNetworkId()).thenReturn(null);
     when(landingZoneApiDispatch.getLandingZoneId(azureCloudContext)).thenReturn(lzId);
     when(landingZoneApiDispatch.listSubnetsWithParentVNetByPurpose(
-            lzId, SubnetResourcePurpose.WORKSPACE_COMPUTE_SUBNET))
+            any(), eq(lzId), eq(SubnetResourcePurpose.WORKSPACE_COMPUTE_SUBNET)))
         .thenReturn(resources);
     when(networks.getById(networkId.toString())).thenReturn(armNetwork);
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -12,7 +12,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureVmUtils;
 import bio.terra.workspace.db.ResourceDao;
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureVmStepTest extends BaseAzureTest {
+public class CreateAzureVmStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
   private static final String STUB_DISK_NAME = "stub-disk-name";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -2,27 +2,29 @@ package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 
 import static bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketHandler.MAX_BUCKET_NAME_LENGTH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 
-import bio.terra.workspace.common.BaseUnitTest;
-import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import java.io.IOException;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 
-public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
-  @MockBean GcpCloudContextService mockGcpCloudContextService;
-
+// TODO: PF-2090 - Spring does not seem to notice that it needs to build a different
+//  application context for this test class, even though it inherits a different set
+//  of mocks. Doing @DirtiesContext forces a new application context and it is built
+//  properly. See the ticket for more details.
+@DirtiesContext(classMode = BEFORE_CLASS)
+public class ControlledGcsBucketHandlerTest extends BaseUnitTestMockGcpCloudContextService {
   private static final UUID fakeWorkspaceId = UUID.randomUUID();
   private static final String FAKE_PROJECT_ID = "fakeprojectid";
 
   @BeforeEach
   public void setup() throws IOException {
-    when(mockGcpCloudContextService.getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
+    when(mockGcpCloudContextService().getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
   }
 
   @Test
@@ -31,7 +33,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -40,7 +42,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yu-hu-yo-yo-" + FAKE_PROJECT_ID));
+    assertEquals("yu-hu-yo-yo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -49,7 +51,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -58,7 +60,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -67,7 +69,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("gooyuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("gooyuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -76,7 +78,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -89,7 +91,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     int maxNameLength = MAX_BUCKET_NAME_LENGTH;
 
     assertEquals(maxNameLength, generateCloudName.length());
-    assertTrue(generateCloudName.equals(generateCloudName.substring(0, maxNameLength)));
+    assertEquals(generateCloudName, generateCloudName.substring(0, maxNameLength));
   }
 
   @Test
@@ -98,6 +100,6 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.bucket;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.service.resource.controlled.flight.clone.bucket.GcsBucketCloneTestFixtures.CREATED_BUCKET_RESOURCE;
 import static bio.terra.workspace.service.resource.controlled.flight.clone.bucket.GcsBucketCloneTestFixtures.DESTINATION_BUCKET_NAME;
 import static bio.terra.workspace.service.resource.controlled.flight.clone.bucket.GcsBucketCloneTestFixtures.DESTINATION_WORKSPACE_ID;
@@ -13,21 +14,20 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
-import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
-import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
-import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import java.util.ArrayList;
@@ -36,30 +36,34 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.Mock;
+import org.springframework.test.annotation.DirtiesContext;
 
-public class CopyGcsBucketDefinitionStepTest extends BaseUnitTest {
-
-  @MockBean private FlightContext mockFlightContext;
-  @MockBean private AuthenticatedUserRequest mockUserRequest;
-  @MockBean private ControlledResourceService mockControlledResourceService;
-  @MockBean private GcpCloudContextService gcpCloudContextService;
+// TODO: PF-2090 - Spring does not seem to notice that it needs to build a different
+//  application context for this test class, even though it inherits a different set
+//  of mocks. Doing @DirtiesContext forces a new application context and it is built
+//  properly. See the ticket for more details.
+@DirtiesContext(classMode = BEFORE_CLASS)
+public class CopyGcsBucketDefinitionStepTest extends BaseUnitTestMockGcpCloudContextService {
   private CopyGcsBucketDefinitionStep copyGcsBucketDefinitionStep;
+
+  @Mock FlightContext mockFlightContext;
 
   @BeforeEach
   public void setup() throws InterruptedException {
     copyGcsBucketDefinitionStep =
         new CopyGcsBucketDefinitionStep(
-            mockUserRequest,
+            USER_REQUEST,
             SOURCE_BUCKET_RESOURCE,
-            mockControlledResourceService,
+            mockControlledResourceService(),
             CloningInstructions.COPY_DEFINITION);
-    when(gcpCloudContextService.getRequiredGcpProject(any(UUID.class)))
+    when(mockGcpCloudContextService().getRequiredGcpProject(any(UUID.class)))
         .thenReturn("my-fake-project");
   }
 
   @Test
   public void testDoStep() throws InterruptedException {
+
     final var inputParameters = new FlightMap();
     inputParameters.put(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, DESTINATION_WORKSPACE_ID);
     inputParameters.put(
@@ -78,7 +82,7 @@ public class CopyGcsBucketDefinitionStepTest extends BaseUnitTest {
     doReturn(workingMap).when(mockFlightContext).getWorkingMap();
 
     doReturn(CREATED_BUCKET_RESOURCE)
-        .when(mockControlledResourceService)
+        .when(mockControlledResourceService())
         .createControlledResourceSync(
             any(ControlledResource.class),
             any(ControlledResourceIamRole.class),
@@ -92,7 +96,7 @@ public class CopyGcsBucketDefinitionStepTest extends BaseUnitTest {
         ArgumentCaptor.forClass(ControlledResourceIamRole.class);
     final ArgumentCaptor<ApiGcpGcsBucketCreationParameters> creationParametersCaptor =
         ArgumentCaptor.forClass(ApiGcpGcsBucketCreationParameters.class);
-    verify(mockControlledResourceService)
+    verify(mockControlledResourceService())
         .createControlledResourceSync(
             destinationBucketCaptor.capture(),
             iamRoleCaptor.capture(),

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource.referenced;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,15 +13,11 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.stairway.StepStatus;
-import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.BaseUnitTestMockDataRepoService;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
 import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.db.exception.InvalidMetadataException;
-import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.datarepo.DataRepoService;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.exception.InvalidResultStateException;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
@@ -48,51 +45,35 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
-@Tag("unit")
-class ReferencedResourceServiceTest extends BaseUnitTest {
+class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
 
   private static final Logger logger = LoggerFactory.getLogger(ReferencedResourceServiceTest.class);
   private static final String DATA_REPO_INSTANCE_NAME = "terra";
   private static final String FAKE_PROJECT_ID = "fakeprojecctid";
-
-  /** A fake authenticated user request. */
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest()
-          .token(Optional.of("fake-token"))
-          .email("fake@email.com")
-          .subjectId("fakeID123");
 
   @Autowired private WorkspaceService workspaceService;
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private ReferencedResourceService referenceResourceService;
   @Autowired private JobService jobService;
   @Autowired private WorkspaceActivityLogDao workspaceActivityLogDao;
-  /** Mock SamService does nothing for all calls that would throw if unauthorized. */
-  @MockBean private SamService mockSamService;
-
-  @MockBean private DataRepoService mockDataRepoService;
-  @MockBean private CrlService mockCrlService;
 
   private UUID workspaceUuid;
   private ReferencedResource referencedResource;
 
   @BeforeEach
   void setup() throws InterruptedException {
-    doReturn(true).when(mockDataRepoService).snapshotReadable(any(), any(), any());
-    when(mockSamService.getUserStatusInfo(any()))
+    doReturn(true).when(mockDataRepoService()).snapshotReadable(any(), any(), any());
+    when(mockSamService().getUserStatusInfo(any()))
         .thenReturn(
             new UserStatusInfo()
                 .userEmail(USER_REQUEST.getEmail())
@@ -568,8 +549,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
     @BeforeEach
     void setup() throws Exception {
       // Make the Verify step always succeed
-      doReturn(true).when(mockCrlService).canReadGcsBucket(any(), any());
-      doReturn(true).when(mockCrlService).canReadGcsObject(any(), any(), any());
+      doReturn(true).when(mockCrlService()).canReadGcsBucket(any(), any());
+      doReturn(true).when(mockCrlService()).canReadGcsObject(any(), any(), any());
     }
 
     private ReferencedGcsObjectResource makeGcsObjectReference() {
@@ -772,8 +753,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
     @BeforeEach
     void setup() throws Exception {
       // Make the Verify step always succeed
-      doReturn(true).when(mockCrlService).canReadBigQueryDataset(any(), any(), any());
-      doReturn(true).when(mockCrlService).canReadBigQueryDataTable(any(), any(), any(), any());
+      doReturn(true).when(mockCrlService()).canReadBigQueryDataset(any(), any(), any());
+      doReturn(true).when(mockCrlService()).canReadBigQueryDataTable(any(), any(), any(), any());
     }
 
     private ReferencedBigQueryDatasetResource makeBigQueryDatasetResource() {
@@ -1092,7 +1073,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
 
     @BeforeEach
     void setup() throws Exception {
-      doReturn(true).when(mockSamService).isAuthorized(any(), any(), any(), any());
+      doReturn(true).when(mockSamService()).isAuthorized(any(), any(), any(), any());
     }
 
     private ReferencedTerraWorkspaceResource makeTerraWorkspaceReference() {

--- a/service/src/test/java/bio/terra/workspace/service/status/WorkspaceManagerStatusServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/status/WorkspaceManagerStatusServiceTest.java
@@ -6,16 +6,12 @@ import static org.mockito.Mockito.doReturn;
 
 import bio.terra.workspace.app.configuration.external.StatusCheckConfiguration;
 import bio.terra.workspace.common.BaseUnitTest;
-import bio.terra.workspace.service.iam.SamService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class WorkspaceManagerStatusServiceTest extends BaseUnitTest {
-
-  @MockBean private SamService mockSamService;
 
   @Autowired private WorkspaceManagerStatusService statusService;
   @Autowired private StatusCheckConfiguration configuration;
@@ -46,14 +42,14 @@ public class WorkspaceManagerStatusServiceTest extends BaseUnitTest {
 
   @Test
   void testStatusWithWorkingEndpoints() {
-    doReturn(IS_OK).when(mockSamService).status();
+    doReturn(IS_OK).when(mockSamService()).status();
     statusService.checkStatus();
     assertTrue(statusService.getCurrentStatus());
   }
 
   @Test
   void testFailureNotOk() {
-    doReturn(NOT_OK).when(mockSamService).status();
+    doReturn(NOT_OK).when(mockSamService()).status();
     statusService.checkStatus();
     assertFalse(statusService.getCurrentStatus());
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.workspace.app.configuration.external.AzureTestConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class AzureWorkspaceTest extends BaseAzureTest {
+public class AzureWorkspaceTest extends BaseAzureConnectedTest {
 
   @Autowired private AzureTestConfiguration azureTestConfiguration;
   @Autowired private JobService jobService;

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,9 +12,6 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceDao;
-import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants.SamSpendProfileAction;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
@@ -27,12 +25,10 @@ import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class GcpCloudContextUnitTest extends BaseUnitTest {
   private static final String GCP_PROJECT_ID = "terra-wsm-t-clean-berry-5152";
@@ -42,14 +38,7 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
   private static final String POLICY_APPLICATION = "policy-application";
   private static final String V1_JSON =
       String.format("{\"version\": 1, \"gcpProjectId\": \"%s\"}", GCP_PROJECT_ID);
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest()
-          .token(Optional.of("fake-token"))
-          .email("fake@email.com")
-          .subjectId("fakeID123");
 
-  @MockBean private SamService mockSamService;
-  @MockBean private CrlService mockCrlService;
   @Autowired private WorkspaceService workspaceService;
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private ResourceDao resourceDao;
@@ -117,22 +106,23 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
     // By default, allow all spend link calls as authorized. (All other isAuthorized calls return
     // false by Mockito default.
     Mockito.when(
-            mockSamService.isAuthorized(
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.eq(SamSpendProfileAction.LINK)))
+            mockSamService()
+                .isAuthorized(
+                    Mockito.any(),
+                    Mockito.any(),
+                    Mockito.any(),
+                    Mockito.eq(SamSpendProfileAction.LINK)))
         .thenReturn(true);
 
     // Fake groups
-    Mockito.when(mockSamService.getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.READER), any()))
+    Mockito.when(mockSamService().getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.READER), any()))
         .thenReturn(POLICY_READER);
-    Mockito.when(mockSamService.getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.WRITER), any()))
+    Mockito.when(mockSamService().getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.WRITER), any()))
         .thenReturn(POLICY_WRITER);
-    Mockito.when(mockSamService.getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.OWNER), any()))
+    Mockito.when(mockSamService().getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.OWNER), any()))
         .thenReturn(POLICY_OWNER);
     Mockito.when(
-            mockSamService.getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.APPLICATION), any()))
+            mockSamService().getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.APPLICATION), any()))
         .thenReturn(POLICY_APPLICATION);
 
     // Create a workspace record
@@ -220,6 +210,6 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
     // Pretend the project is already being deleted.
     Mockito.when(mockResourceManager.projects().get(any()).execute())
         .thenReturn(new Project().setState("DELETE_IN_PROGRESS"));
-    Mockito.when(mockCrlService.getCloudResourceManagerCow()).thenReturn(mockResourceManager);
+    Mockito.when(mockCrlService().getCloudResourceManagerCow()).thenReturn(mockResourceManager);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UFID_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UUID_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
@@ -92,7 +93,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
@@ -112,12 +112,6 @@ import org.springframework.test.web.servlet.MockMvc;
 class WorkspaceServiceTest extends BaseConnectedTest {
 
   public static final String SPEND_PROFILE_ID = "wm-default-spend-profile";
-  /** A fake authenticated user request. */
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest()
-          .token(Optional.of("fake-token"))
-          .email("fake@email.com")
-          .subjectId("fakeID123");
   /** A fake group-constraint policy for a workspace. */
   private static final ApiTpsPolicyInput GROUP_POLICY =
       new ApiTpsPolicyInput()

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlightTest.java
@@ -3,7 +3,7 @@ package bio.terra.workspace.service.workspace.flight;
 import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.stairway.*;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureTestUtils;
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class DeleteAzureContextFlightTest extends BaseAzureTest {
+public class DeleteAzureContextFlightTest extends BaseAzureConnectedTest {
   /**
    * How long to wait for a delete context Stairway flight to complete before timing out the test.
    */

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateAzureContextFlightTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.utils.AzureTestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -21,7 +21,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class CreateAzureContextFlightTest extends BaseAzureTest {
+class CreateAzureContextFlightTest extends BaseAzureConnectedTest {
   /** How long to wait for a Stairway flight to complete before timing out the test. */
   private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(10);
 

--- a/service/src/test/resources/application-connected-test.yml
+++ b/service/src/test/resources/application-connected-test.yml
@@ -6,6 +6,9 @@ workspace:
     user-delegated-service-account-path: ../config/user-delegated-sa.json
     default-user-email: elijah.thunderlord@test.firecloud.org
     second-user-email: liam.dragonmaw@test.firecloud.org
+    # default landing zone id value. This static value allows setting permission in SAM for LZ operation
+    #for user with 'default-user-email'
+    default-landing-zone-id: 435afea6-63b2-4a60-8e6e-9dbf294b783a
 
   crl:
     use-crl: true

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -53,6 +53,10 @@ policy:
 #Terra Landing Zone Service configuration
 landingzone:
   landingzone-database:
+    initialize-on-start: true
+    password: landingzonepwd
+    uri: jdbc:postgresql://127.0.0.1:5432/landingzone_db
+    username: landingzoneuser
     poolMaxIdle: 1
   landingzone-stairway-database:
     poolMaxIdle: 1

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ include 'integration'
 
 // -- Global Variables --
 // For defining shared state and common dependencies
-gradle.ext.wsmVersion = "0.254.402-SNAPSHOT"
+gradle.ext.wsmVersion = "0.254.403-SNAPSHOT"
 
 // Single place to define the versions of dependencies shared between components.
 gradle.ext.librarySwaggerAnnotations = "io.swagger.core.v3:swagger-annotations:2.1.6"

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ include 'integration'
 
 // -- Global Variables --
 // For defining shared state and common dependencies
-gradle.ext.wsmVersion = "0.254.406-SNAPSHOT"
+gradle.ext.wsmVersion = "0.254.407-SNAPSHOT"
 
 // Single place to define the versions of dependencies shared between components.
 gradle.ext.librarySwaggerAnnotations = "io.swagger.core.v3:swagger-annotations:2.1.6"

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ include 'integration'
 
 // -- Global Variables --
 // For defining shared state and common dependencies
-gradle.ext.wsmVersion = "0.254.403-SNAPSHOT"
+gradle.ext.wsmVersion = "0.254.404-SNAPSHOT"
 
 // Single place to define the versions of dependencies shared between components.
 gradle.ext.librarySwaggerAnnotations = "io.swagger.core.v3:swagger-annotations:2.1.6"

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ include 'integration'
 
 // -- Global Variables --
 // For defining shared state and common dependencies
-gradle.ext.wsmVersion = "0.254.405-SNAPSHOT"
+gradle.ext.wsmVersion = "0.254.406-SNAPSHOT"
 
 // Single place to define the versions of dependencies shared between components.
 gradle.ext.librarySwaggerAnnotations = "io.swagger.core.v3:swagger-annotations:2.1.6"

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ include 'integration'
 
 // -- Global Variables --
 // For defining shared state and common dependencies
-gradle.ext.wsmVersion = "0.254.407-SNAPSHOT"
+gradle.ext.wsmVersion = "0.254.408-SNAPSHOT"
 
 // Single place to define the versions of dependencies shared between components.
 gradle.ext.librarySwaggerAnnotations = "io.swagger.core.v3:swagger-annotations:2.1.6"

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ include 'integration'
 
 // -- Global Variables --
 // For defining shared state and common dependencies
-gradle.ext.wsmVersion = "0.254.404-SNAPSHOT"
+gradle.ext.wsmVersion = "0.254.405-SNAPSHOT"
 
 // Single place to define the versions of dependencies shared between components.
 gradle.ext.librarySwaggerAnnotations = "io.swagger.core.v3:swagger-annotations:2.1.6"


### PR DESCRIPTION
This PR addresses new requirements for Azure storage container creation process. Now it is possible to reuse shared storage account from landing zone to create associated container.
Changes:
-Storage container REST API: storageAccountId is not required
-Update logic for Verify step within azure storage container creation flight
-Update logic for Delete step within azure storage container deletion flight