### PR TITLE
Retrofit storage container operations in WSM with LZ integration

### DIFF
--- a/openapi/src/parts/controlled_azure_storage_container.yaml
+++ b/openapi/src/parts/controlled_azure_storage_container.yaml
@@ -81,7 +81,7 @@ components:
         Storage container-specific properties to be set on creation. These are a subset of the values
         accepted by the azure resource API (note that public access is disabled).
       type: object
-      required: [ storageAccountId, storageContainerName ]
+      required: [ storageContainerName ]
       properties:
         storageAccountId:
           description: The resource ID of the storage account in which the container will be created.

--- a/openapi/src/parts/controlled_azure_storage_container.yaml
+++ b/openapi/src/parts/controlled_azure_storage_container.yaml
@@ -84,7 +84,9 @@ components:
       required: [ storageContainerName ]
       properties:
         storageAccountId:
-          description: The resource ID of the storage account in which the container will be created.
+          description: >-
+            The resource ID of the storage account in which the container will be created.
+            If this parameter is not defined shared storage account from landing zone will be used.
           type: string
           format: uuid
         storageContainerName:

--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
@@ -36,6 +36,9 @@ import org.springframework.stereotype.Component;
 public class LandingZoneApiDispatch {
   private static final Logger logger = LoggerFactory.getLogger(LandingZoneApiDispatch.class);
 
+  private static final String AZURE_STORAGE_ACCOUNT_RESOURCE_TYPE =
+      "Microsoft.Storage/storageAccounts";
+
   private final LandingZoneService landingZoneService;
   private final FeatureConfiguration features;
 
@@ -132,12 +135,13 @@ public class LandingZoneApiDispatch {
   public Optional<ApiAzureLandingZoneDeployedResource> getSharedStorageAccount(
       BearerToken bearerToken, UUID landingZoneId) {
     features.azureEnabledCheck();
-    String azureStorageAccountResourceType = "Microsoft.Storage/storageAccounts";
     return listAzureLandingZoneResources(bearerToken, landingZoneId).getResources().stream()
         .filter(rpg -> rpg.getPurpose().equals(ResourcePurpose.SHARED_RESOURCE.toString()))
         .flatMap(r -> r.getDeployedResources().stream())
         .filter(
-            r -> StringUtils.equalsIgnoreCase(r.getResourceType(), azureStorageAccountResourceType))
+            r ->
+                StringUtils.equalsIgnoreCase(
+                    r.getResourceType(), AZURE_STORAGE_ACCOUNT_RESOURCE_TYPE))
         .findFirst();
   }
 

--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -126,6 +127,18 @@ public class LandingZoneApiDispatch {
                                 .map(r -> toApiAzureLandingZoneDeployedResource(r, p))
                                 .toList())));
     return result;
+  }
+
+  public Optional<ApiAzureLandingZoneDeployedResource> getSharedStorageAccount(
+      BearerToken bearerToken, UUID landingZoneId) {
+    features.azureEnabledCheck();
+    String azureStorageAccountResourceType = "Microsoft.Storage/storageAccounts";
+    return listAzureLandingZoneResources(bearerToken, landingZoneId).getResources().stream()
+        .filter(rpg -> rpg.getPurpose().equals(ResourcePurpose.SHARED_RESOURCE.toString()))
+        .flatMap(r -> r.getDeployedResources().stream())
+        .filter(
+            r -> StringUtils.equalsIgnoreCase(r.getResourceType(), azureStorageAccountResourceType))
+        .findFirst();
   }
 
   public List<ApiAzureLandingZoneDeployedResource> listSubnetsWithParentVNetByPurpose(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -96,7 +96,9 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
     return Optional.of(
         new UniquenessCheckAttributes()
             .uniquenessScope(UniquenessScope.WORKSPACE)
-            .addParameter("storageAccountId", getStorageAccountId().toString())
+            .addParameter(
+                "storageAccountId",
+                Optional.ofNullable(getStorageAccountId()).map(UUID::toString).orElse(null))
             .addParameter("storageContainerName", getStorageContainerName()));
   }
 
@@ -113,6 +115,8 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
             flightBeanBag.getAzureConfig(),
             flightBeanBag.getCrlService(),
             flightBeanBag.getResourceDao(),
+            flightBeanBag.getLandingZoneApiDispatch(),
+            userRequest,
             this),
         cloudRetry);
     flight.addStep(
@@ -129,6 +133,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
             flightBeanBag.getAzureConfig(),
             flightBeanBag.getCrlService(),
             flightBeanBag.getResourceDao(),
+            flightBeanBag.getLandingZoneApiDispatch(),
             this),
         RetryRules.cloud());
   }
@@ -193,11 +198,6 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
       throw new InconsistentFieldsException("Expected CONTROLLED_AZURE_STORAGE_CONTAINER");
     }
 
