### PR TITLE
PF-2260: undo should read WORKSPACE_ID value

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStep.java
@@ -1,5 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.workspace;
 
+import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.WORKSPACE_ID;
+
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
@@ -94,9 +96,7 @@ public class CloneAllFoldersStep implements Step {
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
     var destinationWorkspaceId =
-        flightContext
-            .getInputParameters()
-            .get(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, UUID.class);
+        FlightUtils.getRequired(flightContext.getInputParameters(), WORKSPACE_ID, UUID.class);
     folderDao.deleteAllFolders(destinationWorkspaceId);
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStep.java
@@ -9,10 +9,8 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.FolderDao;
 import bio.terra.workspace.service.folder.model.Folder;
-import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.FolderKeys;
-import bio.terra.workspace.service.workspace.model.Workspace;
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,17 +30,11 @@ public class CloneAllFoldersStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    FlightUtils.validateRequiredEntries(
-        context.getInputParameters(),
-        JobMapKeys.REQUEST.getKeyName(),
-        ControlledResourceKeys.SOURCE_WORKSPACE_ID);
-    var sourceWorkspaceId =
-        context.getInputParameters().get(ControlledResourceKeys.SOURCE_WORKSPACE_ID, UUID.class);
-    var destinationWorkspaceId =
-        context
-            .getInputParameters()
-            .get(JobMapKeys.REQUEST.getKeyName(), Workspace.class)
-            .getWorkspaceId();
+    UUID sourceWorkspaceId =
+        FlightUtils.getRequired(
+            context.getInputParameters(), ControlledResourceKeys.SOURCE_WORKSPACE_ID, UUID.class);
+    UUID destinationWorkspaceId =
+        FlightUtils.getRequired(context.getInputParameters(), WORKSPACE_ID, UUID.class);
 
     // Create and clone all folders
     ImmutableList<Folder> sourceFolders = folderDao.listFoldersInWorkspace(sourceWorkspaceId);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStepTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.workspace;
 
+import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.WORKSPACE_ID;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -121,7 +122,7 @@ public class CloneAllFoldersStepTest extends BaseUnitTest {
         WorkspaceUnitTestUtils.createWorkspaceWithGcpContext(workspaceDao);
     Workspace destinationWorkspace = workspaceDao.getWorkspace(destinationWorkspaceId);
     inputParameters.put(ControlledResourceKeys.SOURCE_WORKSPACE_ID, SOURCE_WORKSPACE_ID);
-    inputParameters.put(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, destinationWorkspaceId);
+    inputParameters.put(WORKSPACE_ID, destinationWorkspaceId);
     inputParameters.put(JobMapKeys.REQUEST.getKeyName(), destinationWorkspace);
 
     when(mockFlightContext.getInputParameters()).thenReturn(inputParameters);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStepTest.java
@@ -16,9 +16,7 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.db.FolderDao;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.folder.model.Folder;
-import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
-import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
 import java.util.List;
 import java.util.Map;
@@ -78,9 +76,8 @@ public class CloneAllFoldersStepTest extends BaseUnitTest {
 
     UUID destinationWorkspaceId =
         WorkspaceUnitTestUtils.createWorkspaceWithGcpContext(workspaceDao);
-    Workspace destinationWorkspace = workspaceDao.getWorkspace(destinationWorkspaceId);
     inputParameters.put(ControlledResourceKeys.SOURCE_WORKSPACE_ID, SOURCE_WORKSPACE_ID);
-    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), destinationWorkspace);
+    inputParameters.put(WORKSPACE_ID, destinationWorkspaceId);
 
     when(mockFlightContext.getInputParameters()).thenReturn(inputParameters);
     when(mockFlightContext.getWorkingMap()).thenReturn(workingMap);
@@ -120,10 +117,7 @@ public class CloneAllFoldersStepTest extends BaseUnitTest {
 
     UUID destinationWorkspaceId =
         WorkspaceUnitTestUtils.createWorkspaceWithGcpContext(workspaceDao);
-    Workspace destinationWorkspace = workspaceDao.getWorkspace(destinationWorkspaceId);
-    inputParameters.put(ControlledResourceKeys.SOURCE_WORKSPACE_ID, SOURCE_WORKSPACE_ID);
     inputParameters.put(WORKSPACE_ID, destinationWorkspaceId);
-    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), destinationWorkspace);
 
     when(mockFlightContext.getInputParameters()).thenReturn(inputParameters);
     when(mockFlightContext.getWorkingMap()).thenReturn(workingMap);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStepTest.java
@@ -117,6 +117,7 @@ public class CloneAllFoldersStepTest extends BaseUnitTest {
 
     UUID destinationWorkspaceId =
         WorkspaceUnitTestUtils.createWorkspaceWithGcpContext(workspaceDao);
+    inputParameters.put(ControlledResourceKeys.SOURCE_WORKSPACE_ID, SOURCE_WORKSPACE_ID);
     inputParameters.put(WORKSPACE_ID, destinationWorkspaceId);
 
     when(mockFlightContext.getInputParameters()).thenReturn(inputParameters);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -977,6 +977,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         AwaitCloneAllResourcesFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     FlightDebugInfo debugInfo =
         FlightDebugInfo.newBuilder().undoStepFailures(retrySteps).lastStepFailure(true).build();
+    // TODO(PF-2259): This test is not actually testing the undo of CloneGcpWorkspaceFlight. It is
+    // testing the undo of WorkspaceCreateFlight.
     jobService.setFlightDebugInfoForTest(debugInfo);
 
     assertThrows(


### PR DESCRIPTION
DESTINATION_WORKSPACE_ID value is never set for CloneGcpWorkspaceFlight. So if we undo here, we will throws exception.