### PR TITLE
PF-1968: make created_by and last_changed_by required field

### DIFF
--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -510,7 +510,7 @@ components:
 
     WorkspaceDescription:
       type: object
-      required: [id, userFacingId, highestRole]
+      required: [id, userFacingId, highestRole, createdBy, lastUpdatedBy, createdDate, lastUpdatedDate]
       properties:
         id:
           description: The ID of the workspace. Immutable.

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -66,6 +66,7 @@ import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceAndHighestRole;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import io.opencensus.contrib.spring.aop.Traced;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -276,12 +277,19 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
         .gcpContext(gcpContext)
         .azureContext(azureContext)
         .createdDate(
-            createDetailsOptional.map(ActivityLogChangeDetails::getChangeDate).orElse(null))
-        .createdBy(createDetailsOptional.map(ActivityLogChangeDetails::getActorEmail).orElse(null))
+            createDetailsOptional
+                .map(ActivityLogChangeDetails::getChangeDate)
+                .orElse(OffsetDateTime.MIN))
+        .createdBy(
+            createDetailsOptional.map(ActivityLogChangeDetails::getActorEmail).orElse("unknown"))
         .lastUpdatedDate(
-            lastChangeDetailsOptional.map(ActivityLogChangeDetails::getChangeDate).orElse(null))
+            lastChangeDetailsOptional
+                .map(ActivityLogChangeDetails::getChangeDate)
+                .orElse(OffsetDateTime.MIN))
         .lastUpdatedBy(
-            lastChangeDetailsOptional.map(ActivityLogChangeDetails::getActorEmail).orElse(null))
+            lastChangeDetailsOptional
+                .map(ActivityLogChangeDetails::getActorEmail)
+                .orElse("unknown"))
         .policies(workspacePolicies);
   }
 


### PR DESCRIPTION
For workspaces that are created before the logging exists, there are no entries of them in the log table. So we arbitrarily returns unknown for actor email and a MIN timestamp for the date.