### PR TITLE
Revert "PF-2176: Log workspace update policies endpoint"

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -14,7 +14,6 @@ import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
 import bio.terra.workspace.common.utils.ControllerValidationUtils;
 import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
-import bio.terra.workspace.db.model.DbWorkspaceActivityLog;
 import bio.terra.workspace.generated.controller.WorkspaceApi;
 import bio.terra.workspace.generated.model.ApiAzureContext;
 import bio.terra.workspace.generated.model.ApiCloneWorkspaceRequest;
@@ -372,19 +371,8 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     ApiTpsPaoUpdateResult result =
         tpsApiDispatch.updatePao(
             new BearerToken(userRequest.getRequiredToken()), workspaceId, body);
-    if (Boolean.TRUE.equals(result.isUpdateApplied())) {
-      workspaceActivityLogDao.writeActivity(
-          workspaceId,
-          new DbWorkspaceActivityLog(
-              userRequest.getEmail(), userRequest.getSubjectId(), OperationType.UPDATE));
-      logger.info(
-          "Finished updating workspace policies {} for {}", workspaceId, userRequest.getEmail());
-    } else {
-      logger.warn(
-          "Workspace policies update failed to apply to {} for {}",
-          workspaceId,
-          userRequest.getEmail());
-    }
+    logger.info(
+        "Finished updating workspace policies {} for {}", workspaceId, userRequest.getEmail());
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
@@ -56,10 +56,10 @@ public class WorkspaceActivityLogDao {
         String.format(
             "Writing activity log: workspaceId=%s, operationType=%s, actorEmail=%s, actorSubjectId=%s",
             workspaceId,
-            dbWorkspaceActivityLog.operationType(),
-            dbWorkspaceActivityLog.actorEmail(),
-            dbWorkspaceActivityLog.actorSubjectId()));
-    if (dbWorkspaceActivityLog.operationType() == OperationType.UNKNOWN) {
+            dbWorkspaceActivityLog.getOperationType(),
+            dbWorkspaceActivityLog.getActorEmail(),
+            dbWorkspaceActivityLog.getActorSubjectId()));
+    if (dbWorkspaceActivityLog.getOperationType() == OperationType.UNKNOWN) {
       throw new UnknownFlightOperationTypeException(
           String.format("Flight operation type is unknown in workspace %s", workspaceId));
     }
@@ -70,9 +70,9 @@ public class WorkspaceActivityLogDao {
         new MapSqlParameterSource()
             .addValue("workspace_id", workspaceId.toString())
             .addValue("change_date", Instant.now().atOffset(ZoneOffset.UTC))
-            .addValue("change_type", dbWorkspaceActivityLog.operationType().name())
-            .addValue("actor_email", dbWorkspaceActivityLog.actorEmail())
-            .addValue("actor_subject_id", dbWorkspaceActivityLog.actorSubjectId());
+            .addValue("change_type", dbWorkspaceActivityLog.getOperationType().name())
+            .addValue("actor_email", dbWorkspaceActivityLog.getActorEmail())
+            .addValue("actor_subject_id", dbWorkspaceActivityLog.getActorSubjectId());
     jdbcTemplate.update(sql, params);
   }
 

--- a/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceActivityLog.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceActivityLog.java
@@ -1,12 +1,53 @@
 package bio.terra.workspace.db.model;
 
+import bio.terra.workspace.service.workspace.exceptions.MissingRequiredFieldsException;
 import bio.terra.workspace.service.workspace.model.OperationType;
+import java.util.Optional;
+import java.util.function.Supplier;
 
