### PR TITLE
[TERRA-246] Add awsAccountNumber to SageMakerAttributes

### DIFF
--- a/openapi/src/common/parameters.yaml
+++ b/openapi/src/common/parameters.yaml
@@ -184,7 +184,7 @@ components:
     WorkspaceId:
       name: workspaceId
       in: path
-      description: A UUID to used to identify a workspace in the workspace manager
+      description: A UUID to used to identify a workspace (landing zone) in the workspace manager
       required: true
       schema:
         type: string

--- a/openapi/src/common/parameters.yaml
+++ b/openapi/src/common/parameters.yaml
@@ -184,7 +184,7 @@ components:
     WorkspaceId:
       name: workspaceId
       in: path
-      description: A UUID to used to identify a workspace (landing zone) in the workspace manager
+      description: A UUID to used to identify a workspace in the workspace manager
       required: true
       schema:
         type: string

--- a/openapi/src/parts/controlled_aws_bucket.yaml
+++ b/openapi/src/parts/controlled_aws_bucket.yaml
@@ -111,6 +111,10 @@ components:
         location:
           description: A valid bucket location per https://docs.aws.amazon.com/general/latest/gr/s3.html.
           type: string
+        seed:
+          description: Seed bucket with sample data.
+          type: boolean
+          default: false
 
   responses:
     CreatedControlledAwsBucketResponse:

--- a/openapi/src/resources/aws_sagemaker_notebook.yaml
+++ b/openapi/src/resources/aws_sagemaker_notebook.yaml
@@ -8,9 +8,6 @@ components:
         awsAccountNumber:
           description: Account number of the account containing the notebook instance.
           type: string
-        landingZoneId:
-          description: ID of the landing zone (workapce) containing the notebook instance.
-          type: string
         instanceId:
           description: ID of the created SageMaker notebook instance.
           type: string

--- a/openapi/src/resources/aws_sagemaker_notebook.yaml
+++ b/openapi/src/resources/aws_sagemaker_notebook.yaml
@@ -5,11 +5,17 @@ components:
         SageMaker Notebook properties included in post-creation get.
       type: object
       properties:
+        awsAccountNumber:
+          description: Account number of the account containing the notebook instance.
+          type: string
+        landingZoneId:
+          description: ID of the landing zone (workapce) containing the notebook instance.
+          type: string
         instanceId:
           description: ID of the created SageMaker notebook instance.
           type: string
         region:
-          description: Region in which the notebook was created
+          description: AWS Region containing the notebook instance.
           type: string
         instanceType:
           description: Type of the compute instance to launch for the notebook instance.

--- a/openapi/src/resources/aws_sagemaker_notebook.yaml
+++ b/openapi/src/resources/aws_sagemaker_notebook.yaml
@@ -8,6 +8,10 @@ components:
         awsAccountNumber:
           description: Account number of the account containing the notebook instance.
           type: string
+        landingZoneId:
+          description: ID of the AWS landing zone containing the notebook instance.
+          type: string
+          format: uuid
         instanceId:
           description: ID of the created SageMaker notebook instance.
           type: string

--- a/openapi/src/resources/gcp_ai_notebook.yaml
+++ b/openapi/src/resources/gcp_ai_notebook.yaml
@@ -14,7 +14,7 @@ components:
           description: GCP Location containing the notebook instance, e.g. 'us-east1-b'.
           type: string
         instanceId:
-          description: An instance id unique to this project and location.
+          description: ID of the created AI notebook instance.
           type: string
 
     GcpAiNotebookInstanceResource:

--- a/openapi/src/resources/gcp_ai_notebook.yaml
+++ b/openapi/src/resources/gcp_ai_notebook.yaml
@@ -8,10 +8,10 @@ components:
       required: [projectId, location, instanceId]
       properties:
         projectId:
-          description: The GCP project id for the project containing the notebook instance.
+          description: ID of the project containing the notebook instance.
           type: string
         location:
