### PR TITLE
[PF-2074] Fix disabled SpendProfileBpmConnectedTest

### DIFF
--- a/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileBpmConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileBpmConnectedTest.java
@@ -36,6 +36,10 @@ public class SpendProfileBpmConnectedTest extends BaseConnectedTest {
 
   @BeforeAll
   public void setup() {
+    // BeforeAll and AfterAll will still run even if there are no enabled tests in this class.
+    if(bpmUnavailable()) {
+      return;
+    }
     var profileName = "wsm-test-" + UUID.randomUUID();
     var billingAcctId = spendUtils.defaultBillingAccountId();
     profile =
@@ -45,6 +49,9 @@ public class SpendProfileBpmConnectedTest extends BaseConnectedTest {
 
   @AfterAll
   public void cleanUp() {
+    if(bpmUnavailable()) {
+      return;
+    }
     spendProfileService.deleteProfile(
         UUID.fromString(profile.id().getId()), userAccessUtils.thirdUserAuthRequest());
   }

--- a/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileBpmConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendProfileBpmConnectedTest.java
@@ -37,7 +37,7 @@ public class SpendProfileBpmConnectedTest extends BaseConnectedTest {
   @BeforeAll
   public void setup() {
     // BeforeAll and AfterAll will still run even if there are no enabled tests in this class.
-    if(bpmUnavailable()) {
+    if (bpmUnavailable()) {
       return;
     }
     var profileName = "wsm-test-" + UUID.randomUUID();
@@ -49,7 +49,7 @@ public class SpendProfileBpmConnectedTest extends BaseConnectedTest {
 
   @AfterAll
   public void cleanUp() {
-    if(bpmUnavailable()) {
+    if (bpmUnavailable()) {
       return;
     }
     spendProfileService.deleteProfile(


### PR DESCRIPTION
In #874 I disabled `SpendProfileBpmConnectedTest` methods individually in environments where BPM is disabled, but I forgot that `@Before/AfterAll` will still run (and make calls to BPM) even if no test methods are enabled.