### PR TITLE
[PF-1839] [PF-2106] add the cromwell generation command line and install the cromwell.jar in usr/shared/java 

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -90,9 +90,9 @@ sudo mv nextflow /usr/bin/nextflow
 
 # Install cromwell
 readonly CROMWELL_LATEST_VERSION="81"
-sudo -u "${JUPYTER_USER}" sh -c "mkdir -p /home/${JUPYTER_USER}/cromwell"
+sudo -u "${JUPYTER_USER}" sh -c "mkdir -p usr/share/java"
 sudo -u "${JUPYTER_USER}" sh -c "curl -LO https://github.com/broadinstitute/cromwell/releases/download/${CROMWELL_LATEST_VERSION}/cromwell-${CROMWELL_LATEST_VERSION}.jar"
-mv "cromwell-${CROMWELL_LATEST_VERSION}.jar" "/home/${JUPYTER_USER}/cromwell/"
+sudo -u "${JUPYTER_USER}" sh -c "mv cromwell-${CROMWELL_LATEST_VERSION}.jar usr/share/java"
 
 #Install cromshell
 sudo apt-get -y install mailutils
@@ -116,7 +116,7 @@ fi
 sudo -u "${JUPYTER_USER}" sh -c "terra auth login --mode=APP_DEFAULT_CREDENTIALS"
 
 # Generate cromwell.config
-sudo -u "${JUPYTER_USER}" sh -c "terra cromwell config-generate"
+sudo -u "${JUPYTER_USER}" sh -c "terra cromwell config-generate --dir=cromwell"
 
 ####################################
 # Shell and notebook environment

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -94,6 +94,7 @@ readonly CROMWELL_JAR_PATH="/usr/shared/java/"
 sudo -u "${JUPYTER_USER}" sh -c "mkdir -p /home/${JUPYTER_USER}/cromwell"
 sudo -u "${JUPYTER_USER}" sh -c "curl -LO https://github.com/broadinstitute/cromwell/releases/download/${CROMWELL_LATEST_VERSION}/cromwell-${CROMWELL_LATEST_VERSION}.jar"
 sudo -u "${JUPYTER_USER}" sh -c "mv cromwell-${CROMWELL_LATEST_VERSION}.jar ${CROMWELL_JAR_PATH}"
+echo "export CROMWELL_JAR='/usr/shared/java/cromwell-${CROMWELL_LATEST_VERSION}.jar'" >> "/home/${JUPYTER_USER}/.bash_profile"
 
 #Install cromshell
 sudo apt-get -y install mailutils

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -115,6 +115,9 @@ fi
 # Log in with app-default-credentials
 sudo -u "${JUPYTER_USER}" sh -c "terra auth login --mode=APP_DEFAULT_CREDENTIALS"
 
+# Generate cromwell.config
+sudo -u "${JUPYTER_USER}" sh -c "terra cromwell config-generate"
+
 ####################################
 # Shell and notebook environment
 ####################################

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -90,11 +90,9 @@ sudo mv nextflow /usr/bin/nextflow
 
 # Install cromwell
 readonly CROMWELL_LATEST_VERSION="81"
-readonly CROMWELL_JAR_PATH="/usr/share/java/"
-sudo -u "${JUPYTER_USER}" sh -c "mkdir -p /home/${JUPYTER_USER}/cromwell"
 sudo -u "${JUPYTER_USER}" sh -c "curl -LO https://github.com/broadinstitute/cromwell/releases/download/${CROMWELL_LATEST_VERSION}/cromwell-${CROMWELL_LATEST_VERSION}.jar"
-sudo mv cromwell-${CROMWELL_LATEST_VERSION}.jar ${CROMWELL_JAR_PATH}
-echo "export CROMWELL_JAR='${CROMWELL_JAR_PATH}cromwell-${CROMWELL_LATEST_VERSION}.jar'" >> "/home/${JUPYTER_USER}/.bash_profile"
+sudo mv cromwell-${CROMWELL_LATEST_VERSION}.jar "/usr/share/java/"
+echo "export CROMWELL_JAR='/usr/share/java/cromwell-${CROMWELL_LATEST_VERSION}.jar'" >> "/home/${JUPYTER_USER}/.bash_profile"
 
 #Install cromshell
 sudo apt-get -y install mailutils
@@ -126,9 +124,6 @@ readonly TERRA_WORKSPACE="$(get_metadata_value "instance/attributes/terra-worksp
 if [[ -n "${TERRA_WORKSPACE}" ]]; then
   sudo -u "${JUPYTER_USER}" sh -c "terra workspace set --id=${TERRA_WORKSPACE}"
 fi
-
-# Generate cromwell.config
-sudo -u "${JUPYTER_USER}" sh -c "terra cromwell generate-config --dir=/home/${JUPYTER_USER}/cromwell"
 
 # Set variables into the .bash_profile such that they are available
 # to terminals, notebooks, and other tools
@@ -195,6 +190,9 @@ if [[ -n "$TERRA_SSH_KEY" ]]; then
   sudo -u "${JUPYTER_USER}" sh -c 'chmod go-rwx .ssh/id_rsa'
   sudo -u "${JUPYTER_USER}" sh -c 'ssh-add .ssh/id_rsa; ssh-keyscan -H github.com >> ~/.ssh/known_hosts'
 fi
