### PR TITLE
[PF-1959] common mocks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradleTask: [unitTest, connectedTest, azureUnitTest, azureTest]
+        gradleTask: [unitTest, connectedTest, azureUnitTest, azureConnectedTest]
 
     services:
       postgres:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -224,28 +224,6 @@ View current usage information for `write-config.sh` by entering
 ./scripts/write-config.sh help
 ```
 
-### Writing Unit Tests
-
-There is an issue to be aware of when writing unit tests. Each different combination of `@MockBean` makes
-a different signature for a Spring application context object. Spring caches up to 20 application contexts.
-Each application context has connection pools for WSM database and Stairway database, plus connection pools
-in any amalgam services, like TPS and LZ. An idle connection pool will keep a minimum set of connections open.
-It turned out to be easy to collect enough unique application contexts with enough connection pools holding
-enough open connections to run the backend out of connections.
-
-The initial fix was to reduce the idle size of the pools to 1. However, that is not ideal for test performance.
-
-A better fix is to be more systematic about the sets of mocks in use. When tests share the same mocks, even
-if they are not used by the test, they are able to share the same application context. That means slightly
-faster test runs and less chance of running out of database connections.
-
-
-
-
-
-
-
-
 ### Running Tests
 
 To run unit tests:

--- a/README.md
+++ b/README.md
@@ -289,8 +289,29 @@ There are three groups of tests.
 
 #### Unit Tests
 The unit tests are written using JUnit. The implementations are in
-`src/test/java/bio/terra/workspace/`. Unit tests derive from `common/BaseUnitTest.java`.
+`src/test/java/bio/terra/workspace/`.
 Some unit tests depend on the availability of a running Postgresql server.
+
+Every combination of `@MockBean` creates a distinct Spring application context. Each context holds several
+database connection pools: (WSM db, WSM Stairway db, and any amalgam connection pools). We have run out of
+database connections due to cached application contexts.
+
+To reduce the number of unique combinations, we have put **ALL** `@MockBean` into test base classes. That helps
+limit the unique combinations. You should **NEVER** code a naked `@MockBean` in a test. They should always be
+specified in these bases. That helps us control the number of unique combinations we have.
+
+The test base classes can be found in `src/test/java/bio/terra/workspace/common/`.
+
+The current inheritance for unit test base classes looks like this:
+- `BaseTest` - the base class for unit and connected tests
+    - `BaseUnitTestMocks` - the base set of mocks shared by all unit tests
+        - `BaseUnitTest` - enables the right test tags and profiles for unit testing
+            - `BaseUnitTestMockDataRepoService` - adds one mock for one unit test
+            - `BaseUnitTestMockGcpCloudContextService` - add one mock; used by several tests
+        - `BaseAzureUnitTest` - adds mocks shared by azure unit tests and enables the right test tags and profiles
+
+We keep the Azure tests separated from the general tests, because the Azure feature is not live in all environments.
+Those tests will not successfully run in those environments.
 
 #### Connected Tests
 The connected tests are also written using JUnit.

--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ The current inheritance for unit test base classes looks like this:
 - `BaseTest` - the base class for unit and connected tests
     - `BaseUnitTestMocks` - the base set of mocks shared by all unit tests
         - `BaseUnitTest` - enables the right test tags and profiles for unit testing
-            - `BaseUnitTestMockDataRepoService` - adds one mock for one unit test
-            - `BaseUnitTestMockGcpCloudContextService` - add one mock; used by several tests
+            - `BaseUnitTestMockDataRepoService` - adds one more mock; used in one unit test
+            - `BaseUnitTestMockGcpCloudContextService` - adds one more mock; used by several tests
         - `BaseAzureUnitTest` - adds mocks shared by azure unit tests and enables the right test tags and profiles
 
 We keep the Azure tests separated from the general tests, because the Azure feature is not live in all environments.

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -80,7 +80,7 @@ task connectedTest(type: Test) {
   }
 }
 
-task azureTest(type: Test) {
+task azureConnectedTest(type: Test) {
   useJUnitPlatform {
     includeTags "azure"
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -6,13 +6,10 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.UUID;
 import javax.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -6,19 +6,23 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.UUID;
 import javax.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ControlledGcsBucketHandler implements WsmResourceHandler {
+  private static Logger logger = LoggerFactory.getLogger(ControlledGcsBucketHandler.class);
 
   protected static final int MAX_BUCKET_NAME_LENGTH = 63;
   private static ControlledGcsBucketHandler theHandler;
-  private final GcpCloudContextService gcpCloudContextService;
+  private GcpCloudContextService gcpCloudContextService;
 
   @Autowired
   public ControlledGcsBucketHandler(GcpCloudContextService gcpCloudContextService) {
@@ -26,14 +30,23 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
   }
 
   public static ControlledGcsBucketHandler getHandler() {
+    logger.warn(String.format("Returning handler %s", theHandler));
     return theHandler;
   }
 
   @PostConstruct
   public void init() {
     theHandler = this;
+    logger.warn(String.format("=====> init() setting theHandler to %s", theHandler));
+    logger.warn(String.format("=====> init() service is %s", gcpCloudContextService));
   }
 
+  @VisibleForTesting // Do not use otherwise
+  public void init(GcpCloudContextService gcpCloudContextService) {
+    this.gcpCloudContextService = gcpCloudContextService;
+    logger.info(String.format("=====> init(xx) theHandler is %s", theHandler));
+    logger.info(String.format("=====> init(xx) service set to %s", gcpCloudContextService));
+  }
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -18,11 +18,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ControlledGcsBucketHandler implements WsmResourceHandler {
-  private static Logger logger = LoggerFactory.getLogger(ControlledGcsBucketHandler.class);
-
   protected static final int MAX_BUCKET_NAME_LENGTH = 63;
   private static ControlledGcsBucketHandler theHandler;
-  private GcpCloudContextService gcpCloudContextService;
+  private final GcpCloudContextService gcpCloudContextService;
 
   @Autowired
   public ControlledGcsBucketHandler(GcpCloudContextService gcpCloudContextService) {
@@ -30,23 +28,14 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
   }
 
   public static ControlledGcsBucketHandler getHandler() {
-    logger.warn(String.format("Returning handler %s", theHandler));
     return theHandler;
   }
 
   @PostConstruct
   public void init() {
     theHandler = this;
-    logger.warn(String.format("=====> init() setting theHandler to %s", theHandler));
-    logger.warn(String.format("=====> init() service is %s", gcpCloudContextService));
   }
 
-  @VisibleForTesting // Do not use otherwise
-  public void init(GcpCloudContextService gcpCloudContextService) {
-    this.gcpCloudContextService = gcpCloudContextService;
-    logger.info(String.format("=====> init(xx) theHandler is %s", theHandler));
-    logger.info(String.format("=====> init(xx) service set to %s", gcpCloudContextService));
-  }
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {

--- a/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
@@ -314,7 +314,8 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
                 purposeSubnets2,
                 listSubnets2));
 
-    when(mockLandingZoneService().listResourcesWithPurposes(any(), any())).thenReturn(groupedResources);
+    when(mockLandingZoneService().listResourcesWithPurposes(any(), any()))
+        .thenReturn(groupedResources);
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
@@ -341,7 +342,8 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneResourcesByPurpose groupedResources =
         new LandingZoneResourcesByPurpose(Collections.emptyMap());
 
-    when(mockLandingZoneService().listResourcesWithPurposes(any(), any())).thenReturn(groupedResources);
+    when(mockLandingZoneService().listResourcesWithPurposes(any(), any()))
+        .thenReturn(groupedResources);
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(

--- a/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
@@ -15,13 +15,11 @@ import bio.terra.landingzone.job.LandingZoneJobService;
 import bio.terra.landingzone.library.landingzones.deployment.LandingZonePurpose;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.landingzone.library.landingzones.deployment.SubnetResourcePurpose;
-import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
 import bio.terra.landingzone.service.landingzone.azure.exception.LandingZoneDeleteNotImplemented;
 import bio.terra.landingzone.service.landingzone.azure.model.DeployedLandingZone;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneDefinition;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResource;
 import bio.terra.landingzone.service.landingzone.azure.model.LandingZoneResourcesByPurpose;
-import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.common.fixtures.AzureLandingZoneFixtures;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,7 +31,6 @@ import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -50,18 +47,15 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
   @Autowired private MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;
 
-  @MockBean private LandingZoneService landingZoneService;
-  @MockBean private FeatureConfiguration featureConfiguration;
-
   @Test
   public void createAzureLandingZoneJobRunning() throws Exception {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithRunningState(JOB_ID);
 
-    when(landingZoneService.startLandingZoneCreationJob(any(), any(), any(), any()))
+    when(mockLandingZoneService().startLandingZoneCreationJob(any(), any(), any(), any()))
         .thenReturn(asyncJobResult);
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     var requestBody = AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequest(JOB_ID);
 
@@ -84,10 +78,10 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithSucceededState(JOB_ID, LANDING_ZONE_ID);
 
-    when(landingZoneService.startLandingZoneCreationJob(any(), any(), any(), any()))
+    when(mockLandingZoneService().startLandingZoneCreationJob(any(), any(), any(), any()))
         .thenReturn(asyncJobResult);
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     // TODO SG: check if we need name and description??
     var requestBody = AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequest(JOB_ID);
@@ -114,10 +108,10 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithSucceededState(JOB_ID, LANDING_ZONE_ID);
 
-    when(landingZoneService.startLandingZoneCreationJob(any(), any(), any(), any()))
+    when(mockLandingZoneService().startLandingZoneCreationJob(any(), any(), any(), any()))
         .thenReturn(asyncJobResult);
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     var requestBody =
         AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequestWithoutDefinition(JOB_ID);
@@ -137,10 +131,10 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithSucceededState(JOB_ID, LANDING_ZONE_ID);
 
-    when(landingZoneService.startLandingZoneCreationJob(any(), any(), any(), any()))
+    when(mockLandingZoneService().startLandingZoneCreationJob(any(), any(), any(), any()))
         .thenReturn(asyncJobResult);
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     var requestBody =
         AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequestWithoutTarget(JOB_ID);
@@ -160,7 +154,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithRunningState(JOB_ID);
 
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
 
     mockMvc
         .perform(
@@ -178,7 +172,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneJobService.AsyncJobResult<DeployedLandingZone> asyncJobResult =
         AzureLandingZoneFixtures.createJobResultWithSucceededState(JOB_ID, LANDING_ZONE_ID);
 
-    when(landingZoneService.getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
+    when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
 
     mockMvc
         .perform(
@@ -216,8 +210,8 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
                 .description("barDescription")
                 .version("v1")
                 .build());
-    when(landingZoneService.listLandingZoneDefinitions(any())).thenReturn(definitions);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
+    when(mockLandingZoneService().listLandingZoneDefinitions(any())).thenReturn(definitions);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     mockMvc
         .perform(
@@ -230,7 +224,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
 
   @Test
   public void deleteAzureLandingZoneSuccess() throws Exception {
-    doNothing().when(landingZoneService).deleteLandingZone(any(), any());
+    doNothing().when(mockLandingZoneService()).deleteLandingZone(any(), any());
     mockMvc
         .perform(
             delete(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}", LANDING_ZONE_ID)
@@ -241,7 +235,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
   @Test
   public void deleteAzureLandingZoneNotImplemented() throws Exception {
     doThrow(LandingZoneDeleteNotImplemented.class)
-        .when(landingZoneService)
+        .when(mockLandingZoneService())
         .deleteLandingZone(any(), any());
     mockMvc
         .perform(
@@ -320,9 +314,8 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
                 purposeSubnets2,
                 listSubnets2));
 
-    when(landingZoneService.listResourcesWithPurposes(any(), any())).thenReturn(groupedResources);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
-
+    when(mockLandingZoneService().listResourcesWithPurposes(any(), any())).thenReturn(groupedResources);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
             get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/resources", LANDING_ZONE_ID)
@@ -348,9 +341,8 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     LandingZoneResourcesByPurpose groupedResources =
         new LandingZoneResourcesByPurpose(Collections.emptyMap());
 
-    when(landingZoneService.listResourcesWithPurposes(any(), any())).thenReturn(groupedResources);
-    when(featureConfiguration.isAzureEnabled()).thenReturn(true);
-
+    when(mockLandingZoneService().listResourcesWithPurposes(any(), any())).thenReturn(groupedResources);
+    when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
             get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/resources", LANDING_ZONE_ID)

--- a/service/src/test/java/bio/terra/workspace/amalgam/tps/TpsBasicPaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/amalgam/tps/TpsBasicPaoTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.amalgam.tps;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,9 +26,7 @@ import bio.terra.workspace.generated.model.ApiTpsPolicyInput;
 import bio.terra.workspace.generated.model.ApiTpsPolicyInputs;
 import bio.terra.workspace.generated.model.ApiTpsPolicyPair;
 import bio.terra.workspace.generated.model.ApiTpsUpdateMode;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,9 +43,7 @@ public class TpsBasicPaoTest extends BaseUnitTest {
   private static final String REGION = "region";
   private static final String DDGROUP = "ddgroup";
   private static final String US_REGION = "US";
-  AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
+
   @Autowired private ObjectMapper objectMapper;
   @Autowired private FeatureConfiguration features;
   @Autowired private MockMvc mockMvc;

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/FolderApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/FolderApiControllerTest.java
@@ -5,6 +5,7 @@ import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertM
 import static bio.terra.workspace.common.utils.MockMvcUtils.FOLDERS_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.FOLDER_PROPERTIES_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.FOLDER_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,7 +34,6 @@ import bio.terra.workspace.generated.model.ApiProperties;
 import bio.terra.workspace.generated.model.ApiPropertyKeys;
 import bio.terra.workspace.generated.model.ApiUpdateFolderRequestBody;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
@@ -41,7 +41,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.http.HttpStatus;
@@ -49,35 +48,28 @@ import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 public class FolderApiControllerTest extends BaseUnitTest {
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
-
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
   @Autowired ObjectMapper objectMapper;
-
-  @MockBean SamService mockSamService;
 
   @BeforeEach
   public void setUp() throws InterruptedException {
     // Needed for workspace creation as logging is triggered when a workspace is created in
     // `WorkspaceActivityLogHook` where we extract the user request information and log it to
     // activity log.
-    when(mockSamService.getUserStatusInfo(any()))
+    when(mockSamService().getUserStatusInfo(any()))
         .thenReturn(
             new UserStatusInfo()
                 .userEmail(USER_REQUEST.getEmail())
                 .userSubjectId(USER_REQUEST.getSubjectId()));
 
     // Needed for assertion that requester has role on workspace.
-    when(mockSamService.listRequesterRoles(any(), any(), any()))
+    when(mockSamService().listRequesterRoles(any(), any(), any()))
         .thenReturn(List.of(WsmIamRole.OWNER));
   }
 
@@ -102,7 +94,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
   public void createFolder_doesNotHaveWriteAccess_throws403() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -193,7 +185,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -239,7 +231,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     createFolderExpectCode(workspaceId, HttpStatus.SC_OK);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -259,7 +251,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -344,7 +336,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -416,7 +408,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),
@@ -465,7 +457,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
-        .when(mockSamService)
+        .when(mockSamService())
         .checkAuthz(
             any(AuthenticatedUserRequest.class),
             eq(SamConstants.SamResource.WORKSPACE),

--- a/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/configuration/external/controller/ReferencedGcpResourceControllerTest.java
@@ -36,7 +36,6 @@ import bio.terra.workspace.generated.model.ApiGcpGcsObjectResource;
 import bio.terra.workspace.generated.model.ApiGitRepoResource;
 import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiResourceMetadata;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -47,7 +46,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -58,20 +56,18 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Autowired MockMvcUtils mockMvcUtils;
   @Autowired ObjectMapper objectMapper;
 
-  @MockBean SamService mockSamService;
-
   @BeforeEach
   public void setUp() throws InterruptedException {
     // Needed for workspace creation as logging is triggered when a workspace is created in
     // `WorkspaceActivityLogHook` where we extract the user request information and log it to
     // activity log.
-    when(mockSamService.getUserStatusInfo(any()))
+    when(mockSamService().getUserStatusInfo(any()))
         .thenReturn(
             new UserStatusInfo()
                 .userEmail(USER_REQUEST.getEmail())
                 .userSubjectId(USER_REQUEST.getSubjectId()));
     // Needed for assertion that requester has role on workspace.
-    when(mockSamService.listRequesterRoles(any(), any(), any()))
+    when(mockSamService().listRequesterRoles(any(), any(), any()))
         .thenReturn(List.of(WsmIamRole.OWNER));
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
@@ -1,42 +1,28 @@
 package bio.terra.workspace.app.controller;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_SAS_TOKEN_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiCreateControlledAzureVmRequestBody;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -92,293 +78,5 @@ public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest 
                         .content(objectMapper.writeValueAsString(vmRequest)),
                     USER_REQUEST)))
         .andExpect(status().is(HttpStatus.SC_OK));
-  }
-}
-
-class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
-  @Autowired MockMvc mockMvc;
-  @Autowired AzureConfiguration azureConfiguration;
-  @MockBean ControlledResourceMetadataManager controlledResourceMetadataManager;
-  @MockBean SamService samService;
-  @MockBean AzureStorageAccessService azureStorageAccessService;
-
-  private UUID workspaceId;
-  private UUID storageContainerId;
-
-  private ControlledAzureStorageResource accountResource;
-  private ControlledAzureStorageContainerResource containerResource;
-
-  @BeforeEach
-  public void setup() throws Exception {
-    workspaceId = UUID.randomUUID();
-    storageContainerId = UUID.randomUUID();
-    UUID storageAccountId = UUID.randomUUID();
-
-    containerResource =
-        ControlledAzureStorageContainerResource.builder()
-            .common(
-                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
-                    .workspaceUuid(workspaceId)
-                    .resourceId(storageContainerId)
-                    .build())
-            .storageAccountId(storageAccountId)
-            .storageContainerName("testcontainer")
-            .build();
-
-    when(controlledResourceMetadataManager.validateControlledResourceAndAction(
-            any(), eq(workspaceId), eq(storageContainerId), any()))
-        .thenReturn(containerResource);
-
-    accountResource =
-        ControlledAzureStorageResource.builder()
-            .common(
-                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
-                    .workspaceUuid(workspaceId)
-                    .resourceId(storageAccountId)
-                    .build())
-            .storageAccountName("testaccount")
-            .region("eastus")
-            .build();
-
-    when(controlledResourceMetadataManager.validateControlledResourceAndAction(
-            any(), eq(workspaceId), eq(storageAccountId), any()))
-        .thenReturn(accountResource);
-
-    when(samService.getUserEmailFromSam(eq(USER_REQUEST))).thenReturn(USER_REQUEST.getEmail());
-
-    when(azureStorageAccessService.createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any()))
-        .thenReturn(new AzureStorageAccessService.AzureSasBundle("sasToken", "sasUrl"));
-  }
-
-  @Test
-  void createSASToken400BadDuration() throws Exception {
-    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
-        240L); // maximum of 240 minutes (4 hours)
-
-    // expiration duration must be positive
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasExpirationDuration", "-1"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
-
-    // expiration can't exceed 4 hours = 14400 seconds
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasExpirationDuration", "14401"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
-  }
-
-  @Test
-  void createSASTokenCustomExpirationSuccess() throws Exception {
-    azureConfiguration.setSasTokenStartTimeMinutesOffset(5L); // 5 minutes before
-    azureConfiguration.setSasTokenExpiryTimeMinutesOffset(10L); // 10 minutes after
-    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
-        240L); // maximum of 240 minutes (4 hours)
-
-    // Specify custom expiration duration of 2 hours.
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasExpirationDuration", "7200"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    // Use expiration time as set in configuration.
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    ArgumentCaptor<OffsetDateTime> startTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
-    ArgumentCaptor<OffsetDateTime> endTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
-
-    Mockito.verify(azureStorageAccessService, times(2))
-        .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            startTimeCaptor.capture(),
-            endTimeCaptor.capture(),
-            any(),
-            any(),
-            any(),
-            any());
-
-    // First call uses custom time of 2 hours (plus 5 minutes before) = 7500 seconds.
-    assertEquals(
-        7500,
-        endTimeCaptor.getAllValues().get(0).toEpochSecond()
-            - startTimeCaptor.getAllValues().get(0).toEpochSecond());
-
-    // Second call based on configuration, difference should be 15 minutes = 900 seconds.
-    assertEquals(
-        900,
-        endTimeCaptor.getAllValues().get(1).toEpochSecond()
-            - startTimeCaptor.getAllValues().get(1).toEpochSecond());
-  }
-
-  @Test
-  void createSASToken400BadIPRange() throws Exception {
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasIpRange", "not_an_IP"),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
-  }
-
-  @Test
-  void createSASTokenIpRangeSuccess() throws Exception {
-    String ipRange = "168.1.5.60-168.1.5.70";
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasIpRange", ipRange),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    Mockito.verify(azureStorageAccessService)
-        .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            eq(ipRange),
-            any(),
-            any());
-  }
-
-  @Test
-  void createSASTokenBlobNameSuccess() throws Exception {
-    String blobName = "testing/foo/bar";
-
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasBlobName", blobName),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    Mockito.verify(azureStorageAccessService)
-        .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            any(),
-            eq(blobName),
-            any());
-  }
-
-  @Test
-  void createSASTokenBlobNameInvalidName() throws Exception {
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasBlobName", ""),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
-  }
-
-  @Test
-  void createSASTokenBlobPermissionsSuccess() throws Exception {
-    String permissions = "rwcd";
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasPermissions", permissions),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_OK));
-
-    Mockito.verify(azureStorageAccessService)
-        .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            eq(permissions));
-  }
-
-  @Test
-  void createSASTokenBlobPermissionsInvalidPerms() throws Exception {
-    String permissions = "tfi";
-    mockMvc
-        .perform(
-            addAuth(
-                post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .queryParam("sasPermissions", permissions),
-                USER_REQUEST))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerTest.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_SAS_TOKEN_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,19 +20,15 @@ import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiCreateControlledAzureVmRequestBody;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
-import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
-import bio.terra.workspace.service.workspace.WorkspaceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.OffsetDateTime;
-import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,18 +41,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest {
-  AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
-
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;
-
   @Autowired ControlledAzureResourceApiController controller;
-
-  @MockBean ControlledResourceService controlledResourceServiceMock;
-  @MockBean WorkspaceService workspaceServiceMock;
-  @MockBean JobService jobServiceMock;
 
   @Test
   public void createAzureVm400WithNoParameters() throws Exception {
@@ -90,7 +78,7 @@ public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest 
         controller.buildControlledAzureVmResource(
             creationParameters, controller.toCommonFields(workspaceId, commonFields, USER_REQUEST));
 
-    when(jobServiceMock.retrieveAsyncJobResult(any(), eq(ControlledAzureVmResource.class)))
+    when(mockJobService().retrieveAsyncJobResult(any(), eq(ControlledAzureVmResource.class)))
         .thenReturn(
             new JobService.AsyncJobResult<ControlledAzureVmResource>()
                 .result(resource)
@@ -108,10 +96,6 @@ public class ControlledAzureResourceApiControllerTest extends BaseAzureUnitTest 
 }
 
 class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
-  AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
-
   @Autowired MockMvc mockMvc;
   @Autowired AzureConfiguration azureConfiguration;
   @MockBean ControlledResourceMetadataManager controlledResourceMetadataManager;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.app.controller;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_AI_NOTEBOOK_NAME_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_BQ_DATASET_NAME_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_GCS_BUCKET_NAME_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -10,7 +11,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiAiNotebookCloudId;
 import bio.terra.workspace.generated.model.ApiBqDatasetCloudId;
@@ -18,19 +19,14 @@ import bio.terra.workspace.generated.model.ApiGcsBucketCloudName;
 import bio.terra.workspace.generated.model.ApiGenerateGcpAiNotebookCloudIdRequestBody;
 import bio.terra.workspace.generated.model.ApiGenerateGcpBigQueryDatasetCloudIDRequestBody;
 import bio.terra.workspace.generated.model.ApiGenerateGcpGcsBucketCloudNameRequestBody;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
-import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -38,25 +34,17 @@ import org.springframework.test.web.servlet.MockMvc;
  * Use this instead of ControlledGcpResourceApiControllerConnectedTest if you don't want to talk to
  * real GCP.
  */
-public class ControlledGcpResourceApiControllerTest extends BaseUnitTest {
-
-  AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest(
-          "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
-
+public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpCloudContextService {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
   @Autowired ObjectMapper objectMapper;
 
-  @MockBean GcpCloudContextService mockGcpCloudContextService;
-  @MockBean SamService mockSamService;
-
   @BeforeEach
   public void setup() throws InterruptedException {
-    when(mockGcpCloudContextService.getRequiredGcpProject(any())).thenReturn("fake-project-id");
+    when(mockGcpCloudContextService().getRequiredGcpProject(any())).thenReturn("fake-project-id");
 
     // Needed for assertion that requester has role on workspace.
-    when(mockSamService.listRequesterRoles(any(), any(), any()))
+    when(mockSamService().listRequesterRoles(any(), any(), any()))
         .thenReturn(List.of(WsmIamRole.OWNER));
   }
 
@@ -84,7 +72,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTest {
     ApiGcsBucketCloudName generatedGcsBucketName =
         objectMapper.readValue(serializedGetResponse, ApiGcsBucketCloudName.class);
 
-    String projectId = mockGcpCloudContextService.getRequiredGcpProject(workspaceId);
+    String projectId = mockGcpCloudContextService().getRequiredGcpProject(workspaceId);
     assertEquals(
         generatedGcsBucketName.getGeneratedBucketCloudName(),
         bucketNameRequest.getGcsBucketName() + "-" + projectId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
@@ -1,0 +1,318 @@
+package bio.terra.workspace.app.controller;
+
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_SAS_TOKEN_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.BaseAzureUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
+  @Autowired MockMvc mockMvc;
+  @Autowired AzureConfiguration azureConfiguration;
+
+  private UUID workspaceId;
+  private UUID storageContainerId;
+
+  private ControlledAzureStorageResource accountResource;
+  private ControlledAzureStorageContainerResource containerResource;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    workspaceId = UUID.randomUUID();
+    storageContainerId = UUID.randomUUID();
+    UUID storageAccountId = UUID.randomUUID();
+
+    containerResource =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(storageContainerId)
+                    .build())
+            .storageAccountId(storageAccountId)
+            .storageContainerName("testcontainer")
+            .build();
+
+    when(mockControlledResourceMetadataManager()
+            .validateControlledResourceAndAction(
+                any(), eq(workspaceId), eq(storageContainerId), any()))
+        .thenReturn(containerResource);
+
+    accountResource =
+        ControlledAzureStorageResource.builder()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(storageAccountId)
+                    .build())
+            .storageAccountName("testaccount")
+            .region("eastus")
+            .build();
+
+    when(mockControlledResourceMetadataManager()
+            .validateControlledResourceAndAction(
+                any(), eq(workspaceId), eq(storageAccountId), any()))
+        .thenReturn(accountResource);
+
+    when(mockSamService().getUserEmailFromSam(eq(USER_REQUEST)))
+        .thenReturn(USER_REQUEST.getEmail());
+
+    when(mockAzureStorageAccessService()
+            .createAzureStorageContainerSasToken(
+                eq(workspaceId),
+                eq(containerResource),
+                eq(accountResource),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()))
+        .thenReturn(new AzureStorageAccessService.AzureSasBundle("sasToken", "sasUrl"));
+  }
+
+  @Test
+  void createSASToken400BadDuration() throws Exception {
+    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
+        240L); // maximum of 240 minutes (4 hours)
+
+    // expiration duration must be positive
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasExpirationDuration", "-1"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+
+    // expiration can't exceed 4 hours = 14400 seconds
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasExpirationDuration", "14401"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  void createSASTokenCustomExpirationSuccess() throws Exception {
+    azureConfiguration.setSasTokenStartTimeMinutesOffset(5L); // 5 minutes before
+    azureConfiguration.setSasTokenExpiryTimeMinutesOffset(10L); // 10 minutes after
+    azureConfiguration.setSasTokenExpiryTimeMaximumMinutesOffset(
+        240L); // maximum of 240 minutes (4 hours)
+
+    // Specify custom expiration duration of 2 hours.
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasExpirationDuration", "7200"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    // Use expiration time as set in configuration.
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    ArgumentCaptor<OffsetDateTime> startTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+    ArgumentCaptor<OffsetDateTime> endTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+
+    Mockito.verify(mockAzureStorageAccessService(), times(2))
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            startTimeCaptor.capture(),
+            endTimeCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any());
+
+    // First call uses custom time of 2 hours (plus 5 minutes before) = 7500 seconds.
+    assertEquals(
+        7500,
+        endTimeCaptor.getAllValues().get(0).toEpochSecond()
+            - startTimeCaptor.getAllValues().get(0).toEpochSecond());
+
+    // Second call based on configuration, difference should be 15 minutes = 900 seconds.
+    assertEquals(
+        900,
+        endTimeCaptor.getAllValues().get(1).toEpochSecond()
+            - startTimeCaptor.getAllValues().get(1).toEpochSecond());
+  }
+
+  @Test
+  void createSASToken400BadIPRange() throws Exception {
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasIpRange", "not_an_IP"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  void createSASTokenIpRangeSuccess() throws Exception {
+    String ipRange = "168.1.5.60-168.1.5.70";
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasIpRange", ipRange),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    Mockito.verify(mockAzureStorageAccessService())
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            any(),
+            any(),
+            any(),
+            eq(ipRange),
+            any(),
+            any());
+  }
+
+  @Test
+  void createSASTokenBlobNameSuccess() throws Exception {
+    String blobName = "testing/foo/bar";
+
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasBlobName", blobName),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    Mockito.verify(mockAzureStorageAccessService())
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(blobName),
+            any());
+  }
+
+  @Test
+  void createSASTokenBlobNameInvalidName() throws Exception {
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasBlobName", ""),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  void createSASTokenBlobPermissionsSuccess() throws Exception {
+    String permissions = "rwcd";
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasPermissions", permissions),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_OK));
+
+    Mockito.verify(mockAzureStorageAccessService())
+        .createAzureStorageContainerSasToken(
+            eq(workspaceId),
+            eq(containerResource),
+            eq(accountResource),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(permissions));
+  }
+
+  @Test
+  void createSASTokenBlobPermissionsInvalidPerms() throws Exception {
+    String permissions = "tfi";
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(
+                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .queryParam("sasPermissions", permissions),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
@@ -6,4 +6,4 @@ import org.springframework.test.context.ActiveProfiles;
 /** Base class for azure tests. Treat these as connected tests: connected to Azure */
 @Tag("azure")
 @ActiveProfiles({"azure-test", "connected-test"})
-public class BaseAzureTest extends BaseTest {}
+public class BaseAzureConnectedTest extends BaseTest {}

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
@@ -1,8 +1,34 @@
 package bio.terra.workspace.common;
 
+import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
+import bio.terra.workspace.service.workspace.WorkspaceService;
 import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 @Tag("azure-unit")
 @ActiveProfiles({"azure-unit-test", "unit-test"})
-public class BaseAzureUnitTest extends BaseTest {}
+public class BaseAzureUnitTest extends BaseUnitTestMocks {
+  @MockBean private AzureStorageAccessService mockAzureStorageAccessService;
+  @MockBean private JobService mockJobService;
+  @MockBean private LandingZoneService mockLandingZoneService;
+  @MockBean private WorkspaceService mockWorkspaceService;
+
+  public AzureStorageAccessService mockAzureStorageAccessService() {
+    return mockAzureStorageAccessService;
+  }
+
+  public JobService mockJobService() {
+    return mockJobService;
+  }
+
+  public LandingZoneService mockLandingZoneService() {
+    return mockLandingZoneService;
+  }
+
+  public WorkspaceService mockWorkspaceService() {
+    return mockWorkspaceService;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTest.java
@@ -5,4 +5,4 @@ import org.springframework.test.context.ActiveProfiles;
 
 @Tag("unit")
 @ActiveProfiles("unit-test")
-public class BaseUnitTest extends BaseTest {}
+public class BaseUnitTest extends BaseUnitTestMocks {}

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockDataRepoService.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockDataRepoService.java
@@ -1,0 +1,13 @@
+package bio.terra.workspace.common;
+
+import bio.terra.workspace.service.datarepo.DataRepoService;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+/** Mock out the DataRepoService where needed */
+public class BaseUnitTestMockDataRepoService extends BaseUnitTest {
+  @MockBean private DataRepoService mockDataRepoService;
+
+  public DataRepoService mockDataRepoService() {
+    return mockDataRepoService;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockGcpCloudContextService.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockGcpCloudContextService.java
@@ -1,0 +1,14 @@
+package bio.terra.workspace.common;
+
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+/** Mock out the GcpCloudContextService where needed */
+public class BaseUnitTestMockGcpCloudContextService extends BaseUnitTest {
+  @MockBean private GcpCloudContextService mockGcpCloudContextService;
+
+  public GcpCloudContextService mockGcpCloudContextService() {
+    return mockGcpCloudContextService;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockGcpCloudContextService.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMockGcpCloudContextService.java
@@ -1,14 +1,13 @@
 package bio.terra.workspace.common;
 
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
-import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 /** Mock out the GcpCloudContextService where needed */
 public class BaseUnitTestMockGcpCloudContextService extends BaseUnitTest {
-  @MockBean private GcpCloudContextService mockGcpCloudContextService;
+  @MockBean private GcpCloudContextService gcpCloudContextService;
 
   public GcpCloudContextService mockGcpCloudContextService() {
-    return mockGcpCloudContextService;
+    return gcpCloudContextService;
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMocks.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMocks.java
@@ -3,11 +3,9 @@ package bio.terra.workspace.common;
 import bio.terra.workspace.amalgam.tps.TpsApiDispatch;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.datarepo.DataRepoService;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
-import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 /*

--- a/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMocks.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseUnitTestMocks.java
@@ -1,0 +1,47 @@
+package bio.terra.workspace.common;
+
+import bio.terra.workspace.amalgam.tps.TpsApiDispatch;
+import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.datarepo.DataRepoService;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+/*
+ * Mock beans used by (or not conflicting with) all unit tests
+ */
+public class BaseUnitTestMocks extends BaseTest {
+  @MockBean private ControlledResourceMetadataManager mockControlledResourceMetadataManager;
+  @MockBean private ControlledResourceService mockControlledResourceService;
+  @MockBean private CrlService mockCrlService;
+  @MockBean private FeatureConfiguration mockFeatureConfiguration;
+  @MockBean private SamService mockSamService;
+  @MockBean private TpsApiDispatch mockTpsApiDispatch;
+
+  public ControlledResourceMetadataManager mockControlledResourceMetadataManager() {
+    return mockControlledResourceMetadataManager;
+  }
+
+  public ControlledResourceService mockControlledResourceService() {
+    return mockControlledResourceService;
+  }
+
+  public CrlService mockCrlService() {
+    return mockCrlService;
+  }
+
+  public FeatureConfiguration mockFeatureConfiguration() {
+    return mockFeatureConfiguration;
+  }
+
+  public SamService mockSamService() {
+    return mockSamService;
+  }
+
+  public TpsApiDispatch mockTpsApiDispatch() {
+    return mockTpsApiDispatch;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.common.logging;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys.CONTROLLED_RESOURCES_TO_DELETE;
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.FOLDER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,8 +26,6 @@ import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.folder.flights.DeleteFolderFlight;
 import bio.terra.workspace.service.folder.model.Folder;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
@@ -54,17 +53,8 @@ import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class WorkspaceActivityLogHookTest extends BaseUnitTest {
-
-  /** A fake authenticated user request. */
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest()
-          .token(Optional.of("fake-token"))
-          .email("fake@email.com")
-          .subjectId("fakeID123");
-
   private static final UserStatusInfo USER_STATUS_INFO =
       new UserStatusInfo()
           .userEmail(USER_REQUEST.getEmail())
@@ -74,11 +64,10 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
   @Autowired private ResourceDao resourceDao;
   @Autowired private WorkspaceActivityLogHook hook;
   @Autowired private FolderDao folderDao;
-  @MockBean private SamService mockSamService;
 
   @BeforeEach
   void setUpOnce() throws InterruptedException {
-    when(mockSamService.getUserStatusInfo(any())).thenReturn(USER_STATUS_INFO);
+    when(mockSamService().getUserStatusInfo(any())).thenReturn(USER_STATUS_INFO);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
@@ -1,14 +1,13 @@
 package bio.terra.workspace.common.utils;
 
-import java.util.Random;
+import java.util.UUID;
 
 public class TestUtils {
-  private static final Random RANDOM = new Random();
-
-  public static String appendRandomNumber(String string) {
+  public static String appendRandomNumber(String prefix) {
     // Can't have dash because BQ dataset names can't have dash.
     // Can't have underscore because for controlled buckets, GCP recommends not having underscore
     // in bucket name.
-    return string + RANDOM.nextInt(100000);
+    String randomString = prefix + UUID.randomUUID();
+    return randomString.replaceAll("[-_]", "");
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -12,7 +12,6 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.exception.InvalidJobIdException;
 import bio.terra.workspace.service.job.exception.InvalidResultStateException;
 import bio.terra.workspace.service.job.exception.JobNotFoundException;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.MethodMode;
@@ -41,7 +39,6 @@ class JobServiceTest extends BaseUnitTest {
 
   @Autowired private JobService jobService;
   @Autowired private WorkspaceDao workspaceDao;
-  @MockBean private SamService mockSamService;
 
   /**
    * Reset the {@link JobService} {@link FlightDebugInfo} after each test so that future submissions

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -280,10 +280,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(mockSamService().listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.WRITE_ACTION,
@@ -312,10 +313,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(mockSamService().listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.WRITE_ACTION,
@@ -344,10 +346,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(mockSamService().listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(List.of(SamConstants.SamControlledResourceActions.READ_ACTION));
 
     assertThrows(
@@ -374,10 +377,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(mockSamService().listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.READ_ACTION,
@@ -407,10 +411,11 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             PrivateResourceState.ACTIVE,
             AccessScopeType.ACCESS_SCOPE_PRIVATE,
             ManagedByType.MANAGED_BY_APPLICATION);
-    when(mockSamService().listResourceActions(
-            ArgumentMatchers.eq(userRequest),
-            ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
-            ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
+    when(mockSamService()
+            .listResourceActions(
+                ArgumentMatchers.eq(userRequest),
+                ArgumentMatchers.eq(storageContainerResource.getCategory().getSamResourceName()),
+                ArgumentMatchers.eq(storageContainerResource.getResourceId().toString())))
         .thenReturn(
             List.of(
                 SamConstants.SamControlledResourceActions.READ_ACTION,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureTestUtils;
@@ -48,7 +48,7 @@ import java.util.function.BiFunction;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureTest {
+public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureConnectedTest {
   private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(15);
 
   @Autowired private WorkspaceService workspaceService;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/CreateAzureDiskStepTest.java
@@ -13,7 +13,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureDiskStepTest extends BaseAzureTest {
+public class CreateAzureDiskStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskStepTest.java
@@ -10,7 +10,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureDiskCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class GetAzureDiskStepTest extends BaseAzureTest {
+public class GetAzureDiskStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/CreateAzureIpStepTest.java
@@ -13,7 +13,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureIpStepTest extends BaseAzureTest {
+public class CreateAzureIpStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/GetAzureIpStepTest.java
@@ -10,7 +10,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class GetAzureIpStepTest extends BaseAzureTest {
+public class GetAzureIpStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/CreateAzureNetworkStepTest.java
@@ -13,7 +13,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureNetworkStepTest extends BaseAzureTest {
+public class CreateAzureNetworkStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/GetAzureNetworkStepTest.java
@@ -10,7 +10,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureNetworkCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class GetAzureNetworkStepTest extends BaseAzureTest {
+public class GetAzureNetworkStepTest extends BaseAzureConnectedTest {
   private static final String STUB_STRING_RETURN = "stubbed-return";
 
   @Mock private FlightContext mockFlightContext;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/CreateAzureRelayNamespaceStepTest.java
@@ -13,7 +13,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureIpCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureRelayNamespaceCreationParameters;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureRelayNamespaceStepTest extends BaseAzureTest {
+public class CreateAzureRelayNamespaceStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/GetAzureRelayNamespaceStepTest.java
@@ -12,7 +12,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiAzureRelayNamespaceCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class GetAzureRelayNamespaceStepTest extends BaseAzureTest {
+public class GetAzureRelayNamespaceStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 
 /** Base class for storage account and storage container tests. */
-public class BaseStorageStepTest extends BaseAzureTest {
+public class BaseStorageStepTest extends BaseAzureConnectedTest {
 
   protected final String STUB_STRING_RETURN = "stubbed-return";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -12,7 +12,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureVmUtils;
 import bio.terra.workspace.db.ResourceDao;
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateAzureVmStepTest extends BaseAzureTest {
+public class CreateAzureVmStepTest extends BaseAzureConnectedTest {
 
   private static final String STUB_STRING_RETURN = "stubbed-return";
   private static final String STUB_DISK_NAME = "stub-disk-name";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -4,6 +4,7 @@ import static bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucke
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
@@ -14,18 +15,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 
+@DirtiesContext(classMode = BEFORE_CLASS)
 public class ControlledGcsBucketHandlerTest extends BaseUnitTestMockGcpCloudContextService {
   private static final UUID fakeWorkspaceId = UUID.randomUUID();
   private static final String FAKE_PROJECT_ID = "fakeprojectid";
 
-  @Autowired ControlledGcsBucketHandler handler;
-
   @BeforeEach
   public void setup() throws IOException {
-    // The handler uses @PostConstruct to store a static. The mocked bean is
-    // missed in this process. Use a test-only method to set the static to the mock object.
-    handler.init(mockGcpCloudContextService());
     when(mockGcpCloudContextService().getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -7,20 +7,25 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import java.io.IOException;
 import java.util.UUID;
-
-import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class ControlledGcsBucketHandlerTest extends BaseUnitTestMockGcpCloudContextService {
   private static final UUID fakeWorkspaceId = UUID.randomUUID();
   private static final String FAKE_PROJECT_ID = "fakeprojectid";
 
+  @Autowired ControlledGcsBucketHandler handler;
+
   @BeforeEach
   public void setup() throws IOException {
+    // The handler uses @PostConstruct to store a static. The mocked bean is
+    // missed in this process. Use a test-only method to set the static to the mock object.
+    handler.init(mockGcpCloudContextService());
     when(mockGcpCloudContextService().getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -6,17 +6,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 
-import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
-import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import java.io.IOException;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 
+// TODO: PF-2090 - Spring does not seem to notice that it needs to build a different
+//  application context for this test class, even though it inherits a different set
+//  of mocks. Doing @DirtiesContext forces a new application context and it is built
+//  properly. See the ticket for more details.
 @DirtiesContext(classMode = BEFORE_CLASS)
 public class ControlledGcsBucketHandlerTest extends BaseUnitTestMockGcpCloudContextService {
   private static final UUID fakeWorkspaceId = UUID.randomUUID();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -2,27 +2,26 @@ package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 
 import static bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketHandler.MAX_BUCKET_NAME_LENGTH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.common.BaseUnitTest;
-import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import java.io.IOException;
 import java.util.UUID;
+
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
-  @MockBean GcpCloudContextService mockGcpCloudContextService;
-
+public class ControlledGcsBucketHandlerTest extends BaseUnitTestMockGcpCloudContextService {
   private static final UUID fakeWorkspaceId = UUID.randomUUID();
   private static final String FAKE_PROJECT_ID = "fakeprojectid";
 
   @BeforeEach
   public void setup() throws IOException {
-    when(mockGcpCloudContextService.getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
+    when(mockGcpCloudContextService().getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
   }
 
   @Test
@@ -31,7 +30,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -40,7 +39,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yu-hu-yo-yo-" + FAKE_PROJECT_ID));
+    assertEquals("yu-hu-yo-yo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -49,7 +48,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -58,7 +57,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -67,7 +66,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("gooyuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("gooyuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -76,7 +75,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 
   @Test
@@ -89,7 +88,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     int maxNameLength = MAX_BUCKET_NAME_LENGTH;
 
     assertEquals(maxNameLength, generateCloudName.length());
-    assertTrue(generateCloudName.equals(generateCloudName.substring(0, maxNameLength)));
+    assertEquals(generateCloudName, generateCloudName.substring(0, maxNameLength));
   }
 
   @Test
@@ -98,6 +97,6 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTest {
     String generateCloudName =
         ControlledGcsBucketHandler.getHandler().generateCloudName(fakeWorkspaceId, bucketName);
 
-    assertTrue(generateCloudName.equals("yuhuyoyo-" + FAKE_PROJECT_ID));
+    assertEquals("yuhuyoyo-" + FAKE_PROJECT_ID, generateCloudName);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -41,11 +42,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 
+@DirtiesContext(classMode = BEFORE_CLASS)
 public class CopyGcsBucketDefinitionStepTest extends BaseUnitTestMockGcpCloudContextService {
   private CopyGcsBucketDefinitionStep copyGcsBucketDefinitionStep;
 
-  @Autowired ControlledGcsBucketHandler handler;
   @Mock FlightContext mockFlightContext;
 
   @BeforeEach
@@ -56,9 +58,6 @@ public class CopyGcsBucketDefinitionStepTest extends BaseUnitTestMockGcpCloudCon
             SOURCE_BUCKET_RESOURCE,
             mockControlledResourceService(),
             CloningInstructions.COPY_DEFINITION);
-    // The handler uses @PostConstruct to store a static. The mocked bean is
-    // missed in this process. Use a test-only method to set the static to the mock object.
-    handler.init(mockGcpCloudContextService());
     when(mockGcpCloudContextService().getRequiredGcpProject(any(UUID.class)))
         .thenReturn("my-fake-project");
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
@@ -19,18 +19,15 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFOR
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
-import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
-import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import java.util.ArrayList;
@@ -40,10 +37,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 
+// TODO: PF-2090 - Spring does not seem to notice that it needs to build a different
+//  application context for this test class, even though it inherits a different set
+//  of mocks. Doing @DirtiesContext forces a new application context and it is built
+//  properly. See the ticket for more details.
 @DirtiesContext(classMode = BEFORE_CLASS)
 public class CopyGcsBucketDefinitionStepTest extends BaseUnitTestMockGcpCloudContextService {
   private CopyGcsBucketDefinitionStep copyGcsBucketDefinitionStep;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
@@ -18,15 +18,18 @@ import static org.mockito.Mockito.when;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
+import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
+import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import java.util.ArrayList;
@@ -36,10 +39,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class CopyGcsBucketDefinitionStepTest extends BaseUnitTestMockGcpCloudContextService {
   private CopyGcsBucketDefinitionStep copyGcsBucketDefinitionStep;
 
+  @Autowired ControlledGcsBucketHandler handler;
   @Mock FlightContext mockFlightContext;
 
   @BeforeEach
@@ -50,6 +56,9 @@ public class CopyGcsBucketDefinitionStepTest extends BaseUnitTestMockGcpCloudCon
             SOURCE_BUCKET_RESOURCE,
             mockControlledResourceService(),
             CloningInstructions.COPY_DEFINITION);
+    // The handler uses @PostConstruct to store a static. The mocked bean is
+    // missed in this process. Use a test-only method to set the static to the mock object.
+    handler.init(mockGcpCloudContextService());
     when(mockGcpCloudContextService().getRequiredGcpProject(any(UUID.class)))
         .thenReturn("my-fake-project");
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -50,7 +50,6 @@ import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource.referenced;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,15 +13,11 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.stairway.StepStatus;
-import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.BaseUnitTestMockDataRepoService;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
 import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.db.exception.InvalidMetadataException;
-import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.datarepo.DataRepoService;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.exception.InvalidResultStateException;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
@@ -48,7 +45,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.AfterEach;
@@ -59,40 +55,26 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
-@Tag("unit")
-class ReferencedResourceServiceTest extends BaseUnitTest {
+class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
 
   private static final Logger logger = LoggerFactory.getLogger(ReferencedResourceServiceTest.class);
   private static final String DATA_REPO_INSTANCE_NAME = "terra";
   private static final String FAKE_PROJECT_ID = "fakeprojecctid";
-
-  /** A fake authenticated user request. */
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest()
-          .token(Optional.of("fake-token"))
-          .email("fake@email.com")
-          .subjectId("fakeID123");
 
   @Autowired private WorkspaceService workspaceService;
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private ReferencedResourceService referenceResourceService;
   @Autowired private JobService jobService;
   @Autowired private WorkspaceActivityLogDao workspaceActivityLogDao;
-  /** Mock SamService does nothing for all calls that would throw if unauthorized. */
-  @MockBean private SamService mockSamService;
-
-  @MockBean private DataRepoService mockDataRepoService;
-  @MockBean private CrlService mockCrlService;
 
   private UUID workspaceUuid;
   private ReferencedResource referencedResource;
 
   @BeforeEach
   void setup() throws InterruptedException {
-    doReturn(true).when(mockDataRepoService).snapshotReadable(any(), any(), any());
-    when(mockSamService.getUserStatusInfo(any()))
+    doReturn(true).when(mockDataRepoService()).snapshotReadable(any(), any(), any());
+    when(mockSamService().getUserStatusInfo(any()))
         .thenReturn(
             new UserStatusInfo()
                 .userEmail(USER_REQUEST.getEmail())
@@ -568,8 +550,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
     @BeforeEach
     void setup() throws Exception {
       // Make the Verify step always succeed
-      doReturn(true).when(mockCrlService).canReadGcsBucket(any(), any());
-      doReturn(true).when(mockCrlService).canReadGcsObject(any(), any(), any());
+      doReturn(true).when(mockCrlService()).canReadGcsBucket(any(), any());
+      doReturn(true).when(mockCrlService()).canReadGcsObject(any(), any(), any());
     }
 
     private ReferencedGcsObjectResource makeGcsObjectReference() {
@@ -772,8 +754,8 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
     @BeforeEach
     void setup() throws Exception {
       // Make the Verify step always succeed
-      doReturn(true).when(mockCrlService).canReadBigQueryDataset(any(), any(), any());
-      doReturn(true).when(mockCrlService).canReadBigQueryDataTable(any(), any(), any(), any());
+      doReturn(true).when(mockCrlService()).canReadBigQueryDataset(any(), any(), any());
+      doReturn(true).when(mockCrlService()).canReadBigQueryDataTable(any(), any(), any(), any());
     }
 
     private ReferencedBigQueryDatasetResource makeBigQueryDatasetResource() {
@@ -1092,7 +1074,7 @@ class ReferencedResourceServiceTest extends BaseUnitTest {
 
     @BeforeEach
     void setup() throws Exception {
-      doReturn(true).when(mockSamService).isAuthorized(any(), any(), any(), any());
+      doReturn(true).when(mockSamService()).isAuthorized(any(), any(), any(), any());
     }
 
     private ReferencedTerraWorkspaceResource makeTerraWorkspaceReference() {

--- a/service/src/test/java/bio/terra/workspace/service/status/WorkspaceManagerStatusServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/status/WorkspaceManagerStatusServiceTest.java
@@ -6,16 +6,12 @@ import static org.mockito.Mockito.doReturn;
 
 import bio.terra.workspace.app.configuration.external.StatusCheckConfiguration;
 import bio.terra.workspace.common.BaseUnitTest;
-import bio.terra.workspace.service.iam.SamService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class WorkspaceManagerStatusServiceTest extends BaseUnitTest {
-
-  @MockBean private SamService mockSamService;
 
   @Autowired private WorkspaceManagerStatusService statusService;
   @Autowired private StatusCheckConfiguration configuration;
@@ -46,14 +42,14 @@ public class WorkspaceManagerStatusServiceTest extends BaseUnitTest {
 
   @Test
   void testStatusWithWorkingEndpoints() {
-    doReturn(IS_OK).when(mockSamService).status();
+    doReturn(IS_OK).when(mockSamService()).status();
     statusService.checkStatus();
     assertTrue(statusService.getCurrentStatus());
   }
 
   @Test
   void testFailureNotOk() {
-    doReturn(NOT_OK).when(mockSamService).status();
+    doReturn(NOT_OK).when(mockSamService()).status();
     statusService.checkStatus();
     assertFalse(statusService.getCurrentStatus());
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.workspace.app.configuration.external.AzureTestConfiguration;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class AzureWorkspaceTest extends BaseAzureTest {
+public class AzureWorkspaceTest extends BaseAzureConnectedTest {
 
   @Autowired private AzureTestConfiguration azureTestConfiguration;
   @Autowired private JobService jobService;

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,9 +12,6 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceDao;
-import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants.SamSpendProfileAction;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
@@ -27,12 +25,10 @@ import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class GcpCloudContextUnitTest extends BaseUnitTest {
   private static final String GCP_PROJECT_ID = "terra-wsm-t-clean-berry-5152";
@@ -42,14 +38,7 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
   private static final String POLICY_APPLICATION = "policy-application";
   private static final String V1_JSON =
       String.format("{\"version\": 1, \"gcpProjectId\": \"%s\"}", GCP_PROJECT_ID);
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest()
-          .token(Optional.of("fake-token"))
-          .email("fake@email.com")
-          .subjectId("fakeID123");
 
-  @MockBean private SamService mockSamService;
-  @MockBean private CrlService mockCrlService;
   @Autowired private WorkspaceService workspaceService;
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private ResourceDao resourceDao;
@@ -117,22 +106,23 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
     // By default, allow all spend link calls as authorized. (All other isAuthorized calls return
     // false by Mockito default.
     Mockito.when(
-            mockSamService.isAuthorized(
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.eq(SamSpendProfileAction.LINK)))
+            mockSamService()
+                .isAuthorized(
+                    Mockito.any(),
+                    Mockito.any(),
+                    Mockito.any(),
+                    Mockito.eq(SamSpendProfileAction.LINK)))
         .thenReturn(true);
 
     // Fake groups
-    Mockito.when(mockSamService.getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.READER), any()))
+    Mockito.when(mockSamService().getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.READER), any()))
         .thenReturn(POLICY_READER);
-    Mockito.when(mockSamService.getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.WRITER), any()))
+    Mockito.when(mockSamService().getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.WRITER), any()))
         .thenReturn(POLICY_WRITER);
-    Mockito.when(mockSamService.getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.OWNER), any()))
+    Mockito.when(mockSamService().getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.OWNER), any()))
         .thenReturn(POLICY_OWNER);
     Mockito.when(
-            mockSamService.getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.APPLICATION), any()))
+            mockSamService().getWorkspacePolicy(any(), Mockito.eq(WsmIamRole.APPLICATION), any()))
         .thenReturn(POLICY_APPLICATION);
 
     // Create a workspace record
@@ -220,6 +210,6 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
     // Pretend the project is already being deleted.
     Mockito.when(mockResourceManager.projects().get(any()).execute())
         .thenReturn(new Project().setState("DELETE_IN_PROGRESS"));
-    Mockito.when(mockCrlService.getCloudResourceManagerCow()).thenReturn(mockResourceManager);
+    Mockito.when(mockCrlService().getCloudResourceManagerCow()).thenReturn(mockResourceManager);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UFID_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UUID_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
@@ -92,7 +93,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
@@ -112,12 +112,6 @@ import org.springframework.test.web.servlet.MockMvc;
 class WorkspaceServiceTest extends BaseConnectedTest {
 
   public static final String SPEND_PROFILE_ID = "wm-default-spend-profile";
-  /** A fake authenticated user request. */
-  private static final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest()
-          .token(Optional.of("fake-token"))
-          .email("fake@email.com")
-          .subjectId("fakeID123");
   /** A fake group-constraint policy for a workspace. */
   private static final ApiTpsPolicyInput GROUP_POLICY =
       new ApiTpsPolicyInput()

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlightTest.java
@@ -3,7 +3,7 @@ package bio.terra.workspace.service.workspace.flight;
 import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.stairway.*;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureTestUtils;
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class DeleteAzureContextFlightTest extends BaseAzureTest {
+public class DeleteAzureContextFlightTest extends BaseAzureConnectedTest {
   /**
    * How long to wait for a delete context Stairway flight to complete before timing out the test.
    */

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateAzureContextFlightTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
-import bio.terra.workspace.common.BaseAzureTest;
+import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.utils.AzureTestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -21,7 +21,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class CreateAzureContextFlightTest extends BaseAzureTest {
+class CreateAzureContextFlightTest extends BaseAzureConnectedTest {
   /** How long to wait for a Stairway flight to complete before timing out the test. */
   private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(10);
 


### PR DESCRIPTION
This PR implements a new rule: we will not use naked `@MockBean` directly in tests. We will only use mock beans defined in base classes that can be shared. The goal is to reduce the number of unique application contexts, which reduces the number of database connection pools holding open connections. The layout of the base classes can be found in the Unit Test section in the README.md.

Factoring out the mocks results in lots of minor changes to unit tests. On the bright side, the naming of mock beans is now consistent across all of the unit tests.

Two other minor changes:
- Replaced all of the unique, cut'n'pasted definitions of `USER_REQUEST` with a reference to the version in `MockMvcUtils`. Kudos to whoever created those utils in the first place.
- Renamed `AzureTest` base class and gradle target to be `AzureConnectedTest`. It now parallels the non-Azure targets.

