### PR TITLE
[PF-2104] Add workspace_id index to workspace_activity_log

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -65,6 +65,7 @@ import bio.terra.workspace.service.workspace.model.OperationType;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceAndHighestRole;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
+import io.opencensus.contrib.spring.aop.Traced;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -219,6 +220,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
+  @Traced
   private ApiWorkspaceDescription buildWorkspaceDescription(
       Workspace workspace, WsmIamRole highestRole, AuthenticatedUserRequest userRequest) {
     UUID workspaceUuid = workspace.getWorkspaceId();

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
@@ -53,7 +53,7 @@ public class WorkspaceActivityLogDao {
   public void writeActivity(UUID workspaceId, DbWorkspaceActivityLog dbWorkspaceActivityLog) {
     logger.info(
         String.format(
-            "#writeActivity: workspaceId=%s, operationType=%s, actorEmail=%s, actorSubjectId=%s",
+            "Writing activity log: workspaceId=%s, operationType=%s, actorEmail=%s, actorSubjectId=%s",
             workspaceId,
             dbWorkspaceActivityLog.getOperationType(),
             dbWorkspaceActivityLog.getActorEmail(),

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -14,4 +14,5 @@
     <include file="changesets/20220824_folder_table.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220907_add_resource_properties_column.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220920_add_folder_properties_column.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20221014_workspace_activity_log_add_index.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20221014_workspace_activity_log_add_index.yaml
+++ b/service/src/main/resources/db/changesets/20221014_workspace_activity_log_add_index.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+- changeSet:
+    id: workspace_activity_log_add_index
+    author: melchang
+    changes:
+    - createIndex:
+        tableName:  workspace_activity_log
+        indexName: workspace_id_index
+        unique:  false
+        columns:
+          - column:
+              name:  workspace_id


### PR DESCRIPTION
I didn't include change_date in index. I figure, having 2 rows with same change_date is extremely rare, so it's ok to sort in those cases.

Thanks for your help Dan, I haven't had much experience with DB slowness. :)