+
+# Generate cromwell.conf
+sudo -u "${JUPYTER_USER}" sh -c "terra cromwell generate-config"
 
 # Attempt to clone all the git repo references in the workspace. If the user's ssh key does not exist or doesn't have access
 # to the git references, the corresponding git repo cloning will be skipped.

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -90,11 +90,11 @@ sudo mv nextflow /usr/bin/nextflow
 
 # Install cromwell
 readonly CROMWELL_LATEST_VERSION="81"
-readonly CROMWELL_JAR_PATH="/usr/shared/java/"
+readonly CROMWELL_JAR_PATH="/usr/share/java/"
 sudo -u "${JUPYTER_USER}" sh -c "mkdir -p /home/${JUPYTER_USER}/cromwell"
 sudo -u "${JUPYTER_USER}" sh -c "curl -LO https://github.com/broadinstitute/cromwell/releases/download/${CROMWELL_LATEST_VERSION}/cromwell-${CROMWELL_LATEST_VERSION}.jar"
-sudo -u "${JUPYTER_USER}" sh -c "mv cromwell-${CROMWELL_LATEST_VERSION}.jar ${CROMWELL_JAR_PATH}"
-echo "export CROMWELL_JAR='/usr/shared/java/cromwell-${CROMWELL_LATEST_VERSION}.jar'" >> "/home/${JUPYTER_USER}/.bash_profile"
+sudo mv cromwell-${CROMWELL_LATEST_VERSION}.jar ${CROMWELL_JAR_PATH}
+echo "export CROMWELL_JAR='${CROMWELL_JAR_PATH}cromwell-${CROMWELL_LATEST_VERSION}.jar'" >> "/home/${JUPYTER_USER}/.bash_profile"
 
 #Install cromshell
 sudo apt-get -y install mailutils
@@ -117,9 +117,6 @@ fi
 # Log in with app-default-credentials
 sudo -u "${JUPYTER_USER}" sh -c "terra auth login --mode=APP_DEFAULT_CREDENTIALS"
 
-# Generate cromwell.config
-sudo -u "${JUPYTER_USER}" sh -c "terra cromwell config-generate --dir=cromwell"
-
 ####################################
 # Shell and notebook environment
 ####################################
@@ -129,6 +126,9 @@ readonly TERRA_WORKSPACE="$(get_metadata_value "instance/attributes/terra-worksp
 if [[ -n "${TERRA_WORKSPACE}" ]]; then
   sudo -u "${JUPYTER_USER}" sh -c "terra workspace set --id=${TERRA_WORKSPACE}"
 fi
+
+# Generate cromwell.config
+sudo -u "${JUPYTER_USER}" sh -c "terra cromwell generate-config --dir=/home/${JUPYTER_USER}/cromwell"
 
 # Set variables into the .bash_profile such that they are available
 # to terminals, notebooks, and other tools

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -90,9 +90,10 @@ sudo mv nextflow /usr/bin/nextflow
 
 # Install cromwell
 readonly CROMWELL_LATEST_VERSION="81"
-sudo -u "${JUPYTER_USER}" sh -c "mkdir -p usr/share/java"
+readonly CROMWELL_JAR_PATH="/usr/shared/java/"
+sudo -u "${JUPYTER_USER}" sh -c "mkdir -p /home/${JUPYTER_USER}/cromwell"
 sudo -u "${JUPYTER_USER}" sh -c "curl -LO https://github.com/broadinstitute/cromwell/releases/download/${CROMWELL_LATEST_VERSION}/cromwell-${CROMWELL_LATEST_VERSION}.jar"
-sudo -u "${JUPYTER_USER}" sh -c "mv cromwell-${CROMWELL_LATEST_VERSION}.jar usr/share/java"
+sudo -u "${JUPYTER_USER}" sh -c "mv cromwell-${CROMWELL_LATEST_VERSION}.jar ${CROMWELL_JAR_PATH}"
 
 #Install cromshell
 sudo apt-get -y install mailutils

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -91,7 +91,7 @@ sudo mv nextflow /usr/bin/nextflow
 # Install cromwell
 readonly CROMWELL_LATEST_VERSION="81"
 sudo -u "${JUPYTER_USER}" sh -c "curl -LO https://github.com/broadinstitute/cromwell/releases/download/${CROMWELL_LATEST_VERSION}/cromwell-${CROMWELL_LATEST_VERSION}.jar"
-sudo mv cromwell-${CROMWELL_LATEST_VERSION}.jar "/usr/share/java/"
+sudo mv "cromwell-${CROMWELL_LATEST_VERSION}.jar" "/usr/share/java/"
 echo "export CROMWELL_JAR='/usr/share/java/cromwell-${CROMWELL_LATEST_VERSION}.jar'" >> "/home/${JUPYTER_USER}/.bash_profile"
 
 #Install cromshell


### PR DESCRIPTION
For overall using the whole post-startup script test:

Manual test shows below:  
- The cromwell-81.jar is installed in /usr/share/java  
- The cromwell.config is created in home directory
- Remove the cromwell folder
- Also for writing the ${CROMWLL_JAR} into the bash file successful. 
<img width="1196" alt="Screen Shot 2022-10-20 at 1 57 46 PM" src="https://user-images.githubusercontent.com/100877272/197023497-4b4fe98f-03be-4cca-b1b1-2eeff749bbc2.png">

