### PR TITLE
PF-2159: change delete folder endpoint to async

### DIFF
--- a/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
 import bio.terra.workspace.api.FolderApi;
-import bio.terra.workspace.api.JobsApi;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.ResourceApi;
 import bio.terra.workspace.api.WorkspaceApi;
@@ -44,7 +43,6 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
   private static final String TERRA_FOLDER_ID = "terra-folder-id";
   private FolderApi folderOwnerApi;
   private FolderApi folderWriterApi;
-  private JobsApi jobsApi;
   private ReferencedGcpResourceApi referencedGcpResourceApi;
   private ControlledGcpResourceApi controlledGcpResourceApi;
   private ResourceApi resourceApi;
@@ -72,7 +70,6 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
     referencedGcpResourceApi = new ReferencedGcpResourceApi(ownerApiClient);
     controlledGcpResourceApi = new ControlledGcpResourceApi(ownerApiClient);
     resourceApi = new ResourceApi(ownerApiClient);
-    jobsApi = new JobsApi(ownerApiClient);
   }
 
   @Override

--- a/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
 import bio.terra.workspace.api.FolderApi;
+import bio.terra.workspace.api.JobsApi;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.ResourceApi;
 import bio.terra.workspace.api.WorkspaceApi;
@@ -21,10 +22,14 @@ import bio.terra.workspace.model.GcpBigQueryDatasetAttributes;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
 import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
+import bio.terra.workspace.model.JobReport;
+import bio.terra.workspace.model.JobReport.StatusEnum;
+import bio.terra.workspace.model.JobResult;
 import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.UpdateFolderRequestBody;
 import com.google.api.client.http.HttpStatusCodes;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.function.Executable;
 import scripts.utils.BqDatasetUtils;
@@ -39,6 +44,7 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
   private static final String TERRA_FOLDER_ID = "terra-folder-id";
   private FolderApi folderOwnerApi;
   private FolderApi folderWriterApi;
+  private JobsApi jobsApi;
   private ReferencedGcpResourceApi referencedGcpResourceApi;
   private ControlledGcpResourceApi controlledGcpResourceApi;
   private ResourceApi resourceApi;
@@ -66,6 +72,7 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
     referencedGcpResourceApi = new ReferencedGcpResourceApi(ownerApiClient);
     controlledGcpResourceApi = new ControlledGcpResourceApi(ownerApiClient);
     resourceApi = new ResourceApi(ownerApiClient);
+    jobsApi = new JobsApi(ownerApiClient);
   }
 
   @Override
@@ -204,7 +211,8 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
         () -> folderWriterApi.deleteFolder(getWorkspaceId(), folderLoo.getId()),
         HttpStatusCodes.STATUS_CODE_FORBIDDEN);
     // Second user tries to delete foo and success
-    folderWriterApi.deleteFolder(getWorkspaceId(), folderFoo.getId());
+    JobReport deleteFolderFooJobReport = deleteFolderAndWaitForJobToFinish(folderFoo);
+    assertEquals(StatusEnum.SUCCEEDED, deleteFolderFooJobReport.getStatus());
     assertApiCallThrows(
         () -> folderOwnerApi.getFolder(getWorkspaceId(), folderFoo.getId()),
         HttpStatusCodes.STATUS_CODE_NOT_FOUND);
@@ -215,8 +223,8 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
         HttpStatusCodes.STATUS_CODE_NOT_FOUND);
 
     // First user delete folder bar and success.
-    folderOwnerApi.deleteFolder(getWorkspaceId(), folderBar.getId());
-
+    JobReport deleteFolderBarJobReport = deleteFolderAndWaitForJobToFinish(folderBar);
+    assertEquals(StatusEnum.SUCCEEDED, deleteFolderBarJobReport.getStatus());
     // All the resources in bar and its sub-folder loo are deleted.
     assertApiCallThrows(
         () -> folderOwnerApi.getFolder(getWorkspaceId(), folderBar.getId()),
@@ -246,6 +254,17 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
                 getWorkspaceId(),
                 secondUserPrivateBucket.getAiNotebookInstance().getMetadata().getResourceId()),
         HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+  }
