### PR TITLE
[PF-819] Flesh out tests for cloning referenced BQ dataset

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -37,6 +37,7 @@ import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
@@ -810,10 +811,16 @@ public class ReferencedGcpResourceController extends ControllerBase
       cloneGcpBigQueryDatasetReference(
           UUID workspaceUuid, UUID resourceId, @Valid ApiCloneReferencedResourceRequestBody body) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    if (body.getCloningInstructions() != null) {
+      ResourceValidationUtils.validateCloningInstructions(
+          StewardshipType.REFERENCED,
+          CloningInstructions.fromApiModel(body.getCloningInstructions()));
+    }
     // For cloning, we need to check that the caller has both read access to the source workspace
     // and write access to the destination workspace.
     workspaceService.validateCloneReferenceAction(
         userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+
     final ReferencedResource sourceReferencedResource =
         referenceResourceService.getReferenceResource(workspaceUuid, resourceId);
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
@@ -215,7 +215,6 @@ public class ReferencedResourceService {
                 createdByEmail)
             .castToReferencedResource();
 
-    // launch the creation flight
     return createReferenceResourceForClone(destinationResource, userRequest);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -78,7 +78,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
 
   private String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
   private String sourceDatasetName = TestUtils.appendRandomNumber("source-dataset-name");
-  private ApiGcpBigQueryDatasetResource sourceDataset;
+  private ApiGcpBigQueryDatasetResource sourceResource;
 
   @BeforeAll
   public void setup() throws Exception {
@@ -98,7 +98,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     projectId2 = workspace2.getGcpContext().getProjectId();
 
     // Note to resource authors: Set all request fields (to non-default values).
-    sourceDataset =
+    sourceResource =
         mockMvcUtils
             .createControlledBqDataset(
                 userAccessUtils.defaultUserAuthRequest(),
@@ -111,7 +111,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
             .getBigQueryDataset();
     cloudUtils.populateBqTable(
         userAccessUtils.defaultUser().getGoogleCredentials(),
-        sourceDataset.getAttributes().getProjectId(),
+        sourceResource.getAttributes().getProjectId(),
         sourceDatasetName);
   }
 
@@ -139,7 +139,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
 
     // Assert resource returned by create
     assertBqDataset(
-        sourceDataset,
+        sourceResource,
         ApiStewardshipType.CONTROLLED,
         ApiCloningInstructionsEnum.DEFINITION,
         workspaceId,
@@ -147,13 +147,13 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         projectId,
         sourceDatasetName);
 
-    // Assert got resource is same as created resource
+    // Assert resource returned by get
     ApiGcpBigQueryDatasetResource gotResource =
         mockMvcUtils.getControlledBqDataset(
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,
-            sourceDataset.getMetadata().getResourceId());
-    assertEquals(sourceDataset, gotResource);
+            sourceResource.getMetadata().getResourceId());
+    assertEquals(sourceResource, gotResource);
 
     // Call GCP directly
     cloudUtils.assertBqTableContents(
@@ -173,7 +173,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     mockMvcUtils.cloneControlledBqDatasetAsync(
         userAccessUtils.secondUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
-        /*sourceResourceId=*/ sourceDataset.getMetadata().getResourceId(),
+        /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
         /*destWorkspaceId=*/ workspaceId2,
         ApiCloningInstructionsEnum.RESOURCE,
         /*destResourceName=*/ null,
@@ -199,7 +199,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     mockMvcUtils.cloneControlledBqDatasetAsync(
         userAccessUtils.secondUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
-        /*sourceResourceId=*/ sourceDataset.getMetadata().getResourceId(),
+        /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
         /*destWorkspaceId=*/ workspaceId2,
         ApiCloningInstructionsEnum.RESOURCE,
         /*destResourceName=*/ null,
@@ -227,7 +227,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         mockMvcUtils.cloneControlledBqDataset_jobError(
             userAccessUtils.defaultUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
-            sourceDataset.getMetadata().getResourceId(),
+            sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
             ApiCloningInstructionsEnum.RESOURCE,
             /*destResourceName=*/ null,
@@ -244,7 +244,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         mockMvcUtils.cloneControlledBqDataset(
             userAccessUtils.defaultUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
-            sourceDataset.getMetadata().getResourceId(),
+            sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
             ApiCloningInstructionsEnum.NOTHING,
             destResourceName,
@@ -270,7 +270,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         mockMvcUtils.cloneControlledBqDataset(
             userAccessUtils.defaultUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
-            sourceDataset.getMetadata().getResourceId(),
+            sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId2,
             ApiCloningInstructionsEnum.DEFINITION,
             destResourceName,
@@ -323,7 +323,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         mockMvcUtils.cloneControlledBqDataset(
             userAccessUtils.defaultUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
-            sourceDataset.getMetadata().getResourceId(),
+            sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
             ApiCloningInstructionsEnum.RESOURCE,
             destResourceName,
@@ -378,7 +378,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         mockMvcUtils.cloneControlledBqDataset(
             userAccessUtils.defaultUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
-            sourceDataset.getMetadata().getResourceId(),
+            sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId2,
             ApiCloningInstructionsEnum.RESOURCE,
             destResourceName,
@@ -429,7 +429,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         mockMvcUtils.cloneControlledBqDataset(
             userAccessUtils.defaultUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
-            sourceDataset.getMetadata().getResourceId(),
+            sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
             ApiCloningInstructionsEnum.REFERENCE,
             destResourceName,
@@ -488,7 +488,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     mockMvcUtils.cloneControlledBqDataset(
         userAccessUtils.defaultUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
-        sourceDataset.getMetadata().getResourceId(),
+        sourceResource.getMetadata().getResourceId(),
         /*destWorkspaceId=*/ workspaceId2,
         ApiCloningInstructionsEnum.REFERENCE,
         destResourceName,
@@ -512,7 +512,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     mockMvcUtils.cloneControlledBqDataset_undo(
         userAccessUtils.defaultUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
-        sourceDataset.getMetadata().getResourceId(),
+        sourceResource.getMetadata().getResourceId(),
         /*destWorkspaceId=*/ workspaceId2,
         ApiCloningInstructionsEnum.RESOURCE,
         destResourceName);
@@ -528,7 +528,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     mockMvcUtils.cloneControlledBqDataset_undo(
         userAccessUtils.defaultUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
-        sourceDataset.getMetadata().getResourceId(),
+        sourceResource.getMetadata().getResourceId(),
         /*destWorkspaceId=*/ workspaceId2,
         ApiCloningInstructionsEnum.REFERENCE,
         destResourceName);
@@ -575,7 +575,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         expectedWorkspaceId,
         expectedResourceName,
         /*sourceWorkspaceId=*/ workspaceId,
-        /*sourceResourceId=*/ sourceDataset.getMetadata().getResourceId());
+        /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId());
 
     assertEquals(expectedProjectId, actualDataset.getAttributes().getProjectId());
     assertEquals(expectedDatasetName, actualDataset.getAttributes().getDatasetId());

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -47,8 +47,6 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired FeatureConfiguration features;
 
-  // Store workspace ID instead of workspace, we can easily use existing workspaces
-  // for local development.
   private UUID workspaceId;
   private String projectId;
   private UUID workspaceId2;
@@ -57,12 +55,10 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
   private String sourceDatasetName = TestUtils.appendRandomNumber("source-dataset-name");
   private ApiGcpBigQueryDatasetResource sourceResource;
 
+  // See here for how to skip workspace creation for local runs:
+  // https://github.com/DataBiosphere/terra-workspace-manager/blob/main/DEVELOPMENT.md#for-local-runs-skip-workspacecontext-creation
   @BeforeAll
   public void setup() throws Exception {
-    // workspaceId = UUID.fromString("bed24987-d9ef-4ed4-9808-eef57fb668bb");
-    // projectId = "terra-wsm-t-cold-haricot-7091";
-    // workspaceId2 = UUID.fromString("09342484-f022-4c58-ba58-69c198799f3d");
-
     workspaceId =
         mockMvcUtils
             .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -1,0 +1,310 @@
+package bio.terra.workspace.app.controller;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.common.BaseConnectedTest;
+import bio.terra.workspace.common.fixtures.PolicyFixtures;
+import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.common.utils.TestUtils;
+import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiResourceLineage;
+import bio.terra.workspace.generated.model.ApiResourceType;
+import bio.terra.workspace.generated.model.ApiStewardshipType;
+import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.service.iam.model.WsmIamRole;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** Connected tests for referenced BQ datasets. */
+// Per-class lifecycle on this test to allow a shared workspace object across tests, which saves
+// time creating and deleting GCP contexts.
+@TestInstance(Lifecycle.PER_CLASS)
+public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedTest {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ReferencedGcpResourceControllerBqDatasetTest.class);
+
+  @Autowired MockMvc mockMvc;
+  @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired UserAccessUtils userAccessUtils;
+  @Autowired FeatureConfiguration features;
+
+  // Store workspace ID instead of workspace, we can easily use existing workspaces
+  // for local development.
+  private UUID workspaceId;
+  private String projectId;
+  private UUID workspaceId2;
+
+  private String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
+  private String sourceDatasetName = TestUtils.appendRandomNumber("source-dataset-name");
+  private ApiGcpBigQueryDatasetResource sourceResource;
+
+  @BeforeAll
+  public void setup() throws Exception {
+    // workspaceId = UUID.fromString("bed24987-d9ef-4ed4-9808-eef57fb668bb");
+    // projectId = "terra-wsm-t-cold-haricot-7091";
+    // workspaceId2 = UUID.fromString("09342484-f022-4c58-ba58-69c198799f3d");
+
+    workspaceId =
+        mockMvcUtils
+            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .getId();
+    ApiWorkspaceDescription workspace =
+        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    projectId = workspace.getGcpContext().getProjectId();
+    workspaceId2 =
+        mockMvcUtils
+            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .getId();
+    ApiWorkspaceDescription workspace2 =
+        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+
+    // Note to resource authors: Set all request fields (to non-default values).
+    sourceResource =
+        mockMvcUtils.createReferencedBqDataset(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspaceId,
+            sourceResourceName,
+            projectId,
+            sourceDatasetName);
+  }
+
+  @AfterAll
+  public void cleanup() throws Exception {
+    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+  }
+
+  @Test
+  public void create() throws Exception {
+    // Resource was created in setup()
+
+    // Assert resource returned by create
+    assertBqDataset(
+        sourceResource,
+        ApiStewardshipType.REFERENCED,
+        ApiCloningInstructionsEnum.NOTHING,
+        workspaceId,
+        sourceResourceName,
+        projectId,
+        sourceDatasetName);
+
+    // Assert resource returned by get
+    ApiGcpBigQueryDatasetResource gotResource =
+        mockMvcUtils.getReferencedBqDataset(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspaceId,
+            sourceResource.getMetadata().getResourceId());
+    assertEquals(sourceResource, gotResource);
+  }
+
+  @Test
+  public void clone_requesterNoReadAccessOnSourceWorkspace_throws403() throws Exception {
+    mockMvcUtils.cloneReferencedBqDataset(
+        userAccessUtils.secondUserAuthRequest(),
+        /*sourceWorkspaceId=*/ workspaceId,
+        /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
+        /*destWorkspaceId=*/ workspaceId2,
+        ApiCloningInstructionsEnum.REFERENCE,
+        /*destResourceName=*/ null,
+        HttpStatus.SC_FORBIDDEN);
+  }
+
+  @Test
+  public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId,
+        WsmIamRole.READER,
+        userAccessUtils.getSecondUserEmail());
+    mockMvcUtils.grantRole(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId2,
+        WsmIamRole.READER,
+        userAccessUtils.getSecondUserEmail());
+
+    mockMvcUtils.cloneReferencedBqDataset(
+        userAccessUtils.secondUserAuthRequest(),
+        /*sourceWorkspaceId=*/ workspaceId,
+        /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
+        /*destWorkspaceId=*/ workspaceId2,
+        ApiCloningInstructionsEnum.REFERENCE,
+        /*destResourceName=*/ null,
+        HttpStatus.SC_FORBIDDEN);
+
+    mockMvcUtils.removeRole(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId,
+        WsmIamRole.READER,
+        userAccessUtils.getSecondUserEmail());
+    mockMvcUtils.removeRole(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId2,
+        WsmIamRole.READER,
+        userAccessUtils.getSecondUserEmail());
+  }
+
+  @Test
+  void clone_copyNothing() throws Exception {
+    String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    ApiGcpBigQueryDatasetResource clonedResource =
+        mockMvcUtils.cloneReferencedBqDataset(
+            userAccessUtils.defaultUserAuthRequest(),
+            /*sourceWorkspaceId=*/ workspaceId,
+            sourceResource.getMetadata().getResourceId(),
+            /*destWorkspaceId=*/ workspaceId,
+            ApiCloningInstructionsEnum.NOTHING,
+            destResourceName);
+
+    // Assert clone result has no resource
+    assertNull(clonedResource);
+
+    // Assert clone doesn't exist. There's no resource ID, so search on resource name.
+    mockMvcUtils.assertNoResourceWithName(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId, destResourceName);
+  }
+
+  @Test
+  void clone_copyReference() throws Exception {
+    // Source resource is COPY_DEFINITION
+
+    // Clone resource
+    String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    ApiGcpBigQueryDatasetResource clonedResource =
+        mockMvcUtils.cloneReferencedBqDataset(
+            userAccessUtils.defaultUserAuthRequest(),
+            /*sourceWorkspaceId=*/ workspaceId,
+            sourceResource.getMetadata().getResourceId(),
+            /*destWorkspaceId=*/ workspaceId,
+            ApiCloningInstructionsEnum.REFERENCE,
+            destResourceName);
+
+    // Assert resource returned in clone flight response
+    assertClonedBqDataset(
+        clonedResource,
+        ApiStewardshipType.REFERENCED,
+        ApiCloningInstructionsEnum.NOTHING,
+        /*expectedDestWorkspaceId=*/ workspaceId,
+        destResourceName,
+        /*expectedProjectId=*/ projectId,
+        /*expectedDatasetName=*/ sourceDatasetName);
+
+    // Assert resource returned by ReferencedGcpResource.getBigQueryDatasetReference()
+    final ApiGcpBigQueryDatasetResource gotResource =
+        mockMvcUtils.getReferencedBqDataset(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspaceId,
+            clonedResource.getMetadata().getResourceId());
+    assertEquals(clonedResource, gotResource);
+  }
+
+  // Destination workspace policy is the merge of source workspace policy and pre-clone destination
+  // workspace policy
+  @Test
+  @Disabled("Enable after PF-2217 is fixed")
+  void clone_policiesMerged() throws Exception {
+    logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
+    // Don't run the test if TPS is disabled
+    if (!features.isTpsEnabled()) {
+      return;
+    }
+
+    // Clean up policies from previous runs, if any exist
+    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+
+    // Add group policy to source workspace. Add region policy to dest workspace.
+    mockMvcUtils.updatePolicies(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId,
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToRemove=*/ null);
+    mockMvcUtils.updatePolicies(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId2,
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToRemove=*/ null);
+
+    // Clone resource
+    String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    mockMvcUtils.cloneReferencedBqDataset(
+        userAccessUtils.defaultUserAuthRequest(),
+        /*sourceWorkspaceId=*/ workspaceId,
+        sourceResource.getMetadata().getResourceId(),
+        /*destWorkspaceId=*/ workspaceId2,
+        ApiCloningInstructionsEnum.REFERENCE,
+        destResourceName);
+
+    // Assert dest workspace has group and region policies
+    ApiWorkspaceDescription destWorkspace =
+        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    assertThat(
+        destWorkspace.getPolicies(),
+        containsInAnyOrder(PolicyFixtures.GROUP_POLICY, PolicyFixtures.REGION_POLICY));
+
+    // Clean up: Delete policies
+    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+  }
+
+  private void assertBqDataset(
+      ApiGcpBigQueryDatasetResource actualDataset,
+      ApiStewardshipType expectedStewardshipType,
+      ApiCloningInstructionsEnum expectedCloningInstructions,
+      UUID expectedWorkspaceId,
+      String expectedResourceName,
+      String expectedProjectId,
+      String expectedDatasetName) {
+    mockMvcUtils.assertResourceMetadata(
+        actualDataset.getMetadata(),
+        ApiResourceType.BIG_QUERY_DATASET,
+        expectedStewardshipType,
+        expectedCloningInstructions,
+        expectedWorkspaceId,
+        expectedResourceName,
+        /*expectedResourceLineage=*/ new ApiResourceLineage());
+
+    assertEquals(expectedProjectId, actualDataset.getAttributes().getProjectId());
+    assertEquals(expectedDatasetName, actualDataset.getAttributes().getDatasetId());
+  }
+
+  private void assertClonedBqDataset(
+      ApiGcpBigQueryDatasetResource actualDataset,
+      ApiStewardshipType expectedStewardshipType,
+      ApiCloningInstructionsEnum expectedCloningInstructions,
+      UUID expectedWorkspaceId,
+      String expectedResourceName,
+      String expectedProjectId,
+      String expectedDatasetName) {
+    mockMvcUtils.assertClonedResourceMetadata(
+        actualDataset.getMetadata(),
+        ApiResourceType.BIG_QUERY_DATASET,
+        expectedStewardshipType,
+        expectedCloningInstructions,
+        expectedWorkspaceId,
+        expectedResourceName,
+        /*sourceWorkspaceId=*/ workspaceId,
+        /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId());
+
+    assertEquals(expectedProjectId, actualDataset.getAttributes().getProjectId());
+    assertEquals(expectedDatasetName, actualDataset.getAttributes().getDatasetId());
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -73,7 +73,6 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
     ApiWorkspaceDescription workspace2 =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Note to resource authors: Set all request fields (to non-default values).
     sourceResource =
         mockMvcUtils.createReferencedBqDataset(
             userAccessUtils.defaultUserAuthRequest(),

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerTest.java
@@ -3,12 +3,10 @@ package bio.terra.workspace.app.controller;
 import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeBqDataTableReferenceRequestBody;
 import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeDataRepoSnapshotReferenceRequestBody;
 import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeDefaultReferencedResourceFieldsApi;
-import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeGcpBqDatasetReferenceRequestBody;
 import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeGcsBucketReferenceRequestBody;
 import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeGcsObjectReferenceRequestBody;
 import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeGitRepoReferenceRequestBody;
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_DATA_REPO_SNAPSHOTS_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT;
@@ -26,15 +24,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import bio.terra.workspace.app.controller.shared.PropertiesUtils;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDataTableReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDatasetReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGcpGcsBucketReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGcpGcsObjectReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGitRepoReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableResource;
-import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiGcpGcsObjectResource;
 import bio.terra.workspace.generated.model.ApiGitRepoResource;
@@ -144,20 +141,31 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   }
 
   @Test
-  public void createReferencedBqDatasetResource_commonFieldsAndAttributesCorrectlyPopulated()
-      throws Exception {
+  public void cloneReferencedBqDatasetResource_copyDefinition_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    ApiCreateGcpBigQueryDatasetReferenceRequestBody requestBody =
-        makeGcpBqDatasetReferenceRequestBody();
 
-    ApiGcpBigQueryDatasetResource createdResource =
-        createReferencedBigQueryDatasetResource(workspaceId, requestBody);
+    mockMvcUtils.cloneReferencedBqDataset(
+        USER_REQUEST,
+        workspaceId,
+        /*sourceResourceId=*/ UUID.randomUUID(),
+        /*destWorkspaceId=*/ workspaceId,
+        ApiCloningInstructionsEnum.DEFINITION,
+        /*destResourceName=*/ null,
+        HttpStatus.SC_BAD_REQUEST);
+  }
 
-    assertReferenceResourceCommonFields(requestBody.getMetadata(), createdResource.getMetadata());
-    assertEquals(
-        requestBody.getDataset().getDatasetId(), createdResource.getAttributes().getDatasetId());
-    assertEquals(
-        requestBody.getDataset().getProjectId(), createdResource.getAttributes().getProjectId());
+  @Test
+  public void cloneReferencedBqDatasetResource_copyResource_throws400() throws Exception {
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+
+    mockMvcUtils.cloneReferencedBqDataset(
+        USER_REQUEST,
+        workspaceId,
+        /*sourceResourceId=*/ UUID.randomUUID(),
+        /*destWorkspaceId=*/ workspaceId,
+        ApiCloningInstructionsEnum.RESOURCE,
+        /*destResourceName=*/ null,
+        HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test
@@ -225,18 +233,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
             workspaceId, request, REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT);
 
     return objectMapper.readValue(serializedResponse, ApiGcpGcsObjectResource.class);
-  }
-
-  private ApiGcpBigQueryDatasetResource createReferencedBigQueryDatasetResource(
-      UUID workspaceId, ApiCreateGcpBigQueryDatasetReferenceRequestBody requestBody)
-      throws Exception {
-    var request = objectMapper.writeValueAsString(requestBody);
-
-    String serializedResponse =
-        createReferencedResourceAndGetSerializedResponse(
-            workspaceId, request, REFERENCED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT);
-
-    return objectMapper.readValue(serializedResponse, ApiGcpBigQueryDatasetResource.class);
   }
 
   private ApiGcpBigQueryDataTableResource createReferencedBigQueryDataTableResource(

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.common.fixtures;
 
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.TestUtils.appendRandomNumber;
 
@@ -134,7 +135,7 @@ public class ReferenceResourceFixtures {
   public static ApiReferenceResourceCommonFields makeDefaultReferencedResourceFieldsApi() {
     return new ApiReferenceResourceCommonFields()
         .name(appendRandomNumber("test_resource"))
-        .description("This is a referenced resource")
+        .description(RESOURCE_DESCRIPTION)
         .cloningInstructions(ApiCloningInstructionsEnum.NOTHING)
         .properties(convertMapToApiProperties(DEFAULT_RESOURCE_PROPERTIES));
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -217,7 +217,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     var instanceId = "create-ai-notebook-instance-do";
     var serverName = "verily-autopush";
     int retryWaitSeconds = 30;
-    int retryCount = 10;
+    int retryCount = 20;
 
     cliConfiguration.setServerName(serverName);
     ApiGcpAiNotebookInstanceCreationParameters creationParameters =


### PR DESCRIPTION
Tests uncovered issue:

- We allowed cloning referenced resource where request had COPY_DEFINITION, COPY_RESOURCE. Changed to throw 400.

Also:

- Increased # retries for `createAiNotebookInstanceDo()`. After Dan's fix (#937), test still flaked after exhausting all ten retries ([build scan](https://scans.gradle.com/s/ymg4fcqexjy46/tests/:service:connectedTest/bio.terra.workspace.service.resource.controlled.ControlledResourceServiceTest/createAiNotebookInstanceDo()?top-execution=1)).