### PR TITLE
[WOR-515] Check for empty spend models received from configuration and filter out

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -14,6 +14,7 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.spendprofile.exceptions.BillingProfileManagerServiceAPIException;
 import bio.terra.workspace.service.spendprofile.exceptions.SpendUnauthorizedException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import com.google.api.client.util.Strings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import io.opencensus.contrib.http.jaxrs.JaxrsClientExtractor;
@@ -112,6 +113,11 @@ public class SpendProfileService {
   private static List<SpendProfile> adaptConfigurationModels(
       List<SpendProfileConfiguration.SpendProfileModel> spendModels) {
     return spendModels.stream()
+        .filter(
+            // filter out empty profiles
+            spendModel ->
+                !Strings.isNullOrEmpty(spendModel.getBillingAccountId())
+                    && !Strings.isNullOrEmpty(spendModel.getId()))
         .map(
             spendModel ->
                 new SpendProfile(

--- a/service/src/test/resources/application-connected-test.yml
+++ b/service/src/test/resources/application-connected-test.yml
@@ -11,3 +11,11 @@ workspace:
   crl:
     use-crl: true
     use-janitor: true
+
+  spend:
+    spend-profiles:
+      - id: wm-default-spend-profile
+        billing-account-id: fake-acct
+      # an empty profile to ensure we are resilient to empty spend profile env var values
+      - id:
+        billing-account-id:


### PR DESCRIPTION
We may receive "empty" spend models injected via environment variables (i.e., `WORKSPACE_SPEND_SPENDPROFILES_0_ID=;WORKSPACE_SPEND_SPENDPROFILES_0_BILLINGACCOUNTID=;') will render empty strings and cause the spend profile service to barf when it's instantiated at startup. Rather than set bogus values for those environment variables in all of our environments where they are not needed right now (i.e., prod), we should just check for the empty strings and filter out the models at bootstrap. 