### PR TITLE
Use correct config value names for BPM flagging

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/FeatureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/FeatureConfiguration.java
@@ -86,5 +86,7 @@ public class FeatureConfiguration {
     logger.info("Feature: azure-enabled: {}", isAzureEnabled());
     logger.info("Feature: alpha1-enabled: {}", isAlpha1Enabled());
     logger.info("Feature: tps-enabled: {}", isTpsEnabled());
+    logger.info("Feature: bpm-azure-enabled: {}", isBpmAzureEnabled());
+    logger.info("Feature: bpm-gcp-enabled: {}", isBpmGcpEnabled());
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -206,9 +206,9 @@ feature:
   # tps-enabled - Controls whether Terra Policy Service is called. It is always built into WSM
   tps-enabled: false
   # bpm-enabled-gcp - Controls whether spend profile checks are made for GCP workspaces
-  bpm-enabled-gcp: false
+  bpm-gcp-enabled: false
   # bpm-enabled-azure - Controls whether spend profile checks are made for Azure workspaces
-  bpm-enabled-azure: false
+  bpm-azure-enabled: false
 
 reference:
   gitrepos:


### PR DESCRIPTION
The BPM enabled config values in the YAML do not line up with what the `FeatureConfiguration` class is looking for.