### PR TITLE
SAS token API does not work with storage containers created in Landing Zone storage accounts

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -47,6 +47,7 @@ import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadat
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.SasPermissionsHelper;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.SasTokenOptions;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.ip.ControlledAzureIpResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.network.ControlledAzureNetworkResource;
@@ -73,7 +74,7 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class ControlledAzureResourceApiController extends ControlledResourceControllerBase
     implements ControlledAzureResourceApi {
-  private final Logger logger = LoggerFactory.getLogger(ControlledGcpResourceApiController.class);
+  private final Logger logger = LoggerFactory.getLogger(ControlledAzureResourceApiController.class);
 
   private final ControlledResourceService controlledResourceService;
   private final AzureStorageAccessService azureControlledStorageResourceService;
@@ -233,26 +234,6 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     ControllerValidationUtils.validateSasBlobName(sasBlobName);
     SasPermissionsHelper.validateSasPermissionString(sasPermissions);
 
-    final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    // Creating an AzureStorageContainerSasToken requires checking the user's access to both the
-    // storage container and storage account resources.
-    final ControlledAzureStorageContainerResource storageContainerResource =
-        controlledResourceMetadataManager
-            .validateControlledResourceAndAction(
-                userRequest,
-                workspaceUuid,
-                storageContainerUuid,
-                SamControlledResourceActions.READ_ACTION)
-            .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
-    final ControlledAzureStorageResource storageAccountResource =
-        controlledResourceMetadataManager
-            .validateControlledResourceAndAction(
-                userRequest,
-                workspaceUuid,
-                storageContainerResource.getStorageAccountId(),
-                SamControlledResourceActions.READ_ACTION)
-            .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
-
     OffsetDateTime startTime =
         OffsetDateTime.now().minusMinutes(azureConfiguration.getSasTokenStartTimeMinutesOffset());
     long secondDuration =
@@ -264,14 +245,9 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     var sasBundle =
         azureControlledStorageResourceService.createAzureStorageContainerSasToken(
             workspaceUuid,
-            storageContainerResource,
-            storageAccountResource,
-            startTime,
-            expiryTime,
-            userRequest,
-            sasIpRange,
-            sasBlobName,
-            sasPermissions);
+            storageContainerUuid,
+            getAuthenticatedInfo(),
+            new SasTokenOptions(sasIpRange, startTime, expiryTime, sasBlobName, sasPermissions));
 
     return new ResponseEntity<>(
         new ApiCreatedAzureStorageContainerSasToken()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -1,16 +1,24 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
 import bio.terra.common.exception.ForbiddenException;
+import bio.terra.common.iam.BearerToken;
+import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
+import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.StorageAccountKeyProvider;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
+import bio.terra.workspace.service.workspace.AzureCloudContextService;
 import com.azure.core.http.HttpClient;
+import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.azure.storage.blob.sas.BlobContainerSasPermission;
@@ -21,6 +29,7 @@ import com.azure.storage.common.sas.SasProtocol;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,18 +46,35 @@ import org.springframework.stereotype.Component;
 public class AzureStorageAccessService {
   private static final Logger logger = LoggerFactory.getLogger(AzureStorageAccessService.class);
 
+  record StorageData(
+      String storageAccountName,
+      String endpoint,
+      ControlledAzureStorageContainerResource storageContainerResource) {}
+
   private final SamService samService;
+  private final CrlService crlService;
   private final FeatureConfiguration features;
   private final StorageAccountKeyProvider storageAccountKeyProvider;
+  private final ControlledResourceMetadataManager controlledResourceMetadataManager;
+  private final LandingZoneApiDispatch landingZoneApiDispatch;
+  private final AzureCloudContextService azureCloudContextService;
   private final AzureConfiguration azureConfiguration;
 
   @Autowired
   public AzureStorageAccessService(
       SamService samService,
+      CrlService crlService,
       StorageAccountKeyProvider storageAccountKeyProvider,
+      ControlledResourceMetadataManager controlledResourceMetadataManager,
+      LandingZoneApiDispatch landingZoneApiDispatch,
+      AzureCloudContextService azureCloudContextService,
       FeatureConfiguration features,
       AzureConfiguration azureConfiguration) {
     this.samService = samService;
+    this.crlService = crlService;
+    this.controlledResourceMetadataManager = controlledResourceMetadataManager;
+    this.landingZoneApiDispatch = landingZoneApiDispatch;
+    this.azureCloudContextService = azureCloudContextService;
     this.features = features;
     this.storageAccountKeyProvider = storageAccountKeyProvider;
     this.azureConfiguration = azureConfiguration;
@@ -106,7 +132,6 @@ public class AzureStorageAccessService {
    *
    * @param workspaceUuid id of the workspace that owns the container resource
    * @param storageContainerResource storage container object we want to mint a SAS for
-   * @param storageAccountResource storage account which owns the storage container object
    * @param userRequest The authenticated user's request
    * @param sasIpRange (optional) IP address or range of IPs from which the Azure APIs will accept
    *     requests for the token being minted.
@@ -116,7 +141,6 @@ public class AzureStorageAccessService {
   public AzureSasBundle createAzureStorageContainerSasToken(
       UUID workspaceUuid,
       ControlledAzureStorageContainerResource storageContainerResource,
-      ControlledAzureStorageResource storageAccountResource,
       AuthenticatedUserRequest userRequest,
       String sasIpRange,
       String sasBlobName,
@@ -129,14 +153,9 @@ public class AzureStorageAccessService {
 
     return createAzureStorageContainerSasToken(
         workspaceUuid,
-        storageContainerResource,
-        storageAccountResource,
-        startTime,
-        expiryTime,
+        storageContainerResource.getResourceId(),
         userRequest,
-        sasIpRange,
-        sasBlobName,
-        sasPermissions);
+        new SasTokenOptions(sasIpRange, startTime, expiryTime, sasBlobName, sasPermissions));
   }
 
   /**
@@ -144,65 +163,62 @@ public class AzureStorageAccessService {
    * Azure permissions.
    *
    * @param workspaceUuid id of the workspace that owns the container resource
-   * @param storageContainerResource storage container object we want to mint a SAS for
-   * @param storageAccountResource storage account which owns the storage container object
-   * @param startTime Time at which the SAS will become functional
-   * @param expiryTime Time at which the SAS will expire
+   * @param storageContainerUuid id of the storage container resource
    * @param userRequest The authenticated user's request
-   * @param sasIpRange (optional) IP address or range of IPs from which the Azure APIs will accept
-   *     requests for the token being minted.
+   * @param sasTokenOptions Token options which include 1) ipRange - (optional) IP address or range
+   *     of IPs from which the Azure APIs will accept requests for the token being minted. 2)
+   *     startTime - Time at which the SAS will become functional 3) expiryTime - Time at which the
+   *     SAS will expire 4) blobName - Requests access to a single blob in a container 5)
+   *     permissions - Permissions associated with the SAS indicating what operations a client may
+   *     perform on the resource
    * @return A bundle of 1) a full Azure SAS URL, including the storage account hostname and 2) the
    *     token query param fragment
    */
   public AzureSasBundle createAzureStorageContainerSasToken(
       UUID workspaceUuid,
-      ControlledAzureStorageContainerResource storageContainerResource,
-      ControlledAzureStorageResource storageAccountResource,
-      OffsetDateTime startTime,
-      OffsetDateTime expiryTime,
+      UUID storageContainerUuid,
       AuthenticatedUserRequest userRequest,
-      String sasIpRange,
-      String sasBlobName,
-      String sasPermissions) {
+      SasTokenOptions sasTokenOptions) {
     features.azureEnabledCheck();
 
     logger.info(
         "user {} requesting SAS token for Azure storage container {} in workspace {}",
         userRequest.getEmail(),
-        storageContainerResource.toString(),
+        storageContainerUuid.toString(),
         workspaceUuid.toString());
+
+    var storageData = getStorageAccountData(workspaceUuid, storageContainerUuid, userRequest);
 
     BlobContainerSasPermission blobContainerSasPermission =
         getSasTokenPermissions(
             userRequest,
-            storageContainerResource.getResourceId(),
-            storageContainerResource.getCategory().getSamResourceName(),
-            sasPermissions);
+            storageData.storageContainerResource().getResourceId(),
+            storageData.storageContainerResource.getCategory().getSamResourceName(),
+            sasTokenOptions.permissions());
 
-    String storageAccountName = storageAccountResource.getStorageAccountName();
-    String endpoint = storageAccountResource.getStorageAccountEndpoint();
     StorageSharedKeyCredential storageKey =
-        storageAccountKeyProvider.getStorageAccountKey(workspaceUuid, storageAccountName);
+        storageAccountKeyProvider.getStorageAccountKey(
+            workspaceUuid, storageData.storageAccountName());
 
     BlobContainerClient blobContainerClient =
         new BlobContainerClientBuilder()
             .credential(storageKey)
-            .endpoint(endpoint)
+            .endpoint(storageData.endpoint())
             .httpClient(HttpClient.createDefault())
-            .containerName(storageContainerResource.getStorageContainerName())
+            .containerName(storageData.storageContainerResource.getStorageContainerName())
             .buildClient();
     BlobServiceSasSignatureValues sasValues =
-        new BlobServiceSasSignatureValues(expiryTime, blobContainerSasPermission)
-            .setStartTime(startTime)
+        new BlobServiceSasSignatureValues(sasTokenOptions.expiryTime(), blobContainerSasPermission)
+            .setStartTime(sasTokenOptions.startTime())
             .setProtocol(SasProtocol.HTTPS_ONLY);
 
-    if (sasIpRange != null) {
-      sasValues.setSasIpRange(SasIpRange.parse(sasIpRange));
+    if (sasTokenOptions.ipRange() != null) {
+      sasValues.setSasIpRange(SasIpRange.parse(sasTokenOptions.ipRange()));
     }
 
     String token;
-    if (sasBlobName != null) {
-      var blobClient = blobContainerClient.getBlobClient(sasBlobName);
+    if (sasTokenOptions.blobName() != null) {
+      var blobClient = blobContainerClient.getBlobClient(sasTokenOptions.blobName());
       token = blobClient.generateSas(sasValues);
     } else {
       token = blobContainerClient.generateSas(sasValues);
@@ -210,9 +226,9 @@ public class AzureStorageAccessService {
 
     logger.info(
         "SAS token with expiry time of {} generated for user {} on container {} in workspace {}",
-        expiryTime,
+        sasTokenOptions.expiryTime(),
         userRequest.getEmail(),
-        storageContainerResource.getResourceId(),
+        storageContainerUuid,
         workspaceUuid);
 
     return new AzureSasBundle(
@@ -220,8 +236,8 @@ public class AzureStorageAccessService {
         String.format(
             Locale.ROOT,
             "https://%s.blob.core.windows.net/%s?%s",
-            storageAccountName,
-            storageContainerResource.getStorageContainerName(),
+            storageData.storageAccountName(),
+            storageData.storageContainerResource().getStorageContainerName(),
             token));
   }
 
@@ -246,5 +262,60 @@ public class AzureStorageAccessService {
         .httpClient(HttpClient.createDefault())
         .containerName(containerResource.getStorageContainerName())
         .buildClient();
+  }
+
+  private StorageData getStorageAccountData(
+      UUID workspaceUuid, UUID storageContainerUuid, AuthenticatedUserRequest userRequest) {
+    // Creating an AzureStorageContainerSasToken requires checking the user's access to both the
+    // storage container and storage account resource
+    final ControlledAzureStorageContainerResource storageContainerResource =
+        controlledResourceMetadataManager
+            .validateControlledResourceAndAction(
+                userRequest,
+                workspaceUuid,
+                storageContainerUuid,
+                SamConstants.SamControlledResourceActions.READ_ACTION)
+            .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
+    String storageAccountName;
+    String endpoint;
+    if (storageContainerResource.getStorageAccountId() != null) {
+      final ControlledAzureStorageResource storageAccountResource =
+          controlledResourceMetadataManager
+              .validateControlledResourceAndAction(
+                  userRequest,
+                  workspaceUuid,
+                  storageContainerResource.getStorageAccountId(),
+                  SamConstants.SamControlledResourceActions.READ_ACTION)
+              .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+      storageAccountName = storageAccountResource.getStorageAccountName();
+      endpoint = storageAccountResource.getStorageAccountEndpoint();
+    } else {
+      // get details from LZ shared storage account
+      UUID landingZoneId =
+          landingZoneApiDispatch.getLandingZoneId(
+              new BearerToken(userRequest.getRequiredToken()), workspaceUuid);
+      Optional<ApiAzureLandingZoneDeployedResource> existingSharedStorageAccount =
+          landingZoneApiDispatch.getSharedStorageAccount(
+              new BearerToken(userRequest.getRequiredToken()), landingZoneId);
+      if (existingSharedStorageAccount.isEmpty()) {
+        // redefine exception
+        throw new IllegalStateException(
+            String.format(
+                "Shared storage account not found. LandingZoneId='%s'."
+                    + " Please validate that landing zone deployment complete.",
+                landingZoneId));
+      }
+      var storageManager =
+          crlService.getStorageManager(
+              azureCloudContextService.getRequiredAzureCloudContext(workspaceUuid),
+              azureConfiguration);
+      StorageAccount storageAccount =
+          storageManager
+              .storageAccounts()
+              .getById(existingSharedStorageAccount.get().getResourceId());
+      storageAccountName = storageAccount.name();
+      endpoint = storageAccount.endPoints().primary().blob().toLowerCase(Locale.ROOT);
+    }
+    return new StorageData(storageAccountName, endpoint, storageContainerResource);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopier.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopier.java
@@ -61,7 +61,6 @@ public class BlobCopier {
                 beginCopyBlob(
                     storageAccessService,
                     sourceContainer,
-                    sourceStorageAccount,
                     userRequest,
                     sourceBlobItem,
                     sourceBlobContainerClient,
@@ -88,7 +87,6 @@ public class BlobCopier {
   private SyncPoller<BlobCopyInfo, Void> beginCopyBlob(
       AzureStorageAccessService storageAccessService,
       ControlledAzureStorageContainerResource sourceContainer,
-      ControlledAzureStorageResource sourceStorageAccount,
       AuthenticatedUserRequest userRequest,
       BlobItem sourceBlobItem,
       BlobContainerClient sourceBlobContainerClient,
@@ -97,7 +95,6 @@ public class BlobCopier {
         storageAccessService.createAzureStorageContainerSasToken(
             sourceContainer.getWorkspaceId(),
             sourceContainer,
-            sourceStorageAccount,
             userRequest,
             null,
             sourceBlobItem.getName(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/SasTokenOptions.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/SasTokenOptions.java
@@ -1,0 +1,10 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure;
+
+import java.time.OffsetDateTime;
+
+public record SasTokenOptions(
+    String ipRange,
+    OffsetDateTime startTime,
+    OffsetDateTime expiryTime,
+    String blobName,
+    String permissions) {}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CloneControlledAzureStorageContainerResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CloneControlledAzureStorageContainerResourceFlight.java
@@ -129,7 +129,11 @@ public class CloneControlledAzureStorageContainerResourceFlight extends Flight {
         var azureStorageService =
             new AzureStorageAccessService(
                 flightBeanBag.getSamService(),
+                flightBeanBag.getCrlService(),
                 flightBeanBag.getStorageAccountKeyProvider(),
+                flightBeanBag.getControlledResourceMetadataManager(),
+                flightBeanBag.getLandingZoneApiDispatch(),
+                flightBeanBag.getAzureCloudContextService(),
                 flightBeanBag.getFeatureConfiguration(),
                 flightBeanBag.getAzureConfig());
         addStep(

--- a/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
@@ -13,18 +13,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureUnitTest;
-import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
-import bio.terra.workspace.db.ResourceDao;
-import bio.terra.workspace.db.WorkspaceDao;
-import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureSasBundle;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storage.ControlledAzureStorageResource;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
-import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
-import bio.terra.workspace.service.workspace.WorkspaceService;
-import bio.terra.workspace.service.workspace.model.AzureCloudContext;
-import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
-import java.time.OffsetDateTime;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.SasTokenOptions;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,64 +32,17 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
   private UUID workspaceId;
   private UUID storageContainerId;
 
-  private ControlledAzureStorageResource accountResource;
-  private ControlledAzureStorageContainerResource containerResource;
-  @Autowired ControlledResourceMetadataManager controlledResourceMetadataManager;
-  @Autowired WorkspaceDao workspaceDao;
-  @Autowired WorkspaceService workspaceService;
-  @Autowired ResourceDao resourceDao;
-  @Autowired SpendConnectedTestUtils spendUtils;
+  ArgumentCaptor<SasTokenOptions> sasTokenOptionsCaptor =
+      ArgumentCaptor.forClass(SasTokenOptions.class);
 
   @BeforeEach
   public void setup() throws Exception {
     workspaceId = UUID.randomUUID();
-    var azureCloudContext = new AzureCloudContext("fake", "fake", "fake");
-    WorkspaceUnitTestUtils.createWorkspaceWithAzureContext(
-        workspaceId, workspaceDao, azureCloudContext);
-
     storageContainerId = UUID.randomUUID();
-    UUID storageAccountId = UUID.randomUUID();
-
-    containerResource =
-        ControlledAzureStorageContainerResource.builder()
-            .common(
-                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
-                    .workspaceUuid(workspaceId)
-                    .resourceId(storageContainerId)
-                    .build())
-            .storageAccountId(storageAccountId)
-            .storageContainerName("testcontainer")
-            .build();
-
-    resourceDao.createControlledResource(containerResource);
-
-    accountResource =
-        ControlledAzureStorageResource.builder()
-            .common(
-                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
-                    .workspaceUuid(workspaceId)
-                    .resourceId(storageAccountId)
-                    .build())
-            .storageAccountName("testaccount")
-            .region("eastus")
-            .build();
-
-    resourceDao.createControlledResource(accountResource);
-
-    when(mockSamService().getUserEmailFromSam(eq(USER_REQUEST)))
-        .thenReturn(USER_REQUEST.getEmail());
 
     when(mockAzureStorageAccessService()
             .createAzureStorageContainerSasToken(
-                eq(workspaceId),
-                eq(containerResource),
-                eq(accountResource),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()))
+                eq(workspaceId), eq(storageContainerId), any(), any()))
         .thenReturn(new AzureSasBundle("sasToken", "sasUrl"));
   }
 
@@ -167,32 +110,21 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
                 USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_OK));
 
-    ArgumentCaptor<OffsetDateTime> startTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
-    ArgumentCaptor<OffsetDateTime> endTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
-
     Mockito.verify(mockAzureStorageAccessService(), times(2))
         .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            startTimeCaptor.capture(),
-            endTimeCaptor.capture(),
-            any(),
-            any(),
-            any(),
-            any());
+            eq(workspaceId), eq(storageContainerId), any(), sasTokenOptionsCaptor.capture());
 
     // First call uses custom time of 2 hours (plus 5 minutes before) = 7500 seconds.
     assertEquals(
         7500,
-        endTimeCaptor.getAllValues().get(0).toEpochSecond()
-            - startTimeCaptor.getAllValues().get(0).toEpochSecond());
+        sasTokenOptionsCaptor.getAllValues().get(0).expiryTime().toEpochSecond()
+            - sasTokenOptionsCaptor.getAllValues().get(0).startTime().toEpochSecond());
 
     // Second call based on configuration, difference should be 15 minutes = 900 seconds.
     assertEquals(
         900,
-        endTimeCaptor.getAllValues().get(1).toEpochSecond()
-            - startTimeCaptor.getAllValues().get(1).toEpochSecond());
+        sasTokenOptionsCaptor.getAllValues().get(1).expiryTime().toEpochSecond()
+            - sasTokenOptionsCaptor.getAllValues().get(1).startTime().toEpochSecond());
   }
 
   @Test
@@ -227,15 +159,8 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
 
     Mockito.verify(mockAzureStorageAccessService())
         .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            eq(ipRange),
-            any(),
-            any());
+            eq(workspaceId), eq(storageContainerId), any(), sasTokenOptionsCaptor.capture());
+    assertEquals(ipRange, sasTokenOptionsCaptor.getValue().ipRange());
   }
 
   @Test
@@ -256,15 +181,8 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
 
     Mockito.verify(mockAzureStorageAccessService())
         .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            any(),
-            eq(blobName),
-            any());
+            eq(workspaceId), eq(storageContainerId), any(), sasTokenOptionsCaptor.capture());
+    assertEquals(blobName, sasTokenOptionsCaptor.getValue().blobName());
   }
 
   @Test
@@ -299,15 +217,8 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
 
     Mockito.verify(mockAzureStorageAccessService())
         .createAzureStorageContainerSasToken(
-            eq(workspaceId),
-            eq(containerResource),
-            eq(accountResource),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            eq(permissions));
+            eq(workspaceId), eq(storageContainerId), any(), sasTokenOptionsCaptor.capture());
+    assertEquals(permissions, sasTokenOptionsCaptor.getValue().permissions());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureUnitTest.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.common;
 
 import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
 import bio.terra.workspace.app.controller.shared.JobApiUtils;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageAccessService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import org.junit.jupiter.api.Tag;
@@ -15,6 +16,7 @@ public class BaseAzureUnitTest extends BaseUnitTestMocks {
   @MockBean private JobApiUtils mockJobApiUtils;
   @MockBean private LandingZoneService mockLandingZoneService;
   @MockBean private WorkspaceService mockWorkspaceService;
+  @MockBean private ControlledResourceMetadataManager mockControlledResourceMetadataManager;
 
   public AzureStorageAccessService mockAzureStorageAccessService() {
     return mockAzureStorageAccessService;
@@ -30,5 +32,9 @@ public class BaseAzureUnitTest extends BaseUnitTestMocks {
 
   public WorkspaceService mockWorkspaceService() {
     return mockWorkspaceService;
+  }
+
+  public ControlledResourceMetadataManager mockControlledResourceMetadataManager() {
+    return mockControlledResourceMetadataManager;
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -415,6 +415,29 @@ public class ControlledResourceFixtures {
         /*properties=*/ Map.of());
   }
 
+  public static ControlledAzureStorageResource getAzureStorage(
+      UUID workspaceUuid,
+      UUID accountResourceId,
+      String storageAccountName,
+      String region,
+      String resourceName,
+      String resourceDescription) {
+    return ControlledAzureStorageResource.builder()
+        .common(
+            ControlledResourceFields.builder()
+                .workspaceUuid(workspaceUuid)
+                .resourceId(accountResourceId)
+                .name(resourceName)
+                .description(resourceDescription)
+                .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                .build())
+        .storageAccountName(storageAccountName)
+        .region(region)
+        .build();
+  }
+
   public static ControlledAzureStorageContainerResource getAzureStorageContainer(
       UUID storageAccountId, String storageContainerName) {
     return new ControlledAzureStorageContainerResource(
@@ -433,6 +456,29 @@ public class ControlledResourceFixtures {
         storageContainerName,
         /*resourceLineage=*/ null,
         /*properties=*/ Map.of());
+  }
+
+  public static ControlledAzureStorageContainerResource getAzureStorageContainer(
+      UUID workspaceUuid,
+      UUID accountResourceId,
+      UUID containerResourceId,
+      String containerName,
+      String resourceName,
+      String resourceDescription) {
+    return ControlledAzureStorageContainerResource.builder()
+        .common(
+            ControlledResourceFields.builder()
+                .workspaceUuid(workspaceUuid)
+                .resourceId(containerResourceId)
+                .name(resourceName)
+                .description(resourceDescription)
+                .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                .build())
+        .storageAccountId(accountResourceId)
+        .storageContainerName(containerName)
+        .build();
   }
 
   public static ControlledAzureVmResource getAzureVm(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -237,20 +237,13 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
 
     final UUID accountResourceId = UUID.randomUUID();
     ControlledAzureStorageResource accountResource =
-        ControlledAzureStorageResource.builder()
-            .common(
-                ControlledResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(accountResourceId)
-                    .name(getAzureName("rs"))
-                    .description(getAzureName("rs-desc"))
-                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .build())
-            .storageAccountName(accountCreationParameters.getStorageAccountName())
-            .region(accountCreationParameters.getRegion())
-            .build();
+        ControlledResourceFixtures.getAzureStorage(
+            workspaceUuid,
+            accountResourceId,
+            accountCreationParameters.getStorageAccountName(),
+            accountCreationParameters.getRegion(),
+            getAzureName("rs"),
+            getAzureName("rs-desc"));
 
     // Submit a storage account creation flight and then verify the resource exists in the
     // workspace.
@@ -265,20 +258,13 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     final UUID containerResourceId = UUID.randomUUID();
     final String containerName = ControlledResourceFixtures.uniqueBucketName();
     ControlledAzureStorageContainerResource containerResource =
-        ControlledAzureStorageContainerResource.builder()
-            .common(
-                ControlledResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(containerResourceId)
-                    .name(getAzureName("rc"))
-                    .description(getAzureName("rc-desc"))
-                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .build())
-            .storageAccountId(accountResourceId)
-            .storageContainerName(containerName)
-            .build();
+        ControlledResourceFixtures.getAzureStorageContainer(
+            workspaceUuid,
+            accountResourceId,
+            containerResourceId,
+            containerName,
+            getAzureName("rc"),
+            getAzureName("rc-desc"));
     createResource(
         workspaceUuid,
         userRequest,
@@ -341,21 +327,13 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     final UUID containerResourceId = UUID.randomUUID();
     final String storageContainerName = ControlledResourceFixtures.uniqueBucketName();
     ControlledAzureStorageContainerResource containerResource =
-        ControlledAzureStorageContainerResource.builder()
-            .common(
-                ControlledResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(containerResourceId)
-                    .name(getAzureName("rc"))
-                    .description(getAzureName("rc-desc"))
-                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .build())
-            /*set it explicitly to show that landing zone shared storage account will be used*/
-            .storageAccountId(null)
-            .storageContainerName(storageContainerName)
-            .build();
+        ControlledResourceFixtures.getAzureStorageContainer(
+            workspaceUuid,
+            null,
+            containerResourceId,
+            storageContainerName,
+            getAzureName("rc"),
+            getAzureName("rc-desc"));
 
     createResource(
         workspaceUuid,
@@ -396,21 +374,13 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     final UUID containerResourceId = UUID.randomUUID();
     final String storageContainerName = ControlledResourceFixtures.uniqueBucketName();
     ControlledAzureStorageContainerResource containerResource =
-        ControlledAzureStorageContainerResource.builder()
-            .common(
-                ControlledResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(containerResourceId)
-                    .name(getAzureName("rc"))
-                    .description(getAzureName("rc-desc"))
-                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .build())
-            /*set it explicitly to show that landing zone shared storage account will be used*/
-            .storageAccountId(null)
-            .storageContainerName(storageContainerName)
-            .build();
+        ControlledResourceFixtures.getAzureStorageContainer(
+            workspaceUuid,
+            null,
+            containerResourceId,
+            storageContainerName,
+            getAzureName("rc"),
+            getAzureName("rc-desc"));
 
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
@@ -456,21 +426,13 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     final UUID containerResourceId = UUID.randomUUID();
     final String storageContainerName = ControlledResourceFixtures.uniqueBucketName();
     ControlledAzureStorageContainerResource containerResource =
-        ControlledAzureStorageContainerResource.builder()
-            .common(
-                ControlledResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(containerResourceId)
-                    .name(getAzureName("rc"))
-                    .description(getAzureName("rc-desc"))
-                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .build())
-            /*set it explicitly to show that landing zone shared storage account will be used*/
-            .storageAccountId(null)
-            .storageContainerName(storageContainerName)
-            .build();
+        ControlledResourceFixtures.getAzureStorageContainer(
+            workspaceUuid,
+            null,
+            containerResourceId,
+            storageContainerName,
+            getAzureName("rc"),
+            getAzureName("rc-desc"));
 
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
@@ -501,20 +463,13 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
 
     final UUID accountResourceId = UUID.randomUUID();
     ControlledAzureStorageResource accountResource =
-        ControlledAzureStorageResource.builder()
-            .common(
-                ControlledResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(accountResourceId)
-                    .name(getAzureName("rs"))
-                    .description(getAzureName("rs-desc"))
-                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .build())
-            .storageAccountName(accountCreationParameters.getStorageAccountName())
-            .region(accountCreationParameters.getRegion())
-            .build();
+        ControlledResourceFixtures.getAzureStorage(
+            workspaceUuid,
+            accountResourceId,
+            accountCreationParameters.getStorageAccountName(),
+            accountCreationParameters.getRegion(),
+            getAzureName("rs"),
+            getAzureName("rs-desc"));
 
     // Submit a storage account creation flight and then verify the resource exists in the
     // workspace.
@@ -529,20 +484,14 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     final UUID containerResourceId = UUID.randomUUID();
     final String containerName = ControlledResourceFixtures.uniqueBucketName();
     ControlledAzureStorageContainerResource containerResource =
-        ControlledAzureStorageContainerResource.builder()
-            .common(
-                ControlledResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(containerResourceId)
-                    .name(getAzureName("rc"))
-                    .description(getAzureName("rc-desc"))
-                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .build())
-            .storageAccountId(accountResourceId)
-            .storageContainerName(containerName)
-            .build();
+        ControlledResourceFixtures.getAzureStorageContainer(
+            workspaceUuid,
+            accountResourceId,
+            containerResourceId,
+            containerName,
+            getAzureName("rc"),
+            getAzureName("rc-desc"));
+
     createResource(
         workspaceUuid,
         userRequest,
@@ -618,21 +567,13 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     final UUID containerResourceId = UUID.randomUUID();
     final String storageContainerName = ControlledResourceFixtures.uniqueBucketName();
     ControlledAzureStorageContainerResource containerResource =
-        ControlledAzureStorageContainerResource.builder()
-            .common(
-                ControlledResourceFields.builder()
-                    .workspaceUuid(workspaceUuid)
-                    .resourceId(containerResourceId)
-                    .name(getAzureName("rc"))
-                    .description(getAzureName("rc-desc"))
-                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
-                    .build())
-            /*set it explicitly to show that landing zone shared storage account will be used*/
-            .storageAccountId(null)
-            .storageContainerName(storageContainerName)
-            .build();
+        ControlledResourceFixtures.getAzureStorageContainer(
+            workspaceUuid,
+            null,
+            containerResourceId,
+            storageContainerName,
+            getAzureName("rc"),
+            getAzureName("rc-desc"));
 
     // create azure storage container
     createResource(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -48,6 +48,8 @@ import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -70,6 +72,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private CrlService crlService;
   @Autowired private AzureConfiguration azureConfig;
+  @Autowired private AzureStorageAccessService azureStorageAccessService;
 
   private void createCloudContext(UUID workspaceUuid, AuthenticatedUserRequest userRequest)
       throws InterruptedException {
@@ -303,18 +306,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
     // Verify containers have been deleted (Can't do this in submitControlledResourceDeletionFlight
     // because the get function takes a different number of arguments. Also no need to sleep another
     // 5 seconds.)
-    com.azure.core.exception.HttpResponseException exception =
-        assertThrows(
-            com.azure.core.exception.HttpResponseException.class,
-            () ->
-                azureTestUtils
-                    .getStorageManager()
-                    .blobContainers()
-                    .get(
-                        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                        accountResource.getStorageAccountName(),
-                        containerName));
-    assertEquals(404, exception.getResponse().getStatusCode());
+    verifyStorageAccountContainerIsDeleted(accountResource, containerName);
   }
 
   @Test
@@ -495,6 +487,180 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
 
     // clean up resources - delete lz database record only
     testLandingZoneManager.deleteLandingZoneWithoutResources(landingZoneId);
+  }
+
+  @Test
+  public void generateAzureStorageContainerSasToken() throws InterruptedException {
+    Workspace workspace = azureTestUtils.createWorkspace(workspaceService);
+    UUID workspaceUuid = workspace.getWorkspaceId();
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
+
+    final ApiAzureStorageCreationParameters accountCreationParameters =
+        ControlledResourceFixtures.getAzureStorageCreationParameters();
+
+    final UUID accountResourceId = UUID.randomUUID();
+    ControlledAzureStorageResource accountResource =
+        ControlledAzureStorageResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(accountResourceId)
+                    .name(getAzureName("rs"))
+                    .description(getAzureName("rs-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .storageAccountName(accountCreationParameters.getStorageAccountName())
+            .region(accountCreationParameters.getRegion())
+            .build();
+
+    // Submit a storage account creation flight and then verify the resource exists in the
+    // workspace.
+    createResource(
+        workspaceUuid,
+        userRequest,
+        accountResource,
+        WsmResourceType.CONTROLLED_AZURE_STORAGE_ACCOUNT);
+
+    // Submit a storage container creation flight and then verify the resource exists in the
+    // workspace.
+    final UUID containerResourceId = UUID.randomUUID();
+    final String containerName = ControlledResourceFixtures.uniqueBucketName();
+    ControlledAzureStorageContainerResource containerResource =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(containerResourceId)
+                    .name(getAzureName("rc"))
+                    .description(getAzureName("rc-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            .storageAccountId(accountResourceId)
+            .storageContainerName(containerName)
+            .build();
+    createResource(
+        workspaceUuid,
+        userRequest,
+        containerResource,
+        WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
+
+    TimeUnit.SECONDS.sleep(15);
+
+    // create SAS token for the storage container above validate
+    OffsetDateTime startTime = OffsetDateTime.now();
+    OffsetDateTime expiryTime = startTime.plusMinutes(15L);
+    var azureSasBundle =
+        azureStorageAccessService.createAzureStorageContainerSasToken(
+            workspaceUuid,
+            containerResourceId,
+            userRequest,
+            new SasTokenOptions(null, startTime, expiryTime, null, null));
+    assertNotNull(azureSasBundle);
+    assertNotNull(azureSasBundle.sasToken());
+    assertNotNull(azureSasBundle.sasUrl());
+
+    // clean up resources - delete storage container resource
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        containerResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        containerResource.getStorageContainerName(),
+        null); // Don't sleep/verify deletion yet.
+
+    // clean up resources - delete storage account resource
+    submitControlledResourceDeletionFlight(
+        workspaceUuid,
+        userRequest,
+        accountResource,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        accountResource.getStorageAccountName(),
+        azureTestUtils.getStorageManager().storageAccounts()::getByResourceGroup);
+
+    verifyStorageAccountContainerIsDeleted(accountResource, containerName);
+  }
+
+  @Test
+  public void generateAzureStorageContainerSasTokenBasedOnLandingZoneSharedStorageAccount()
+      throws InterruptedException {
+    // name of the shared storage account in landing zone
+    String storageAccountName = String.format("lzsharedsa%s", Instant.now().getEpochSecond());
+
+    Workspace workspace = azureTestUtils.createWorkspace(workspaceService);
+    UUID workspaceUuid = workspace.getWorkspaceId();
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    createCloudContext(workspaceUuid, userRequest);
+
+    // create quasi landing zone with a single resource - shared storage account
+    UUID landingZoneId = UUID.fromString(landingZoneTestUtils.getDefaultLandingZoneId());
+
+    TestLandingZoneManager testLandingZoneManager =
+        new TestLandingZoneManager(
+            azureCloudContextService,
+            landingZoneDao,
+            workspaceDao,
+            crlService,
+            azureConfig,
+            workspaceUuid);
+
+    testLandingZoneManager.createLandingZoneWithSharedStorageAccount(
+        landingZoneId, workspaceUuid, storageAccountName, "eastus");
+
+    TimeUnit.MINUTES.sleep(1);
+
+    // Submit a storage container creation flight and then verify the resource exists in the
+    // workspace.
+    final UUID containerResourceId = UUID.randomUUID();
+    final String storageContainerName = ControlledResourceFixtures.uniqueBucketName();
+    ControlledAzureStorageContainerResource containerResource =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceUuid)
+                    .resourceId(containerResourceId)
+                    .name(getAzureName("rc"))
+                    .description(getAzureName("rc-desc"))
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
+                    .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                    .build())
+            /*set it explicitly to show that landing zone shared storage account will be used*/
+            .storageAccountId(null)
+            .storageContainerName(storageContainerName)
+            .build();
+
+    // create azure storage container
+    createResource(
+        workspaceUuid,
+        userRequest,
+        containerResource,
+        WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
+
+    TimeUnit.MINUTES.sleep(1);
+
+    // create SAS token for the storage container above validate
+    OffsetDateTime startTime = OffsetDateTime.now();
+    OffsetDateTime expiryTime = startTime.plusMinutes(15L);
+    var azureSasBundle =
+        azureStorageAccessService.createAzureStorageContainerSasToken(
+            workspaceUuid,
+            containerResourceId,
+            userRequest,
+            new SasTokenOptions(null, startTime, expiryTime, null, null));
+    assertNotNull(azureSasBundle);
+    assertNotNull(azureSasBundle.sasToken());
+    assertNotNull(azureSasBundle.sasUrl());
+
+    // clean up resources - delete lz database record and storage account
+    testLandingZoneManager.deleteLandingZoneWithSharedStorageAccount(
+        landingZoneId,
+        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+        storageAccountName);
   }
 
   @Test
@@ -1325,5 +1491,21 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
               () -> findResource.apply(azureResourceGroupId, resourceName));
       assertEquals(404, exception.getResponse().getStatusCode());
     }
+  }
+
+  private void verifyStorageAccountContainerIsDeleted(
+      ControlledAzureStorageResource accountResource, String containerName) {
+    com.azure.core.exception.HttpResponseException exception =
+        assertThrows(
+            com.azure.core.exception.HttpResponseException.class,
+            () ->
+                azureTestUtils
+                    .getStorageManager()
+                    .blobContainers()
+                    .get(
+                        azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
+                        accountResource.getStorageAccountName(),
+                        containerName));
+    assertEquals(404, exception.getResponse().getStatusCode());
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-264
-Fix issue: handle situation when storage container belongs to shared storage account from landing zone
-Refactoring