### PR TITLE
PF-2060: Add missing permission that has broken notebook creation.

### DIFF
--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -157,6 +157,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
             resource.getAttributes().getInstanceId());
     AIPlatformNotebooks userNotebooks = ClientTestUtils.getAIPlatformNotebooksClient(resourceUser);
 
+    NotebookUtils.assertInstanceHasProxyUrl(userNotebooks, instanceName);
     assertTrue(
         NotebookUtils.userHasProxyAccess(
             creationResult, resourceUser, resource.getAttributes().getProjectId()),

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstancePostStartup.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstancePostStartup.java
@@ -1,7 +1,6 @@
 package scripts.testscripts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
@@ -12,7 +11,6 @@ import bio.terra.workspace.model.GcpAiNotebookInstanceResource;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import com.google.api.services.notebooks.v1.AIPlatformNotebooks;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -63,28 +61,7 @@ public class PrivateControlledAiNotebookInstancePostStartup
     AIPlatformNotebooks userNotebooks = ClientTestUtils.getAIPlatformNotebooksClient(resourceUser);
     GcpAiNotebookInstanceResource resource = getNotebookResource(resourceUserApi, creationResult);
     var instanceName = composeInstanceName(resource);
-    String proxyUrl =
-        ClientTestUtils.getWithRetryOnException(
-            () -> {
-              try {
-                String p =
-                    userNotebooks
-                        .projects()
-                        .locations()
-                        .instances()
-                        .get(instanceName)
-                        .execute()
-                        .getProxyUri();
-                if (p == null) {
-                  throw new NullPointerException();
-                }
-                return p;
-                // Do not retry if it's an IO exception.
-              } catch (IOException ignored) {
-              }
-              return null;
-            });
-    assertNotNull(proxyUrl);
+    NotebookUtils.assertInstanceHasProxyUrl(userNotebooks, instanceName);
     Map<String, String> metadata =
         userNotebooks.projects().locations().instances().get(instanceName).execute().getMetadata();
     assertEquals(testValue, metadata.get("terra-test-value"));

--- a/integration/src/main/java/scripts/utils/NotebookUtils.java
+++ b/integration/src/main/java/scripts/utils/NotebookUtils.java
@@ -180,10 +180,6 @@ public class NotebookUtils {
   /**
    * Asserts that the notebook instance contains proxy url. It usually takes 1-2 min for the proxy
    * url to be set.
-   *
-   * @param userNotebooks
-   * @param instanceName
-   * @throws Exception
    */
   public static void assertInstanceHasProxyUrl(
       AIPlatformNotebooks userNotebooks, String instanceName) throws Exception {

--- a/integration/src/main/java/scripts/utils/NotebookUtils.java
+++ b/integration/src/main/java/scripts/utils/NotebookUtils.java
@@ -1,6 +1,7 @@
 package scripts.utils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static scripts.utils.CommonResourceFieldsUtil.makeControlledResourceCommonFields;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
@@ -174,5 +175,39 @@ public class NotebookUtils {
     return Optional.ofNullable(maybePermissionsList)
         .map(list -> list.contains(actAsPermission))
         .orElse(false);
+  }
+
+  /**
+   * Asserts that the notebook instance contains proxy url. It usually takes 1-2 min for the proxy
+   * url to be set.
+   *
+   * @param userNotebooks
+   * @param instanceName
+   * @throws Exception
+   */
+  public static void assertInstanceHasProxyUrl(
+      AIPlatformNotebooks userNotebooks, String instanceName) throws Exception {
+    String proxyUrl =
+        ClientTestUtils.getWithRetryOnException(
+            () -> {
+              try {
+                String p =
+                    userNotebooks
+                        .projects()
+                        .locations()
+                        .instances()
+                        .get(instanceName)
+                        .execute()
+                        .getProxyUri();
+                if (p == null) {
+                  throw new NullPointerException();
+                }
+                return p;
+                // Do not retry if it's an IO exception.
+              } catch (IOException ignored) {
+              }
+              return null;
+            });
+    assertNotNull(proxyUrl);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
@@ -67,7 +67,6 @@ public class CustomGcpIamRoleMapping {
           .build();
   static final ImmutableList<String> AI_NOTEBOOK_INSTANCE_READER_PERMISSIONS =
       ImmutableList.of(
-          "compute.instances.get",
           "notebooks.instances.get",
           "notebooks.instances.list",
           "notebooks.locations.get",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
@@ -67,6 +67,7 @@ public class CustomGcpIamRoleMapping {
           .build();
   static final ImmutableList<String> AI_NOTEBOOK_INSTANCE_READER_PERMISSIONS =
       ImmutableList.of(
+          "compute.instances.get",
           "notebooks.instances.get",
           "notebooks.instances.list",
           "notebooks.locations.get",

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -76,7 +76,6 @@ public class CloudSyncRoleMapping {
               "iam.serviceAccounts.list",
               "lifesciences.operations.cancel",
               "lifesciences.workflows.run",
-              "notebooks.instances.get",
               "notebooks.operations.cancel",
               "notebooks.operations.delete",
               "notebooks.operations.get",

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -76,6 +76,7 @@ public class CloudSyncRoleMapping {
               "iam.serviceAccounts.list",
               "lifesciences.operations.cancel",
               "lifesciences.workflows.run",
+              "notebooks.instances.get",
               "notebooks.operations.cancel",
               "notebooks.operations.delete",
               "notebooks.operations.get",

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -71,6 +71,7 @@ public class CloudSyncRoleMapping {
               "artifactregistry.tags.update",
               "cloudbuild.builds.create",
               "cloudbuild.builds.update",
+              "compute.instances.get",
               "iam.serviceAccounts.get",
               "iam.serviceAccounts.list",
               "lifesciences.operations.cancel",

--- a/service/src/test/java/bio/terra/workspace/service/folder/FolderServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/folder/FolderServiceTest.java
@@ -43,6 +43,7 @@ import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.Refer
 import bio.terra.workspace.service.workspace.model.WorkspaceConstants.ResourceProperties;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -99,7 +100,7 @@ public class FolderServiceTest extends BaseConnectedTest {
     controlledBucketInFoo =
         ControlledGcsBucketResource.builder()
             .common(createControlledResourceCommonFieldWithFolderId(workspaceId, fooFolder.id()))
-            .bucketName(randomAlphabetic(10))
+            .bucketName(randomAlphabetic(10).toLowerCase(Locale.ROOT))
             .build();
     controlledResourceService.createControlledResourceSync(
         controlledBucketInFoo,
@@ -110,7 +111,7 @@ public class FolderServiceTest extends BaseConnectedTest {
     controlledBucket2InFooFoo =
         ControlledGcsBucketResource.builder()
             .common(createControlledResourceCommonFieldWithFolderId(workspaceId, fooFooFolder.id()))
-            .bucketName(randomAlphabetic(10))
+            .bucketName(randomAlphabetic(10).toLowerCase(Locale.ROOT))
             .build();
     controlledResourceService.createControlledResourceSync(
         controlledBucket2InFooFoo,

--- a/service/src/test/java/bio/terra/workspace/service/folder/FolderServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/folder/FolderServiceTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.folder;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -98,7 +99,7 @@ public class FolderServiceTest extends BaseConnectedTest {
     controlledBucketInFoo =
         ControlledGcsBucketResource.builder()
             .common(createControlledResourceCommonFieldWithFolderId(workspaceId, fooFolder.id()))
-            .bucketName(TestUtils.appendRandomNumber("my-gcs-bucket"))
+            .bucketName(randomAlphabetic(10))
             .build();
     controlledResourceService.createControlledResourceSync(
         controlledBucketInFoo,
@@ -109,7 +110,7 @@ public class FolderServiceTest extends BaseConnectedTest {
     controlledBucket2InFooFoo =
         ControlledGcsBucketResource.builder()
             .common(createControlledResourceCommonFieldWithFolderId(workspaceId, fooFooFolder.id()))
-            .bucketName(TestUtils.appendRandomNumber("my-gcs-bucket-2"))
+            .bucketName(randomAlphabetic(10))
             .build();
     controlledResourceService.createControlledResourceSync(
         controlledBucket2InFooFoo,


### PR DESCRIPTION
example log for the cloud console: 
```
Sep 29 18:22:46 testnotebook4 c2d-startup[431]: Registering with Proxy...
Sep 29 18:22:46 testnotebook4 c2d-startup[431]: Proxy URL from the config: https://us-central1.notebooks.cloud.google.com/tun/m/4592f092208ecc84946b8f8f8016274df1b36a14
Sep 29 18:23:08 testnotebook4 c2d-startup[431]: ERROR: (gcloud.compute.instances.describe) Could not fetch resource:
Sep 29 18:23:08 testnotebook4 c2d-startup[431]:  - Required 'compute.instances.get' permission for 'projects/terra-vdevel-clean-celery-1754/zones/us-central1-a/instances/testnotebook4'
Sep 29 18:23:08 testnotebook4 c2d-startup[431]: Proxy Registration failed. Unable to get Service Account from VM
```

Missing permission `compute.instances.get`. I tried adding it at the resource level but it didn't work so I added the permission at the project level. 