### PR TITLE
PF-2294: change the set up to beforeAll and afterAll

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -33,9 +33,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -51,6 +53,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * <p>Use this instead of WorkspaceApiControllerTest, if you want to use real
  * bio.terra.workspace.service.iam.SamService.
  */
+@TestInstance(Lifecycle.PER_CLASS)
 public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Autowired private MockMvc mockMvc;
@@ -60,14 +63,14 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   private ApiCreatedWorkspace workspace;
 
-  @BeforeEach
+  @BeforeAll
   public void setup() throws Exception {
     workspace =
         mockMvcUtils.createWorkspaceWithoutCloudContext(userAccessUtils.defaultUserAuthRequest());
   }
 
   /** Clean up workspaces from Broad dev SAM. */
-  @AfterEach
+  @AfterAll
   public void cleanup() throws Exception {
     mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
   }


### PR DESCRIPTION
The test are all read-only (GET and LIST) so we don't need to create and delete the workspace per test.

From local run, the test now takes 18 sec. It took 58 sec before.