### PR TITLE
[PF-1930] Implement cloning controlled dataset to referenced

### DIFF
--- a/openapi/src/parts/controlled_gcp_big_query_dataset.yaml
+++ b/openapi/src/parts/controlled_gcp_big_query_dataset.yaml
@@ -183,7 +183,9 @@ components:
           type: string
           format: uuid
         destinationDatasetName:
-          description: Name for destination dataset. Letters, numbers and underscores only.
+          description: >-
+            Name for destination dataset. Must not be set if cloningInstructions
+            is COPY_REFERENCE. Letters, numbers and underscores only.
           type: string
         cloningInstructions:
           $ref: "#/components/schemas/CloningInstructionsEnum"
@@ -194,7 +196,8 @@ components:
         location:
           description: >-
             A valid dataset location per https://cloud.google.com/bigquery/docs/locations.
-            If null, will use source dataset's location.
+            Must not be set if cloningInstructions is COPY_REFERENCE. If null,
+            will use source dataset's location.
           type: string
         jobControl:
           $ref: '#/components/schemas/JobControl'
@@ -290,7 +293,9 @@ components:
 
   responses:
     CloneControlledGcpBigQueryDatasetResponse:
-      description: response to clone BigQuery dataset operation.
+      description: >-
+        Response to clone BigQuery dataset operation where source dataset is
+        controlled. (Destination dataset may be controlled or referenced.)
       content:
         application/json:
           schema:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -512,6 +512,14 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
       UUID workspaceUuid,
       UUID resourceId,
       @Valid ApiCloneControlledGcpBigQueryDatasetRequest body) {
+    if (body.getCloningInstructions() == ApiCloningInstructionsEnum.REFERENCE
+        && (!StringUtils.isEmpty(body.getDestinationDatasetName())
+            || !StringUtils.isEmpty(body.getLocation()))) {
+      throw new BadRequestException(
+          String.format(
+              "When cloning controlled dataset with COPY_REFERENCE, cannot set destination dataset name or location in request"));
+    }
+
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     // This technically duplicates the first step of the flight as the clone flight is re-used for
     // cloneWorkspace, but this also saves us from launching and failing a flight if the user does

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -207,7 +207,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
             || !StringUtils.isEmpty(body.getLocation()))) {
       throw new BadRequestException(
           String.format(
-              "When cloning controlled bucket with COPY_REFERENCE, cannot set bucket or location in request"));
+              "Cannot set bucket or location when cloning a controlled bucket with COPY_REFERENCE"));
     }
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
@@ -517,7 +517,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
             || !StringUtils.isEmpty(body.getLocation()))) {
       throw new BadRequestException(
           String.format(
-              "When cloning controlled dataset with COPY_REFERENCE, cannot set destination dataset name or location in request"));
+              "Cannot set destination dataset name or location when cloning controlled dataset with COPY_REFERENCE"));
     }
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetReferencedDestinationGcsBucketInWorkingMapStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetReferencedDestinationGcsBucketInWorkingMapStep.java
@@ -70,12 +70,7 @@ public class SetReferencedDestinationGcsBucketInWorkingMapStep implements Step {
 
     ReferencedGcsBucketResource destinationBucketResource =
         WorkspaceCloneUtils.buildDestinationReferencedGcsBucketFromControlled(
-            sourceBucket,
-            destinationWorkspaceId,
-            destinationResourceId,
-            resourceName,
-            description,
-            sourceBucket.getBucketName());
+            sourceBucket, destinationWorkspaceId, destinationResourceId, resourceName, description);
 
     workingMap.put(
         ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE, destinationBucketResource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetReferencedDestinationGcsBucketWorkingMapStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/SetReferencedDestinationGcsBucketWorkingMapStep.java
@@ -1,0 +1,97 @@
+package bio.terra.workspace.service.resource.controlled.flight.clone.bucket;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
+import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.WorkspaceCloneUtils;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResourceService;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
+import com.google.common.base.Preconditions;
+import java.util.UUID;
+
+/**
+ * Adds ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE and ResourceKeys.RESOURCE_TYPE to
+ * working map, for CreateReferenceMetadataStep to use.
+ */
+public class SetReferencedDestinationGcsBucketWorkingMapStep implements Step {
+
+  private final AuthenticatedUserRequest userRequest;
+  private final ControlledGcsBucketResource sourceBucket;
+  private final ReferencedResourceService referencedResourceService;
+  private final CloningInstructions resolvedCloningInstructions;
+
+  public SetReferencedDestinationGcsBucketWorkingMapStep(
+      AuthenticatedUserRequest userRequest,
+      ControlledGcsBucketResource sourceBucket,
+      ReferencedResourceService referencedResourceService,
+      CloningInstructions resolvedCloningInstructions) {
+    this.userRequest = userRequest;
+    this.sourceBucket = sourceBucket;
+    this.referencedResourceService = referencedResourceService;
+    this.resolvedCloningInstructions = resolvedCloningInstructions;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    final FlightMap inputParameters = flightContext.getInputParameters();
+    final FlightMap workingMap = flightContext.getWorkingMap();
+    FlightUtils.validateRequiredEntries(
+        inputParameters,
+        ControlledResourceKeys.DESTINATION_WORKSPACE_ID,
+        ControlledResourceKeys.DESTINATION_RESOURCE_ID);
+    Preconditions.checkState(
+        resolvedCloningInstructions == CloningInstructions.COPY_REFERENCE,
+        "CloningInstructions must be COPY_REFERENCE");
+    final String resourceName =
+        FlightUtils.getInputParameterOrWorkingValue(
+            flightContext,
+            ResourceKeys.RESOURCE_NAME,
+            ResourceKeys.PREVIOUS_RESOURCE_NAME,
+            String.class);
+    final String description =
+        FlightUtils.getInputParameterOrWorkingValue(
+            flightContext,
+            ResourceKeys.RESOURCE_DESCRIPTION,
+            ResourceKeys.PREVIOUS_RESOURCE_DESCRIPTION,
+            String.class);
+    final UUID destinationWorkspaceId =
+        inputParameters.get(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, UUID.class);
+    final var destinationResourceId =
+        inputParameters.get(ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class);
+
+    ReferencedGcsBucketResource destinationBucketResource =
+        WorkspaceCloneUtils.buildDestinationReferencedGcsBucketFromControlled(
+            sourceBucket,
+            destinationWorkspaceId,
+            destinationResourceId,
+            resourceName,
+            description,
+            sourceBucket.getBucketName());
+
+    flightContext
+        .getWorkingMap()
+        // ResourceKeys.RESOURCE was used for source bucket. So use
+        // ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE for dest bucket.
+        .put(ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE, destinationBucketResource);
+    flightContext
+        .getWorkingMap()
+        .put(ResourceKeys.RESOURCE_TYPE, destinationBucketResource.getResourceType());
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    // Nothing to undo
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
@@ -62,7 +62,7 @@ public class CloneControlledGcpBigQueryDatasetResourceFlight extends Flight {
     // Flight Plan
     // 1. Validate user has read access to the source object
     // 2. Gather controlled resource metadata for source object
-    // 3. Gather creation parameters from existing object
+    // 3. Gather cloud attributes from existing object
     // 4. If cloning to referenced resource, do the clone and finish flight
     // 5. Launch sub-flight to create destination controlled resource
     addStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/SetReferencedDestinationBigQueryDatasetInWorkingMapStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/SetReferencedDestinationBigQueryDatasetInWorkingMapStep.java
@@ -1,4 +1,4 @@
-package bio.terra.workspace.service.resource.controlled.flight.clone.bucket;
+package bio.terra.workspace.service.resource.controlled.flight.clone.dataset;
 
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -7,11 +7,11 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.WorkspaceCloneUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.ReferencedResourceService;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import com.google.common.base.Preconditions;
@@ -21,20 +21,20 @@ import java.util.UUID;
  * Adds ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE and ResourceKeys.RESOURCE_TYPE to
  * working map, for CreateReferenceMetadataStep to use.
  */
-public class SetReferencedDestinationGcsBucketWorkingMapStep implements Step {
+public class SetReferencedDestinationBigQueryDatasetInWorkingMapStep implements Step {
 
   private final AuthenticatedUserRequest userRequest;
-  private final ControlledGcsBucketResource sourceBucket;
+  private final ControlledBigQueryDatasetResource sourceDataset;
   private final ReferencedResourceService referencedResourceService;
   private final CloningInstructions resolvedCloningInstructions;
 
-  public SetReferencedDestinationGcsBucketWorkingMapStep(
+  public SetReferencedDestinationBigQueryDatasetInWorkingMapStep(
       AuthenticatedUserRequest userRequest,
-      ControlledGcsBucketResource sourceBucket,
+      ControlledBigQueryDatasetResource sourceDataset,
       ReferencedResourceService referencedResourceService,
       CloningInstructions resolvedCloningInstructions) {
     this.userRequest = userRequest;
-    this.sourceBucket = sourceBucket;
+    this.sourceDataset = sourceDataset;
     this.referencedResourceService = referencedResourceService;
     this.resolvedCloningInstructions = resolvedCloningInstructions;
   }
@@ -68,23 +68,17 @@ public class SetReferencedDestinationGcsBucketWorkingMapStep implements Step {
     final var destinationResourceId =
         inputParameters.get(ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class);
 
-    ReferencedGcsBucketResource destinationBucketResource =
-        WorkspaceCloneUtils.buildDestinationReferencedGcsBucketFromControlled(
-            sourceBucket,
+    ReferencedBigQueryDatasetResource destinationDatasetResource =
+        WorkspaceCloneUtils.buildDestinationReferencedBigQueryDatasetFromControlled(
+            sourceDataset,
             destinationWorkspaceId,
             destinationResourceId,
             resourceName,
-            description,
-            sourceBucket.getBucketName());
+            description);
 
-    flightContext
-        .getWorkingMap()
-        // ResourceKeys.RESOURCE was used for source bucket. So use
-        // ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE for dest bucket.
-        .put(ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE, destinationBucketResource);
-    flightContext
-        .getWorkingMap()
-        .put(ResourceKeys.RESOURCE_TYPE, destinationBucketResource.getResourceType());
+    workingMap.put(
+        ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE, destinationDatasetResource);
+    workingMap.put(ResourceKeys.RESOURCE_TYPE, destinationDatasetResource.getResourceType());
 
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/SetReferencedDestinationBigQueryDatasetResponseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/SetReferencedDestinationBigQueryDatasetResponseStep.java
@@ -1,0 +1,54 @@
+package bio.terra.workspace.service.resource.controlled.flight.clone.dataset;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.generated.model.ApiClonedControlledGcpBigQueryDataset;
+import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Sets flight response to destination dataset.
+ *
+ * <p>Note - This can't be done in SetReferencedDestinationBigQueryDatasetInWorkingMapStep, because
+ * CreateReferenceMetadataStep sets flight response to dest resource ID. So this must be done after
+ * CreateReferenceMetadataStep.
+ */
+public class SetReferencedDestinationBigQueryDatasetResponseStep implements Step {
+
+  public SetReferencedDestinationBigQueryDatasetResponseStep() {}
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    ControlledResource sourceDataset =
+        context.getInputParameters().get(ResourceKeys.RESOURCE, ControlledResource.class);
+    ReferencedBigQueryDatasetResource destDataset =
+        context
+            .getWorkingMap()
+            .get(
+                ControlledResourceKeys.DESTINATION_REFERENCED_RESOURCE,
+                ReferencedBigQueryDatasetResource.class);
+
+    final ApiClonedControlledGcpBigQueryDataset apiClonedDataset =
+        new ApiClonedControlledGcpBigQueryDataset()
+            .effectiveCloningInstructions(ApiCloningInstructionsEnum.REFERENCE)
+            .dataset(destDataset.toApiResource())
+            .sourceWorkspaceId(sourceDataset.getWorkspaceId())
+            .sourceResourceId(sourceDataset.getResourceId());
+    FlightUtils.setResponse(context, apiClonedDataset, HttpStatus.OK);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  // No side effects to undo.
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtils.java
@@ -211,8 +211,7 @@ public class WorkspaceCloneUtils {
       UUID destinationWorkspaceId,
       UUID destinationResourceId,
       @Nullable String name,
-      @Nullable String description,
-      String bucketName) {
+      @Nullable String description) {
     CloningInstructions destCloningInstructions =
         // COPY_RESOURCE and COPY_DEFINITION aren't valid for referenced resources, so use
         // COPY_REFERENCE instead.
@@ -234,7 +233,7 @@ public class WorkspaceCloneUtils {
     final ReferencedGcsBucketResource.Builder resultBuilder =
         ReferencedGcsBucketResource.builder()
             .wsmResourceFields(wsmResourceFields)
-            .bucketName(bucketName);
+            .bucketName(sourceBucketResource.getBucketName());
     return resultBuilder.build();
   }
 
@@ -257,21 +256,55 @@ public class WorkspaceCloneUtils {
   }
 
   private static ReferencedResource buildDestinationReferencedBigQueryDataset(
-      ReferencedBigQueryDatasetResource sourceBigQueryResource,
+      ReferencedBigQueryDatasetResource sourceDatasetResource,
       UUID destinationWorkspaceId,
       UUID destinationResourceId,
       @Nullable String name,
       @Nullable String description) {
     // keep projectId and dataset name the same since they are for the referent
     final ReferencedBigQueryDatasetResource.Builder resultBuilder =
-        sourceBigQueryResource.toBuilder()
+        sourceDatasetResource.toBuilder()
             .wsmResourceFields(
                 buildDestinationResourceCommonFields(
                     destinationWorkspaceId,
                     destinationResourceId,
                     name,
                     description,
-                    sourceBigQueryResource));
+                    sourceDatasetResource));
+    return resultBuilder.build();
+  }
+
+  public static ReferencedBigQueryDatasetResource
+      buildDestinationReferencedBigQueryDatasetFromControlled(
+          ControlledBigQueryDatasetResource sourceDatasetResource,
+          UUID destinationWorkspaceId,
+          UUID destinationResourceId,
+          @Nullable String name,
+          @Nullable String description) {
+    CloningInstructions destCloningInstructions =
+        // COPY_RESOURCE and COPY_DEFINITION aren't valid for referenced resources, so use
+        // COPY_REFERENCE instead.
+        sourceDatasetResource.getCloningInstructions() == CloningInstructions.COPY_RESOURCE
+                || sourceDatasetResource.getCloningInstructions()
+                    == CloningInstructions.COPY_DEFINITION
+            ? CloningInstructions.COPY_REFERENCE
+            : sourceDatasetResource.getCloningInstructions();
+
+    WsmResourceFields wsmResourceFields =
+        buildDestinationResourceCommonFields(
+                destinationWorkspaceId,
+                destinationResourceId,
+                name,
+                description,
+                sourceDatasetResource)
+            .toBuilder()
+            .cloningInstructions(destCloningInstructions)
+            .build();
+    final ReferencedBigQueryDatasetResource.Builder resultBuilder =
+        ReferencedBigQueryDatasetResource.builder()
+            .wsmResourceFields(wsmResourceFields)
+            .projectId(sourceDatasetResource.getProjectId())
+            .datasetName(sourceDatasetResource.getDatasetName());
     return resultBuilder.build();
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.app.controller;
 
+import static bio.terra.workspace.common.utils.MockMvcUtils.FAKE_AUTH_USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_AI_NOTEBOOK_NAME_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_BQ_DATASET_NAME_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_GCS_BUCKET_NAME_PATH_FORMAT;
@@ -72,7 +73,8 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void getCloudNameFromGcsBucketName() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId =
+        mockMvcUtils.createWorkspaceWithoutCloudContext(FAKE_AUTH_USER_REQUEST).getId();
     ApiGenerateGcpGcsBucketCloudNameRequestBody bucketNameRequest =
         new ApiGenerateGcpGcsBucketCloudNameRequestBody().gcsBucketName("my-bucket");
 
@@ -85,7 +87,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(bucketNameRequest)),
-                    USER_REQUEST))
+                    FAKE_AUTH_USER_REQUEST))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
             .getResponse()
@@ -102,7 +104,8 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void getCloudNameFromBigQueryDatasetName() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId =
+        mockMvcUtils.createWorkspaceWithoutCloudContext(FAKE_AUTH_USER_REQUEST).getId();
     ApiGenerateGcpBigQueryDatasetCloudIDRequestBody bqDatasetNameRequest =
         new ApiGenerateGcpBigQueryDatasetCloudIDRequestBody().bigQueryDatasetName("bq-dataset");
 
@@ -115,7 +118,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(bqDatasetNameRequest)),
-                    USER_REQUEST))
+                    FAKE_AUTH_USER_REQUEST))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
             .getResponse()
