### PR TITLE
PF-2250: Introduce a new method createWorkspace in WorkspaceFixtures

### DIFF
--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -56,7 +56,6 @@ public class WorkspaceFixtures {
     return Workspace.builder()
         .workspaceId(id)
         .userFacingId("a" + id)
-        .spendProfileId(null)
         .workspaceStage(WorkspaceStage.MC_WORKSPACE);
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -33,13 +33,17 @@ public class WorkspaceFixtures {
     return createWorkspaceRequestBody(ApiWorkspaceStageModel.MC_WORKSPACE);
   }
 
-  public static Workspace createWorkspace(
+  public static Workspace buildWorkspace(
       @Nullable UUID workspaceUuid, WorkspaceStage workspaceStage) {
     return defaultWorkspaceBuilder(workspaceUuid).workspaceStage(workspaceStage).build();
   }
 
-  public static Workspace createMcWorkspace() {
-    return createWorkspace(null, WorkspaceStage.MC_WORKSPACE);
+  public static Workspace buildMcWorkspace() {
+    return buildMcWorkspace(null);
+  }
+
+  public static Workspace buildMcWorkspace(@Nullable UUID workspaceUuid) {
+    return buildWorkspace(workspaceUuid, WorkspaceStage.MC_WORKSPACE);
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -4,9 +4,13 @@ import bio.terra.workspace.generated.model.ApiCreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiProperties;
 import bio.terra.workspace.generated.model.ApiProperty;
 import bio.terra.workspace.generated.model.ApiWorkspaceStageModel;
+import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceConstants.Properties;
+import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.google.common.collect.ImmutableList;
+import java.util.Optional;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 public class WorkspaceFixtures {
 
@@ -27,6 +31,33 @@ public class WorkspaceFixtures {
    */
   public static ApiCreateWorkspaceRequestBody createWorkspaceRequestBody() {
     return createWorkspaceRequestBody(ApiWorkspaceStageModel.MC_WORKSPACE);
+  }
+
+  public static Workspace createWorkspace(
+      @Nullable UUID workspaceUuid, WorkspaceStage workspaceStage) {
+    return defaultWorkspaceBuilder(workspaceUuid).workspaceStage(workspaceStage).build();
+  }
+
+  public static Workspace createWorkspace() {
+    return createWorkspace(null, WorkspaceStage.MC_WORKSPACE);
+  }
+
+  /**
+   * Convenience method for getting a WorkspaceRequest builder with some pre-filled default values.
+   * Default to an MC workspace.
+   *
+   * <p>This provides default values for jobId (random UUID), spend profile (Optional.empty()), and
+   * workspace stage (MC_WORKSPACE).
+   *
+   * @param workspaceUuid if null, a uuid will be generated as the workspace id.
+   */
+  public static Workspace.Builder defaultWorkspaceBuilder(@Nullable UUID workspaceUuid) {
+    var id = Optional.ofNullable(workspaceUuid).orElse(UUID.randomUUID());
+    return Workspace.builder()
+        .workspaceId(id)
+        .userFacingId("a" + id)
+        .spendProfileId(null)
+        .workspaceStage(WorkspaceStage.MC_WORKSPACE);
   }
 
   public static ApiCreateWorkspaceRequestBody createWorkspaceRequestBody(

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -38,7 +38,7 @@ public class WorkspaceFixtures {
     return defaultWorkspaceBuilder(workspaceUuid).workspaceStage(workspaceStage).build();
   }
 
-  public static Workspace createWorkspace() {
+  public static Workspace createMcWorkspace() {
     return createWorkspace(null, WorkspaceStage.MC_WORKSPACE);
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -42,7 +42,6 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.OperationType;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -156,9 +155,7 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     assertTrue(emptyChangeDetails.isEmpty());
 
     workspaceDao.createWorkspace(
-        WorkspaceFixtures.createWorkspace(
-            workspaceUuid, WorkspaceStage.MC_WORKSPACE), /* applicationIds */
-        null);
+        WorkspaceFixtures.buildMcWorkspace(workspaceUuid), /* applicationIds */ null);
     FlightMap inputParams = buildInputParams(workspaceUuid, OperationType.DELETE);
     hook.endFlight(
         new FakeFlightContext(
@@ -194,9 +191,7 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     assertTrue(emptyChangeDetails.isEmpty());
 
     workspaceDao.createWorkspace(
-        WorkspaceFixtures.createWorkspace(
-            workspaceUuid, WorkspaceStage.MC_WORKSPACE), /* applicationIds */
-        null);
+        WorkspaceFixtures.buildMcWorkspace(workspaceUuid), /* applicationIds */ null);
     var flightId = UUID.randomUUID().toString();
     workspaceDao.createCloudContextStart(workspaceUuid, CloudPlatform.GCP, flightId);
     workspaceDao.createCloudContextFinish(

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -42,6 +42,7 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.OperationType;
+import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -154,7 +155,10 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     var emptyChangeDetails = activityLogDao.getLastUpdateDetails(workspaceUuid);
     assertTrue(emptyChangeDetails.isEmpty());
 
-    workspaceDao.createWorkspace(WorkspaceFixtures.createMcWorkspace(), /* applicationIds */ null);
+    workspaceDao.createWorkspace(
+        WorkspaceFixtures.createWorkspace(
+            workspaceUuid, WorkspaceStage.MC_WORKSPACE), /* applicationIds */
+        null);
     FlightMap inputParams = buildInputParams(workspaceUuid, OperationType.DELETE);
     hook.endFlight(
         new FakeFlightContext(
@@ -189,7 +193,10 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     var emptyChangeDetails = activityLogDao.getLastUpdateDetails(workspaceUuid);
     assertTrue(emptyChangeDetails.isEmpty());
 
-    workspaceDao.createWorkspace(WorkspaceFixtures.createMcWorkspace(), /* applicationIds */ null);
+    workspaceDao.createWorkspace(
+        WorkspaceFixtures.createWorkspace(
+            workspaceUuid, WorkspaceStage.MC_WORKSPACE), /* applicationIds */
+        null);
     var flightId = UUID.randomUUID().toString();
     workspaceDao.createCloudContextStart(workspaceUuid, CloudPlatform.GCP, flightId);
     workspaceDao.createCloudContextFinish(

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -19,6 +19,7 @@ import bio.terra.stairway.Stairway;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.exception.UnknownFlightClassNameException;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
 import bio.terra.workspace.db.FolderDao;
 import bio.terra.workspace.db.ResourceDao;
@@ -41,8 +42,6 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.OperationType;
-import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -155,13 +154,7 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     var emptyChangeDetails = activityLogDao.getLastUpdateDetails(workspaceUuid);
     assertTrue(emptyChangeDetails.isEmpty());
 
-    workspaceDao.createWorkspace(
-        Workspace.builder()
-            .workspaceId(workspaceUuid)
-            .userFacingId(workspaceUuid.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build(),
-        /* applicationIds */ null);
+    workspaceDao.createWorkspace(WorkspaceFixtures.createWorkspace(), /* applicationIds */ null);
     FlightMap inputParams = buildInputParams(workspaceUuid, OperationType.DELETE);
     hook.endFlight(
         new FakeFlightContext(
@@ -196,13 +189,7 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     var emptyChangeDetails = activityLogDao.getLastUpdateDetails(workspaceUuid);
     assertTrue(emptyChangeDetails.isEmpty());
 
-    workspaceDao.createWorkspace(
-        Workspace.builder()
-            .workspaceId(workspaceUuid)
-            .userFacingId(workspaceUuid.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build(),
-        /* applicationIds */ null);
+    workspaceDao.createWorkspace(WorkspaceFixtures.createWorkspace(), /* applicationIds */ null);
     var flightId = UUID.randomUUID().toString();
     workspaceDao.createCloudContextStart(workspaceUuid, CloudPlatform.GCP, flightId);
     workspaceDao.createCloudContextFinish(

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -154,7 +154,7 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     var emptyChangeDetails = activityLogDao.getLastUpdateDetails(workspaceUuid);
     assertTrue(emptyChangeDetails.isEmpty());
 
-    workspaceDao.createWorkspace(WorkspaceFixtures.createWorkspace(), /* applicationIds */ null);
+    workspaceDao.createWorkspace(WorkspaceFixtures.createMcWorkspace(), /* applicationIds */ null);
     FlightMap inputParams = buildInputParams(workspaceUuid, OperationType.DELETE);
     hook.endFlight(
         new FakeFlightContext(
@@ -189,7 +189,7 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     var emptyChangeDetails = activityLogDao.getLastUpdateDetails(workspaceUuid);
     assertTrue(emptyChangeDetails.isEmpty());
 
-    workspaceDao.createWorkspace(WorkspaceFixtures.createWorkspace(), /* applicationIds */ null);
+    workspaceDao.createWorkspace(WorkspaceFixtures.createMcWorkspace(), /* applicationIds */ null);
     var flightId = UUID.randomUUID().toString();
     workspaceDao.createCloudContextStart(workspaceUuid, CloudPlatform.GCP, flightId);
     workspaceDao.createCloudContextFinish(

--- a/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
@@ -45,7 +45,7 @@ public class AzureTestUtils {
   }
 
   public Workspace createWorkspace(WorkspaceService workspaceService) {
-    Workspace workspace = WorkspaceFixtures.createWorkspace();
+    Workspace workspace = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(
         workspace, null, null, userAccessUtils.defaultUserAuthRequest());
     return workspace;

--- a/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
@@ -45,7 +46,10 @@ public class AzureTestUtils {
   }
 
   public Workspace createWorkspace(WorkspaceService workspaceService) {
-    Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
+    Workspace workspace =
+        WorkspaceFixtures.defaultWorkspaceBuilder(null)
+            .spendProfileId(new SpendProfileId(UUID.randomUUID().toString()))
+            .build();
     workspaceService.createWorkspace(
         workspace, null, null, userAccessUtils.defaultUserAuthRequest());
     return workspace;

--- a/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
@@ -45,7 +45,7 @@ public class AzureTestUtils {
   }
 
   public Workspace createWorkspace(WorkspaceService workspaceService) {
-    Workspace workspace = WorkspaceFixtures.createMcWorkspace();
+    Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(
         workspace, null, null, userAccessUtils.defaultUserAuthRequest());
     return workspace;

--- a/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
@@ -5,6 +5,7 @@ import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKey
 import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.app.configuration.external.AzureTestConfiguration;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.service.crl.CrlService;
@@ -12,7 +13,6 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.StewardshipType;
-import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
@@ -20,7 +20,6 @@ import bio.terra.workspace.service.workspace.flight.create.azure.CreateAzureCont
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.relay.RelayManager;
 import com.azure.resourcemanager.storage.StorageManager;
@@ -46,14 +45,7 @@ public class AzureTestUtils {
   }
 
   public Workspace createWorkspace(WorkspaceService workspaceService) {
-    UUID uuid = UUID.randomUUID();
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId(uuid.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .spendProfileId(new SpendProfileId(UUID.randomUUID().toString()))
-            .build();
+    Workspace workspace = WorkspaceFixtures.createWorkspace();
     workspaceService.createWorkspace(
         workspace, null, null, userAccessUtils.defaultUserAuthRequest());
     return workspace;

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -2,9 +2,9 @@ package bio.terra.workspace.connected;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Component;
 public class WorkspaceConnectedTestUtils {
   private @Autowired WorkspaceService workspaceService;
   private @Autowired JobService jobService;
-  private @Autowired SpendConnectedTestUtils spendUtils;
 
   /**
    * Creates a workspace with a GCP cloud context.
@@ -26,15 +25,8 @@ public class WorkspaceConnectedTestUtils {
    * automatically deletes cloud context.
    */
   public Workspace createWorkspaceWithGcpContext(AuthenticatedUserRequest userRequest) {
-    UUID workspaceUuid = UUID.randomUUID();
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceUuid)
-            .userFacingId(UUID.randomUUID().toString())
-            .spendProfileId(spendUtils.defaultSpendId())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
-    workspaceService.createWorkspace(workspace, null, null, userRequest);
+    Workspace workspace = createWorkspace(userRequest);
+    UUID workspaceUuid = workspace.getWorkspaceId();
     String gcpContextJobId = UUID.randomUUID().toString();
     workspaceService.createGcpCloudContext(
         workspace, gcpContextJobId, userRequest, "fakeResultPath");
@@ -43,12 +35,17 @@ public class WorkspaceConnectedTestUtils {
     return workspaceService.getWorkspace(workspaceUuid);
   }
 
+  public Workspace createWorkspace(AuthenticatedUserRequest userRequest) {
+    UUID workspaceUuid = UUID.randomUUID();
+    Workspace workspace =
+        WorkspaceFixtures.createWorkspace(workspaceUuid, WorkspaceStage.MC_WORKSPACE);
+    workspaceService.createWorkspace(workspace, null, null, userRequest);
+
+    return workspaceService.getWorkspace(workspaceUuid);
+  }
+
   public void deleteWorkspaceAndGcpContext(AuthenticatedUserRequest userRequest, UUID workspaceId) {
     workspaceService.deleteWorkspace(
-        Workspace.builder()
-            .workspaceId(workspaceId)
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build(),
-        userRequest);
+        WorkspaceFixtures.createWorkspace(workspaceId, WorkspaceStage.MC_WORKSPACE), userRequest);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -7,7 +7,6 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -37,15 +36,13 @@ public class WorkspaceConnectedTestUtils {
 
   public Workspace createWorkspace(AuthenticatedUserRequest userRequest) {
     UUID workspaceUuid = UUID.randomUUID();
-    Workspace workspace =
-        WorkspaceFixtures.createWorkspace(workspaceUuid, WorkspaceStage.MC_WORKSPACE);
+    Workspace workspace = WorkspaceFixtures.buildMcWorkspace(workspaceUuid);
     workspaceService.createWorkspace(workspace, null, null, userRequest);
 
     return workspaceService.getWorkspace(workspaceUuid);
   }
 
   public void deleteWorkspaceAndGcpContext(AuthenticatedUserRequest userRequest, UUID workspaceId) {
-    workspaceService.deleteWorkspace(
-        WorkspaceFixtures.createWorkspace(workspaceId, WorkspaceStage.MC_WORKSPACE), userRequest);
+    workspaceService.deleteWorkspace(WorkspaceFixtures.buildMcWorkspace(workspaceId), userRequest);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import java.util.UUID;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 public class WorkspaceConnectedTestUtils {
   private @Autowired WorkspaceService workspaceService;
   private @Autowired JobService jobService;
+  private @Autowired SpendConnectedTestUtils spendUtils;
 
   /**
    * Creates a workspace with a GCP cloud context.
@@ -36,7 +38,10 @@ public class WorkspaceConnectedTestUtils {
 
   public Workspace createWorkspace(AuthenticatedUserRequest userRequest) {
     UUID workspaceUuid = UUID.randomUUID();
-    Workspace workspace = WorkspaceFixtures.buildMcWorkspace(workspaceUuid);
+    Workspace workspace =
+        WorkspaceFixtures.defaultWorkspaceBuilder(workspaceUuid)
+            .spendProfileId(spendUtils.defaultSpendId())
+            .build();
     workspaceService.createWorkspace(workspace, null, null, userRequest);
 
     return workspaceService.getWorkspace(workspaceUuid);

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
@@ -165,13 +166,8 @@ class WorkspaceDaoTest extends BaseUnitTest {
   void offsetSkipsWorkspaceInList() {
     Workspace firstWorkspace = defaultWorkspace();
     workspaceDao.createWorkspace(firstWorkspace, /* applicationIds */ null);
-    UUID uuid = UUID.randomUUID();
     Workspace secondWorkspace =
-        Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId(uuid.toString())
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
+        WorkspaceFixtures.createWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
     workspaceDao.createWorkspace(secondWorkspace, /* applicationIds */ null);
     List<Workspace> workspaceList =
         workspaceDao.getWorkspacesMatchingList(
@@ -186,13 +182,9 @@ class WorkspaceDaoTest extends BaseUnitTest {
   void listWorkspaceLimitEnforced() {
     Workspace firstWorkspace = defaultWorkspace();
     workspaceDao.createWorkspace(firstWorkspace, /* applicationIds */ null);
-    UUID uuid = UUID.randomUUID();
     Workspace secondWorkspace =
-        Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId(uuid.toString())
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
+        WorkspaceFixtures.createWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
+    ;
     workspaceDao.createWorkspace(secondWorkspace, /* applicationIds */ null);
     List<Workspace> workspaceList =
         workspaceDao.getWorkspacesMatchingList(
@@ -368,11 +360,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
   }
 
   private Workspace defaultWorkspace() {
-    return Workspace.builder()
-        .workspaceId(workspaceUuid)
-        .userFacingId(workspaceUuid.toString())
-        .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-        .build();
+    return WorkspaceFixtures.createWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
   }
 
   private GcpCloudContext makeCloudContext() {

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -89,7 +89,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   void createAndDeleteWorkspace() {
-    workspaceDao.createWorkspace(defaultWorkspace(), /* applicationIds */ null);
+    workspaceDao.createWorkspace(defaultWorkspace(workspaceUuid), /* applicationIds */ null);
 
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("id", workspaceUuid.toString());
@@ -106,7 +106,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   void createAndGetWorkspace() {
-    Workspace createdWorkspace = defaultWorkspace();
+    Workspace createdWorkspace = defaultWorkspace(workspaceUuid);
     workspaceDao.createWorkspace(createdWorkspace, /* applicationIds */ null);
 
     Workspace workspace = workspaceDao.getWorkspace(workspaceUuid);
@@ -116,7 +116,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   void getWorkspacesFromList() {
-    Workspace realWorkspace = defaultWorkspace();
+    Workspace realWorkspace = defaultWorkspace(workspaceUuid);
     workspaceDao.createWorkspace(realWorkspace, /* applicationIds */ null);
     UUID fakeWorkspaceId = UUID.randomUUID();
     List<Workspace> workspaceList =
@@ -164,10 +164,10 @@ class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   void offsetSkipsWorkspaceInList() {
-    Workspace firstWorkspace = defaultWorkspace();
+    Workspace firstWorkspace = defaultWorkspace(workspaceUuid);
     workspaceDao.createWorkspace(firstWorkspace, /* applicationIds */ null);
     Workspace secondWorkspace =
-        WorkspaceFixtures.createWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
+        WorkspaceFixtures.buildWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
     workspaceDao.createWorkspace(secondWorkspace, /* applicationIds */ null);
     List<Workspace> workspaceList =
         workspaceDao.getWorkspacesMatchingList(
@@ -180,10 +180,10 @@ class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   void listWorkspaceLimitEnforced() {
-    Workspace firstWorkspace = defaultWorkspace();
+    Workspace firstWorkspace = defaultWorkspace(workspaceUuid);
     workspaceDao.createWorkspace(firstWorkspace, /* applicationIds */ null);
     Workspace secondWorkspace =
-        WorkspaceFixtures.createWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
+        WorkspaceFixtures.buildWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
     ;
     workspaceDao.createWorkspace(secondWorkspace, /* applicationIds */ null);
     List<Workspace> workspaceList =
@@ -265,7 +265,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   void duplicateWorkspaceFails() {
-    Workspace workspace = defaultWorkspace();
+    Workspace workspace = defaultWorkspace(workspaceUuid);
     workspaceDao.createWorkspace(workspace, /* applicationIds */ null);
 
     assertThrows(
@@ -299,7 +299,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
 
     @BeforeEach
     void setUp() {
-      workspaceDao.createWorkspace(defaultWorkspace(), /* applicationIds */ null);
+      workspaceDao.createWorkspace(defaultWorkspace(workspaceUuid), /* applicationIds */ null);
     }
 
     @Test
@@ -359,8 +359,8 @@ class WorkspaceDaoTest extends BaseUnitTest {
     assertEquals("GCP", CloudPlatform.GCP.toString());
   }
 
-  private Workspace defaultWorkspace() {
-    return WorkspaceFixtures.createWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
+  private Workspace defaultWorkspace(UUID workspaceUuid) {
+    return WorkspaceFixtures.buildWorkspace(workspaceUuid, WorkspaceStage.RAWLS_WORKSPACE);
   }
 
   private GcpCloudContext makeCloudContext() {

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -463,7 +463,7 @@ class SamServiceTest extends BaseConnectedTest {
   }
 
   private Workspace createWorkspaceForUser(AuthenticatedUserRequest userRequest) {
-    Workspace workspace = WorkspaceFixtures.createWorkspace();
+    Workspace workspace = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(workspace, null, null, userRequest);
     return workspace;
   }

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -20,6 +20,7 @@ import bio.terra.common.sam.exception.SamNotFoundException;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
@@ -225,11 +226,7 @@ class SamServiceTest extends BaseConnectedTest {
     samService.createWorkspaceWithDefaults(defaultUserRequest(), workspaceUuid);
 
     Workspace rawlsWorkspace =
-        Workspace.builder()
-            .workspaceId(workspaceUuid)
-            .userFacingId(workspaceUuid.toString())
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
+        WorkspaceFixtures.createWorkspace(workspaceUuid, WorkspaceStage.RAWLS_WORKSPACE);
     workspaceService.createWorkspace(rawlsWorkspace, null, null, defaultUserRequest());
     ApiGrantRoleRequestBody request =
         new ApiGrantRoleRequestBody().memberEmail(userAccessUtils.getSecondUserEmail());
@@ -466,13 +463,7 @@ class SamServiceTest extends BaseConnectedTest {
   }
 
   private Workspace createWorkspaceForUser(AuthenticatedUserRequest userRequest) {
-    UUID uuid = UUID.randomUUID();
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId(uuid.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
+    Workspace workspace = WorkspaceFixtures.createWorkspace();
     workspaceService.createWorkspace(workspace, null, null, userRequest);
     return workspace;
   }

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -226,7 +226,7 @@ class SamServiceTest extends BaseConnectedTest {
     samService.createWorkspaceWithDefaults(defaultUserRequest(), workspaceUuid);
 
     Workspace rawlsWorkspace =
-        WorkspaceFixtures.createWorkspace(workspaceUuid, WorkspaceStage.RAWLS_WORKSPACE);
+        WorkspaceFixtures.buildWorkspace(workspaceUuid, WorkspaceStage.RAWLS_WORKSPACE);
     workspaceService.createWorkspace(rawlsWorkspace, null, null, defaultUserRequest());
     ApiGrantRoleRequestBody request =
         new ApiGrantRoleRequestBody().memberEmail(userAccessUtils.getSecondUserEmail());
@@ -463,7 +463,7 @@ class SamServiceTest extends BaseConnectedTest {
   }
 
   private Workspace createWorkspaceForUser(AuthenticatedUserRequest userRequest) {
-    Workspace workspace = WorkspaceFixtures.createMcWorkspace();
+    Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(workspace, null, null, userRequest);
     return workspace;
   }

--- a/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -22,8 +22,7 @@ import bio.terra.workspace.service.job.exception.JobNotFoundException;
 import bio.terra.workspace.service.job.model.EnumeratedJob;
 import bio.terra.workspace.service.job.model.EnumeratedJobs;
 import bio.terra.workspace.service.workspace.model.OperationType;
-import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
+import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -106,19 +105,21 @@ class JobServiceTest extends BaseUnitTest {
   // have some failed jobs left over from other tests.
   @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
   @Test
-  void retrieveTest() throws Exception {
+  void retrieveTest() {
     // We perform 7 flights and then retrieve and enumerate them.
     // The fids list should be in exactly the same order as the database ordered by submit time.
 
     List<String> jobIds1 = new ArrayList<>();
-    UUID workspace1 = makeFakeWorkspace();
+    UUID workspace1 = WorkspaceUnitTestUtils.createWorkspaceWithoutGcpContext(workspaceDao);
+    ;
     for (int i = 0; i < 3; i++) {
       String jobId = runFlight(workspace1, makeDescription(i));
       jobIds1.add(jobId);
     }
 
     List<String> jobIds2 = new ArrayList<>();
-    UUID workspace2 = makeFakeWorkspace();
+    UUID workspace2 = WorkspaceUnitTestUtils.createWorkspaceWithoutGcpContext(workspaceDao);
+    ;
     for (int i = 0; i < 4; i++) {
       String jobId = runFlight(workspace2, makeDescription(i));
       jobIds2.add(jobId);
@@ -205,19 +206,6 @@ class JobServiceTest extends BaseUnitTest {
     assertThat(jr.getId(), equalTo(fids.get(index)));
     assertThat(jr.getStatus(), equalTo(ApiJobReport.StatusEnum.SUCCEEDED));
     assertThat(jr.getStatusCode(), equalTo(HttpStatus.I_AM_A_TEAPOT.value()));
-  }
-
-  private UUID makeFakeWorkspace() {
-    UUID workspaceUuid = UUID.randomUUID();
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(workspaceUuid)
-            .userFacingId(workspaceUuid.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .description("Fake workspace")
-            .build();
-    workspaceDao.createWorkspace(workspace, /* applicationIds */ null);
-    return workspaceUuid;
   }
 
   // Submit a flight; wait for it to finish; return the flight id

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -16,6 +16,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.generated.model.ApiAzureContext;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
@@ -26,11 +27,8 @@ import bio.terra.workspace.generated.model.ApiCreateControlledAzureNetworkReques
 import bio.terra.workspace.generated.model.ApiCreateControlledAzureVmRequestBody;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -46,10 +44,10 @@ import org.springframework.test.web.servlet.MockMvc;
 public class AzureDisabledTest extends BaseConnectedTest {
   @Autowired private MockMvc mockMvc;
 
-  @Autowired private WorkspaceService workspaceService;
   @Autowired private UserAccessUtils userAccessUtils;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private FeatureConfiguration featureConfiguration;
+  @Autowired private WorkspaceConnectedTestUtils connectedTestUtils;
 
   @BeforeEach
   public void setUp() {
@@ -60,14 +58,8 @@ public class AzureDisabledTest extends BaseConnectedTest {
   @Test
   public void azureDisabledTest() throws Exception {
     Workspace workspace =
-        Workspace.builder()
-            .workspaceId(UUID.randomUUID())
-            .userFacingId("a" + UUID.randomUUID())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
-    UUID workspaceUuid =
-        workspaceService.createWorkspace(
-            workspace, null, null, userAccessUtils.defaultUserAuthRequest());
+        connectedTestUtils.createWorkspace(userAccessUtils.defaultUserAuthRequest());
+    var workspaceUuid = workspace.getWorkspaceId();
 
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     String fakeJobId = "a pretend job ID";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
@@ -10,6 +10,7 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
@@ -39,11 +40,7 @@ public class StoreControlledResourceMetadataStepTest extends BaseUnitTest {
     // database insert will pass FK constraints.
     UUID workspaceUuid = UUID.randomUUID();
     Workspace workspace =
-        Workspace.builder()
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .workspaceId(workspaceUuid)
-            .userFacingId("a" + workspaceUuid)
-            .build();
+        WorkspaceFixtures.createWorkspace(workspaceUuid, WorkspaceStage.RAWLS_WORKSPACE);
     workspaceDao.createWorkspace(workspace, /* applicationIds */ null);
 
     gcpCloudContextService.createGcpCloudContextStart(workspaceUuid, "flight-testentersinfo");

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/StoreControlledResourceMetadataStepTest.java
@@ -40,7 +40,7 @@ public class StoreControlledResourceMetadataStepTest extends BaseUnitTest {
     // database insert will pass FK constraints.
     UUID workspaceUuid = UUID.randomUUID();
     Workspace workspace =
-        WorkspaceFixtures.createWorkspace(workspaceUuid, WorkspaceStage.RAWLS_WORKSPACE);
+        WorkspaceFixtures.buildWorkspace(workspaceUuid, WorkspaceStage.RAWLS_WORKSPACE);
     workspaceDao.createWorkspace(workspace, /* applicationIds */ null);
 
     gcpCloudContextService.createGcpCloudContextStart(workspaceUuid, "flight-testentersinfo");

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStepTest.java
@@ -18,6 +18,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
@@ -31,7 +32,6 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.Contr
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpHeaders;
@@ -75,11 +75,7 @@ public class CopyGcsBucketDefinitionStepTest extends BaseUnitTestMockGcpCloudCon
   @BeforeEach
   public void setup() throws InterruptedException, IOException {
     Workspace workspace =
-        Workspace.builder()
-            .workspaceId(DESTINATION_WORKSPACE_ID)
-            .userFacingId(DESTINATION_WORKSPACE_ID.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
+        WorkspaceFixtures.defaultWorkspaceBuilder(DESTINATION_WORKSPACE_ID).build();
     workspaceDao.createWorkspace(workspace, /*applicationIds=*/ null);
     WorkspaceUnitTestUtils.createGcpCloudContextInDatabase(
         workspaceDao, DESTINATION_WORKSPACE_ID, PROJECT_ID);

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -256,7 +256,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
    * MC_WORKSPACE. Returns the generated workspace ID.
    */
   private UUID createMcTestWorkspace() {
-    Workspace request = WorkspaceFixtures.createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     return workspaceService.createWorkspace(request, null, null, USER_REQUEST);
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -13,6 +13,7 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.BaseUnitTestMockDataRepoService;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.db.exception.InvalidMetadataException;
@@ -34,7 +35,6 @@ import bio.terra.workspace.service.resource.referenced.model.ReferencedResource;
 import bio.terra.workspace.service.resource.referenced.terra.workspace.ReferencedTerraWorkspaceResource;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -256,14 +256,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
    * MC_WORKSPACE. Returns the generated workspace ID.
    */
   private UUID createMcTestWorkspace() {
-    UUID uuid = UUID.randomUUID();
-    Workspace request =
-        Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
-            .spendProfileId(null)
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
+    Workspace request = WorkspaceFixtures.createWorkspace();
     return workspaceService.createWorkspace(request, null, null, USER_REQUEST);
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -256,7 +256,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
    * MC_WORKSPACE. Returns the generated workspace ID.
    */
   private UUID createMcTestWorkspace() {
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     return workspaceService.createWorkspace(request, null, null, USER_REQUEST);
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
@@ -119,9 +119,9 @@ public class ApplicationServiceTest extends BaseUnitTest {
     appService.processApp(NORM_APP, dbAppMap);
 
     // Create two workspaces
-    workspace = WorkspaceFixtures.createMcWorkspace();
+    workspace = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(workspace, null, null, USER_REQUEST);
-    workspace2 = WorkspaceFixtures.createMcWorkspace();
+    workspace2 = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(workspace2, null, null, USER_REQUEST);
   }
 
@@ -154,7 +154,7 @@ public class ApplicationServiceTest extends BaseUnitTest {
     assertThrows(
         ApplicationNotFoundException.class,
         () -> appService.enableWorkspaceApplication(USER_REQUEST, workspace, UNKNOWN_ID));
-    Workspace fakeWorkspace = WorkspaceFixtures.createMcWorkspace();
+    Workspace fakeWorkspace = WorkspaceFixtures.buildMcWorkspace();
     // This calls a service method, rather than a controller method, so it does not hit the authz
     // check. Instead, we validate that inserting this into the DB violates constraints.
     assertThrows(

--- a/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
@@ -119,9 +119,9 @@ public class ApplicationServiceTest extends BaseUnitTest {
     appService.processApp(NORM_APP, dbAppMap);
 
     // Create two workspaces
-    workspace = WorkspaceFixtures.createWorkspace();
+    workspace = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(workspace, null, null, USER_REQUEST);
-    workspace2 = WorkspaceFixtures.createWorkspace();
+    workspace2 = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(workspace2, null, null, USER_REQUEST);
   }
 
@@ -154,7 +154,7 @@ public class ApplicationServiceTest extends BaseUnitTest {
     assertThrows(
         ApplicationNotFoundException.class,
         () -> appService.enableWorkspaceApplication(USER_REQUEST, workspace, UNKNOWN_ID));
-    Workspace fakeWorkspace = WorkspaceFixtures.createWorkspace();
+    Workspace fakeWorkspace = WorkspaceFixtures.createMcWorkspace();
     // This calls a service method, rather than a controller method, so it does not hit the authz
     // check. Instead, we validate that inserting this into the DB violates constraints.
     assertThrows(

--- a/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.db.ApplicationDao;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.RawDaoTestFixture;
@@ -29,7 +30,6 @@ import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.WsmApplicationService.WsmDbApplication;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import bio.terra.workspace.service.workspace.model.WsmApplication;
 import bio.terra.workspace.service.workspace.model.WsmApplicationState;
 import bio.terra.workspace.service.workspace.model.WsmWorkspaceApplication;
@@ -119,25 +119,9 @@ public class ApplicationServiceTest extends BaseUnitTest {
     appService.processApp(NORM_APP, dbAppMap);
 
     // Create two workspaces
-    UUID workspaceUuid = UUID.randomUUID();
-    workspace =
-        Workspace.builder()
-            .workspaceId(workspaceUuid)
-            .userFacingId("a" + workspaceUuid)
-            .spendProfileId(null)
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
-
+    workspace = WorkspaceFixtures.createWorkspace();
     workspaceService.createWorkspace(workspace, null, null, USER_REQUEST);
-
-    UUID workspaceId2 = UUID.randomUUID();
-    workspace2 =
-        Workspace.builder()
-            .workspaceId(workspaceId2)
-            .userFacingId("a" + workspaceId2)
-            .spendProfileId(null)
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
+    workspace2 = WorkspaceFixtures.createWorkspace();
     workspaceService.createWorkspace(workspace2, null, null, USER_REQUEST);
   }
 
@@ -170,11 +154,7 @@ public class ApplicationServiceTest extends BaseUnitTest {
     assertThrows(
         ApplicationNotFoundException.class,
         () -> appService.enableWorkspaceApplication(USER_REQUEST, workspace, UNKNOWN_ID));
-    Workspace fakeWorkspace =
-        Workspace.builder()
-            .workspaceId(UUID.randomUUID())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
+    Workspace fakeWorkspace = WorkspaceFixtures.createWorkspace();
     // This calls a service method, rather than a controller method, so it does not hit the authz
     // check. Instead, we validate that inserting this into the DB violates constraints.
     assertThrows(

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.workspace.app.configuration.external.AzureTestConfiguration;
 import bio.terra.workspace.common.BaseAzureConnectedTest;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
@@ -12,7 +13,6 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -37,13 +37,9 @@ public class AzureWorkspaceTest extends BaseAzureConnectedTest {
             .email("fake@email.com")
             .subjectId("fakeID123");
 
-    UUID uuid = UUID.randomUUID();
     Workspace workspace =
-        Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
+        WorkspaceFixtures.defaultWorkspaceBuilder(null)
             .spendProfileId(spendUtils.defaultSpendId())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
             .build();
 
     workspaceService.createWorkspace(workspace, null, null, userRequest);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -347,12 +347,16 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
     assertThrows(
         ErrorReportException.class,
-        () -> workspaceService.createWorkspace(WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
+        () ->
+            workspaceService.createWorkspace(
+                WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
     // This second call shares the above operation ID, and so should return the same exception
     // instead of a more generic internal Stairway exception.
     assertThrows(
         ErrorReportException.class,
-        () -> workspaceService.createWorkspace(WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
+        () ->
+            workspaceService.createWorkspace(
+                WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
   }
 
   @Test
@@ -529,7 +533,9 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     ErrorReportException exception =
         assertThrows(
             SamInternalServerErrorException.class,
-            () -> workspaceService.createWorkspace(WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
+            () ->
+                workspaceService.createWorkspace(
+                    WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
     assertEquals(apiErrorMsg, exception.getMessage());
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -1,5 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.createWorkspace;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.defaultWorkspaceBuilder;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UFID_PATH_FORMAT;
@@ -183,7 +185,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void getWorkspace_existing() {
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = createWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     assertEquals(
@@ -212,7 +214,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void getWorkspace_forbiddenExisting() throws Exception {
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = createWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     doThrow(new ForbiddenException("forbid!"))
@@ -229,7 +231,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   @Test
   void getWorkspaceByUserFacingId_existing() {
     String userFacingId = "user-facing-id-getworkspacebyuserfacingid_existing";
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).userFacingId(userFacingId).build();
+    Workspace request = defaultWorkspaceBuilder(null).userFacingId(userFacingId).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     assertEquals(
@@ -267,7 +269,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   @Test
   void getWorkspaceByUserFacingId_forbiddenExisting() throws Exception {
     String userFacingId = "user-facing-id-getworkspacebyuserfacingid_forbiddenexisting";
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).userFacingId(userFacingId).build();
+    Workspace request = defaultWorkspaceBuilder(null).userFacingId(userFacingId).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     doThrow(new ForbiddenException("forbid!"))
@@ -290,7 +292,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     when(mockSamService.listRequesterRoles(any(), any(), any()))
         .thenReturn(ImmutableList.of(WsmIamRole.OWNER, WsmIamRole.WRITER));
 
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = createWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     assertEquals(
@@ -299,10 +301,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void testWorkspaceStagePersists() {
-    Workspace mcWorkspaceRequest =
-        defaultRequestBuilder(UUID.randomUUID())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
+    Workspace mcWorkspaceRequest = createWorkspace();
     workspaceService.createWorkspace(mcWorkspaceRequest, null, null, USER_REQUEST);
     Workspace createdWorkspace = workspaceService.getWorkspace(mcWorkspaceRequest.getWorkspaceId());
     assertEquals(mcWorkspaceRequest.getWorkspaceId(), createdWorkspace.getWorkspaceId());
@@ -311,10 +310,10 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void duplicateWorkspaceIdRequestsRejected() {
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = createWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     Workspace duplicateWorkspace =
-        defaultRequestBuilder(request.getWorkspaceId())
+        defaultWorkspaceBuilder(request.getWorkspaceId())
             .description("slightly different workspace")
             .build();
     assertThrows(
@@ -325,10 +324,10 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   @Test
   void duplicateWorkspaceUserFacingIdRequestsRejected() {
     String userFacingId = "create-workspace-user-facing-id";
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).userFacingId(userFacingId).build();
+    Workspace request = defaultWorkspaceBuilder(null).userFacingId(userFacingId).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     Workspace duplicateUserFacingId =
-        defaultRequestBuilder(UUID.randomUUID()).userFacingId(userFacingId).build();
+        defaultWorkspaceBuilder(null).userFacingId(userFacingId).build();
 
     DuplicateUserFacingIdException ex =
         assertThrows(
@@ -348,23 +347,18 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
     assertThrows(
         ErrorReportException.class,
-        () ->
-            workspaceService.createWorkspace(
-                defaultRequestBuilder(UUID.randomUUID()).build(), null, null, USER_REQUEST));
+        () -> workspaceService.createWorkspace(createWorkspace(), null, null, USER_REQUEST));
     // This second call shares the above operation ID, and so should return the same exception
     // instead of a more generic internal Stairway exception.
     assertThrows(
         ErrorReportException.class,
-        () ->
-            workspaceService.createWorkspace(
-                defaultRequestBuilder(UUID.randomUUID()).build(), null, null, USER_REQUEST));
+        () -> workspaceService.createWorkspace(createWorkspace(), null, null, USER_REQUEST));
   }
 
   @Test
   void testWithSpendProfile() {
     SpendProfileId spendProfileId = new SpendProfileId("foo");
-    Workspace request =
-        defaultRequestBuilder(UUID.randomUUID()).spendProfileId(spendProfileId).build();
+    Workspace request = defaultWorkspaceBuilder(null).spendProfileId(spendProfileId).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     Workspace createdWorkspace = workspaceService.getWorkspace(request.getWorkspaceId());
@@ -377,7 +371,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     String name = "My workspace";
     String description = "The greatest workspace";
     Workspace request =
-        defaultRequestBuilder(UUID.randomUUID()).displayName(name).description(description).build();
+        defaultWorkspaceBuilder(null).displayName(name).description(description).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     Workspace createdWorkspace = workspaceService.getWorkspace(request.getWorkspaceId());
@@ -389,7 +383,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void testUpdateWorkspace() {
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = createWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     UUID workspaceUuid = request.getWorkspaceId();
     var lastUpdateDetails = workspaceActivityLogDao.getLastUpdateDetails(workspaceUuid);
@@ -479,10 +473,10 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   void testUpdateWorkspaceUserFacingIdAlreadyExistsRejected() {
     // Create one workspace with userFacingId, one without.
     String userFacingId = "update-workspace-user-facing-id";
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).userFacingId(userFacingId).build();
+    Workspace request = defaultWorkspaceBuilder(null).userFacingId(userFacingId).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     UUID secondWorkspaceUuid = UUID.randomUUID();
-    request = defaultRequestBuilder(secondWorkspaceUuid).build();
+    request = defaultWorkspaceBuilder(secondWorkspaceUuid).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     // Try to set second workspace's userFacing to first.
@@ -506,7 +500,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
             put("xyzzy", "plohg");
           }
         };
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = defaultWorkspaceBuilder(null).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     UUID workspaceUuid = request.getWorkspaceId();
     var lastUpdateDetails = workspaceActivityLogDao.getLastUpdateDetails(workspaceUuid);
@@ -535,15 +529,13 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     ErrorReportException exception =
         assertThrows(
             SamInternalServerErrorException.class,
-            () ->
-                workspaceService.createWorkspace(
-                    defaultRequestBuilder(UUID.randomUUID()).build(), null, null, USER_REQUEST));
+            () -> workspaceService.createWorkspace(createWorkspace(), null, null, USER_REQUEST));
     assertEquals(apiErrorMsg, exception.getMessage());
   }
 
   @Test
   void createAndDeleteWorkspace() {
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = createWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     workspaceService.deleteWorkspace(request, USER_REQUEST);
@@ -554,7 +546,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void createMcWorkspaceDoSteps() {
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = createWorkspace();
     Map<String, StepStatus> retrySteps = new HashMap<>();
     retrySteps.put(CreateWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(
@@ -570,9 +562,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   @Test
   void createRawlsWorkspaceDoSteps() throws InterruptedException {
     Workspace request =
-        defaultRequestBuilder(UUID.randomUUID())
-            .workspaceStage(WorkspaceStage.RAWLS_WORKSPACE)
-            .build();
+        defaultWorkspaceBuilder(null).workspaceStage(WorkspaceStage.RAWLS_WORKSPACE).build();
     // Ensure the auth check in CheckSamWorkspaceAuthzStep always succeeds.
     doReturn(true).when(mockSamService).isAuthorized(any(), any(), any(), any());
     Map<String, StepStatus> retrySteps = new HashMap<>();
@@ -588,7 +578,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void createMcWorkspaceUndoSteps() {
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = createWorkspace();
     // Retry undo steps once and fail at the end of the flight.
     Map<String, StepStatus> retrySteps = new HashMap<>();
     retrySteps.put(CreateWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
@@ -617,7 +607,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     propertyMap.put("foo", "bar");
     propertyMap.put("xyzzy", "plohg");
 
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).properties(propertyMap).build();
+    Workspace request = defaultWorkspaceBuilder(null).properties(propertyMap).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     UUID workspaceUuid = request.getWorkspaceId();
     var lastUpdateDetails = workspaceActivityLogDao.getLastUpdateDetails(workspaceUuid);
@@ -657,7 +647,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void deleteForbiddenExistingWorkspace() throws Exception {
-    Workspace request = defaultRequestBuilder(UUID.randomUUID()).build();
+    Workspace request = createWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     doThrow(new ForbiddenException("forbid!"))
@@ -676,7 +666,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   void deleteWorkspaceWithDataReference() {
     // First, create a workspace.
     UUID workspaceUuid = UUID.randomUUID();
-    Workspace request = defaultRequestBuilder(workspaceUuid).build();
+    Workspace request = defaultWorkspaceBuilder(workspaceUuid).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     // Next, add a data reference to that workspace.
@@ -713,10 +703,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void deleteWorkspaceWithGoogleContext() throws Exception {
     Workspace request =
-        defaultRequestBuilder(UUID.randomUUID())
-            .spendProfileId(spendUtils.defaultSpendId())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
+        defaultWorkspaceBuilder(null).spendProfileId(spendUtils.defaultSpendId()).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     String jobId = UUID.randomUUID().toString();
     workspaceService.createGcpCloudContext(request, jobId, USER_REQUEST, "/fake/value");
@@ -739,10 +726,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createGetDeleteGoogleContext() {
     Workspace request =
-        defaultRequestBuilder(UUID.randomUUID())
-            .spendProfileId(spendUtils.defaultSpendId())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .build();
+        defaultWorkspaceBuilder(null).spendProfileId(spendUtils.defaultSpendId()).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     String jobId = UUID.randomUUID().toString();
@@ -763,7 +747,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .thenReturn(true);
     UUID workspaceId = UUID.randomUUID();
     Workspace request =
-        defaultRequestBuilder(workspaceId).workspaceStage(WorkspaceStage.RAWLS_WORKSPACE).build();
+        defaultWorkspaceBuilder(workspaceId).workspaceStage(WorkspaceStage.RAWLS_WORKSPACE).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     String jobId = UUID.randomUUID().toString();
     ApiCreateCloudContextRequest contextRequest =
@@ -786,7 +770,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   public void cloneGcpWorkspace() {
     // Create a workspace
     final Workspace sourceWorkspace =
-        defaultRequestBuilder(UUID.randomUUID())
+        defaultWorkspaceBuilder(null)
             .userFacingId("source-user-facing-id")
             .displayName("Source Workspace")
             .description("The original workspace.")
@@ -855,7 +839,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     final ControlledGcsBucketResource createdBucketResource =
         createdResource.castByEnum(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
     final Workspace destinationWorkspace =
-        defaultRequestBuilder(UUID.randomUUID())
+        defaultWorkspaceBuilder(null)
             .userFacingId("dest-user-facing-id")
             .displayName("Destination Workspace")
             .description("Copied from source")
@@ -913,7 +897,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   public void cloneGcpWorkspaceUndoSteps() {
     // Create a workspace
     final Workspace sourceWorkspace =
-        defaultRequestBuilder(UUID.randomUUID())
+        defaultWorkspaceBuilder(null)
             .userFacingId("source-user-facing-id")
             .displayName("Source Workspace")
             .description("The original workspace.")
@@ -966,7 +950,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
             .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
 
     final Workspace destinationWorkspace =
-        defaultRequestBuilder(UUID.randomUUID())
+        defaultWorkspaceBuilder(null)
             .userFacingId("dest-user-facing-id")
             .displayName("Destination Workspace")
             .description("Copied from source")
@@ -1019,22 +1003,5 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     jobService.setFlightDebugInfoForTest(null);
     workspaceService.deleteWorkspace(sourceWorkspace, USER_REQUEST);
     workspaceService.deleteWorkspace(destinationWorkspace, USER_REQUEST);
-  }
-
-  /**
-   * Convenience method for getting a WorkspaceRequest builder with some pre-filled default values.
-   *
-   * <p>This provides default values for jobId (random UUID), spend profile (Optional.empty()), and
-   * workspace stage (MC_WORKSPACE).
-   *
-   * <p>Because the tests in this class mock Sam, we do not need to explicitly clean up workspaces
-   * created here.
-   */
-  private Workspace.Builder defaultRequestBuilder(UUID workspaceUuid) {
-    return Workspace.builder()
-        .workspaceId(workspaceUuid)
-        .userFacingId("a" + workspaceUuid.toString())
-        .spendProfileId(null)
-        .workspaceStage(WorkspaceStage.MC_WORKSPACE);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.workspace;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.createWorkspace;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.defaultWorkspaceBuilder;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
@@ -36,6 +35,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.db.FolderDao;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceActivityLogDao;
@@ -185,7 +185,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void getWorkspace_existing() {
-    Workspace request = createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     assertEquals(
@@ -214,7 +214,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void getWorkspace_forbiddenExisting() throws Exception {
-    Workspace request = createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     doThrow(new ForbiddenException("forbid!"))
@@ -292,7 +292,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     when(mockSamService.listRequesterRoles(any(), any(), any()))
         .thenReturn(ImmutableList.of(WsmIamRole.OWNER, WsmIamRole.WRITER));
 
-    Workspace request = createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     assertEquals(
@@ -301,7 +301,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void testWorkspaceStagePersists() {
-    Workspace mcWorkspaceRequest = createWorkspace();
+    Workspace mcWorkspaceRequest = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(mcWorkspaceRequest, null, null, USER_REQUEST);
     Workspace createdWorkspace = workspaceService.getWorkspace(mcWorkspaceRequest.getWorkspaceId());
     assertEquals(mcWorkspaceRequest.getWorkspaceId(), createdWorkspace.getWorkspaceId());
@@ -310,7 +310,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void duplicateWorkspaceIdRequestsRejected() {
-    Workspace request = createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     Workspace duplicateWorkspace =
         defaultWorkspaceBuilder(request.getWorkspaceId())
@@ -347,12 +347,12 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
     assertThrows(
         ErrorReportException.class,
-        () -> workspaceService.createWorkspace(createWorkspace(), null, null, USER_REQUEST));
+        () -> workspaceService.createWorkspace(WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
     // This second call shares the above operation ID, and so should return the same exception
     // instead of a more generic internal Stairway exception.
     assertThrows(
         ErrorReportException.class,
-        () -> workspaceService.createWorkspace(createWorkspace(), null, null, USER_REQUEST));
+        () -> workspaceService.createWorkspace(WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
   }
 
   @Test
@@ -383,7 +383,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void testUpdateWorkspace() {
-    Workspace request = createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     UUID workspaceUuid = request.getWorkspaceId();
     var lastUpdateDetails = workspaceActivityLogDao.getLastUpdateDetails(workspaceUuid);
@@ -529,13 +529,13 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     ErrorReportException exception =
         assertThrows(
             SamInternalServerErrorException.class,
-            () -> workspaceService.createWorkspace(createWorkspace(), null, null, USER_REQUEST));
+            () -> workspaceService.createWorkspace(WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
     assertEquals(apiErrorMsg, exception.getMessage());
   }
 
   @Test
   void createAndDeleteWorkspace() {
-    Workspace request = createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     workspaceService.deleteWorkspace(request, USER_REQUEST);
@@ -546,7 +546,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void createMcWorkspaceDoSteps() {
-    Workspace request = createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     Map<String, StepStatus> retrySteps = new HashMap<>();
     retrySteps.put(CreateWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(
@@ -578,7 +578,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void createMcWorkspaceUndoSteps() {
-    Workspace request = createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     // Retry undo steps once and fail at the end of the flight.
     Map<String, StepStatus> retrySteps = new HashMap<>();
     retrySteps.put(CreateWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
@@ -647,7 +647,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void deleteForbiddenExistingWorkspace() throws Exception {
-    Workspace request = createWorkspace();
+    Workspace request = WorkspaceFixtures.createMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     doThrow(new ForbiddenException("forbid!"))

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -185,7 +185,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void getWorkspace_existing() {
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     assertEquals(
@@ -214,7 +214,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void getWorkspace_forbiddenExisting() throws Exception {
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     doThrow(new ForbiddenException("forbid!"))
@@ -292,7 +292,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     when(mockSamService.listRequesterRoles(any(), any(), any()))
         .thenReturn(ImmutableList.of(WsmIamRole.OWNER, WsmIamRole.WRITER));
 
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     assertEquals(
@@ -301,7 +301,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void testWorkspaceStagePersists() {
-    Workspace mcWorkspaceRequest = WorkspaceFixtures.createMcWorkspace();
+    Workspace mcWorkspaceRequest = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(mcWorkspaceRequest, null, null, USER_REQUEST);
     Workspace createdWorkspace = workspaceService.getWorkspace(mcWorkspaceRequest.getWorkspaceId());
     assertEquals(mcWorkspaceRequest.getWorkspaceId(), createdWorkspace.getWorkspaceId());
@@ -310,7 +310,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void duplicateWorkspaceIdRequestsRejected() {
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     Workspace duplicateWorkspace =
         defaultWorkspaceBuilder(request.getWorkspaceId())
@@ -349,14 +349,14 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         ErrorReportException.class,
         () ->
             workspaceService.createWorkspace(
-                WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
+                WorkspaceFixtures.buildMcWorkspace(), null, null, USER_REQUEST));
     // This second call shares the above operation ID, and so should return the same exception
     // instead of a more generic internal Stairway exception.
     assertThrows(
         ErrorReportException.class,
         () ->
             workspaceService.createWorkspace(
-                WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
+                WorkspaceFixtures.buildMcWorkspace(), null, null, USER_REQUEST));
   }
 
   @Test
@@ -387,7 +387,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void testUpdateWorkspace() {
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     UUID workspaceUuid = request.getWorkspaceId();
     var lastUpdateDetails = workspaceActivityLogDao.getLastUpdateDetails(workspaceUuid);
@@ -535,13 +535,13 @@ class WorkspaceServiceTest extends BaseConnectedTest {
             SamInternalServerErrorException.class,
             () ->
                 workspaceService.createWorkspace(
-                    WorkspaceFixtures.createMcWorkspace(), null, null, USER_REQUEST));
+                    WorkspaceFixtures.buildMcWorkspace(), null, null, USER_REQUEST));
     assertEquals(apiErrorMsg, exception.getMessage());
   }
 
   @Test
   void createAndDeleteWorkspace() {
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     workspaceService.deleteWorkspace(request, USER_REQUEST);
@@ -552,7 +552,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void createMcWorkspaceDoSteps() {
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     Map<String, StepStatus> retrySteps = new HashMap<>();
     retrySteps.put(CreateWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(
@@ -584,7 +584,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void createMcWorkspaceUndoSteps() {
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     // Retry undo steps once and fail at the end of the flight.
     Map<String, StepStatus> retrySteps = new HashMap<>();
     retrySteps.put(CreateWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
@@ -653,7 +653,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
   @Test
   void deleteForbiddenExistingWorkspace() throws Exception {
-    Workspace request = WorkspaceFixtures.createMcWorkspace();
+    Workspace request = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
 
     doThrow(new ForbiddenException("forbid!"))

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlightTest.java
@@ -6,6 +6,7 @@ import bio.terra.stairway.*;
 import bio.terra.workspace.common.BaseAzureConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.utils.AzureTestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
@@ -66,10 +67,7 @@ public class DeleteAzureContextFlightTest extends BaseAzureConnectedTest {
     // Create a new workspace at the start of each test.
     workspaceUuid = UUID.randomUUID();
     workspace =
-        Workspace.builder()
-            .workspaceId(workspaceUuid)
-            .userFacingId("a" + workspaceUuid.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+        WorkspaceFixtures.defaultWorkspaceBuilder(workspaceUuid)
             .spendProfileId(spendUtils.defaultSpendId())
             .build();
     workspaceService.createWorkspace(
@@ -247,10 +245,7 @@ public class DeleteAzureContextFlightTest extends BaseAzureConnectedTest {
     // create new workspace so delete at end of test won't interfere with @AfterEach teardown
     UUID uuid = UUID.randomUUID();
     Workspace request =
-        Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+        WorkspaceFixtures.defaultWorkspaceBuilder(uuid)
             .spendProfileId(spendUtils.defaultSpendId())
             .build();
     UUID mcWorkspaceUuid = workspaceService.createWorkspace(request, null, null, userRequest);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlightTest.java
@@ -12,6 +12,7 @@ import bio.terra.stairway.FlightStatus;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -22,7 +23,6 @@ import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import java.time.Duration;
 import java.util.HashMap;
@@ -60,10 +60,7 @@ class DeleteGcpContextFlightTest extends BaseConnectedTest {
     // Create a new workspace at the start of each test.
     UUID uuid = UUID.randomUUID();
     workspace =
-        Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+        WorkspaceFixtures.defaultWorkspaceBuilder(uuid)
             .spendProfileId(spendUtils.defaultSpendId())
             .build();
     workspaceUuid =

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -14,6 +14,7 @@ import bio.terra.workspace.app.controller.shared.JobApiUtils;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.GcpCloudUtils;
 import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
@@ -38,7 +39,6 @@ import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.CloudContextHolder;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.iam.v1.Iam;
@@ -75,14 +75,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void removeUserFromWorkspaceFlightDoUndo() throws Exception {
     // Create a workspace as the default test user
-    UUID uuid = UUID.randomUUID();
-    Workspace workspace =
-        Workspace.builder()
-            .workspaceId(uuid)
-            .userFacingId("a" + uuid.toString())
-            .workspaceStage(WorkspaceStage.MC_WORKSPACE)
-            .spendProfileId(spendUtils.defaultSpendId())
-            .build();
+    Workspace workspace = WorkspaceFixtures.createWorkspace();
     UUID workspaceUuid =
         workspaceService.createWorkspace(
             workspace, null, null, userAccessUtils.defaultUserAuthRequest());

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -75,7 +75,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void removeUserFromWorkspaceFlightDoUndo() throws Exception {
     // Create a workspace as the default test user
-    Workspace workspace = WorkspaceFixtures.createWorkspace();
+    Workspace workspace = WorkspaceFixtures.createMcWorkspace();
     UUID workspaceUuid =
         workspaceService.createWorkspace(
             workspace, null, null, userAccessUtils.defaultUserAuthRequest());

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -14,8 +14,8 @@ import bio.terra.workspace.app.controller.shared.JobApiUtils;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.GcpCloudUtils;
 import bio.terra.workspace.common.StairwayTestUtils;
-import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
 import bio.terra.workspace.service.iam.SamService;
@@ -34,7 +34,6 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
-import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.CloudContextHolder;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
@@ -68,17 +67,16 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
   @Autowired private JobApiUtils jobApiUtils;
   @Autowired private SamService samService;
   @Autowired private PetSaService petSaService;
-  @Autowired private SpendConnectedTestUtils spendUtils;
   @Autowired private UserAccessUtils userAccessUtils;
+  @Autowired private WorkspaceConnectedTestUtils connectedTestUtils;
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void removeUserFromWorkspaceFlightDoUndo() throws Exception {
     // Create a workspace as the default test user
-    Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
-    UUID workspaceUuid =
-        workspaceService.createWorkspace(
-            workspace, null, null, userAccessUtils.defaultUserAuthRequest());
+    Workspace workspace =
+        connectedTestUtils.createWorkspace(userAccessUtils.defaultUserAuthRequest());
+    var workspaceUuid = workspace.getWorkspaceId();
     // Add the secondary test user as a writer
     samService.grantWorkspaceRole(
         workspaceUuid,

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromWorkspaceFlightTest.java
@@ -75,7 +75,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void removeUserFromWorkspaceFlightDoUndo() throws Exception {
     // Create a workspace as the default test user
-    Workspace workspace = WorkspaceFixtures.createMcWorkspace();
+    Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     UUID workspaceUuid =
         workspaceService.createWorkspace(
             workspace, null, null, userAccessUtils.defaultUserAuthRequest());


### PR DESCRIPTION
When i add a new required fields in Workspace, i have to go to all the test files and update them. So I created this method to centralize the creation of default workspace. 