+
+  private JobReport deleteFolderAndWaitForJobToFinish(Folder folderFoo)
+      throws ApiException, InterruptedException {
+    JobResult jobResult = folderWriterApi.deleteFolder(getWorkspaceId(), folderFoo.getId());
+    JobReport jobReport = jobResult.getJobReport();
+    while (ClientTestUtils.jobIsRunning(jobReport)) {
+      TimeUnit.SECONDS.sleep(10);
+      jobReport = jobsApi.retrieveJob(jobReport.getId());
+    }
+    return jobReport;
   }
 
   private static void assertApiCallThrows(Executable executable, int code) {

--- a/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
@@ -262,7 +262,10 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
     JobReport jobReport = jobResult.getJobReport();
     while (ClientTestUtils.jobIsRunning(jobReport)) {
       TimeUnit.SECONDS.sleep(10);
-      jobReport = jobsApi.retrieveJob(jobReport.getId());
+      jobReport =
+          folderWriterApi
+              .getDeleteFolderResult(getWorkspaceId(), folderFoo.getId(), jobReport.getId())
+              .getJobReport();
     }
     return jobReport;
   }

--- a/openapi/src/common/responses.yaml
+++ b/openapi/src/common/responses.yaml
@@ -44,4 +44,11 @@ components:
         application/json:
             schema:
               $ref: '#/components/schemas/DeleteControlledAzureResourceResult'
+
+    JobResultResponse:
+      description: Result of a job (failed or succeded)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/JobResult'
   

--- a/openapi/src/common/schemas.yaml
+++ b/openapi/src/common/schemas.yaml
@@ -291,3 +291,14 @@ components:
       type: array
       items:
         type: string
+
+    JobResult:
+      type: object
+      description: |
+        The result of an async call that triggers a stairway job in WSM.
+      required: [jobReport]
+      properties:
+        jobReport:
+          $ref: '#/components/schemas/JobReport'
+        errorReport:
+          $ref: '#/components/schemas/ErrorReport'

--- a/openapi/src/parts/admin.yaml
+++ b/openapi/src/parts/admin.yaml
@@ -9,26 +9,14 @@ paths:
       tags: [Admin]
       responses:
         '200':
-          $ref: '#/components/responses/SyncIamRolesResultResponse'
+          $ref: '#/components/responses/JobResultResponse'
         '202':
-          $ref: '#/components/responses/SyncIamRolesResultResponse'
+          $ref: '#/components/responses/JobResultResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '500':
           $ref: '#/components/responses/ServerError'
 components:
-  schemas:
-    SyncIamRolesResult:
-      type: object
-      description: |
-        The result of a call to sync IAM roles of all the existing workspace's
-        GCP projects.
-      properties:
-        jobReport:
-          $ref: '#/components/schemas/JobReport'
-        errorReport:
-          $ref: '#/components/schemas/ErrorReport'
-
   parameters:
     WetRun:
       name: wetRun
@@ -37,11 +25,3 @@ components:
       required: false
       schema:
         type: boolean
-
-  responses:
-    SyncIamRolesResultResponse:
-      description: Job is completed (succeeded or failed)
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/SyncIamRolesResult'

--- a/openapi/src/parts/admin.yaml
+++ b/openapi/src/parts/admin.yaml
@@ -16,6 +16,28 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/admin/v1/workspaces/cloudcontexts/syncIamRoles/result/{jobId}:
+    parameters:
+    - $ref: '#/components/parameters/JobId'
+    get:
+      summary: Get the result of a async job to sync IAM roles.
+      operationId: getSyncIamRolesResult
+      tags: [ Admin ]
+      responses:
+        '200':
+          $ref: '#/components/responses/JobResultResponse'
+        '202':
+          $ref: '#/components/responses/JobResultResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
 components:
   parameters:
     WetRun:

--- a/openapi/src/parts/folder.yaml
+++ b/openapi/src/parts/folder.yaml
@@ -88,8 +88,10 @@ paths:
       operationId: deleteFolder
       tags: [Folder]
       responses:
-        '204':
-          description: Success
+        '200':
+          $ref: '#/components/responses/JobResultResponse'
+        '202':
+          $ref: '#/components/responses/JobResultResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -208,3 +210,4 @@ components:
             Whether to update parent folder id.
           type: boolean
           default: false
+

