### PR TITLE
[PF-2074] Disable BPM connected tests if BPM is not configured

### DIFF
--- a/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileBpmConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileBpmConnectedTest.java
@@ -10,10 +10,12 @@ import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.spendprofile.exceptions.BillingProfileManagerServiceAPIException;
 import bio.terra.workspace.service.spendprofile.exceptions.SpendUnauthorizedException;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
@@ -26,6 +28,11 @@ public class SpendProfileBpmConnectedTest extends BaseConnectedTest {
   @Autowired SpendProfileService spendProfileService;
 
   SpendProfile profile;
+
+  /** Condition used to disable these tests if run in a deployment where BPM is not configured. */
+  public boolean bpmUnavailable() {
+    return StringUtils.isEmpty(spendProfileConfiguration.getBasePath());
+  }
 
   @BeforeAll
   public void setup() {
@@ -43,6 +50,7 @@ public class SpendProfileBpmConnectedTest extends BaseConnectedTest {
   }
 
   @Test
+  @DisabledIf("bpmUnavailable")
   void authorizeLinkingSuccess() {
     var linkedProfile =
         spendProfileService.authorizeLinking(
@@ -52,6 +60,7 @@ public class SpendProfileBpmConnectedTest extends BaseConnectedTest {
   }
 
   @Test
+  @DisabledIf("bpmUnavailable")
   void authorizeLinkingFailure() {
     assertThrows(
         SpendUnauthorizedException.class,
@@ -61,6 +70,7 @@ public class SpendProfileBpmConnectedTest extends BaseConnectedTest {
   }
 
   @Test
+  @DisabledIf("bpmUnavailable")
   void authorizeLinkingUnknownId() {
     var ex =
         assertThrows(

--- a/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileServiceTest.java
@@ -9,7 +9,9 @@ import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.spendprofile.exceptions.SpendUnauthorizedException;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class SpendProfileServiceTest extends BaseConnectedTest {
@@ -18,7 +20,13 @@ class SpendProfileServiceTest extends BaseConnectedTest {
   @Autowired SpendConnectedTestUtils spendUtils;
   @Autowired UserAccessUtils userAccessUtils;
 
+  /** Condition used to disable these tests if run in a deployment where BPM is not configured. */
+  public boolean bpmUnavailable() {
+    return StringUtils.isEmpty(spendProfileConfiguration.getBasePath());
+  }
+
   @Test
+  @DisabledIf("bpmUnavailable")
   void authorizeLinkingSuccess() {
     SpendProfileId id = spendUtils.defaultSpendId();
     SpendProfile profile =
@@ -31,6 +39,7 @@ class SpendProfileServiceTest extends BaseConnectedTest {
   }
 
   @Test
+  @DisabledIf("bpmUnavailable")
   void authorizeLinkingSamUnauthorizedThrowsUnauthorized() {
     SpendProfileId id = spendUtils.defaultSpendId();
     SpendProfile profile =
@@ -44,6 +53,7 @@ class SpendProfileServiceTest extends BaseConnectedTest {
   }
 
   @Test
+  @DisabledIf("bpmUnavailable")
   void authorizeLinkingUnknownIdThrowsUnauthorized() {
     SpendProfileService service =
         new SpendProfileService(samService, ImmutableList.of(), spendProfileConfiguration);
@@ -55,6 +65,7 @@ class SpendProfileServiceTest extends BaseConnectedTest {
   }
 
   @Test
+  @DisabledIf("bpmUnavailable")
   void parseSpendProfileConfiguration() {
     SpendProfileService service = new SpendProfileService(samService, spendProfileConfiguration);
     assertEquals(


### PR DESCRIPTION
BPM isn't deployed at Verily yet, so these tests (which assume a valid BPM server is available) break, regardless of flag values. We should remove these annotations once one is available, which should be within a week or two.