@@ -130,7 +133,8 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void getCloudNameFromAiNotebookInstanceName() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId =
+        mockMvcUtils.createWorkspaceWithoutCloudContext(FAKE_AUTH_USER_REQUEST).getId();
     ApiGenerateGcpAiNotebookCloudIdRequestBody aiNotebookNameRequest =
         new ApiGenerateGcpAiNotebookCloudIdRequestBody().aiNotebookName("ai-notebook");
 
@@ -143,7 +147,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(aiNotebookNameRequest)),
-                    USER_REQUEST))
+                    FAKE_AUTH_USER_REQUEST))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
             .getResponse()

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
@@ -59,7 +59,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void cloneBqDataset_badRequest_throws400() throws Exception {
-    // Cannot set destinationDataName for COPY_REFERENCE clone
+    // Cannot set destinationDatasetName for COPY_REFERENCE clone
     mockMvcUtils.cloneControlledBqDatasetAsync(
         USER_REQUEST,
         /*sourceWorkspaceId=*/ UUID.randomUUID(),

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.app.controller;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.FAKE_AUTH_USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_AI_NOTEBOOK_NAME_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_BQ_DATASET_NAME_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_GCS_BUCKET_NAME_PATH_FORMAT;
@@ -59,6 +58,19 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
   }
 
   @Test
+  public void cloneBqDataset_badRequest_throws400() throws Exception {
+    // Cannot set destinationDataName for COPY_REFERENCE clone
+    mockMvcUtils.cloneControlledBqDatasetAsync(
+        USER_REQUEST,
+        /*sourceWorkspaceId=*/ UUID.randomUUID(),
+        /*sourceResourceId=*/ UUID.randomUUID(),
+        /*destWorkspaceId=*/ UUID.randomUUID(),
+        ApiCloningInstructionsEnum.REFERENCE,
+        "datasetName",
+        HttpStatus.SC_BAD_REQUEST);
+  }
+
+  @Test
   public void cloneGcsBucket_badRequest_throws400() throws Exception {
     // Cannot set bucketName for COPY_REFERENCE clone
     mockMvcUtils.cloneControlledGcsBucketAsync(
@@ -73,8 +85,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void getCloudNameFromGcsBucketName() throws Exception {
-    UUID workspaceId =
-        mockMvcUtils.createWorkspaceWithoutCloudContext(FAKE_AUTH_USER_REQUEST).getId();
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiGenerateGcpGcsBucketCloudNameRequestBody bucketNameRequest =
         new ApiGenerateGcpGcsBucketCloudNameRequestBody().gcsBucketName("my-bucket");
 
@@ -87,7 +98,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(bucketNameRequest)),
-                    FAKE_AUTH_USER_REQUEST))
+                    USER_REQUEST))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
             .getResponse()
