### PR TITLE
PF-2250: When creating a common field in a resource, use the helper method

### DIFF
--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -424,14 +424,12 @@ public class ControlledResourceFixtures {
       String resourceDescription) {
     return ControlledAzureStorageResource.builder()
         .common(
-            ControlledResourceFields.builder()
+            makeDefaultControlledResourceFieldsBuilder()
                 .workspaceUuid(workspaceUuid)
                 .resourceId(accountResourceId)
                 .name(resourceName)
                 .description(resourceDescription)
                 .cloningInstructions(CloningInstructions.COPY_NOTHING)
-                .accessScope(AccessScopeType.fromApi(ApiAccessScope.SHARED_ACCESS))
-                .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
                 .build())
         .storageAccountName(storageAccountName)
         .region(region)

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/GcsBucketCloneTestFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/GcsBucketCloneTestFixtures.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.bucket;
 
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketDefaultStorageClass;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycle;
@@ -47,36 +48,12 @@ public class GcsBucketCloneTestFixtures {
       ControlledGcsBucketResource.builder()
           .bucketName(SOURCE_BUCKET_NAME)
           .common(
-              ControlledResourceFields.builder()
+              ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
                   .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
-                  .applicationId(null)
-                  .assignedUser(null)
                   .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                  .description(null)
                   .iamRole(ControlledResourceIamRole.OWNER)
-                  .managedBy(ManagedByType.MANAGED_BY_USER)
                   .name(SOURCE_RESOURCE_NAME)
-                  .privateResourceState(null)
-                  .resourceId(UUID.randomUUID())
                   .workspaceUuid(SOURCE_WORKSPACE_ID)
-                  .build())
-          .build();
-  public static final ControlledGcsBucketResource CREATED_BUCKET_RESOURCE =
-      ControlledGcsBucketResource.builder()
-          .bucketName(DESTINATION_BUCKET_NAME)
-          .common(
-              ControlledResourceFields.builder()
-                  .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
-                  .applicationId(null)
-                  .assignedUser(null)
-                  .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                  .description(null)
-                  .iamRole(ControlledResourceIamRole.OWNER)
-                  .managedBy(ManagedByType.MANAGED_BY_USER)
-                  .name("clone_of_source_bucket")
-                  .privateResourceState(null)
-                  .resourceId(UUID.randomUUID())
-                  .workspaceUuid(DESTINATION_WORKSPACE_ID)
                   .build())
           .build();
   // Stairway ser/des doesn't handle unmodifiable lists

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/GcsBucketCloneTestFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/GcsBucketCloneTestFixtures.java
@@ -11,8 +11,6 @@ import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycleRuleCondition
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
-import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
-import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import com.google.cloud.Identity;
 import com.google.cloud.Policy;


### PR DESCRIPTION
this is so that when I add a new required field for WsmResources, I don't need to go find all the random places that create resource and update them all.

Most of them are calling the write method with only two exceptions.