--- a/openapi/src/parts/folder.yaml
+++ b/openapi/src/parts/folder.yaml
@@ -101,6 +101,31 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/workspaces/v1/{workspaceId}/folders/{folderId}/result/{jobId}:
+    parameters:
+    - $ref: '#/components/parameters/WorkspaceId'
+    - $ref: '#/components/parameters/FolderId'
+    - $ref: '#/components/parameters/JobId'
+    get:
+      summary: Get the result of a async job to delete a folder.
+      operationId: getDeleteFolderResult
+      tags: [ Folder ]
+      responses:
+        '200':
+          $ref: '#/components/responses/JobResultResponse'
+        '202':
+          $ref: '#/components/responses/JobResultResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/workspaces/v1/{workspaceId}/folders/{folderId}/properties:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'

--- a/service/src/main/java/bio/terra/workspace/app/controller/AdminApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/AdminApiController.java
@@ -1,9 +1,8 @@
 package bio.terra.workspace.app.controller;
 
 import bio.terra.workspace.app.controller.shared.JobApiUtils;
-import bio.terra.workspace.app.controller.shared.JobApiUtils.AsyncJobResult;
 import bio.terra.workspace.generated.controller.AdminApi;
-import bio.terra.workspace.generated.model.ApiSyncIamRolesResult;
+import bio.terra.workspace.generated.model.ApiJobResult;
 import bio.terra.workspace.service.admin.AdminService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
@@ -32,7 +31,7 @@ public class AdminApiController extends ControllerBase implements AdminApi {
   }
 
   @Override
