### PR TITLE
[PF-2096] Enable clone of Rawls workspaces

### DIFF
--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -336,10 +336,7 @@ components:
           type: string
           format: uuid
         destinationUserFacingId:
-          description: |
-            Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers,
-            dashes, or underscores, and start with lowercase letter or number.
-          type: string
+          $ref: '#/components/schemas/UserFacingId'
         resources:
           type: array
           items:
@@ -360,12 +357,13 @@ components:
       required:
         - spendProfile
       properties:
-        userFacingId:
+        destinationWorkspaceId:
           description: |
-            Human-settable, mutable id for cloned workspace. Must have 3-63 characters, contain lowercase letters, numbers,
-            dashes, or underscores, and start with lowercase letter or number. Optional. If this isn't set, one will be
-            generated.
+            Optional identifier for the destination workspace. If not present, a UUID is generated
           type: string
+          format: uuid
+        userFacingId:
+          $ref: '#/components/schemas/UserFacingId'
         displayName:
           description: The human readable name of the workspace
           type: string
@@ -380,11 +378,6 @@ components:
             GCP Location to use for cloud-based resources. If omitted, the location of the source
             resource will be used.
           type: string
-        destinationWorkspaceId:
-          description: |
-            Optional identifier for the destination workspace. If not present, a UUID is generated
-          type: string
-          format: uuid
 
     ResourceCloneDetails:
       description: >-
@@ -448,11 +441,7 @@ components:
           type: string
           format: uuid
         userFacingId:
-          description: |
-            Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter or number. Optional. If this isn't set, one will be generated based on
-            id (uuid).
-          type: string
+          $ref: '#/components/schemas/UserFacingId'
         displayName:
           description: The human readable name of the workspace
           type: string
@@ -505,16 +494,19 @@ components:
       type: object
       properties:
         userFacingId:
-          description: |
-            Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter or number.
-          type: string
+          $ref: '#/components/schemas/UserFacingId'
         displayName:
           description: The human readable name of the workspace
           type: string
         description:
           description: A description of the workspace
           type: string
+
+    UserFacingId:
+      description: |
+        Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
+        underscores, and start with lowercase letter or number.
+      type: string
 
     WorkspaceDescription:
       type: object
@@ -525,10 +517,7 @@ components:
           type: string
           format: uuid
         userFacingId:
-          description: |
-            Human-settable, mutable id. Must have 3-63 characters, contain lowercase letters, numbers, dashes, or
-            underscores, and start with lowercase letter or number.
-          type: string
+          $ref: '#/components/schemas/UserFacingId'
         displayName:
           description: The human readable name of the workspace
           type: string

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -354,7 +354,7 @@ components:
         
     CloneWorkspaceRequest:
       description: >-
-        Request body for cloning an entire workspace. The stage is always MC. Cloning instructions
+        Request body for cloning an entire workspace. Cloning instructions
         are taken from individual resources.
       type: object
       required:
@@ -380,6 +380,11 @@ components:
             GCP Location to use for cloud-based resources. If omitted, the location of the source
             resource will be used.
           type: string
+        destinationWorkspaceId:
+          description: |
+            Optional identifier for the destination workspace. If not present, a UUID is generated
+          type: string
+          format: uuid
 
     ResourceCloneDetails:
       description: >-

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -62,7 +62,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserAccessUtils userAccessUtils;
 
-  private ApiWorkspaceDescription workspace;
+  private ApiCreatedWorkspace workspace;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -137,9 +137,12 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Test
   public void getWorkspaceByUserFacingId_requesterIsOwner_returnsFullWorkspace() throws Exception {
+    ApiWorkspaceDescription workspaceDescription =
+        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+
     ApiWorkspaceDescription gotWorkspace =
         getWorkspaceByUserFacingId(
-            userAccessUtils.defaultUserAuthRequest(), workspace.getUserFacingId());
+            userAccessUtils.defaultUserAuthRequest(), workspaceDescription.getUserFacingId());
 
     assertFullWorkspace(gotWorkspace);
   }
@@ -147,6 +150,9 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Test
   public void getWorkspaceByUserFacingId_requesterIsDiscoverer_requestMinHighestRoleNotSet_throws()
       throws Exception {
+    ApiWorkspaceDescription workspaceDescription =
+        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+
     mockMvcUtils.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
@@ -155,7 +161,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
     getWorkspaceByUserFacingIdExpectingError(
         userAccessUtils.secondUserAuthRequest(),
-        workspace.getUserFacingId(),
+        workspaceDescription.getUserFacingId(),
         /*minimumHighestRole=*/ Optional.empty(),
         HttpStatus.SC_FORBIDDEN);
   }
@@ -164,6 +170,9 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       getWorkspaceByUserFacingId_requesterIsDiscoverer_requestMinHighestRoleSetToReader_throws()
           throws Exception {
+    ApiWorkspaceDescription workspaceDescription =
+        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+
     mockMvcUtils.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
@@ -172,7 +181,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
     getWorkspaceByUserFacingIdExpectingError(
         userAccessUtils.secondUserAuthRequest(),
-        workspace.getUserFacingId(),
+        workspaceDescription.getUserFacingId(),
         /*minimumHighestRole=*/ Optional.of(ApiIamRole.READER),
         HttpStatus.SC_FORBIDDEN);
   }
