### PR TITLE
Fix flaky test listWorkspaces_requesterIsOwner_returnsFullWorkspace

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -350,7 +350,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
    * Call listWorkspaces and return workspace with specified workspaceId.
    *
    * <p>This should be used instead of just calling listWorkspaces. Tests run in parallel.
-   * listWorkspaces will return workspaces created by a different thread.
+   * listWorkspaces will return workspaces created by a different test on a different thread.
    */
   private Optional<ApiWorkspaceDescription> getWorkspaceUsingListWorkspaces(
       AuthenticatedUserRequest request, UUID workspaceId, Optional<ApiIamRole> minimumHighestRole)

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -349,8 +349,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   /**
    * Call listWorkspaces and return workspace with specified workspaceId.
    *
-   * <p>This should be used instead of just calling listWorkspaces. Tests run in parallel.
-   * listWorkspaces will return workspaces created by a different test on a different thread.
+   * <p>This should be used instead of just calling listWorkspaces. listWorkspaces might return
+   * workspaces that other tests forgot to clean up.
    */
   private Optional<ApiWorkspaceDescription> getWorkspaceUsingListWorkspaces(
       AuthenticatedUserRequest request, UUID workspaceId, Optional<ApiIamRole> minimumHighestRole)


### PR DESCRIPTION
Example flake: https://scans.gradle.com/s/grsyqwlai4suw

The test creates a workspace and expects `listWorkspaces()` to return exactly 1 workspace.

Now that tests run in parallel, the test sometimes fails because `listWorkspaces()` returned 2 workspaces. 1 of the workspaces was created by a different test on a different thread.

Changed test to filter `listWorkspaces()` results by workspace ID.