-    if (getStorageAccountId() == null) {
-      throw new MissingRequiredFieldException(
-          "Missing required storage account ID field for ControlledAzureStorageContainer.");
-    }
-
     if (getStorageContainerName() == null) {
       throw new MissingRequiredFieldException(
           "Missing required storage container name field for ControlledAzureStorageContainer.");
@@ -214,14 +214,16 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
 
     ControlledAzureStorageContainerResource that = (ControlledAzureStorageContainerResource) o;
 
-    return storageAccountId.equals(that.getStorageAccountId())
+    return (storageAccountId == null || storageAccountId.equals(that.getStorageAccountId()))
         && storageContainerName.equals(that.getStorageContainerName());
   }
 
   @Override
   public int hashCode() {
     int result = super.hashCode();
-    result = 31 * result + storageAccountId.hashCode();
+    if (storageAccountId != null) {
+      result = 31 * result + storageAccountId.hashCode();
+    }
     result = 31 * result + storageContainerName.hashCode();
     return result;
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/CreateAzureStorageContainerStep.java
@@ -44,6 +44,7 @@ public class CreateAzureStorageContainerStep implements Step {
         crlService.getStorageManager(azureCloudContext, azureConfig);
 
     // The storage account name is stored by VerifyAzureStorageContainerCanBeCreated.
+    // It can be workspace managed storage account or landing zone shared storage account
     final String storageAccountName =
         context.getWorkingMap().get(ControlledResourceKeys.STORAGE_ACCOUNT_NAME, String.class);
     if (storageAccountName == null) {
@@ -69,7 +70,6 @@ public class CreateAzureStorageContainerStep implements Step {
                       .setStorageContainerName(resource.getStorageContainerName())
                       .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
                       .build()));
-
     } catch (ManagementException e) {
       logger.error(
           "Failed to create the Azure storage container '{}' with storage account with the ID '{}'. Error Code: {}",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -1,12 +1,18 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
 
+import bio.terra.common.iam.BearerToken;
+import bio.terra.landingzone.db.exception.LandingZoneNotFoundException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.resource.model.WsmResource;
@@ -15,6 +21,9 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.Contr
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.StorageManager;
+import com.azure.resourcemanager.storage.models.StorageAccount;
+import java.util.Optional;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,16 +35,19 @@ public class DeleteAzureStorageContainerStep implements Step {
   private final CrlService crlService;
   private final ControlledAzureStorageContainerResource resource;
   private final ResourceDao resourceDao;
+  private final LandingZoneApiDispatch landingZoneApiDispatch;
 
   public DeleteAzureStorageContainerStep(
       AzureConfiguration azureConfig,
       CrlService crlService,
       ResourceDao resourceDao,
+      LandingZoneApiDispatch landingZoneApiDispatch,
       ControlledAzureStorageContainerResource resource) {
     this.crlService = crlService;
     this.azureConfig = azureConfig;
     this.resource = resource;
     this.resourceDao = resourceDao;
+    this.landingZoneApiDispatch = landingZoneApiDispatch;
   }
 
   @Override
@@ -48,24 +60,63 @@ public class DeleteAzureStorageContainerStep implements Step {
     final StorageManager manager = crlService.getStorageManager(azureCloudContext, azureConfig);
 
     try {
-      WsmResource wsmResource =
-          resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
-      ControlledAzureStorageResource storageAccount =
-          wsmResource
-              .castToControlledResource()
-              .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+      String storageAccountName;
+      if (resource.getStorageAccountId() != null) {
+        WsmResource wsmResource =
+            resourceDao.getResource(resource.getWorkspaceId(), resource.getStorageAccountId());
+        ControlledAzureStorageResource storageAccount =
+            wsmResource
+                .castToControlledResource()
+                .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+        storageAccountName = storageAccount.getStorageAccountName();
+      } else {
+        try {
+          AuthenticatedUserRequest userRequest =
+              context
+                  .getInputParameters()
+                  .get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+
+          // Storage container was created based on landing zone shared storage account
+          UUID landingZoneId = landingZoneApiDispatch.getLandingZoneId(azureCloudContext);
+          Optional<ApiAzureLandingZoneDeployedResource> sharedStorageAccount =
+              landingZoneApiDispatch.getSharedStorageAccount(
+                  new BearerToken(userRequest.getRequiredToken()), landingZoneId);
+          if (sharedStorageAccount.isPresent()) {
+            StorageAccount storageAccount =
+                manager.storageAccounts().getById(sharedStorageAccount.get().getResourceId());
+            storageAccountName = storageAccount.name();
+          } else {
+            return new StepResult(
+                StepStatus.STEP_RESULT_FAILURE_FATAL,
+                new ResourceNotFoundException(
+                    String.format(
+                        "Shared storage account not found in landing zone. Landing zone ID='%s'.",
+                        landingZoneId)));
+          }
+        } catch (IllegalStateException illegalStateException) { // Thrown by landingZoneApiDispatch
+          return new StepResult(
+              StepStatus.STEP_RESULT_FAILURE_FATAL,
+              new LandingZoneNotFoundException(
+                  String.format(
+                      "Landing zone associated with the Azure cloud context not found. TenantId='%s', SubscriptionId='%s', ResourceGroupId='%s'",
+                      azureCloudContext.getAzureTenantId(),
+                      azureCloudContext.getAzureSubscriptionId(),
+                      azureCloudContext.getAzureResourceGroupId())));
+        }
+      }
 
       logger.info(
           "Attempting to delete storage container '{}' in account '{}'",
           resource.getStorageContainerName(),
-          storageAccount.getStorageAccountName());
+          storageAccountName);
       manager
           .blobContainers()
           .delete(
               azureCloudContext.getAzureResourceGroupId(),
-              storageAccount.getStorageAccountName(),
+              storageAccountName,
               resource.getStorageContainerName());
       return StepResult.getStepResultSuccess();
+
     } catch (
         ResourceNotFoundException resourceNotFoundException) { // Thrown by resourceDao.getResource
       return new StepResult(
@@ -81,6 +132,15 @@ public class DeleteAzureStorageContainerStep implements Step {
           ex.getValue().getCode(),
           ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+    } catch (IllegalStateException illegalStateException) { // Thrown by landingZoneApiDispatch
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new LandingZoneNotFoundException(
+              String.format(
+                  "Landing zone associated with the Azure cloud context not found. TenantId='%s', SubscriptionId='%s', ResourceGroupId='%s'",
+                  azureCloudContext.getAzureTenantId(),
+                  azureCloudContext.getAzureSubscriptionId(),
+                  azureCloudContext.getAzureResourceGroupId())));
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/resourcemanager/data/BaseStorageContainerRequestData.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.storageConta
 import bio.terra.cloudres.azure.resourcemanager.common.ResourceManagerRequestData;
 import com.google.gson.JsonObject;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 /**
  * Extends {@link ResourceManagerRequestData} to add common fields for working with the Storage
@@ -22,6 +23,7 @@ public abstract class BaseStorageContainerRequestData implements ResourceManager
   public abstract String resourceGroupName();
 
   /** The storage account resource ID. */
+  @Nullable
   public abstract UUID storageAccountId();
 
   /**
@@ -32,7 +34,9 @@ public abstract class BaseStorageContainerRequestData implements ResourceManager
     JsonObject requestData = new JsonObject();
     requestData.addProperty("resourceGroupName", resourceGroupName());
     requestData.addProperty("storageContainerName", storageContainerName());
-    requestData.addProperty("storageAccountId", storageAccountId().toString());
+    if (storageAccountId() != null) {
+      requestData.addProperty("storageAccountId", storageAccountId().toString());
+    }
     return requestData;
   }
 }

--- a/service/src/test/java/bio/terra/workspace/connected/LandingZoneTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/LandingZoneTestUtils.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("connected-test")
+@Profile("azure-test")
 public class LandingZoneTestUtils {
   @Value("${workspace.azure-test.default-landing-zone-id}")
   private String defaultLandingZoneId;

--- a/service/src/test/java/bio/terra/workspace/connected/LandingZoneTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/LandingZoneTestUtils.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Profile("connected-test")
 public class LandingZoneTestUtils {
-  @Value("${workspace.connected-test.default-landing-zone-id}")
+  @Value("${workspace.azure-test.default-landing-zone-id}")
   private String defaultLandingZoneId;
 
   public String getDefaultLandingZoneId() {

--- a/service/src/test/java/bio/terra/workspace/connected/LandingZoneTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/LandingZoneTestUtils.java
@@ -1,0 +1,16 @@
+package bio.terra.workspace.connected;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("connected-test")
+public class LandingZoneTestUtils {
+  @Value("${workspace.connected-test.default-landing-zone-id}")
+  private String defaultLandingZoneId;
+
+  public String getDefaultLandingZoneId() {
+    return defaultLandingZoneId;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -335,7 +335,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     testLandingZoneManager.createLandingZoneWithSharedStorageAccount(
         landingZoneId, storageAccountName, "eastus");
 
-    Thread.sleep(60000);
+    TimeUnit.MINUTES.sleep(1);
 
     // Submit a storage container creation flight and then verify the resource exists in the
     // workspace.
@@ -364,7 +364,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
         containerResource,
         WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
 
-    Thread.sleep(60000);
+    TimeUnit.MINUTES.sleep(1);
 
     // clean up resources - delete storage container resource
     submitControlledResourceDeletionFlight(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -2,15 +2,20 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import bio.terra.landingzone.db.LandingZoneDao;
+import bio.terra.landingzone.db.exception.LandingZoneNotFoundException;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureTestUtils;
 import bio.terra.workspace.common.utils.AzureVmUtils;
+import bio.terra.workspace.connected.LandingZoneTestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.*;
+import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.WsmResourceService;
@@ -29,6 +34,7 @@ import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
@@ -54,10 +60,14 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
   @Autowired private WorkspaceService workspaceService;
   @Autowired private JobService jobService;
   @Autowired private AzureTestUtils azureTestUtils;
+  @Autowired private LandingZoneTestUtils landingZoneTestUtils;
   @Autowired private UserAccessUtils userAccessUtils;
   @Autowired private ControlledResourceService controlledResourceService;
   @Autowired private WsmResourceService wsmResourceService;
   @Autowired private AzureCloudContextService azureCloudContextService;
+  @Autowired private LandingZoneDao landingZoneDao;
+  @Autowired private CrlService crlService;
+  @Autowired private AzureConfiguration azureConfig;
 
   private void createCloudContext(UUID workspaceUuid, AuthenticatedUserRequest userRequest)
       throws InterruptedException {
@@ -303,6 +313,176 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
                         accountResource.getStorageAccountName(),
                         containerName));
     assertEquals(404, exception.getResponse().getStatusCode());
+  }
+
+  @Test
+  public void createAndDeleteAzureStorageContainerBasedOnLandingZoneSharedStorageAccount()
+      throws InterruptedException {
+    String storageAccountName = "lzsharedstorageaccount";
+
+    Workspace workspace = azureTestUtils.createWorkspace(workspaceService);
+    UUID workspaceUuid = workspace.getWorkspaceId();
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
+
+    // create quasi landing zone with a single resource - shared storage account
+    UUID landingZoneId = UUID.fromString(landingZoneTestUtils.getDefaultLandingZoneId());
+
+    TestLandingZoneManager testLandingZoneManager =
+        new TestLandingZoneManager(
+            azureCloudContextService, landingZoneDao, crlService, azureConfig, workspaceUuid);
+
+    testLandingZoneManager.createLandingZoneWithSharedStorageAccount(
+        landingZoneId, storageAccountName, "eastus");
+
+    Thread.sleep(60000);
+
+    // Submit a storage container creation flight and then verify the resource exists in the
+    // workspace.
+    final UUID containerResourceId = UUID.randomUUID();
+    final String storageContainerName = ControlledResourceFixtures.uniqueBucketName();
+    ControlledAzureStorageContainerResource containerResource =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(containerResourceId)
+                    .name(getAzureName("rc"))
+                    .description(getAzureName("rc-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            /*set it explicitly to show that landing zone shared storage account will be used*/
+            .storageAccountId(null)
+            .storageContainerName(storageContainerName)
+            .build();
+
+    createResource(
+        workspaceUuid,
+        userRequest,
+        containerResource,
+        WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
+
+    Thread.sleep(60000);
+
+    // clean up resources - delete storage container resource
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        containerResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        containerResource.getStorageContainerName(),
+        null); // Don't sleep/verify deletion yet.
+
+    // clean up resources - delete lz database record and storage account
+    testLandingZoneManager.deleteLandingZoneWithSharedStorageAccount(
+        landingZoneId,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        storageAccountName);
+  }
+
+  @Test
+  public void createAzureStorageContainerFlightFailedBecauseLandingZoneDoesntExist()
+      throws InterruptedException {
+    Workspace workspace = azureTestUtils.createWorkspace(workspaceService);
+    UUID workspaceUuid = workspace.getWorkspaceId();
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
+
+    // landing zone doesn't exist
+
+    // Submit a storage container creation flight and then verify the resource exists in the
+    // workspace.
+    final UUID containerResourceId = UUID.randomUUID();
+    final String storageContainerName = ControlledResourceFixtures.uniqueBucketName();
+    ControlledAzureStorageContainerResource containerResource =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(containerResourceId)
+                    .name(getAzureName("rc"))
+                    .description(getAzureName("rc-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            /*set it explicitly to show that landing zone shared storage account will be used*/
+            .storageAccountId(null)
+            .storageContainerName(storageContainerName)
+            .build();
+
+    FlightState flightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceUuid, userRequest, containerResource, null),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+
+    assertEquals(FlightStatus.ERROR, flightState.getFlightStatus());
+    assertTrue(flightState.getException().isPresent());
+    assertEquals(flightState.getException().get().getClass(), LandingZoneNotFoundException.class);
+
+    // no need to clean up resources
+  }
+
+  @Test
+  public void
+      createAzureStorageContainerFlightFailedBecauseLandingZoneDoesntHaveSharedStorageAccount()
+          throws InterruptedException {
+    Workspace workspace = azureTestUtils.createWorkspace(workspaceService);
+    UUID workspaceUuid = workspace.getWorkspaceId();
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
+
+    // create quasi landing zone without resources
+    UUID landingZoneId = UUID.fromString(landingZoneTestUtils.getDefaultLandingZoneId());
+
+    TestLandingZoneManager testLandingZoneManager =
+        new TestLandingZoneManager(
+            azureCloudContextService, landingZoneDao, crlService, azureConfig, workspaceUuid);
+
+    testLandingZoneManager.createLandingZoneWithoutResources(landingZoneId);
+
+    // Submit a storage container creation flight and then verify the resource exists in the
+    // workspace.
+    final UUID containerResourceId = UUID.randomUUID();
+    final String storageContainerName = ControlledResourceFixtures.uniqueBucketName();
+    ControlledAzureStorageContainerResource containerResource =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(containerResourceId)
+                    .name(getAzureName("rc"))
+                    .description(getAzureName("rc-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            /*set it explicitly to show that landing zone shared storage account will be used*/
+            .storageAccountId(null)
+            .storageContainerName(storageContainerName)
+            .build();
+
+    FlightState flightState =
+        StairwayTestUtils.blockUntilFlightCompletes(
+            jobService.getStairway(),
+            CreateControlledResourceFlight.class,
+            azureTestUtils.createControlledResourceInputParameters(
+                workspaceUuid, userRequest, containerResource, null),
+            STAIRWAY_FLIGHT_TIMEOUT,
+            null);
+
+    assertEquals(FlightStatus.ERROR, flightState.getFlightStatus());
+    assertTrue(flightState.getException().isPresent());
+    assertEquals(flightState.getException().get().getClass(), ResourceNotFoundException.class);
+
+    // clean up resources - delete lz database record only
+    testLandingZoneManager.deleteLandingZoneWithoutResources(landingZoneId);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
@@ -1,0 +1,125 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import bio.terra.cloudres.azure.resourcemanager.common.Defaults;
+import bio.terra.landingzone.db.LandingZoneDao;
+import bio.terra.landingzone.db.model.LandingZone;
+import bio.terra.landingzone.library.landingzones.deployment.LandingZoneTagKeys;
+import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.resourcemanager.data.CreateStorageAccountRequestData;
+import bio.terra.workspace.service.workspace.AzureCloudContextService;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.Region;
+import com.azure.resourcemanager.storage.StorageManager;
+import com.azure.resourcemanager.storage.models.StorageAccount;
+import java.util.UUID;
+
+/**
+ * This class allows creating 2 different landing zones. It is created for integration test purposes
+ * only. It simplifies process of creation/deletion of a landing zone with custom resources without
+ * using high-level LZ API. This class might be improved/refactored in future if we need to handle
+ * wide range of different LZs. Currently, it has 2 sets of symmetrical create/delete operations for
+ * 2 different LZs.
+ *
+ * <p>We are cheating here when creating landing zone. One of the main reason is that LZ service has
+ * limited number of available landing zones for creation and also LZ service doesn't have LZ delete
+ * operation implemented yet. In this particular case we don't need to use high-level LZ service
+ * API. Here we mimic landing zone creation/deletion process by using LZ low-level api:
+ *
+ * <p>-register landing zone in LZ database
+ *
+ * <p>-create shared storage account with appropriate tags
+ */
+public class TestLandingZoneManager {
+  private final AzureCloudContextService azureCloudContextService;
+  private final LandingZoneDao landingZoneDao;
+  private final CrlService crlService;
+  private final AzureConfiguration azureConfig;
+  private final UUID workspaceUuid;
+  private final AzureCloudContext azureCloudContext;
+  private final StorageManager storageManager;
+
+  public TestLandingZoneManager(
+      AzureCloudContextService azureCloudContextService,
+      LandingZoneDao landingZoneDao,
+      CrlService crlService,
+      AzureConfiguration azureConfig,
+      UUID workspaceUuid) {
+    this.azureCloudContextService = azureCloudContextService;
+    this.landingZoneDao = landingZoneDao;
+    this.crlService = crlService;
+    this.azureConfig = azureConfig;
+    this.workspaceUuid = workspaceUuid;
+
+    azureCloudContext = azureCloudContextService.getAzureCloudContext(workspaceUuid).orElse(null);
+    assertNotNull(azureCloudContext, "Azure cloud context should exist. Make sure it was created.");
+
+    storageManager = crlService.getStorageManager(azureCloudContext, azureConfig);
+  }
+
+  public void createLandingZoneWithSharedStorageAccount(
+      UUID landingZoneId, String storageAccountName, String region) {
+    createLandingZoneDbRecord(landingZoneId);
+    createStorageAccount(storageAccountName, region, landingZoneId);
+  }
+
+  public void deleteLandingZoneWithSharedStorageAccount(
+      UUID landingZoneId, String azureResourceGroup, String storageAccountName) {
+    landingZoneDao.deleteLandingZone(landingZoneId);
+
+    storageManager.storageAccounts().deleteByResourceGroup(azureResourceGroup, storageAccountName);
+  }
+
+  public void createLandingZoneWithoutResources(UUID landingZoneId) {
+    createLandingZoneDbRecord(landingZoneId);
+  }
+
+  public void deleteLandingZoneWithoutResources(UUID landingZoneId) {
+    landingZoneDao.deleteLandingZone(landingZoneId);
+  }
+
+  private void createLandingZoneDbRecord(UUID landingZoneId) {
+    String definition = "QuasiLandingZoneWithSharedStorageAccount";
+    String version = "v1";
+    // create record in LZ database
+    landingZoneDao.createLandingZone(
+        LandingZone.builder()
+            .landingZoneId(landingZoneId)
+            .definition(definition)
+            .version(version)
+            .description(String.format("Definition:%s Version:%s", definition, version))
+            .displayName(definition)
+            .properties(null)
+            .resourceGroupId(azureCloudContext.getAzureResourceGroupId())
+            .subscriptionId(azureCloudContext.getAzureSubscriptionId())
+            .tenantId(azureCloudContext.getAzureTenantId())
+            .build());
+  }
+
+  private StorageAccount createStorageAccount(
+      String storageAccountName, String region, UUID landingZoneId) {
+    StorageAccount storageAccount =
+        storageManager
+            .storageAccounts()
+            .define(storageAccountName)
+            .withRegion(region)
+            .withExistingResourceGroup(azureCloudContext.getAzureResourceGroupId())
+            .withHnsEnabled(true)
+            .withTag("workspaceId", workspaceUuid.toString())
+            .withTag(LandingZoneTagKeys.LANDING_ZONE_ID.toString(), landingZoneId.toString())
+            .withTag(
+                LandingZoneTagKeys.LANDING_ZONE_PURPOSE.toString(),
+                ResourcePurpose.SHARED_RESOURCE.toString())
+            .create(
+                Defaults.buildContext(
+                    CreateStorageAccountRequestData.builder()
+                        .setName(storageAccountName)
+                        .setRegion(Region.fromName(region))
+                        .setResourceGroupName(azureCloudContext.getAzureResourceGroupId())
+                        .build()));
+    return storageAccount;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStepTest.java
@@ -1,0 +1,189 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.landingzone.db.exception.LandingZoneNotFoundException;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
+import bio.terra.workspace.generated.model.ApiAzureStorageContainerCreationParameters;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.job.JobMapKeys;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.BaseStorageStepTest;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.resourcemanager.storage.models.BlobContainers;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+public class DeleteAzureStorageContainerStepTest extends BaseStorageStepTest {
+  @Mock private BlobContainers mockBlobContainers;
+  @Mock private ResourceDao mockResourceDao;
+  @Mock private LandingZoneApiDispatch mockLandingZoneApiDispatch;
+  @Mock private FlightMap mockFlightMap;
+  @Mock private AuthenticatedUserRequest mockAuthenticatedUserRequest;
+
+  @Captor ArgumentCaptor<String> resourceGroupNameCaptor;
+  @Captor ArgumentCaptor<String> accountNameCaptor;
+  @Captor ArgumentCaptor<String> containerNameCaptor;
+
+  private final ApiAzureStorageContainerCreationParameters creationParameters =
+      ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
+  private final String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
+  private final ControlledAzureStorageResource storageAccountResource =
+      ControlledResourceFixtures.getAzureStorage(storageAccountName, "mockRegion");
+  private ControlledAzureStorageContainerResource storageContainerResource;
+  private DeleteAzureStorageContainerStep deleteAzureStorageContainerStep;
+
+  @BeforeEach
+  public void setup() {
+    super.setup();
+    when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
+    setupFlightContext();
+  }
+
+  private void initDeleteValidationStep(Optional<UUID> storageAccountId) {
+    storageContainerResource =
+        ControlledResourceFixtures.getAzureStorageContainer(
+            storageAccountId.orElse(null), creationParameters.getStorageContainerName());
+
+    deleteAzureStorageContainerStep =
+        new DeleteAzureStorageContainerStep(
+            mockAzureConfig,
+            mockCrlService,
+            mockResourceDao,
+            mockLandingZoneApiDispatch,
+            storageContainerResource);
+  }
+
+  private void setupFlightContext() {
+    when(mockAuthenticatedUserRequest.getRequiredToken()).thenReturn("FAKE_TOKEN");
+    when(mockFlightMap.get(
+            eq(JobMapKeys.AUTH_USER_INFO.getKeyName()), eq(AuthenticatedUserRequest.class)))
+        .thenReturn(mockAuthenticatedUserRequest);
+    when(mockFlightContext.getInputParameters()).thenReturn(mockFlightMap);
+  }
+
+  @Test
+  public void deleteStorageAccountContainerControlledByWsmStorageAccountSuccess()
+      throws InterruptedException {
+    initDeleteValidationStep(Optional.of(creationParameters.getStorageAccountId()));
+    when(mockResourceDao.getResource(
+            storageContainerResource.getWorkspaceId(), creationParameters.getStorageAccountId()))
+        .thenReturn(storageAccountResource);
+
+    // act
+    final StepResult stepResult = deleteAzureStorageContainerStep.doStep(mockFlightContext);
+
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+
+    verify(mockBlobContainers, times(1))
+        .delete(
+            resourceGroupNameCaptor.capture(),
+            accountNameCaptor.capture(),
+            containerNameCaptor.capture());
+    assertThat(
+        resourceGroupNameCaptor.getValue(),
+        equalTo(mockAzureCloudContext.getAzureResourceGroupId()));
+    assertThat(
+        accountNameCaptor.getValue(), equalTo(storageAccountResource.getStorageAccountName()));
+    assertThat(
+        containerNameCaptor.getValue(),
+        equalTo(storageContainerResource.getStorageContainerName()));
+  }
+
+  @Test
+  public void deleteStorageAccountContainerControlledByLzStorageAccountSuccess()
+      throws InterruptedException {
+    UUID landingZoneId = UUID.randomUUID();
+    initDeleteValidationStep(Optional.empty());
+
+    when(mockLandingZoneApiDispatch.getLandingZoneId(any(AzureCloudContext.class)))
+        .thenReturn(landingZoneId);
+    ApiAzureLandingZoneDeployedResource mockSharedStorageAccount =
+        mock(ApiAzureLandingZoneDeployedResource.class);
+    String sharedAccountId = UUID.randomUUID().toString();
+    when(mockSharedStorageAccount.getResourceId()).thenReturn(sharedAccountId);
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(
+            any(BearerToken.class), eq(landingZoneId)))
+        .thenReturn(Optional.of(mockSharedStorageAccount));
+    String sharedStorageAccountName = "sharedStorageAccount";
+    when(mockStorageAccount.name()).thenReturn(sharedStorageAccountName);
+    when(mockStorageAccounts.getById(sharedAccountId)).thenReturn(mockStorageAccount);
+
+    // act
+    final StepResult stepResult = deleteAzureStorageContainerStep.doStep(mockFlightContext);
+
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+
+    verify(mockBlobContainers, times(1))
+        .delete(
+            resourceGroupNameCaptor.capture(),
+            accountNameCaptor.capture(),
+            containerNameCaptor.capture());
+    assertThat(
+        resourceGroupNameCaptor.getValue(),
+        equalTo(mockAzureCloudContext.getAzureResourceGroupId()));
+    assertThat(accountNameCaptor.getValue(), equalTo(sharedStorageAccountName));
+    assertThat(
+        containerNameCaptor.getValue(),
+        equalTo(storageContainerResource.getStorageContainerName()));
+  }
+
+  @Test
+  public void deleteStorageAccountContainerControlledByLzStorageAccountFailure_NoLandingZone()
+      throws InterruptedException {
+    initDeleteValidationStep(Optional.empty());
+
+    when(mockLandingZoneApiDispatch.getLandingZoneId(any(AzureCloudContext.class)))
+        .thenThrow(
+            new IllegalStateException(
+                "Could not find a landing zone id for the given Azure context. "
+                    + "Please check that the landing zone deployment is complete."));
+
+    // act
+    final StepResult stepResult = deleteAzureStorageContainerStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(LandingZoneNotFoundException.class));
+  }
+
+  @Test
+  public void
+      deleteStorageAccountContainerControlledByLzStorageAccountFailure_NoSharedStorageAccount()
+          throws InterruptedException {
+    UUID landingZoneId = UUID.randomUUID();
+    initDeleteValidationStep(Optional.empty());
+
+    when(mockLandingZoneApiDispatch.getLandingZoneId(any(AzureCloudContext.class)))
+        .thenReturn(landingZoneId);
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(
+            any(BearerToken.class), eq(landingZoneId)))
+        .thenReturn(Optional.empty());
+
+    // act
+    final StepResult stepResult = deleteAzureStorageContainerStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(ResourceNotFoundException.class));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStepTest.java
@@ -3,14 +3,25 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.storageConta
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.iam.BearerToken;
+import bio.terra.landingzone.db.exception.LandingZoneNotFoundException;
+import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.ManagementExceptionUtils;
 import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
+import bio.terra.workspace.generated.model.ApiAzureLandingZoneResourcesList;
+import bio.terra.workspace.generated.model.ApiAzureLandingZoneResourcesPurposeGroup;
 import bio.terra.workspace.generated.model.ApiAzureStorageContainerCreationParameters;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.BaseStorageStepTest;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
@@ -20,6 +31,10 @@ import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.models.BlobContainer;
 import com.azure.resourcemanager.storage.models.BlobContainers;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -29,13 +44,16 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
   @Mock private BlobContainers mockBlobContainers;
   @Mock private BlobContainer mockBlobContainer;
   @Mock private ResourceDao mockResourceDao;
+  @Mock private LandingZoneApiDispatch mockLandingZoneApiDispatch;
+  @Mock private AuthenticatedUserRequest mockUserRequest;
+
+  private static final UUID LANDING_ZONE_ID =
+      UUID.fromString("b2db9b47-fd0f-4ae9-b9b4-f675550b0291");
 
   private final String storageAccountName = ControlledResourceFixtures.uniqueStorageAccountName();
   final ApiAzureStorageContainerCreationParameters creationParameters =
       ControlledResourceFixtures.getAzureStorageContainerCreationParameters();
-  final ControlledAzureStorageContainerResource storageContainerResource =
-      ControlledResourceFixtures.getAzureStorageContainer(
-          creationParameters.getStorageAccountId(), creationParameters.getStorageContainerName());
+  private ControlledAzureStorageContainerResource storageContainerResource;
   private final ControlledAzureStorageResource storageAccountResource =
       ControlledResourceFixtures.getAzureStorage(storageAccountName, "mockRegion");
   private final ManagementException containerNotFoundException =
@@ -51,9 +69,21 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
   public void setup() {
     super.setup();
     when(mockStorageManager.blobContainers()).thenReturn(mockBlobContainers);
+  }
+
+  private void initValidationStep(Optional<UUID> storageAccountId) {
+    storageContainerResource =
+        ControlledResourceFixtures.getAzureStorageContainer(
+            storageAccountId.orElse(null), creationParameters.getStorageContainerName());
+
     verifyCanBeCreatedStep =
         new VerifyAzureStorageContainerCanBeCreatedStep(
-            mockAzureConfig, mockCrlService, mockResourceDao, storageContainerResource);
+            mockAzureConfig,
+            mockCrlService,
+            mockResourceDao,
+            mockLandingZoneApiDispatch,
+            mockUserRequest,
+            storageContainerResource);
   }
 
   private void mockStorageAccountExists() {
@@ -71,6 +101,7 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
 
   @Test
   public void getStorageContainer_containerCanBeCreated() throws InterruptedException {
+    initValidationStep(Optional.of(creationParameters.getStorageAccountId()));
     mockStorageAccountExists();
 
     // The storage container must not already exist.
@@ -87,8 +118,33 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
   }
 
   @Test
+  public void getStorageContainer_containerCanBeCreatedBasedOnLandingZoneSharedStorageAccount()
+      throws InterruptedException {
+    initValidationStep(Optional.empty());
+
+    when(mockLandingZoneApiDispatch.getLandingZoneId(any())).thenReturn(LANDING_ZONE_ID);
+    ApiAzureLandingZoneDeployedResource mockSharedStorageAccount =
+        mock(ApiAzureLandingZoneDeployedResource.class);
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(
+            any(BearerToken.class), eq(LANDING_ZONE_ID)))
+        .thenReturn(Optional.of(mockSharedStorageAccount));
+    String sharedAccountId = UUID.randomUUID().toString();
+    when(mockSharedStorageAccount.getResourceId()).thenReturn(sharedAccountId);
+    String sharedStorageAccountName = "sharedStorageAccount";
+    when(mockStorageAccount.name()).thenReturn(sharedStorageAccountName);
+    when(mockStorageAccounts.getById(sharedAccountId)).thenReturn(mockStorageAccount);
+    when(mockUserRequest.getRequiredToken()).thenReturn("FAKE_TOKEN");
+
+    // act
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
+
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+  }
+
+  @Test
   public void getStorageAccountContainer_storageAccountDoesNotExistInWSM()
       throws InterruptedException {
+    initValidationStep(Optional.of(creationParameters.getStorageAccountId()));
     // Storage account doesn't exist in WSM
     when(mockResourceDao.getResource(
             storageContainerResource.getWorkspaceId(), creationParameters.getStorageAccountId()))
@@ -104,6 +160,7 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
   @Test
   public void getStorageAccountContainer_storageAccountDoesNotExistInAzure()
       throws InterruptedException {
+    initValidationStep(Optional.of(creationParameters.getStorageAccountId()));
     // Storage account exists in WSM.
     when(mockResourceDao.getResource(
             storageContainerResource.getWorkspaceId(), creationParameters.getStorageAccountId()))
@@ -122,7 +179,44 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
   }
 
   @Test
+  public void getStorageAccountContainer_landingZoneDoesntExist() throws InterruptedException {
+    initValidationStep(Optional.empty());
+
+    // there are no landing zone association with azure cloud context
+    when(mockLandingZoneApiDispatch.getLandingZoneId(any()))
+        .thenThrow(
+            new IllegalStateException(
+                "Could not find a landing zone id for the given Azure context. "
+                    + "Please check that the landing zone deployment is complete."));
+
+    // act
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(LandingZoneNotFoundException.class));
+  }
+
+  @Test
+  public void getStorageAccountContainer_landingZoneDoesntHaveSharedStorageAccount()
+      throws InterruptedException {
+    initValidationStep(Optional.empty());
+
+    when(mockLandingZoneApiDispatch.getLandingZoneId(any())).thenReturn(LANDING_ZONE_ID);
+    when(mockLandingZoneApiDispatch.getSharedStorageAccount(
+            any(BearerToken.class), eq(LANDING_ZONE_ID)))
+        .thenReturn(Optional.empty());
+    when(mockUserRequest.getRequiredToken()).thenReturn("FAKE_TOKEN");
+
+    // act
+    final StepResult stepResult = verifyCanBeCreatedStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(stepResult.getException().get(), instanceOf(ResourceNotFoundException.class));
+  }
+
+  @Test
   public void getStorageContainer_containerAlreadyExists() throws InterruptedException {
+    initValidationStep(Optional.of(creationParameters.getStorageAccountId()));
     mockStorageAccountExists();
 
     // A storage container with this name already exists.
@@ -137,5 +231,57 @@ public class VerifyAzureStorageContainerCanBeCreatedStepTest extends BaseStorage
     // Verify step fails.
     assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
     assertThat(stepResult.getException().get(), instanceOf(DuplicateResourceException.class));
+  }
+
+  private ApiAzureLandingZoneResourcesList getExistingLandingZoneResources() {
+    List<ApiAzureLandingZoneDeployedResource> landingZoneDeployedResourcesWithSharedPurpose =
+        Collections.singletonList(
+            new ApiAzureLandingZoneDeployedResource()
+                .resourceId("resourceId")
+                .resourceType(
+                    VerifyAzureStorageContainerCanBeCreatedStep.AZURE_STORAGE_ACCOUNT_RESOURCE_TYPE)
+                .region("us-west-2")
+                .resourceName("sharedStorageAccount"));
+    ApiAzureLandingZoneResourcesPurposeGroup landingZoneSharedResourcesPurposeGroup =
+        new ApiAzureLandingZoneResourcesPurposeGroup()
+            .purpose(ResourcePurpose.SHARED_RESOURCE.toString())
+            .deployedResources(landingZoneDeployedResourcesWithSharedPurpose);
+
+    List<ApiAzureLandingZoneDeployedResource> landingZoneDeployedResourcesWithDifferentPurpose =
+        Collections.singletonList(
+            new ApiAzureLandingZoneDeployedResource()
+                .resourceId("resourceId")
+                .resourceType("Microsoft.Storage/otherResource")
+                .region("us-west-2")
+                .resourceName("otherResourceName"));
+    ApiAzureLandingZoneResourcesPurposeGroup landingZoneOtherPurposeResourcesPurposeGroup =
+        new ApiAzureLandingZoneResourcesPurposeGroup()
+            .purpose("OTHER_PURPOSE")
+            .deployedResources(landingZoneDeployedResourcesWithDifferentPurpose);
+
+    List<ApiAzureLandingZoneResourcesPurposeGroup> resourceGroupList =
+        List.of(
+            landingZoneSharedResourcesPurposeGroup, landingZoneOtherPurposeResourcesPurposeGroup);
+
+    return new ApiAzureLandingZoneResourcesList().id(LANDING_ZONE_ID).resources(resourceGroupList);
+  }
+
+  private ApiAzureLandingZoneResourcesList getLandingZoneWithoutSharedStorageAccount() {
+    List<ApiAzureLandingZoneDeployedResource> landingZoneDeployedResourcesWithDifferentPurpose =
+        Collections.singletonList(
+            new ApiAzureLandingZoneDeployedResource()
+                .resourceId("resourceId")
+                .resourceType("Microsoft.Storage/otherResource")
+                .region("us-west-2")
+                .resourceName("otherResourceName"));
+    ApiAzureLandingZoneResourcesPurposeGroup landingZoneOtherPurposeResourcesPurposeGroup =
+        new ApiAzureLandingZoneResourcesPurposeGroup()
+            .purpose("OTHER_PURPOSE")
+            .deployedResources(landingZoneDeployedResourcesWithDifferentPurpose);
+
+    List<ApiAzureLandingZoneResourcesPurposeGroup> resourceGroupList =
+        List.of(landingZoneOtherPurposeResourcesPurposeGroup);
+
+    return new ApiAzureLandingZoneResourcesList().id(LANDING_ZONE_ID).resources(resourceGroupList);
   }
 }

--- a/service/src/test/resources/application-azure-test.yml
+++ b/service/src/test/resources/application-azure-test.yml
@@ -9,6 +9,10 @@ workspace:
     # MRG
     managed-resource-group-id: mrg-terra-integration-test-20211118
 
+    # default landing zone id value. This static value allows setting permission in SAM for LZ operation
+    #for user with 'default-user-email'
+    default-landing-zone-id: 435afea6-63b2-4a60-8e6e-9dbf294b783a
+
 feature:
   # Enable azure support when running azure tests
   azure-enabled: true

--- a/service/src/test/resources/application-connected-test.yml
+++ b/service/src/test/resources/application-connected-test.yml
@@ -6,9 +6,6 @@ workspace:
     user-delegated-service-account-path: ../config/user-delegated-sa.json
     default-user-email: elijah.thunderlord@test.firecloud.org
     second-user-email: liam.dragonmaw@test.firecloud.org
-    # default landing zone id value. This static value allows setting permission in SAM for LZ operation
-    #for user with 'default-user-email'
-    default-landing-zone-id: 435afea6-63b2-4a60-8e6e-9dbf294b783a
 
   crl:
     use-crl: true

--- a/service/src/test/resources/application-connected-test.yml
+++ b/service/src/test/resources/application-connected-test.yml
@@ -6,6 +6,9 @@ workspace:
     user-delegated-service-account-path: ../config/user-delegated-sa.json
     default-user-email: elijah.thunderlord@test.firecloud.org
     second-user-email: liam.dragonmaw@test.firecloud.org
+    # default landing zone id value. This static value allows setting permission in SAM for LZ operation
+    #for user with 'default-user-email'
+    default-landing-zone-id: 435afea6-63b2-4a60-8e6e-9dbf294b783a
 
   crl:
     use-crl: true


### PR DESCRIPTION
This PR addresses new requirements for Azure storage container creation process. Now it is possible to reuse shared storage account from landing zone to create associated container.
Changes:
-Storage container REST API: storageAccountId is not required
-Update logic for Verify step within azure storage container creation flight
-Update logic for Delete step within azure storage container deletion flight