### PR TITLE
PF-2159: add a post endpoint for delete async.

### DIFF
--- a/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
@@ -205,7 +205,7 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
     // Second user unable to delete folder Loo. Loo has a private notebook owned by first user.
     // Second user is only workspace writer.
     assertApiCallThrows(
-        () -> folderWriterApi.deleteFolder(getWorkspaceId(), folderLoo.getId()),
+        () -> folderWriterApi.deleteFolderAsync(getWorkspaceId(), folderLoo.getId()),
         HttpStatusCodes.STATUS_CODE_FORBIDDEN);
     // Second user tries to delete foo and success
     JobReport deleteFolderFooJobReport = deleteFolderAndWaitForJobToFinish(folderFoo);
@@ -255,7 +255,7 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
 
   private JobReport deleteFolderAndWaitForJobToFinish(Folder folderFoo)
       throws ApiException, InterruptedException {
-    JobResult jobResult = folderWriterApi.deleteFolder(getWorkspaceId(), folderFoo.getId());
+    JobResult jobResult = folderWriterApi.deleteFolderAsync(getWorkspaceId(), folderFoo.getId());
     JobReport jobReport = jobResult.getJobReport();
     while (ClientTestUtils.jobIsRunning(jobReport)) {
       TimeUnit.SECONDS.sleep(10);

--- a/openapi/src/parts/folder.yaml
+++ b/openapi/src/parts/folder.yaml
@@ -83,8 +83,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-    delete:
-      summary: Delete a folder.
+    post:
+      summary: Delete a folder asynchronously.
       operationId: deleteFolder
       tags: [Folder]
       responses:

--- a/openapi/src/parts/folder.yaml
+++ b/openapi/src/parts/folder.yaml
@@ -83,9 +83,26 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+    delete:
+      summary: (Deprecated) Delete a folder. Use the post endpoint instead.
+      operationId: deleteFolder
+      tags: [ Folder ]
+      responses:
+        '200':
+          $ref: '#/components/responses/JobResultResponse'
+        '202':
+          $ref: '#/components/responses/JobResultResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
     post:
       summary: Delete a folder asynchronously.
-      operationId: deleteFolder
+      operationId: deleteFolderAsync
       tags: [Folder]
       responses:
         '200':

--- a/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -682,7 +681,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     return mockMvc
         .perform(
             addAuth(
-                delete(String.format(FOLDER_V1_PATH_FORMAT, workspaceId, folderId)), USER_REQUEST))
+                post(String.format(FOLDER_V1_PATH_FORMAT, workspaceId, folderId)), USER_REQUEST))
         .andExpect(status().is(code));
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -237,13 +237,12 @@ public class MockMvcUtils {
   }
 
   public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
-      @Nullable AuthenticatedUserRequest userRequest) throws Exception {
+      AuthenticatedUserRequest userRequest) throws Exception {
     return createWorkspaceWithoutCloudContext(userRequest, ApiWorkspaceStageModel.MC_WORKSPACE);
   }
 
   public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
-      @Nullable AuthenticatedUserRequest userRequest, ApiWorkspaceStageModel stageModel)
-      throws Exception {
+      AuthenticatedUserRequest userRequest, ApiWorkspaceStageModel stageModel) throws Exception {
 
     ApiCreateWorkspaceRequestBody request =
         WorkspaceFixtures.createWorkspaceRequestBody(stageModel);
@@ -262,7 +261,7 @@ public class MockMvcUtils {
   }
 
   public ApiErrorReport createWorkspaceWithoutCloudContextExpectError(
-      @Nullable AuthenticatedUserRequest userRequest,
+      AuthenticatedUserRequest userRequest,
       UUID workspaceId,
       @Nullable ApiWorkspaceStageModel stageModel,
       @Nullable ApiTpsPolicyInputs policyInputs,

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -237,12 +237,13 @@ public class MockMvcUtils {
   }
 
   public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
-      AuthenticatedUserRequest userRequest) throws Exception {
+      @Nullable AuthenticatedUserRequest userRequest) throws Exception {
     return createWorkspaceWithoutCloudContext(userRequest, ApiWorkspaceStageModel.MC_WORKSPACE);
   }
 
   public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
-      AuthenticatedUserRequest userRequest, ApiWorkspaceStageModel stageModel) throws Exception {
+      @Nullable AuthenticatedUserRequest userRequest, ApiWorkspaceStageModel stageModel)
+      throws Exception {
 
     ApiCreateWorkspaceRequestBody request =
         WorkspaceFixtures.createWorkspaceRequestBody(stageModel);
@@ -261,7 +262,7 @@ public class MockMvcUtils {
   }
 
   public ApiErrorReport createWorkspaceWithoutCloudContextExpectError(
-      AuthenticatedUserRequest userRequest,
+      @Nullable AuthenticatedUserRequest userRequest,
       UUID workspaceId,
       @Nullable ApiWorkspaceStageModel stageModel,
       @Nullable ApiTpsPolicyInputs policyInputs,


### PR DESCRIPTION
@rogerwangcs pointed this out that the rest of the async endpoint are using POST.