-public record DbWorkspaceActivityLog(
-    String actorEmail, String actorSubjectId, OperationType operationType) {
+public class DbWorkspaceActivityLog {
+
+  private OperationType operationType;
+
+  private String actorEmail;
+
+  private String actorSubjectId;
+
+  private static final Supplier<RuntimeException> MISSING_REQUIRED_FIELD =
+      () -> new MissingRequiredFieldsException("Missing required field");
+
+  private DbWorkspaceActivityLog operationType(OperationType operationType) {
+    this.operationType = operationType;
+    return this;
+  }
+
+  private DbWorkspaceActivityLog actorEmail(String actorEmail) {
+    this.actorEmail = actorEmail;
+    return this;
+  }
+
+  private DbWorkspaceActivityLog actorSubjectId(String actorSubjectId) {
+    this.actorSubjectId = actorSubjectId;
+    return this;
+  }
+
+  public OperationType getOperationType() {
+    return Optional.ofNullable(operationType).orElseThrow(MISSING_REQUIRED_FIELD);
+  }
+
+  public String getActorEmail() {
+    return Optional.ofNullable(actorEmail).orElseThrow(MISSING_REQUIRED_FIELD);
+  }
+
+  public String getActorSubjectId() {
+    return Optional.ofNullable(actorSubjectId).orElseThrow(MISSING_REQUIRED_FIELD);
+  }
 
   public static DbWorkspaceActivityLog getDbWorkspaceActivityLog(
-      OperationType operationType, String actorEmail, String actorSubjectId) {
-    return new DbWorkspaceActivityLog(actorEmail, actorSubjectId, operationType);
+      OperationType operationType, String userEmail, String subjectId) {
+    return new DbWorkspaceActivityLog()
+        .operationType(operationType)
+        .actorEmail(userEmail)
+        .actorSubjectId(subjectId);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -3,7 +3,6 @@ package bio.terra.workspace.app.controller;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.SHORT_DESCRIPTION_PROPERTY;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.TYPE_PROPERTY;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.VERSION_PROPERTY;
-import static bio.terra.workspace.common.utils.MockMvcUtils.UPDATE_WORKSPACES_V1_POLICIES_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.UPDATE_WORKSPACES_V1_PROPERTIES_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_PATH;
@@ -12,7 +11,6 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,7 +23,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.workspace.common.BaseUnitTestMockDataRepoService;
 import bio.terra.workspace.common.utils.MockMvcUtils;
-import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.generated.model.ApiCloneWorkspaceResult;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
@@ -37,12 +34,9 @@ import bio.terra.workspace.generated.model.ApiResourceCloneDetails;
 import bio.terra.workspace.generated.model.ApiTpsComponent;
 import bio.terra.workspace.generated.model.ApiTpsObjectType;
 import bio.terra.workspace.generated.model.ApiTpsPaoGetResult;
-import bio.terra.workspace.generated.model.ApiTpsPaoUpdateRequest;
-import bio.terra.workspace.generated.model.ApiTpsPaoUpdateResult;
 import bio.terra.workspace.generated.model.ApiTpsPolicyInput;
 import bio.terra.workspace.generated.model.ApiTpsPolicyInputs;
 import bio.terra.workspace.generated.model.ApiTpsPolicyPair;
-import bio.terra.workspace.generated.model.ApiTpsUpdateMode;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescriptionList;
 import bio.terra.workspace.generated.model.ApiWorkspaceStageModel;
@@ -53,7 +47,6 @@ import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.workspace.model.WorkspaceConstants.Properties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -65,7 +58,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 
 /**
  * An example of a mockMvc-based unit test for a controller.
@@ -88,7 +80,6 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
   @Autowired ObjectMapper objectMapper;
-  @Autowired WorkspaceActivityLogDao workspaceActivityLogDao;
 
   private static ApiTpsPaoGetResult emptyWorkspacePao() {
     return new ApiTpsPaoGetResult()
@@ -372,44 +363,6 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
     assertNull(gotWorkspace.getPolicies());
   }
 
-  @Test
-  public void updatePolicies_tpsDisabled_throws501() throws Exception {
-    when(mockFeatureConfiguration().isTpsEnabled()).thenReturn(false);
-    ApiCreatedWorkspace workspace = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST);
-
-    updatePoliciesExpect(workspace.getId(), HttpStatus.SC_NOT_IMPLEMENTED);
-  }
-
-  @Test
-  public void updatePolicies_tpsEnabledAndPolicyUpdated_log() throws Exception {
-    ApiCreatedWorkspace workspace = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST);
-    when(mockTpsApiDispatch().updatePao(any(), eq(workspace.getId()), any()))
-        .thenReturn(new ApiTpsPaoUpdateResult().updateApplied(true));
-    OffsetDateTime lastChangedDate =
-        workspaceActivityLogDao.getLastUpdateDetails(workspace.getId()).get().getChangeDate();
-
-    ApiTpsPaoUpdateResult result = updatePolicies(workspace.getId());
-    assertTrue(result.isUpdateApplied());
-    assertTrue(
-        lastChangedDate.isBefore(
-            workspaceActivityLogDao.getLastUpdateDetails(workspace.getId()).get().getChangeDate()));
-  }
-
-  @Test
-  public void updatePolicies_tpsEnabledAndPolicyNotUpdated_notLog() throws Exception {
-    ApiCreatedWorkspace workspace = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST);
-    when(mockTpsApiDispatch().updatePao(any(), eq(workspace.getId()), any()))
-        .thenReturn(new ApiTpsPaoUpdateResult().updateApplied(false));
-    OffsetDateTime lastChangedDate =
-        workspaceActivityLogDao.getLastUpdateDetails(workspace.getId()).get().getChangeDate();
-
-    ApiTpsPaoUpdateResult result = updatePolicies(workspace.getId());
-    assertFalse(result.isUpdateApplied());
-    assertTrue(
-        lastChangedDate.isEqual(
-            workspaceActivityLogDao.getLastUpdateDetails(workspace.getId()).get().getChangeDate()));
-  }
-
   private ApiErrorReport createRawlsWorkspaceWithPolicyExpectError(int expectedCode)
       throws Exception {
     ApiTpsPolicyInputs policyInputs =
@@ -473,38 +426,5 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         .filter(w -> w.getId().equals(id))
         .findFirst()
         .orElseThrow(() -> new RuntimeException("workspace " + id + "not found in list!"));
-  }
-
-  private ApiTpsPaoUpdateResult updatePolicies(UUID workspaceId) throws Exception {
-    var serializedResponse =
-        updatePoliciesExpect(workspaceId, HttpStatus.SC_OK)
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-    return objectMapper.readValue(serializedResponse, ApiTpsPaoUpdateResult.class);
-  }
-
-  private ResultActions updatePoliciesExpect(UUID workspaceId, int code) throws Exception {
-    ApiTpsPaoUpdateRequest updateRequest =
-        new ApiTpsPaoUpdateRequest()
-            .updateMode(ApiTpsUpdateMode.ENFORCE_CONFLICT)
-            .addAttributes(
-                new ApiTpsPolicyInputs()
-                    .addInputsItem(
-                        new ApiTpsPolicyInput()
-                            .namespace("terra")
-                            .name("region-constraint")
-                            .addAdditionalDataItem(
-                                new ApiTpsPolicyPair().key("foo").value("bar"))));
-    return mockMvc
-        .perform(
-            addAuth(
-                patch(String.format(UPDATE_WORKSPACES_V1_POLICIES_PATH_FORMAT, workspaceId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .content(objectMapper.writeValueAsString(updateRequest)),
-                USER_REQUEST))
-        .andExpect(status().is(code));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -49,7 +49,6 @@ import bio.terra.workspace.generated.model.ApiTpsPolicyInputs;
 import bio.terra.workspace.generated.model.ApiUpdateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWorkspaceStageModel;
-import bio.terra.workspace.service.iam.AuthHeaderKeys;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -91,8 +90,6 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/clone-result/%s";
   public static final String UPDATE_WORKSPACES_V1_PROPERTIES_PATH_FORMAT =
       "/api/workspaces/v1/%s/properties";
-  public static final String UPDATE_WORKSPACES_V1_POLICIES_PATH_FORMAT =
-      "/api/workspaces/v1/%S/policies";
   public static final String GRANT_ROLE_PATH_FORMAT = "/api/workspaces/v1/%s/roles/%s/members";
   public static final String CREATE_SNAPSHOT_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/referenced/datarepo/snapshots";
@@ -167,10 +164,7 @@ public class MockMvcUtils {
 
   public static MockHttpServletRequestBuilder addAuth(
       MockHttpServletRequestBuilder request, AuthenticatedUserRequest userRequest) {
-    return request
-        .header(AUTH_HEADER, "Bearer " + userRequest.getRequiredToken())
-        .header(AuthHeaderKeys.OIDC_CLAIM_EMAIL.getKeyName(), userRequest.getEmail())
-        .header(AuthHeaderKeys.OIDC_CLAIM_USER_ID.getKeyName(), userRequest.getSubjectId());
+    return request.header(AUTH_HEADER, "Bearer " + userRequest.getRequiredToken());
   }
 
   public static MockHttpServletRequestBuilder addJsonContentType(

--- a/service/src/test/java/bio/terra/workspace/connected/UserAccessUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/UserAccessUtils.java
@@ -31,9 +31,6 @@ public class UserAccessUtils {
   @Value("${workspace.connected-test.default-user-email}")
   private String defaultUserEmail;
 
-  @Value("${workspace.connected-test.default-user-subject-id}")
-  private String defaultUserSubjectId;
-
   /**
    * The email address of a second, not-the-default user to use for testing. Useful for tests that
    * require two valid users.
@@ -41,14 +38,8 @@ public class UserAccessUtils {
   @Value("${workspace.connected-test.second-user-email}")
   private String secondUserEmail;
 
-  @Value("${workspace.connected-test.second-user-subject-id}")
-  private String secondUserSubjectId;
-
   @Value("${workspace.connected-test.billing-user-email}")
   private String billingUserEmail;
-
-  @Value("${workspace.connected-test.billing-user-subject-id}")
-  private String billingUserSubjectId;
 
   /** Creates Google credentials for the user. Relies on domain delegation. */
   public GoogleCredentials generateCredentials(String userEmail) {
@@ -71,7 +62,7 @@ public class UserAccessUtils {
 
   /** Creates a {@link TestUser} for the default test user. */
   public TestUser defaultUser() {
-    return new TestUser(defaultUserEmail, defaultUserSubjectId);
+    return new TestUser(defaultUserEmail);
   }
 
   /** Generates an OAuth access token for the default test user. */
@@ -108,7 +99,6 @@ public class UserAccessUtils {
   public AuthenticatedUserRequest defaultUserAuthRequest() {
     return new AuthenticatedUserRequest()
         .email(getDefaultUserEmail())
-        .subjectId(defaultUserSubjectId)
         .token(Optional.of(defaultUserAccessToken().getTokenValue()));
   }
 
@@ -116,14 +106,12 @@ public class UserAccessUtils {
   public AuthenticatedUserRequest secondUserAuthRequest() {
     return new AuthenticatedUserRequest()
         .email(getSecondUserEmail())
-        .subjectId(secondUserSubjectId)
         .token(Optional.of(secondUserAccessToken().getTokenValue()));
   }
 
   public AuthenticatedUserRequest thirdUserAuthRequest() {
     return new AuthenticatedUserRequest()
         .email(getBillingUserEmail())
-        .subjectId(billingUserSubjectId)
         .token(Optional.of(billingUserAccessToken().getTokenValue()));
   }
 
@@ -134,11 +122,9 @@ public class UserAccessUtils {
    */
   public class TestUser {
     private final String email;
-    private final String subjectId;
 
-    public TestUser(String email, String subjectId) {
+    public TestUser(String email) {
       this.email = email;
-      this.subjectId = subjectId;
     }
 
     public String getEmail() {
@@ -155,7 +141,6 @@ public class UserAccessUtils {
 
     public AuthenticatedUserRequest getAuthenticatedRequest() {
       return new AuthenticatedUserRequest()
-          .subjectId(subjectId)
           .email(email)
           .token(Optional.of(getAccessToken().getTokenValue()));
     }

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -48,6 +48,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.hamcrest.collection.IsMapContaining;
@@ -79,7 +80,7 @@ class SamServiceTest extends BaseConnectedTest {
 
   @AfterEach
   public void tearDown() {
-    workspaceService.deleteWorkspace(workspace, userAccessUtils.defaultUserAuthRequest());
+    workspaceService.deleteWorkspace(workspace, defaultUserRequest());
   }
 
   @Test
@@ -100,11 +101,11 @@ class SamServiceTest extends BaseConnectedTest {
         .perform(
             addAuth(
                 get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceUuid)),
-                userAccessUtils.secondUserAuthRequest()))
+                secondaryUserRequest()))
         .andExpect(status().is(HttpStatus.SC_FORBIDDEN));
     samService.grantWorkspaceRole(
         workspaceUuid,
-        userAccessUtils.defaultUserAuthRequest(),
+        defaultUserRequest(),
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
     // After being granted permission, secondary user can read the workspace.
@@ -112,7 +113,7 @@ class SamServiceTest extends BaseConnectedTest {
         .perform(
             addAuth(
                 get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceUuid)),
-                userAccessUtils.secondUserAuthRequest()))
+                secondaryUserRequest()))
         .andExpect(status().is(HttpStatus.SC_OK));
   }
 
@@ -135,14 +136,14 @@ class SamServiceTest extends BaseConnectedTest {
             addJsonContentType(
                     addAuth(
                         post(String.format(CREATE_SNAPSHOT_PATH_FORMAT, workspaceUuid)),
-                        userAccessUtils.secondUserAuthRequest()))
+                        secondaryUserRequest()))
                 .content(objectMapper.writeValueAsString(referenceRequest)))
         .andExpect(status().is(HttpStatus.SC_FORBIDDEN));
 
     // After being granted permission, secondary user can modify the workspace.
     samService.grantWorkspaceRole(
         workspaceUuid,
-        userAccessUtils.defaultUserAuthRequest(),
+        defaultUserRequest(),
         WsmIamRole.WRITER,
         userAccessUtils.getSecondUserEmail());
     String serializedResponse =
@@ -151,7 +152,7 @@ class SamServiceTest extends BaseConnectedTest {
                 addJsonContentType(
                         addAuth(
                             post(String.format(CREATE_SNAPSHOT_PATH_FORMAT, workspaceUuid)),
-                            userAccessUtils.secondUserAuthRequest()))
+                            secondaryUserRequest()))
                     .content(objectMapper.writeValueAsString(referenceRequest)))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
@@ -175,31 +176,31 @@ class SamServiceTest extends BaseConnectedTest {
         .perform(
             addAuth(
                 get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceUuid)),
-                userAccessUtils.secondUserAuthRequest()))
+                secondaryUserRequest()))
         .andExpect(status().is(HttpStatus.SC_FORBIDDEN));
     // After being granted permission, secondary user can read the workspace.
     samService.grantWorkspaceRole(
         workspaceUuid,
-        userAccessUtils.defaultUserAuthRequest(),
+        defaultUserRequest(),
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
     mockMvc
         .perform(
             addAuth(
                 get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceUuid)),
-                userAccessUtils.secondUserAuthRequest()))
+                secondaryUserRequest()))
         .andExpect(status().is(HttpStatus.SC_OK));
     // After removing permission, secondary user can no longer read.
     samService.removeWorkspaceRole(
         workspaceUuid,
-        userAccessUtils.defaultUserAuthRequest(),
+        defaultUserRequest(),
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
     mockMvc
         .perform(
             addAuth(
                 get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceUuid)),
-                userAccessUtils.secondUserAuthRequest()))
+                secondaryUserRequest()))
         .andExpect(status().is(HttpStatus.SC_FORBIDDEN));
   }
 