-  public ResponseEntity<ApiSyncIamRolesResult> syncIamRoles(Boolean wetRun) {
+  public ResponseEntity<ApiJobResult> syncIamRoles(Boolean wetRun) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     SamRethrow.onInterrupted(
         () -> getSamService().checkAdminAuthz(userRequest),
@@ -40,14 +39,7 @@ public class AdminApiController extends ControllerBase implements AdminApi {
 
     String jobId =
         adminService.syncIamRoleForAllGcpProjects(userRequest, Boolean.TRUE.equals(wetRun));
-    ApiSyncIamRolesResult response = fetchSyncIamRolesResult(jobId);
+    var response = jobApiUtils.fetchJobResult(jobId);
     return new ResponseEntity<>(response, getAsyncResponseCode(response.getJobReport()));
-  }
-
-  private ApiSyncIamRolesResult fetchSyncIamRolesResult(String jobId) {
-    AsyncJobResult<Void> jobResult = jobApiUtils.retrieveAsyncJobResult(jobId, null);
-    return new ApiSyncIamRolesResult()
-        .jobReport(jobResult.getJobReport())
-        .errorReport(jobResult.getApiErrorReport());
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/JobApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/JobApiUtils.java
@@ -8,6 +8,7 @@ import bio.terra.workspace.app.configuration.external.IngressConfiguration;
 import bio.terra.workspace.common.utils.ErrorReportUtils;
 import bio.terra.workspace.generated.model.ApiErrorReport;
 import bio.terra.workspace.generated.model.ApiJobReport;
+import bio.terra.workspace.generated.model.ApiJobResult;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.exception.InternalStairwayException;
@@ -128,6 +129,13 @@ public class JobApiUtils {
             .resultURL(resultUrlFromFlightState(flightState));
 
     return jobReport;
+  }
+
+  public ApiJobResult fetchJobResult(String jobId) {
+    AsyncJobResult<Void> jobResult = retrieveAsyncJobResult(jobId, null);
+    return new ApiJobResult()
+        .jobReport(jobResult.getJobReport())
+        .errorReport(jobResult.getApiErrorReport());
   }
 
   private ApiJobReport.StatusEnum mapFlightStatusToApi(FlightStatus flightStatus) {

--- a/service/src/main/java/bio/terra/workspace/service/folder/FolderService.java
+++ b/service/src/main/java/bio/terra/workspace/service/folder/FolderService.java
@@ -24,14 +24,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FolderService {
 
-  private static final Logger logger = LoggerFactory.getLogger(FolderService.class);
   private final FolderDao folderDao;
   private final ResourceDao resourceDao;
   private final JobService jobService;

--- a/service/src/main/java/bio/terra/workspace/service/folder/flights/DeleteFolderRecursiveStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/folder/flights/DeleteFolderRecursiveStep.java
@@ -4,10 +4,8 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
-import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.FolderDao;
 import java.util.UUID;
-import org.springframework.http.HttpStatus;
 
 public class DeleteFolderRecursiveStep implements Step {
 
@@ -23,8 +21,7 @@ public class DeleteFolderRecursiveStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    boolean deleted = folderDao.deleteFoldersRecursive(workspaceId, folderId);
-    FlightUtils.setResponse(context, deleted, HttpStatus.OK);
+    folderDao.deleteFoldersRecursive(workspaceId, folderId);
     return StepResult.getStepResultSuccess();
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -502,7 +502,7 @@ public class ResourceValidationUtils {
   public static void validateProperties(Map<String, String> properties) {
     if (properties.containsKey(FOLDER_ID_KEY)) {
       try {
-        var uuid = UUID.fromString(properties.get(FOLDER_ID_KEY));
+        var unused = UUID.fromString(properties.get(FOLDER_ID_KEY));
       } catch (IllegalArgumentException e) {
         throw new BadRequestException(
             String.format(

--- a/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
@@ -30,6 +30,7 @@ import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiCreateFolderRequestBody;
 import bio.terra.workspace.generated.model.ApiFolder;
 import bio.terra.workspace.generated.model.ApiFolderList;
+import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
 import bio.terra.workspace.generated.model.ApiJobResult;
 import bio.terra.workspace.generated.model.ApiProperties;
@@ -283,6 +284,16 @@ public class FolderApiControllerTest extends BaseUnitTest {
     ApiFolder thirdFolder =
         createFolder(workspaceId, /*displayName=*/ "foo", /*parentFolderId=*/ secondFolder.getId());
 
+    ApiJobReport jobReport = deleteFolderAndWaitForJob(workspaceId, firstFolder);
+
+    assertEquals(StatusEnum.SUCCEEDED, jobReport.getStatus());
+    getFolderExpectCode(workspaceId, firstFolder.getId(), HttpStatus.SC_NOT_FOUND);
+    getFolderExpectCode(workspaceId, secondFolder.getId(), HttpStatus.SC_NOT_FOUND);
+    getFolderExpectCode(workspaceId, thirdFolder.getId(), HttpStatus.SC_NOT_FOUND);
+  }
+
+  private ApiJobReport deleteFolderAndWaitForJob(UUID workspaceId, ApiFolder firstFolder)
+      throws Exception {
     var serializedResponse =
         deleteFolderExpectCode(workspaceId, firstFolder.getId(), HttpStatus.SC_ACCEPTED)
             .andReturn()
@@ -295,11 +306,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
       Thread.sleep(Duration.ofSeconds(1).toMillis());
       jobReport = mockMvcUtils.getJobReport(jobId, USER_REQUEST);
     }
-
-    assertEquals(StatusEnum.SUCCEEDED, jobReport.getStatus());
-    getFolderExpectCode(workspaceId, firstFolder.getId(), HttpStatus.SC_NOT_FOUND);
-    getFolderExpectCode(workspaceId, secondFolder.getId(), HttpStatus.SC_NOT_FOUND);
-    getFolderExpectCode(workspaceId, thirdFolder.getId(), HttpStatus.SC_NOT_FOUND);
+    return jobReport;
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertApiPropertyToMap;
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
+import static bio.terra.workspace.common.utils.MockMvcUtils.DELETE_FOLDER_JOB_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.FOLDERS_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.FOLDER_PROPERTIES_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.FOLDER_V1_PATH_FORMAT;
@@ -292,10 +293,10 @@ public class FolderApiControllerTest extends BaseUnitTest {
     getFolderExpectCode(workspaceId, thirdFolder.getId(), HttpStatus.SC_NOT_FOUND);
   }
 
-  private ApiJobReport deleteFolderAndWaitForJob(UUID workspaceId, ApiFolder firstFolder)
+  private ApiJobReport deleteFolderAndWaitForJob(UUID workspaceId, ApiFolder folder)
       throws Exception {
     var serializedResponse =
-        deleteFolderExpectCode(workspaceId, firstFolder.getId(), HttpStatus.SC_ACCEPTED)
+        deleteFolderExpectCode(workspaceId, folder.getId(), HttpStatus.SC_ACCEPTED)
             .andReturn()
             .getResponse()
             .getContentAsString();
@@ -304,7 +305,11 @@ public class FolderApiControllerTest extends BaseUnitTest {
     var jobId = jobReport.getId();
     while (jobReport.getStatus() == StatusEnum.RUNNING) {
       Thread.sleep(Duration.ofSeconds(1).toMillis());
-      jobReport = mockMvcUtils.getJobReport(jobId, USER_REQUEST);
+      jobReport =
+          mockMvcUtils.getJobReport(
+              DELETE_FOLDER_JOB_V1_PATH_FORMAT.formatted(
+                  workspaceId, folder.getId().toString(), jobId),
+              USER_REQUEST);
     }
     return jobReport;
   }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -42,6 +42,7 @@ import bio.terra.workspace.generated.model.ApiGrantRoleRequestBody;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
+import bio.terra.workspace.generated.model.ApiJobResult;
 import bio.terra.workspace.generated.model.ApiProperty;
 import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiTpsPolicyInputs;
@@ -146,7 +147,8 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/referenced/gcp/bigquerydatatables";
   public static final String REFERENCED_GIT_REPO_V1_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/referenced/gitrepos";
-  public static final String JOB_V1_PATH_FORMAT = "/api/job/v1/jobs/%s";
+  public static final String DELETE_FOLDER_JOB_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/folders/%s/result/%s";
   // Only use this if you are mocking SAM. If you're using real SAM,
   // use userAccessUtils.defaultUserAuthRequest() instead.
   public static final AuthenticatedUserRequest USER_REQUEST =
@@ -723,16 +725,15 @@ public class MockMvcUtils {
     assertThat(expected, containsInAnyOrder(actual.toArray()));
   }
 
-  public ApiJobReport getJobReport(String jobId, AuthenticatedUserRequest userRequest)
+  public ApiJobReport getJobReport(String path, AuthenticatedUserRequest userRequest)
       throws Exception {
     String serializedResponse =
         mockMvc
-            .perform(
-                addJsonContentType(addAuth(get(JOB_V1_PATH_FORMAT.formatted(jobId)), userRequest)))
+            .perform(addJsonContentType(addAuth(get(path), userRequest)))
             .andExpect(status().is2xxSuccessful())
             .andReturn()
             .getResponse()
             .getContentAsString();
-    return objectMapper.readValue(serializedResponse, ApiJobReport.class);
+    return objectMapper.readValue(serializedResponse, ApiJobResult.class).getJobReport();
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -146,6 +146,7 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/referenced/gcp/bigquerydatatables";
   public static final String REFERENCED_GIT_REPO_V1_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/referenced/gitrepos";
+  public static final String JOB_V1_PATH_FORMAT = "/api/job/v1/jobs/%s";
   // Only use this if you are mocking SAM. If you're using real SAM,
   // use userAccessUtils.defaultUserAuthRequest() instead.
   public static final AuthenticatedUserRequest USER_REQUEST =
@@ -720,5 +721,18 @@ public class MockMvcUtils {
 
   public void assertProperties(List<ApiProperty> expected, List<ApiProperty> actual) {
     assertThat(expected, containsInAnyOrder(actual.toArray()));
+  }
+
+  public ApiJobReport getJobReport(String jobId, AuthenticatedUserRequest userRequest)
+      throws Exception {
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addJsonContentType(addAuth(get(JOB_V1_PATH_FORMAT.formatted(jobId)), userRequest)))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return objectMapper.readValue(serializedResponse, ApiJobReport.class);
   }
 }


### PR DESCRIPTION
DELETE /api/workspaces/v1/{workspaceId}/folders/{folderId}:
{
  "jobReport": {
    "id": "fc6d2ff2-f421-4f3c-8e19-11fe443a2ad9",
    "description": "Delete folder 6839d139-8bb6-4f78-99d3-1852203f06cd in workspace 52ee1aea-9bbe-430b-892e-e524c3b92c8d",
    "status": "RUNNING",
    "statusCode": 202,
    "submitted": "2022-10-27T19:31:29.823243Z",
    "resultURL": "http://localhost:8080"
  }
}

GET /api/job/v1/jobs/{jobId}
{
  "id": "fc6d2ff2-f421-4f3c-8e19-11fe443a2ad9",
  "description": "Delete folder 6839d139-8bb6-4f78-99d3-1852203f06cd in workspace 52ee1aea-9bbe-430b-892e-e524c3b92c8d",
  "status": "SUCCEEDED",
  "statusCode": 200,
  "submitted": "2022-10-27T19:31:29.823243Z",
  "completed": "2022-10-27T19:31:31.775950Z",
  "resultURL": "http://localhost:8080"
}