@@ -181,6 +190,9 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       getWorkspaceByUserFacingId_requesterIsDiscoverer_requestMinHighestRoleSetToDiscoverer_returnsStrippedWorkspace()
           throws Exception {
+    ApiWorkspaceDescription workspaceDescription =
+        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+
     mockMvcUtils.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
@@ -190,7 +202,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     ApiWorkspaceDescription gotWorkspace =
         getWorkspaceByUserFacingId(
             userAccessUtils.secondUserAuthRequest(),
-            workspace.getUserFacingId(),
+            workspaceDescription.getUserFacingId(),
             /*minimumHighestRole=*/ Optional.of(ApiIamRole.DISCOVERER));
 
     assertStrippedWorkspace(gotWorkspace);

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -26,6 +26,11 @@ public class WorkspaceFixtures {
    * <p>All values are mutable, and tests should change any they explicitly need.
    */
   public static ApiCreateWorkspaceRequestBody createWorkspaceRequestBody() {
+    return createWorkspaceRequestBody(ApiWorkspaceStageModel.MC_WORKSPACE);
+  }
+
+  public static ApiCreateWorkspaceRequestBody createWorkspaceRequestBody(
+      ApiWorkspaceStageModel stageModel) {
     UUID workspaceId = UUID.randomUUID();
     ApiProperties properties = new ApiProperties();
     properties.addAll(
@@ -36,7 +41,7 @@ public class WorkspaceFixtures {
         .displayName(WORKSPACE_NAME)
         .description("A test workspace created by createWorkspaceRequestBody")
         .userFacingId(getUserFacingId(workspaceId))
-        .stage(ApiWorkspaceStageModel.MC_WORKSPACE)
+        .stage(stageModel)
         .spendProfile("wm-default-spend-profile")
         .properties(properties);
   }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -1,5 +1,14 @@
 package bio.terra.workspace.common.utils;
 
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters;
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultGcsBucketCreationParameters;
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.generated.model.ApiCloneControlledGcpBigQueryDatasetRequest;
@@ -30,6 +39,9 @@ import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import java.util.UUID;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -39,19 +51,6 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-
-import javax.annotation.Nullable;
-import java.util.Optional;
-import java.util.UUID;
-
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters;
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultGcsBucketCreationParameters;
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * A collection of utilities and constants useful for MockMVC-based tests. This style of tests lets

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -1,42 +1,36 @@
 package bio.terra.workspace.common.utils;
 
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters;
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultGcsBucketCreationParameters;
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.generated.model.ApiCloneControlledGcpBigQueryDatasetRequest;
 import bio.terra.workspace.generated.model.ApiCloneControlledGcpBigQueryDatasetResult;
 import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketRequest;
 import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketResult;
+import bio.terra.workspace.generated.model.ApiCloneWorkspaceResult;
 import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiCreateCloudContextRequest;
 import bio.terra.workspace.generated.model.ApiCreateCloudContextResult;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpBigQueryDatasetRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpGcsBucketRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpBigQueryDataset;
 import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
+import bio.terra.workspace.generated.model.ApiDataRepoSnapshotAttributes;
+import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiGrantRoleRequestBody;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
+import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Optional;
-import java.util.UUID;
-import javax.annotation.Nullable;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +39,19 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.UUID;
+
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultBigQueryDatasetCreationParameters;
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultGcsBucketCreationParameters;
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * A collection of utilities and constants useful for MockMVC-based tests. This style of tests lets
@@ -56,15 +63,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  */
 @Component
 public class MockMvcUtils {
-  private static final Logger logger = LoggerFactory.getLogger(MockMvcUtils.class);
-
-  // Do not Autowire UserAccessUtils. UserAccessUtils are for connected tests and not unit tests
-  // (since unit tests don't use real SAM). Instead, each method must take in userRequest.
-  @Autowired private MockMvc mockMvc;
-  @Autowired private ObjectMapper objectMapper;
-
   public static final String AUTH_HEADER = "Authorization";
-
   public static final String WORKSPACES_V1_PATH = "/api/workspaces/v1";
   public static final String WORKSPACES_V1_BY_UUID_PATH_FORMAT = "/api/workspaces/v1/%s";
   public static final String WORKSPACES_V1_BY_UFID_PATH_FORMAT =
@@ -72,6 +71,8 @@ public class MockMvcUtils {
   public static final String ADD_USER_TO_WORKSPACE_PATH_FORMAT =
       "/api/workspaces/v1/%s/roles/%s/members";
   public static final String CLONE_WORKSPACE_PATH_FORMAT = "/api/workspaces/v1/%s/clone";
+  public static final String CLONE_WORKSPACE_RESULT_PATH_FORMAT =
+      "/api/workspaces/v1/%s/clone-result/%s";
   public static final String UPDATE_WORKSPACES_V1_PROPERTIES_PATH_FORMAT =
       "/api/workspaces/v1/%s/properties";
   public static final String GRANT_ROLE_PATH_FORMAT = "/api/workspaces/v1/%s/roles/%s/members";
@@ -81,7 +82,6 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/cloudcontexts";
   public static final String GET_CLOUD_CONTEXT_PATH_FORMAT =
       "/api/workspaces/v1/%s/cloudcontexts/result/%s";
-
   public static final String CREATE_AZURE_IP_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/ip";
   public static final String CREATE_AZURE_DISK_PATH_FORMAT =
@@ -92,7 +92,6 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/controlled/azure/vm";
   public static final String CREATE_AZURE_SAS_TOKEN_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/getSasToken";
-
   public static final String GET_REFERENCED_GCP_GCS_BUCKET_FORMAT =
       "/api/workspaces/v1/%s/resources/referenced/gcp/buckets/%s";
   public static final String CLONE_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
@@ -133,15 +132,18 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/referenced/gcp/bigquerydatatables";
   public static final String REFERENCED_GIT_REPO_V1_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/referenced/gitrepos";
-
-  private static final String DEST_BUCKET_RESOURCE_NAME =
-      TestUtils.appendRandomNumber("i-am-the-cloned-bucket");
-
   // Only use this if you are mocking SAM. If you're using real SAM,
   // use userAccessUtils.defaultUserAuthRequest() instead.
   public static final AuthenticatedUserRequest USER_REQUEST =
       new AuthenticatedUserRequest(
           "fake@email.com", "subjectId123456", Optional.of("ThisIsNotARealBearerToken"));
+  private static final Logger logger = LoggerFactory.getLogger(MockMvcUtils.class);
+  private static final String DEST_BUCKET_RESOURCE_NAME =
+      TestUtils.appendRandomNumber("i-am-the-cloned-bucket");
+  // Do not Autowire UserAccessUtils. UserAccessUtils are for connected tests and not unit tests
+  // (since unit tests don't use real SAM). Instead, each method must take in userRequest.
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
 
   public static MockHttpServletRequestBuilder addAuth(
       MockHttpServletRequestBuilder request, AuthenticatedUserRequest userRequest) {
@@ -248,6 +250,24 @@ public class MockMvcUtils {
             .getResponse()
             .getContentAsString();
     return objectMapper.readValue(serializedResponse, ApiCreateCloudContextResult.class);
+  }
+
+  public ApiCloneWorkspaceResult getCloneWorkspaceResult(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, String jobId) throws Exception {
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addJsonContentType(
+                    addAuth(
+                        get(
+                            CLONE_WORKSPACE_RESULT_PATH_FORMAT.formatted(
+                                workspaceId.toString(), jobId)),
+                        userRequest)))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return objectMapper.readValue(serializedResponse, ApiCloneWorkspaceResult.class);
   }
 
   public void deleteWorkspace(AuthenticatedUserRequest userRequest, UUID workspaceId)
@@ -499,7 +519,40 @@ public class MockMvcUtils {
             .andReturn()
             .getResponse()
             .getContentAsString();
+
     return objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);
+  }
+
+  public ApiDataRepoSnapshotResource createDataRepoSnapshotReference(
+      AuthenticatedUserRequest userRequest, UUID workspaceId) throws Exception {
+
+    var datarepoSnapshotRequest =
+        new ApiCreateDataRepoSnapshotReferenceRequestBody()
+            .metadata(
+                new ApiReferenceResourceCommonFields()
+                    .cloningInstructions(ApiCloningInstructionsEnum.REFERENCE)
+                    .description("description")
+                    .name(RandomStringUtils.randomAlphabetic(10)))
+            .snapshot(
+                new ApiDataRepoSnapshotAttributes().instanceName("terra").snapshot("polaroid"));
+
+    String serializedGetResponse =
+        mockMvc
+            .perform(
+                addAuth(
+                    post(String.format(
+                            REFERENCED_DATA_REPO_SNAPSHOTS_V1_PATH_FORMAT, workspaceId.toString()))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8")
+                        .content(objectMapper.writeValueAsString(datarepoSnapshotRequest)),
+                    userRequest))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    return objectMapper.readValue(serializedGetResponse, ApiDataRepoSnapshotResource.class);
   }
 
   public void grantRole(


### PR DESCRIPTION
This change set allows Rawls stage workspaces to be cloned.

- The clone method now accepts a destination workspace id. That id will be used to create the workspace, in the same way the regular create workspace endpoint works.
- The restriction against cloning Rawls workspaces is removed.
- We take the workspace stage from the source and use that as the destination stage.
- We only create a GCP cloud context in the destination if there was a context in the source workspace
- I did not wire in policy service interaction for Rawls workspaces

The hardest part of the change was writing the test :)

----
Based on Melissa's comments I did some test cleanup:
1. Make a common create workspace path for MC and RAWLS
2. Make a common clone workspace method for MC and RAWLS
3. Do not always run a `getWorkspace` on every create. Moved gets to the specific userFacingId tests that needed them.
4. Moved the `destinationWorkspaceId` field as suggested. Noticed and fixed the repetitive specification of `userFacingId`