@@ -104,8 +115,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void getCloudNameFromBigQueryDatasetName() throws Exception {
-    UUID workspaceId =
-        mockMvcUtils.createWorkspaceWithoutCloudContext(FAKE_AUTH_USER_REQUEST).getId();
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiGenerateGcpBigQueryDatasetCloudIDRequestBody bqDatasetNameRequest =
         new ApiGenerateGcpBigQueryDatasetCloudIDRequestBody().bigQueryDatasetName("bq-dataset");
 
@@ -118,7 +128,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(bqDatasetNameRequest)),
-                    FAKE_AUTH_USER_REQUEST))
+                    USER_REQUEST))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
             .getResponse()
@@ -133,8 +143,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void getCloudNameFromAiNotebookInstanceName() throws Exception {
-    UUID workspaceId =
-        mockMvcUtils.createWorkspaceWithoutCloudContext(FAKE_AUTH_USER_REQUEST).getId();
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiGenerateGcpAiNotebookCloudIdRequestBody aiNotebookNameRequest =
         new ApiGenerateGcpAiNotebookCloudIdRequestBody().aiNotebookName("ai-notebook");
 
@@ -147,7 +156,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(aiNotebookNameRequest)),
-                    FAKE_AUTH_USER_REQUEST))
+                    USER_REQUEST))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
             .getResponse()

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -528,7 +528,7 @@ public class ControlledResourceFixtures {
    *
    * @return resource builder
    */
-  public static ControlledBigQueryDatasetResource.Builder makeDefaultControlledBigQueryBuilder(
+  public static ControlledBigQueryDatasetResource.Builder makeDefaultControlledBqDatasetBuilder(
       @Nullable UUID workspaceUuid) {
     return new Builder()
         .common(makeDefaultControlledResourceFields(workspaceUuid))

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -67,7 +67,7 @@ public class ResourceDaoTest extends BaseUnitTest {
   @Test
   public void createGetDeleteControlledBigQueryDataset() {
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceUuid).build();
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspaceUuid).build();
     resourceDao.createControlledResource(resource);
 
     assertEquals(
@@ -93,7 +93,7 @@ public class ResourceDaoTest extends BaseUnitTest {
     ControlledGcsBucketResource bucket =
         ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceUuid).build();
     ControlledBigQueryDatasetResource dataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceUuid).build();
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspaceUuid).build();
     resourceDao.createControlledResource(bucket);
     resourceDao.createControlledResource(dataset);
 
@@ -273,7 +273,7 @@ public class ResourceDaoTest extends BaseUnitTest {
   @Test
   public void updateResourceProperties_propertiesUpdated() {
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceUuid).build();
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspaceUuid).build();
     resourceDao.createControlledResource(resource);
     Map<String, String> properties = Map.of("foo", "bar1", "sweet", "cake");
 
@@ -302,7 +302,7 @@ public class ResourceDaoTest extends BaseUnitTest {
   public void
       updateResourceProperties_emptyUpdateProperties_throwsMissingRequiredFieldsException() {
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceUuid).build();
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspaceUuid).build();
     resourceDao.createControlledResource(resource);
 
     assertThrows(
@@ -315,7 +315,7 @@ public class ResourceDaoTest extends BaseUnitTest {
   @Test
   public void deleteResourceProperties_resourcePropertiesDeleted() {
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceUuid).build();
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspaceUuid).build();
     resourceDao.createControlledResource(resource);
 
     resourceDao.deleteResourceProperties(
@@ -330,7 +330,7 @@ public class ResourceDaoTest extends BaseUnitTest {
   public void deleteResourceProperties_nonExistingKeys_nothingIsDeleted() {
     UUID workspaceUuid = createWorkspaceWithGcpContext(workspaceDao);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceUuid).build();
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspaceUuid).build();
     resourceDao.createControlledResource(resource);
 
     resourceDao.deleteResourceProperties(
@@ -345,7 +345,7 @@ public class ResourceDaoTest extends BaseUnitTest {
   public void deleteResourceProperties_noKeySpecified_throwsMissingRequiredFieldsException() {
     UUID workspaceUuid = createWorkspaceWithGcpContext(workspaceDao);
     ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceUuid).build();
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspaceUuid).build();
     resourceDao.createControlledResource(resource);
 
     assertThrows(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/UpdateBigQueryDatasetStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/UpdateBigQueryDatasetStepTest.java
@@ -70,7 +70,7 @@ public class UpdateBigQueryDatasetStepTest extends BaseUnitTest {
             eq(mockBigQueryCow), eq(PROJECT_ID), any(String.class), datasetCaptor.capture());
 
     final ControlledBigQueryDatasetResource datasetResource =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(null).build();
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(null).build();
 
     doReturn(PROJECT_ID)
         .when(mockGcpCloudContextService)

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtilsTest.java
@@ -39,7 +39,7 @@ public class WorkspaceCloneUtilsTest extends BaseUnitTest {
   @Test
   public void buildDestinationControlledBigQueryDataset_cloneSucceeds() {
     var sourceDataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(WORKSPACE_ID).build();
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(WORKSPACE_ID).build();
     var cloneResourceName = RandomStringUtils.randomAlphabetic(5);
     var cloneDescription = "This is a cloned dataset";
     var cloneDatasetName = RandomStringUtils.randomAlphabetic(5);
@@ -66,7 +66,7 @@ public class WorkspaceCloneUtilsTest extends BaseUnitTest {
   public void
       buildDestinationControlledBigQueryDataset_private_setPrivateResourceStateToInitializing() {
     ControlledBigQueryDatasetResource sourceDataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(WORKSPACE_ID)
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(WORKSPACE_ID)
             .common(
                 ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
                     .privateResourceState(PrivateResourceState.ACTIVE)

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
@@ -175,7 +175,7 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
         workspaceUuid, CloudPlatform.GCP, fakeContext.serialize(), flightId);
     // Create a controlled resource in the DB
     ControlledBigQueryDatasetResource bqDataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspaceUuid)
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspaceUuid)
             .projectId(projectId)
             .build();
     resourceDao.createControlledResource(bqDataset);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlightTest.java
@@ -50,7 +50,7 @@ public class WorkspaceDeleteFlightTest extends BaseConnectedTest {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     Workspace workspace = connectedTestUtils.createWorkspaceWithGcpContext(userRequest);
     ControlledBigQueryDatasetResource dataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspace.getWorkspaceId())
             .build();
 
     var creationParameters =
@@ -111,7 +111,7 @@ public class WorkspaceDeleteFlightTest extends BaseConnectedTest {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     Workspace workspace = connectedTestUtils.createWorkspaceWithGcpContext(userRequest);
     ControlledBigQueryDatasetResource dataset =
-        ControlledResourceFixtures.makeDefaultControlledBigQueryBuilder(workspace.getWorkspaceId())
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspace.getWorkspaceId())
             .build();
     var creationParameters =
         ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters()


### PR DESCRIPTION
Similar to #835. Manually tested:

```
{
  "resources": [
    {
      "metadata": {
        "workspaceId": "4613d18c-555c-489e-bd54-5918e95b8947",
        "resourceId": "b33afd14-7d50-4a76-a6f7-4e058c852909",
        "name": "dest-dataset",
        "resourceType": "BIG_QUERY_DATASET",
        "stewardshipType": "REFERENCED",
        "cloudPlatform": "GCP",
        "cloningInstructions": "COPY_REFERENCE",
        "resourceLineage": [
          {
            "sourceWorkspaceId": "4613d18c-555c-489e-bd54-5918e95b8947",
            "sourceResourceId": "b6a09f7f-7851-4d69-8279-e640e5f6a87a"
          }
        ],
        "properties": []
      },
      "resourceAttributes": {
        "gcpBqDataset": {
          "projectId": "terra-wsm-t-sparkly-lime-5340",
          "datasetId": "melchang202210101732"
        }
      }
    },
    {
      "metadata": {
        "workspaceId": "4613d18c-555c-489e-bd54-5918e95b8947",
        "resourceId": "b6a09f7f-7851-4d69-8279-e640e5f6a87a",
        "name": "source-dataset",
        "resourceType": "BIG_QUERY_DATASET",
        "stewardshipType": "CONTROLLED",
        "cloudPlatform": "GCP",
        "cloningInstructions": "COPY_DEFINITION",
        "controlledResourceMetadata": {
          "accessScope": "SHARED_ACCESS",
          "managedBy": "USER",
          "privateResourceUser": {},
          "privateResourceState": "NOT_APPLICABLE"
        },
        "resourceLineage": [],
        "properties": []
      },
      "resourceAttributes": {
        "gcpBqDataset": {
          "projectId": "terra-wsm-t-sparkly-lime-5340",
          "datasetId": "melchang202210101732"
        }
      }
    }
  ]
}
```