@@ -212,7 +213,7 @@ class SamServiceTest extends BaseConnectedTest {
         () ->
             samService.grantWorkspaceRole(
                 workspaceUuid,
-                userAccessUtils.secondUserAuthRequest(),
+                secondaryUserRequest(),
                 WsmIamRole.READER,
                 userAccessUtils.getSecondUserEmail()));
   }
@@ -221,7 +222,7 @@ class SamServiceTest extends BaseConnectedTest {
   void permissionsApiFailsInRawlsWorkspace() throws Exception {
     UUID workspaceUuid = UUID.randomUUID();
     // RAWLS_WORKSPACEs do not own their own Sam resources, so we need to manage them separately.
-    samService.createWorkspaceWithDefaults(userAccessUtils.defaultUserAuthRequest(), workspaceUuid);
+    samService.createWorkspaceWithDefaults(defaultUserRequest(), workspaceUuid);
 
     Workspace rawlsWorkspace =
         Workspace.builder()
@@ -229,8 +230,7 @@ class SamServiceTest extends BaseConnectedTest {
             .userFacingId(workspaceUuid.toString())
             .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
             .build();
-    workspaceService.createWorkspace(
-        rawlsWorkspace, null, userAccessUtils.defaultUserAuthRequest());
+    workspaceService.createWorkspace(rawlsWorkspace, null, defaultUserRequest());
     ApiGrantRoleRequestBody request =
         new ApiGrantRoleRequestBody().memberEmail(userAccessUtils.getSecondUserEmail());
     mockMvc
@@ -242,10 +242,10 @@ class SamServiceTest extends BaseConnectedTest {
                             workspaceUuid,
                             WsmIamRole.READER.toSamRole()))
                         .content(objectMapper.writeValueAsString(request)),
-                    userAccessUtils.defaultUserAuthRequest())))
+                    defaultUserRequest())))
         .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
 