-          description: The GCP location containing the notebook instance, e.g. 'us-east1-b'
+          description: GCP Location containing the notebook instance, e.g. 'us-east1-b'.
           type: string
         instanceId:
           description: An instance id unique to this project and location.

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AwsConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AwsConfiguration.java
@@ -15,6 +15,8 @@ public class AwsConfiguration {
 
   private List<AwsLandingZoneConfiguration> landingZones;
 
+  private List<AwsBucketSeedFile> bucketSeedFiles;
+
   public String getDefaultLandingZone() {
     return defaultLandingZone;
   }
@@ -37,6 +39,14 @@ public class AwsConfiguration {
 
   public void setLandingZones(List<AwsLandingZoneConfiguration> landingZones) {
     this.landingZones = landingZones;
+  }
+
+  public List<AwsBucketSeedFile> getBucketSeedFiles() {
+    return bucketSeedFiles;
+  }
+
+  public void setBucketSeedFiles(List<AwsBucketSeedFile> bucketSeedFiles) {
+    this.bucketSeedFiles = bucketSeedFiles;
   }
 
   public static class AwsLandingZoneBucket {
@@ -114,6 +124,27 @@ public class AwsConfiguration {
 
     public void setBuckets(List<AwsLandingZoneBucket> buckets) {
       this.buckets = buckets;
+    }
+  }
+
+  public static class AwsBucketSeedFile {
+    private String path;
+    private String content;
+
+    public String getPath() {
+      return path;
+    }
+
+    public void setPath(String path) {
+      this.path = path;
+    }
+
+    public String getContent() {
+      return content;
+    }
+
+    public void setContent(String content) {
+      this.content = content;
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AwsConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AwsConfiguration.java
@@ -65,6 +65,7 @@ public class AwsConfiguration {
     private String accountNumber;
     private String serviceRoleArn;
     private String userRoleArn;
+    private String notebookLifecycleConfigArn;
     private List<AwsLandingZoneBucket> buckets;
 
     public String getName() {
@@ -97,6 +98,14 @@ public class AwsConfiguration {
 
     public void setUserRoleArn(String userRoleArn) {
       this.userRoleArn = userRoleArn;
+    }
+
+    public String getNotebookLifecycleConfigArn() {
+      return notebookLifecycleConfigArn;
+    }
+
+    public void setNotebookLifecycleConfigArn(String notebookLifecycleConfigArn) {
+      this.notebookLifecycleConfigArn = notebookLifecycleConfigArn;
     }
 
     public List<AwsLandingZoneBucket> getBuckets() {

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -332,6 +332,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
       ControlledAwsSageMakerNotebookResource resource = jobResult.getResult();
       apiResource = resource.toApiResource();
       apiResource.getAttributes().setAwsAccountNumber(getAwsAccountNumber(apiResource));
+      apiResource.getAttributes().setLandingZoneId(getLandingZoneId(apiResource));
     }
     return new ApiCreatedControlledAwsSageMakerNotebookResult()
         .jobReport(jobResult.getJobReport())
@@ -343,6 +344,13 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
     return awsCloudContextService
         .getRequiredAwsCloudContext(apiResource.getMetadata().getWorkspaceId())
         .getAccountNumber();
+  }
+
+  private UUID getLandingZoneId(ApiAwsSageMakerNotebookResource apiResource) {
+    return UUID.fromString(
+        awsCloudContextService
+            .getRequiredAwsCloudContext(apiResource.getMetadata().getWorkspaceId())
+            .getLandingZoneName());
   }
 
   @Override
@@ -360,6 +368,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
 
     ApiAwsSageMakerNotebookResource apiResource = resource.toApiResource();
     apiResource.getAttributes().setAwsAccountNumber(getAwsAccountNumber(apiResource));
+    apiResource.getAttributes().setLandingZoneId(getLandingZoneId(apiResource));
 
     return new ResponseEntity<>(apiResource, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -309,7 +309,6 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
 
     ApiCreatedControlledAwsSageMakerNotebookResult result =
         fetchNotebookInstanceCreateResult(jobId);
-
     return new ResponseEntity<>(result, getAsyncResponseCode((result.getJobReport())));
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -130,7 +130,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
         ControlledAwsBucketResource.builder()
             .common(commonFields)
             .s3BucketName(s3BucketName)
-            .prefix(AwsUtils.generateUniquePrefix())
+            .prefix(commonFields.getName())
             .region(creationParameters.getLocation())
             .build();
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -309,6 +309,13 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
 
     ApiCreatedControlledAwsSageMakerNotebookResult result =
         fetchNotebookInstanceCreateResult(jobId);
+
+    result
+        .getAiNotebookInstance()
+        .getAttributes()
+        .setAwsAccountNumber(
+            awsCloudContextService.getRequiredAwsCloudContext(workspaceUuid).getAccountNumber());
+
     return new ResponseEntity<>(result, getAsyncResponseCode((result.getJobReport())));
   }
 

--- a/service/src/main/java/bio/terra/workspace/common/utils/AwsUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/AwsUtils.java
@@ -258,16 +258,26 @@ public class AwsUtils {
   public static void createFolder(
       Credentials credentials, Regions region, String bucketName, String folder) {
     // Creating a "folder" requires writing an empty object ending with the delimiter ('/').
-    AmazonS3 s3 = getS3Session(credentials, region);
     String folderKey = String.format("%s/", folder);
-    s3.putObject(bucketName, folderKey, "");
+    putObject(credentials, region, bucketName, folderKey, "");
   }
 
   public static void undoCreateFolder(
       Credentials credentials, Regions region, String bucketName, String folder) {
-    AmazonS3 s3 = getS3Session(credentials, region);
     String folderKey = String.format("%s/", folder);
-    DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucketName, folderKey);
+    deleteObject(credentials, region, bucketName, folderKey);
+  }
+
+  public static void putObject(
+      Credentials credentials, Regions region, String bucketName, String key, String content) {
+    AmazonS3 s3 = getS3Session(credentials, region);
+    s3.putObject(bucketName, key, content);
+  }
+
+  public static void deleteObject(
+      Credentials credentials, Regions region, String bucketName, String key) {
+    AmazonS3 s3 = getS3Session(credentials, region);
+    DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucketName, key);
     s3.deleteObject(deleteObjectRequest);
   }
 

--- a/service/src/main/java/bio/terra/workspace/common/utils/AwsUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/AwsUtils.java
@@ -311,12 +311,26 @@ public class AwsUtils {
     addUserTags(tags, user);
     addWorkspaceTags(tags, workspaceUuid);
 
+    logger.info(
+        String.format(
+            "Creating SageMaker notebook instance with name '%s' and type '%s'.",
+            notebookName, instanceType));
+
     CreateNotebookInstanceRequest request =
         new CreateNotebookInstanceRequest()
             .withNotebookInstanceName(notebookName)
             .withInstanceType(instanceType)
             .withRoleArn(awsCloudContext.getUserRoleArn().toString())
             .withTags(toSagemakerTags(tags));
+
+    if (awsCloudContext.getNotebookLifecycleConfigArn() != null) {
+      String policyName =
+          awsCloudContext.getNotebookLifecycleConfigArn().getResource().getResource();
+      logger.info(
+          String.format(
+              "Attaching lifecycle policy '%s' to notebook '%s'.", policyName, notebookName));
+      request.withLifecycleConfigName(policyName);
+    }
 
     sageMaker.createNotebookInstance(request);
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookAttributes.java
@@ -10,10 +10,12 @@ public class ControlledAwsSageMakerNotebookAttributes {
 
   @JsonCreator
   public ControlledAwsSageMakerNotebookAttributes(
+      @JsonProperty("awsAccountNumber") String awsAccountNumber,
       @JsonProperty("instanceId") String instanceId,
       @JsonProperty("region") String region,
       @JsonProperty("instanceType") String instanceType,
       @JsonProperty("defaultBucket") DefaultBucket defaultBucket) {
+    this.awsAccountNumber = awsAccountNumber;
     this.instanceId = instanceId;
     this.region = region;
     this.instanceType = instanceType;
@@ -51,10 +53,15 @@ public class ControlledAwsSageMakerNotebookAttributes {
     }
   }
 
+  private final String awsAccountNumber;
   private final String instanceId;
   private final String region;
   private final String instanceType;
   private final DefaultBucket defaultBucket;
+
+  public String getAwsAccountNumber() {
+    return awsAccountNumber;
+  }
 
   public String getInstanceId() {
     return instanceId;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookAttributes.java
@@ -11,11 +11,13 @@ public class ControlledAwsSageMakerNotebookAttributes {
   @JsonCreator
   public ControlledAwsSageMakerNotebookAttributes(
       @JsonProperty("awsAccountNumber") String awsAccountNumber,
+      @JsonProperty("landingZoneId") UUID landingZoneId,
       @JsonProperty("instanceId") String instanceId,
       @JsonProperty("region") String region,
       @JsonProperty("instanceType") String instanceType,
       @JsonProperty("defaultBucket") DefaultBucket defaultBucket) {
     this.awsAccountNumber = awsAccountNumber;
+    this.landingZoneId = landingZoneId;
     this.instanceId = instanceId;
     this.region = region;
     this.instanceType = instanceType;
@@ -54,6 +56,7 @@ public class ControlledAwsSageMakerNotebookAttributes {
   }
 
   private final String awsAccountNumber;
+  private final UUID landingZoneId;
   private final String instanceId;
   private final String region;
   private final String instanceType;
@@ -61,6 +64,10 @@ public class ControlledAwsSageMakerNotebookAttributes {
 
   public String getAwsAccountNumber() {
     return awsAccountNumber;
+  }
+
+  public UUID getLandingZoneId() {
+    return landingZoneId;
   }
 
   public String getInstanceId() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookHandler.java
@@ -31,6 +31,7 @@ public class ControlledAwsSageMakerNotebookHandler implements WsmResourceHandler
     return ControlledAwsSageMakerNotebookResource.builder()
         .common(new ControlledResourceFields(dbResource))
         .awsAccountNumber(attributes.getAwsAccountNumber())
+        .landingZoneId(attributes.getLandingZoneId())
         .instanceId(attributes.getInstanceId())
         .region(attributes.getRegion())
         .instanceType(attributes.getInstanceId())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookHandler.java
@@ -30,6 +30,7 @@ public class ControlledAwsSageMakerNotebookHandler implements WsmResourceHandler
 
     return ControlledAwsSageMakerNotebookResource.builder()
         .common(new ControlledResourceFields(dbResource))
+        .awsAccountNumber(attributes.getAwsAccountNumber())
         .instanceId(attributes.getInstanceId())
         .region(attributes.getRegion())
         .instanceType(attributes.getInstanceId())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookResource.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
+  private final String awsAccountNumber;
   private final String instanceId;
   private final String region;
   private final String instanceType;
@@ -54,6 +55,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
       @JsonProperty("accessScope") AccessScopeType accessScope,
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") String applicationId,
+      @JsonProperty("awsAccountNumber") String awsAccountNumber,
       @JsonProperty("instanceId") String instanceId,
       @JsonProperty("region") String region,
       @JsonProperty("instanceType") String instanceType,
@@ -74,6 +76,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
         privateResourceState,
         resourceLineage,
         properties);
+    this.awsAccountNumber = instanceId;
     this.instanceId = instanceId;
     this.region = region;
     this.instanceType = instanceType;
@@ -83,11 +86,13 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
 
   private ControlledAwsSageMakerNotebookResource(
       ControlledResourceFields common,
+      String awsAccountNumber,
       String instanceId,
       String region,
       String instanceType,
       ControlledAwsSageMakerNotebookAttributes.DefaultBucket defaultBucket) {
     super(common);
+    this.awsAccountNumber = awsAccountNumber;
     this.instanceId = instanceId;
     this.region = region;
     this.instanceType = instanceType;
@@ -155,6 +160,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
 
   public ApiAwsSageMakerNotebookAttributes toApiAttributes() {
     return new ApiAwsSageMakerNotebookAttributes()
+        .awsAccountNumber(awsAccountNumber)
         .instanceId(getInstanceId())
         .region(getRegion())
         .instanceType(getInstanceType())
@@ -184,7 +190,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
   public String attributesToJson() {
     return DbSerDes.toJson(
         new ControlledAwsSageMakerNotebookAttributes(
-            getInstanceId(), getRegion(), getInstanceType(), getDefaultBucket()));
+            awsAccountNumber, getInstanceId(), getRegion(), getInstanceType(), getDefaultBucket()));
   }
 
   @Override
@@ -222,6 +228,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
 
   public static class Builder {
     private ControlledResourceFields common;
+    private String awsAccountNumber;
     private String instanceId;
     private String region;
     private String instanceType;
@@ -229,6 +236,11 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
 
     public Builder common(ControlledResourceFields common) {
       this.common = common;
+      return this;
+    }
+
+    public Builder awsAccountNumber(String awsAccountNumber) {
+      this.awsAccountNumber = awsAccountNumber;
       return this;
     }
 
@@ -263,7 +275,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
 
     public ControlledAwsSageMakerNotebookResource build() {
       return new ControlledAwsSageMakerNotebookResource(
-          common, instanceId, region, instanceType, defaultBucket);
+          common, awsAccountNumber, instanceId, region, instanceType, defaultBucket);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookResource.java
@@ -76,7 +76,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
         privateResourceState,
         resourceLineage,
         properties);
-    this.awsAccountNumber = instanceId;
+    this.awsAccountNumber = awsAccountNumber;
     this.instanceId = instanceId;
     this.region = region;
     this.instanceType = instanceType;
@@ -140,6 +140,10 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
   @Override
   public void addDeleteSteps(DeleteControlledResourcesFlight flight, FlightBeanBag flightBeanBag) {
     // TODO: Implement and add delete flight steps.
+  }
+
+  public String getAwsAccountNumber() {
+    return awsAccountNumber;
   }
 
   public String getInstanceId() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakernotebook/ControlledAwsSageMakerNotebookResource.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 
 public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
   private final String awsAccountNumber;
+  private final UUID landingZoneId;
   private final String instanceId;
   private final String region;
   private final String instanceType;
@@ -56,6 +57,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
       @JsonProperty("managedBy") ManagedByType managedBy,
       @JsonProperty("applicationId") String applicationId,
       @JsonProperty("awsAccountNumber") String awsAccountNumber,
+      @JsonProperty("landingZoneId") UUID landingZoneId,
       @JsonProperty("instanceId") String instanceId,
       @JsonProperty("region") String region,
       @JsonProperty("instanceType") String instanceType,
@@ -77,6 +79,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
         resourceLineage,
         properties);
     this.awsAccountNumber = awsAccountNumber;
+    this.landingZoneId = landingZoneId;
     this.instanceId = instanceId;
     this.region = region;
     this.instanceType = instanceType;
@@ -87,12 +90,14 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
   private ControlledAwsSageMakerNotebookResource(
       ControlledResourceFields common,
       String awsAccountNumber,
+      UUID landingZoneId,
       String instanceId,
       String region,
       String instanceType,
       ControlledAwsSageMakerNotebookAttributes.DefaultBucket defaultBucket) {
     super(common);
     this.awsAccountNumber = awsAccountNumber;
+    this.landingZoneId = landingZoneId;
     this.instanceId = instanceId;
     this.region = region;
     this.instanceType = instanceType;
@@ -146,6 +151,10 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
     return awsAccountNumber;
   }
 
+  public UUID getLandingZoneId() {
+    return landingZoneId;
+  }
+
   public String getInstanceId() {
     return instanceId;
   }
@@ -165,6 +174,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
   public ApiAwsSageMakerNotebookAttributes toApiAttributes() {
     return new ApiAwsSageMakerNotebookAttributes()
         .awsAccountNumber(awsAccountNumber)
+        .landingZoneId(landingZoneId)
         .instanceId(getInstanceId())
         .region(getRegion())
         .instanceType(getInstanceType())
@@ -194,7 +204,12 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
   public String attributesToJson() {
     return DbSerDes.toJson(
         new ControlledAwsSageMakerNotebookAttributes(
-            awsAccountNumber, getInstanceId(), getRegion(), getInstanceType(), getDefaultBucket()));
+            awsAccountNumber,
+            landingZoneId,
+            getInstanceId(),
+            getRegion(),
+            getInstanceType(),
+            getDefaultBucket()));
   }
 
   @Override
@@ -233,6 +248,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
   public static class Builder {
     private ControlledResourceFields common;
     private String awsAccountNumber;
+    private UUID landingZoneId;
     private String instanceId;
     private String region;
     private String instanceType;
@@ -245,6 +261,11 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
 
     public Builder awsAccountNumber(String awsAccountNumber) {
       this.awsAccountNumber = awsAccountNumber;
+      return this;
+    }
+
+    public Builder landingZoneId(UUID landingZoneId) {
+      this.landingZoneId = landingZoneId;
       return this;
     }
 
@@ -279,7 +300,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
 
     public ControlledAwsSageMakerNotebookResource build() {
       return new ControlledAwsSageMakerNotebookResource(
-          common, awsAccountNumber, instanceId, region, instanceType, defaultBucket);
+          common, awsAccountNumber, landingZoneId, instanceId, region, instanceType, defaultBucket);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/storagebucket/SeedAwsBucketStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/storagebucket/SeedAwsBucketStep.java
@@ -1,0 +1,77 @@
+package bio.terra.workspace.service.resource.controlled.cloud.aws.storagebucket;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.app.configuration.external.AwsConfiguration;
+import bio.terra.workspace.common.utils.AwsUtils;
+import bio.terra.workspace.common.utils.MultiCloudUtils;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.model.AwsCloudContext;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.securitytoken.model.Credentials;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+public class SeedAwsBucketStep implements Step {
+
+  private final List<AwsConfiguration.AwsBucketSeedFile> seedFiles;
+  private final ControlledAwsBucketResource resource;
+
+  public SeedAwsBucketStep(
+      List<AwsConfiguration.AwsBucketSeedFile> seedFiles, ControlledAwsBucketResource resource) {
+    this.seedFiles = seedFiles;
+    this.resource = resource;
+  }
+
+  private String getKey(String path) {
+    return String.format("%s/%s", resource.getPrefix(), path);
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    final String awsCloudContextString =
+        flightContext
+            .getWorkingMap()
+            .get(WorkspaceFlightMapKeys.ControlledResourceKeys.AWS_CLOUD_CONTEXT, String.class);
+
+    final AwsCloudContext awsCloudContext = AwsCloudContext.deserialize(awsCloudContextString);
+    final Credentials awsCredentials = MultiCloudUtils.assumeAwsServiceRoleFromGcp(awsCloudContext);
+
+    for (AwsConfiguration.AwsBucketSeedFile seedFile : seedFiles) {
+      String content =
+          new String(
+              Base64.getDecoder().decode(seedFile.getContent().getBytes(StandardCharsets.UTF_8)));
+      String key = getKey(seedFile.getPath());
+      AwsUtils.putObject(
+          awsCredentials,
+          Regions.fromName(resource.getRegion()),
+          resource.getS3BucketName(),
+          key,
+          content);
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    final String awsCloudContextString =
+        flightContext
+            .getWorkingMap()
+            .get(WorkspaceFlightMapKeys.ControlledResourceKeys.AWS_CLOUD_CONTEXT, String.class);
+
+    final AwsCloudContext awsCloudContext = AwsCloudContext.deserialize(awsCloudContextString);
+    final Credentials awsCredentials = MultiCloudUtils.assumeAwsServiceRoleFromGcp(awsCloudContext);
+
+    for (AwsConfiguration.AwsBucketSeedFile seedFile : seedFiles) {
+      String key = getKey(seedFile.getPath());
+      AwsUtils.deleteObject(
+          awsCredentials, Regions.fromName(resource.getRegion()), resource.getS3BucketName(), key);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/resources/tools/on-start.sh
+++ b/service/src/main/resources/tools/on-start.sh
@@ -34,7 +34,7 @@ fi
 EOM
 
 # Change the terminal shell to bash
-echo "c.NotebookApp.terminado_settings={'shell_command': ['/bin/bash']}" | tee -a /home/ec2-user/.jupyter/jupyter_notebook_config.py >/dev/null
+echo "exec -l bash" > /home/ec2-user/.profile
 
 sudo -u ec2-user -i <<'EOF'
 

--- a/service/src/main/resources/tools/on-start.sh
+++ b/service/src/main/resources/tools/on-start.sh
@@ -20,7 +20,7 @@ nohup yum install -y google-cloud-cli &
 cat << EOM | sed -i '/^# User specific aliases and functions$/ r /dev/stdin' /home/ec2-user/.bashrc
 if [ ! -f '/home/ec2-user/SageMaker/.terra/notebook_metadata.json' ]; then
     # The user has not configured their environment to access Terra yet, call now.
-    /home/ec2-user/terra/terra-auth.py --configure
+    /usr/local/bin/terra-auth --configure
     retVal=\$?
 
     # If this got status 1, that means user was not authenticated.  Prompt them to authenticate
@@ -28,7 +28,7 @@ if [ ! -f '/home/ec2-user/SageMaker/.terra/notebook_metadata.json' ]; then
     if [ \${retVal} -eq 1 ]; then
       echo "Please log in with Google Application Default Credentials in order to authenticate with Terra.\n"
       /usr/bin/gcloud auth application-default login
-      /home/ec2-user/terra/terra-auth.py --configure
+      /usr/local/bin/terra-auth --configure
     fi
 fi
 EOM
@@ -36,11 +36,11 @@ EOM
 # Change the terminal shell to bash
 echo "exec -l bash" > /home/ec2-user/.profile
 
-sudo -u ec2-user -i <<'EOF'
-
 # Copy in the Terra auth helper CLI (eventually this will install Terra CLI instead)
 wget https://raw.githubusercontent.com/DataBiosphere/terra-workspace-manager/jczerk/aws_wlz_interface/service/src/main/resources/tools/terra-auth.py -O "/usr/local/bin/terra-auth"
 chmod +x "/usr/local/bin/terra-auth"
+
+sudo -u ec2-user -i <<'EOF'
 
 # Lazy create terra persistence directory and symlink
 mkdir -p /home/ec2-user/SageMaker/.terra
@@ -60,16 +60,18 @@ for env in /home/ec2-user/anaconda3/envs/*; do
     fi
 
     # We don't need to wait for these and delay startup, so nohup them in background
-    nohup -c 'source /home/ec2-user/anaconda3/bin/activate $(basename "$env") && \
-    pip install google-auth && \
-    source /home/ec2-user/anaconda3/bin/deactivate' &
+    nohup sh -c \
+        'source /home/ec2-user/anaconda3/bin/activate $(basename "$env") && \
+         pip install google-auth && \
+         source /home/ec2-user/anaconda3/bin/deactivate'\
+    &> "nohup.out.pip.$(basename $env)" &
 done
 
 # If we have ADC, attempt to re-configure at startup.
 if [ -f /home/ec2-user/.config/gcloud/application_default_credentials.json ]; then
   source /home/ec2-user/anaconda3/bin/activate base
   pip install google-auth
-  /home/ec2-user/terra/terra-auth.py --configure
+  /usr/local/bin/terra-auth --configure
   source /home/ec2-user/anaconda3/bin/deactivate
 fi
 

--- a/service/src/main/resources/tools/on-start.sh
+++ b/service/src/main/resources/tools/on-start.sh
@@ -17,7 +17,9 @@ EOM
 nohup yum install -y google-cloud-cli &
 
 # In bash login script, check if the environment has been configured for Terra and, if not, attempt to do so.
-cat << EOM | sed -i '/^# User specific aliases and functions$/ r /dev/stdin' /home/ec2-user/.bashrc
+cat << EOM | sed -i '/^# <<< conda initialize <<<$/ r /dev/stdin' /home/ec2-user/.bashrc
+
+# Terra Configuration
 if [ ! -f '/home/ec2-user/SageMaker/.terra/notebook_metadata.json' ]; then
     # The user has not configured their environment to access Terra yet, call now.
     /usr/local/bin/terra-auth --configure

--- a/service/src/main/resources/tools/on-start.sh
+++ b/service/src/main/resources/tools/on-start.sh
@@ -54,16 +54,18 @@ mkdir -p /home/ec2-user/.config
 ln -s /home/ec2-user/SageMaker/.config/gcloud /home/ec2-user/.config/gcloud
 
 # Install google auth python package in all conda environments
+pip download google-auth
 
 # Note that "base" is special environment name, include it there as well.
 for env in base /home/ec2-user/anaconda3/envs/*; do
-    source /home/ec2-user/anaconda3/bin/activate $(basename "$env")
     if [ $env = 'JupyterSystemEnv' ]; then
         continue
     fi
-    pip install google-auth
-    source /home/ec2-user/anaconda3/bin/deactivate
+    source /home/ec2-user/anaconda3/bin/activate $(basename "$env") && \
+    pip install google-auth && \
+    source /home/ec2-user/anaconda3/bin/deactivate &
 done
+wait
 
 # If we have ADC, attempt to re-configure at startup.
 if [ -f /home/ec2-user/.config/gcloud/application_default_credentials.json ]; then

--- a/service/src/main/resources/tools/terra-auth.py
+++ b/service/src/main/resources/tools/terra-auth.py
@@ -20,7 +20,7 @@ NOTEBOOK_NOT_FOUND = 6
 
 WSM_API_ENDPOINT = 'https://terra-mc-feature-dev-wsm.api.verily.com/api/workspaces/v1'
 INSTANCE_METADATA_FILE = '/opt/ml/metadata/resource-metadata.json'
-NOTEBOOK_METADATA_FILE = f'{os.path.expanduser("~")}/SageMaker/.terra/notebook_metadata.json'
+NOTEBOOK_METADATA_FILE = f'{os.path.expanduser("~")}/.terra/notebook_metadata.json'
 
 def parse_args():
     parser = argparse.ArgumentParser(description = 'Terra AWS Auth Helper')

--- a/service/src/main/resources/tools/terra-auth.py
+++ b/service/src/main/resources/tools/terra-auth.py
@@ -153,17 +153,20 @@ def find_notebook_metadata(session):
 def get_notebook_metadata(session):
     if(os.path.exists(NOTEBOOK_METADATA_FILE)):
         with open(NOTEBOOK_METADATA_FILE, 'r') as f:
-            return json.load(f)
-    else:
-        metadata = find_notebook_metadata(session)
+            metadata = json.load(f)
+            if 'Workspace' in metadata and 'Notebook' in metadata:
+                return metadata
 
-        if metadata['Workspace'] is None or metadata['Notebook'] is None:
-            print("Workspace and Notebook Resource ID could not be resolved.", file=sys.stderr)
-            sys.exit(NOTEBOOK_NOT_FOUND)
+    metadata = find_notebook_metadata(session)
 
-        with open(NOTEBOOK_METADATA_FILE, 'w') as f:
-            json.dump(metadata, f, indent=4)
-        return metadata
+    if metadata['Workspace'] is None or metadata['Notebook'] is None:
+        print("Workspace and Notebook Resource ID could not be resolved.", file=sys.stderr)
+        sys.exit(NOTEBOOK_NOT_FOUND)
+
+    with open(NOTEBOOK_METADATA_FILE, 'w') as f:
+        json.dump(metadata, f, indent=4)
+
+    return metadata
 
 def get_notebook_config(label, notebook_metadata):
     return f'''[{label}]

--- a/service/src/main/resources/tools/terra-auth.py
+++ b/service/src/main/resources/tools/terra-auth.py
@@ -266,7 +266,7 @@ def main():
         with open(f'{os.path.expanduser("~")}/.aws/config', 'w') as f:
             f.write(config)
     elif args.notebook:
-        notebook_id = notebook_metadata['Notebook']['resourceId']
+        notebook_id = notebook_metadata['Notebook']['metadata']['resourceId']
         print(get_notebook_cred(session, workspace_id, notebook_id, args.access))
 
     elif args.bucket:

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextUnitTest.java
@@ -20,10 +20,13 @@ public class AwsCloudContextUnitTest extends BaseAwsUnitTest {
 
   // This configuration must match the default configuration as defined in
   // services/src/test/resources/application-aws-unit-tests.yml
+  static final String LZ_NAME = "test-lz";
   static final String ACCOUNT_ID = "123456789012";
   static final String GOOGLE_JWT_AUDIENCE = "test_jwt_audience";
   static final Arn ROLE_ARN_SERVICE = getRoleArn(ACCOUNT_ID, "ServiceRole");
   static final Arn ROLE_ARN_USER = getRoleArn(ACCOUNT_ID, "UserRole");
+  static final Arn NOTEBOOK_LIFECYCLE_CONFIG_ARN =
+      getLifecycleConfigArn(ACCOUNT_ID, "terra-nb-lifecycle-config-default");
   static final String BUCKET_NAME_US_EAST = "east-region-bucket";
   static final String BUCKET_NAME_US_WEST = "west-region-bucket";
 
@@ -37,31 +40,63 @@ public class AwsCloudContextUnitTest extends BaseAwsUnitTest {
         .build();
   }
 
-  private AwsCloudContext buildTestContext() {
+  private static Arn getLifecycleConfigArn(String accountId, String configName) {
+    return Arn.builder()
+        .withPartition("aws")
+        .withService("sagemaker")
+        .withRegion("us-east-1")
+        .withAccountId(accountId)
+        .withResource(String.format("notebook-instance-lifecycle-config/%s", configName))
+        .build();
+  }
+
+  private AwsCloudContext buildTestContext(boolean includeNotebookLifecycleConfig) {
     return AwsCloudContext.builder()
+        .landingZoneName(LZ_NAME)
         .accountNumber(ACCOUNT_ID)
         .serviceRoleArn(ROLE_ARN_SERVICE)
         .serviceRoleAudience(GOOGLE_JWT_AUDIENCE)
         .userRoleArn(ROLE_ARN_USER)
+        .notebookLifecycleConfigArn(
+            includeNotebookLifecycleConfig ? NOTEBOOK_LIFECYCLE_CONFIG_ARN : null)
         .addBucket(Regions.US_EAST_1, BUCKET_NAME_US_EAST)
         .addBucket(Regions.US_WEST_1, BUCKET_NAME_US_WEST)
         .build();
   }
 
-  private void validateContext(AwsCloudContext compareContext) {
+  private AwsCloudContext buildTestContext() {
+    return buildTestContext(true);
+  }
+
+  private void validateContext(
+      AwsCloudContext compareContext, boolean expectNotebookLifecycleConfig) {
+    assertEquals(LZ_NAME, compareContext.getLandingZoneName());
     assertEquals(ACCOUNT_ID, compareContext.getAccountNumber());
     assertEquals(ROLE_ARN_SERVICE, compareContext.getServiceRoleArn());
     assertEquals(GOOGLE_JWT_AUDIENCE, compareContext.getServiceRoleAudience());
     assertEquals(ROLE_ARN_USER, compareContext.getUserRoleArn());
+    assertEquals(
+        expectNotebookLifecycleConfig ? NOTEBOOK_LIFECYCLE_CONFIG_ARN : null,
+        compareContext.getNotebookLifecycleConfigArn());
     assertEquals(BUCKET_NAME_US_EAST, compareContext.getBucketNameForRegion(Regions.US_EAST_1));
     assertEquals(BUCKET_NAME_US_WEST, compareContext.getBucketNameForRegion(Regions.US_WEST_1));
     assertEquals(null, compareContext.getBucketNameForRegion(Regions.EU_CENTRAL_1));
+  }
+
+  private void validateContext(AwsCloudContext compareContext) {
+    validateContext(compareContext, true);
   }
 
   @Test
   void basic() {
     AwsCloudContext testContext = buildTestContext();
     validateContext(testContext);
+  }
+
+  @Test
+  void basicNoNotebookLifecycleConfig() {
+    AwsCloudContext testContext = buildTestContext(false);
+    validateContext(testContext, false);
   }
 
   @Test
@@ -99,15 +134,23 @@ public class AwsCloudContextUnitTest extends BaseAwsUnitTest {
   @Test
   void formatV1() {
     String goodJson =
-        "{\"version\":257,\"accountNumber\":\"123456789012\",\"serviceRoleArn\":\"arn:aws:iam::123456789012:ServiceRole\",\"serviceRoleAudience\":\"test_jwt_audience\",\"userRoleArn\":\"arn:aws:iam::123456789012:UserRole\",\"bucketList\":[{\"version\":257,\"regionName\":\"us-east-1\",\"bucketName\":\"east-region-bucket\"},{\"version\":257,\"regionName\":\"us-west-1\",\"bucketName\":\"west-region-bucket\"}]}\n";
+        "{\"version\":257,\"landingZoneName\":\"test-lz\",\"accountNumber\":\"123456789012\",\"serviceRoleArn\":\"arn:aws:iam::123456789012:ServiceRole\",\"serviceRoleAudience\":\"test_jwt_audience\",\"userRoleArn\":\"arn:aws:iam::123456789012:UserRole\",\"notebookLifecycleConfigArn\":\"arn:aws:sagemaker:us-east-1:123456789012:notebook-instance-lifecycle-config/terra-nb-lifecycle-config-default\",\"bucketList\":[{\"version\":257,\"regionName\":\"us-east-1\",\"bucketName\":\"east-region-bucket\"},{\"version\":257,\"regionName\":\"us-west-1\",\"bucketName\":\"west-region-bucket\"}]}";
     AwsCloudContext compareContext = AwsCloudContext.deserialize(goodJson);
     validateContext(compareContext);
   }
 
   @Test
+  void formatV1NoNotebookLifecycleConfig() {
+    String goodJson =
+        "{\"version\":257,\"landingZoneName\":\"test-lz\",\"accountNumber\":\"123456789012\",\"serviceRoleArn\":\"arn:aws:iam::123456789012:ServiceRole\",\"serviceRoleAudience\":\"test_jwt_audience\",\"userRoleArn\":\"arn:aws:iam::123456789012:UserRole\",\"bucketList\":[{\"version\":257,\"regionName\":\"us-east-1\",\"bucketName\":\"east-region-bucket\"},{\"version\":257,\"regionName\":\"us-west-1\",\"bucketName\":\"west-region-bucket\"}]}\n";
+    AwsCloudContext compareContext = AwsCloudContext.deserialize(goodJson);
+    validateContext(compareContext, false);
+  }
+
+  @Test
   void badVersion() {
     String badJson =
-        "{\"version\":0,\"accountNumber\":\"123456789012\",\"serviceRoleArn\":\"arn:aws:iam::123456789012:ServiceRole\",\"serviceRoleAudience\":\"test_jwt_audience\",\"userRoleArn\":\"arn:aws:iam::123456789012:UserRole\",\"bucketList\":[{\"version\":257,\"regionName\":\"us-east-1\",\"bucketName\":\"east-region-bucket\"},{\"version\":257,\"regionName\":\"us-west-1\",\"bucketName\":\"west-region-bucket\"}]}\n";
+        "{\"version\":0,\"landingZoneName\":\"test-lz\",\"accountNumber\":\"123456789012\",\"serviceRoleArn\":\"arn:aws:iam::123456789012:ServiceRole\",\"serviceRoleAudience\":\"test_jwt_audience\",\"userRoleArn\":\"arn:aws:iam::123456789012:UserRole\",\"bucketList\":[{\"version\":257,\"regionName\":\"us-east-1\",\"bucketName\":\"east-region-bucket\"},{\"version\":257,\"regionName\":\"us-west-1\",\"bucketName\":\"west-region-bucket\"}]}\n";
     assertThrows(
         InvalidSerializedVersionException.class, () -> AwsCloudContext.deserialize(badJson));
   }
@@ -115,7 +158,7 @@ public class AwsCloudContextUnitTest extends BaseAwsUnitTest {
   @Test
   void badBucketVersion() {
     String badJson =
-        "{\"version\":257,\"accountNumber\":\"123456789012\",\"serviceRoleArn\":\"arn:aws:iam::123456789012:ServiceRole\",\"serviceRoleAudience\":\"test_jwt_audience\",\"userRoleArn\":\"arn:aws:iam::123456789012:UserRole\",\"bucketList\":[{\"version\":0,\"regionName\":\"us-east-1\",\"bucketName\":\"east-region-bucket\"},{\"version\":257,\"regionName\":\"us-west-1\",\"bucketName\":\"west-region-bucket\"}]}\n";
+        "{\"version\":257,\"landingZoneName\":\"test-lz\",\"accountNumber\":\"123456789012\",\"serviceRoleArn\":\"arn:aws:iam::123456789012:ServiceRole\",\"serviceRoleAudience\":\"test_jwt_audience\",\"userRoleArn\":\"arn:aws:iam::123456789012:UserRole\",\"bucketList\":[{\"version\":0,\"regionName\":\"us-east-1\",\"bucketName\":\"east-region-bucket\"},{\"version\":257,\"regionName\":\"us-west-1\",\"bucketName\":\"west-region-bucket\"}]}\n";
     assertThrows(
         InvalidSerializedVersionException.class, () -> AwsCloudContext.deserialize(badJson));
   }

--- a/service/src/test/resources/application-aws-unit-test.yml
+++ b/service/src/test/resources/application-aws-unit-test.yml
@@ -7,6 +7,7 @@ workspace:
         account-number: "123456789012"
         service-role-arn: "arn:aws:iam::123456789012:ServiceRole"
         user-role-arn: "arn:aws:iam::123456789012:UserRole"
+        notebook-lifecycle-config-arn: "arn:aws:sagemaker:us-east-1:123456789012:notebook-instance-lifecycle-config/terra-nb-lifecycle-config-default"
         buckets:
           - name: "east-region-bucket"
             region: "us-east-1"


### PR DESCRIPTION
Add awsAccountNumber to SageMakerAttributes (open api spec)
Set awsAccountNumber in SageMakerResource return values 

Adding awsAccountNumber inline with google Project Id in GCP. 
LandingZoneId is already part of resource.metadata as workspaceId