### PR TITLE
PF-2179: user jupyter own ~/.bash_profile

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -125,6 +125,10 @@ if [[ -n "${TERRA_WORKSPACE}" ]]; then
   sudo -u "${JUPYTER_USER}" sh -c "terra workspace set --id=${TERRA_WORKSPACE}"
 fi
 
+# transfer ownership of .bash_profile to user jupyter.
+chown ${JUPYTER_USER}: /home/${JUPYTER_USER}/.bash_profile
+chmod u+w /home/${JUPYTER_USER}/.bash_profile
+
 # Set variables into the .bash_profile such that they are available
 # to terminals, notebooks, and other tools
 #


### PR DESCRIPTION
tested the script with a newly created notebook:
1. edit .bash_profile and added a line echo "hello"
2. source ~/.bash_profile and confirmed i can execute it.

```
(base) jupyter@testnotebook1:~$ whoami
jupyter
(base) jupyter@testnotebook1:~$ source ~/.bash_profile
Agent pid 19187
HELLO
```