### PR TITLE
PF-2060: Revert back the change

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudSyncRoleMapping.java
@@ -71,7 +71,6 @@ public class CloudSyncRoleMapping {
               "artifactregistry.tags.update",
               "cloudbuild.builds.create",
               "cloudbuild.builds.update",
-              "compute.instances.get",
               "iam.serviceAccounts.get",
               "iam.serviceAccounts.list",
               "lifesciences.operations.cancel",


### PR DESCRIPTION
GCP rolled back their change that requires `compute.instances.get` on  notebook creation.