### PR TITLE
[WOR-624] Handle landing zone not found when cloning a container

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/RetrieveDestinationStorageAccountResourceIdStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/RetrieveDestinationStorageAccountResourceIdStep.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.azure.container;
 
 import bio.terra.common.iam.BearerToken;
+import bio.terra.landingzone.db.exception.LandingZoneNotFoundException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -83,7 +84,7 @@ public class RetrieveDestinationStorageAccountResourceIdStep implements Step {
                 lzStorageAcct.get().getResourceId());
         return StepResult.getStepResultSuccess();
       }
-    } catch (IllegalStateException e) {
+    } catch (IllegalStateException | LandingZoneNotFoundException e) {
       logger.info(
           String.format(
               "Landing zone associated with the Azure cloud context not found. TenantId='%s', SubscriptionId='%s', ResourceGroupId='%s'",


### PR DESCRIPTION
When we go to pull the storage account for the destination workspace, we are not resilient when the landing zone is not found. We need to catch the resulting `LandingZoneNotFoundException` and fall back to the workspace's storage account if present. [This](https://github.com/DataBiosphere/terra-landing-zone-service/blob/7f39f4e0eca3a48b4bb348366bd2bcc40d2a74ed/service/src/main/java/bio/terra/landingzone/db/LandingZoneDao.java#L180) is the line in the LZ code we're bumping into.