-    samService.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceUuid);
+    samService.deleteWorkspace(defaultUserRequest(), workspaceUuid);
   }
 
   @Test
@@ -255,7 +255,7 @@ class SamServiceTest extends BaseConnectedTest {
         () ->
             samService.grantWorkspaceRole(
                 workspaceUuid,
-                userAccessUtils.defaultUserAuthRequest(),
+                defaultUserRequest(),
                 WsmIamRole.READER,
                 "!!!INVALID EMAIL ADDRESS!!!!"));
   }
@@ -264,11 +264,10 @@ class SamServiceTest extends BaseConnectedTest {
   void listPermissionsIncludesAddedUsers() throws Exception {
     samService.grantWorkspaceRole(
         workspaceUuid,
-        userAccessUtils.defaultUserAuthRequest(),
+        defaultUserRequest(),
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    List<RoleBinding> policyList =
-        samService.listRoleBindings(workspaceUuid, userAccessUtils.defaultUserAuthRequest());
+    List<RoleBinding> policyList = samService.listRoleBindings(workspaceUuid, defaultUserRequest());
 
     RoleBinding expectedOwnerBinding =
         RoleBinding.builder()
@@ -300,12 +299,12 @@ class SamServiceTest extends BaseConnectedTest {
   void writerCannotListPermissions() throws Exception {
     samService.grantWorkspaceRole(
         workspaceUuid,
-        userAccessUtils.defaultUserAuthRequest(),
+        defaultUserRequest(),
         WsmIamRole.WRITER,
         userAccessUtils.getSecondUserEmail());
     assertThrows(
         ForbiddenException.class,
-        () -> samService.listRoleBindings(workspaceUuid, userAccessUtils.secondUserAuthRequest()));
+        () -> samService.listRoleBindings(workspaceUuid, secondaryUserRequest()));
   }
 
   @Test
@@ -316,7 +315,7 @@ class SamServiceTest extends BaseConnectedTest {
         () ->
             samService.grantWorkspaceRole(
                 fakeId,
-                userAccessUtils.defaultUserAuthRequest(),
+                defaultUserRequest(),
                 WsmIamRole.READER,
                 userAccessUtils.getSecondUserEmail()));
   }
@@ -326,7 +325,7 @@ class SamServiceTest extends BaseConnectedTest {
     UUID fakeId = UUID.randomUUID();
     assertThrows(
         SamNotFoundException.class,
-        () -> samService.listRoleBindings(fakeId, userAccessUtils.defaultUserAuthRequest()));
+        () -> samService.listRoleBindings(fakeId, defaultUserRequest()));
   }
 
   @Test
@@ -343,24 +342,23 @@ class SamServiceTest extends BaseConnectedTest {
     // Default user is workspace owner, secondary user is workspace reader
     samService.grantWorkspaceRole(
         workspaceUuid,
-        userAccessUtils.defaultUserAuthRequest(),
+        defaultUserRequest(),
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
 
     ControlledResource bucketResource =
         ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceUuid).build();
-    samService.createControlledResource(
-        bucketResource, null, null, userAccessUtils.defaultUserAuthRequest());
+    samService.createControlledResource(bucketResource, null, null, defaultUserRequest());
 
     // Workspace reader should have read access on a user-shared resource via inheritance
     assertTrue(
         samService.isAuthorized(
-            userAccessUtils.secondUserAuthRequest(),
+            secondaryUserRequest(),
             ControlledResourceCategory.USER_SHARED.getSamResourceName(),
             bucketResource.getResourceId().toString(),
             SamWorkspaceAction.READ));
 
-    samService.deleteControlledResource(bucketResource, userAccessUtils.defaultUserAuthRequest());
+    samService.deleteControlledResource(bucketResource, defaultUserRequest());
   }
 
   @Test
@@ -368,7 +366,7 @@ class SamServiceTest extends BaseConnectedTest {
     // Default user is workspace owner, secondary user is workspace reader
     samService.grantWorkspaceRole(
         workspaceUuid,
-        userAccessUtils.defaultUserAuthRequest(),
+        defaultUserRequest(),
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
 
@@ -391,48 +389,45 @@ class SamServiceTest extends BaseConnectedTest {
         bucketResource,
         ControlledResourceIamRole.EDITOR,
         userAccessUtils.getDefaultUserEmail(),
-        userAccessUtils.defaultUserAuthRequest());
+        defaultUserRequest());
 
     // Workspace reader should not have read access on a private resource.
     assertFalse(
         samService.isAuthorized(
-            userAccessUtils.secondUserAuthRequest(),
+            secondaryUserRequest(),
             ControlledResourceCategory.USER_PRIVATE.getSamResourceName(),
             bucketResource.getResourceId().toString(),
             SamConstants.SamWorkspaceAction.READ));
     // However, the assigned user should have read access.
     assertTrue(
         samService.isAuthorized(
-            userAccessUtils.defaultUserAuthRequest(),
+            defaultUserRequest(),
             ControlledResourceCategory.USER_PRIVATE.getSamResourceName(),
             bucketResource.getResourceId().toString(),
             SamConstants.SamWorkspaceAction.READ));
 
-    samService.deleteControlledResource(bucketResource, userAccessUtils.defaultUserAuthRequest());
+    samService.deleteControlledResource(bucketResource, defaultUserRequest());
   }
 
   @Test
   void duplicateResourceCreateIgnored() throws Exception {
     ControlledResource bucketResource =
         ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceUuid).build();
-    samService.createControlledResource(
-        bucketResource, null, null, userAccessUtils.defaultUserAuthRequest());
+    samService.createControlledResource(bucketResource, null, null, defaultUserRequest());
     // This duplicate call should complete without throwing.
-    samService.createControlledResource(
-        bucketResource, null, null, userAccessUtils.defaultUserAuthRequest());
+    samService.createControlledResource(bucketResource, null, null, defaultUserRequest());
     // Delete the bucket so we can clean up the workspace.
-    samService.deleteControlledResource(bucketResource, userAccessUtils.defaultUserAuthRequest());
+    samService.deleteControlledResource(bucketResource, defaultUserRequest());
   }
 
   @Test
   void duplicateResourceDeleteIgnored() throws Exception {
     ControlledResource bucketResource =
         ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceUuid).build();
