### PR TITLE
Randomize storage account name to avoid conflicts

### DIFF
--- a/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/TestUtils.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.common.utils;
 
+import java.util.Locale;
 import java.util.UUID;
 
 public class TestUtils {
@@ -9,5 +10,23 @@ public class TestUtils {
     // in bucket name.
     String randomString = prefix + UUID.randomUUID();
     return randomString.replaceAll("[-_]", "");
+  }
+
+  /**
+   * Generates random string based on UUID value. Hyphens are removed from the result string.
+   * Maximum length of result string is 32: UUID length of 36 minus 4 hyphens.
+   *
+   * @param length maximum length of the output string. Length will be cut off down to its max value
+   *     if exceeds max value of 32.
+   * @return string value containing lowercase characters and digits
+   */
+  public static String getRandomString(int length) {
+    // removes hyphen since it's forbidden to use in Azure storage account
+    int maxLength = 32;
+    return UUID.randomUUID()
+        .toString()
+        .toLowerCase(Locale.ROOT)
+        .replace("-", "")
+        .substring(0, length <= maxLength ? length - 1 : maxLength - 1);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/CreateAndDeleteAzureControlledResourceFlightTest.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.utils.AzureTestUtils;
 import bio.terra.workspace.common.utils.AzureVmUtils;
+import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.LandingZoneTestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.db.WorkspaceDao;
@@ -298,7 +299,7 @@ public class CreateAndDeleteAzureControlledResourceFlightTest extends BaseAzureC
   @Test
   public void createAndDeleteAzureStorageContainerBasedOnLandingZoneSharedStorageAccount()
       throws InterruptedException {
-    String storageAccountName = "lzsharedstorageaccount";
+    String storageAccountName = String.format("lzsharedstacc%s", TestUtils.getRandomString(6));
 
     Workspace workspace = azureTestUtils.createWorkspace(workspaceService);
     UUID workspaceUuid = workspace.getWorkspaceId();


### PR DESCRIPTION
Avoid name conflicts for Azure storage account name during parallel test run