-    samService.createControlledResource(
-        bucketResource, null, null, userAccessUtils.defaultUserAuthRequest());
+    samService.createControlledResource(bucketResource, null, null, defaultUserRequest());
 
-    samService.deleteControlledResource(bucketResource, userAccessUtils.defaultUserAuthRequest());
-    samService.deleteControlledResource(bucketResource, userAccessUtils.defaultUserAuthRequest());
+    samService.deleteControlledResource(bucketResource, defaultUserRequest());
+    samService.deleteControlledResource(bucketResource, defaultUserRequest());
   }
 
   @Test
@@ -445,9 +440,29 @@ class SamServiceTest extends BaseConnectedTest {
         () -> samService.checkAdminAuthz(userAccessUtils.secondUserAuthRequest()));
   }
 
+  /**
+   * Convenience method to build an AuthenticatedUserRequest from utils' default user.
+   *
+   * <p>This only fills in access token, not email or subjectId.
+   */
+  private AuthenticatedUserRequest defaultUserRequest() {
+    return new AuthenticatedUserRequest(
+        null, null, Optional.of(userAccessUtils.defaultUserAccessToken().getTokenValue()));
+  }
+
+  /**
+   * Convenience method to build an AuthenticatedUserRequest from utils' secondary default user.
+   *
+   * <p>This only fills in access token, not email or subjectId.
+   */
+  private AuthenticatedUserRequest secondaryUserRequest() {
+    return new AuthenticatedUserRequest(
+        null, null, Optional.of(userAccessUtils.secondUserAccessToken().getTokenValue()));
+  }
+
   /** Create a workspace using the default test user for connected tests, return its ID. */
   private Workspace createWorkspaceDefaultUser() {
-    return createWorkspaceForUser(userAccessUtils.defaultUserAuthRequest());
+    return createWorkspaceForUser(defaultUserRequest());
   }
 
   private Workspace createWorkspaceForUser(AuthenticatedUserRequest userRequest) {

--- a/service/src/test/resources/application-connected-test.yml
+++ b/service/src/test/resources/application-connected-test.yml
@@ -5,12 +5,8 @@ workspace:
   connected-test:
     user-delegated-service-account-path: ../config/user-delegated-sa.json
     default-user-email: elijah.thunderlord@test.firecloud.org
-    default-user-subject-id: 106856642778103672195
     second-user-email: liam.dragonmaw@test.firecloud.org
-    second-user-subject-id: 101362377780312584307
     billing-user-email: hermione.owner@test.firecloud.org
-    billing-user-subject-id: 110530393451290928813
-
 
   crl:
     use-crl: true


### PR DESCRIPTION
Reverts DataBiosphere/terra-workspace-manager#892

PF-2176 hard-coded some subject IDs specific to broad-dev. Verily downstream tests failed.