### PR TITLE
[PF-2320] Retry 403 on nightly tests

### DIFF
--- a/integration/src/main/java/scripts/utils/NotebookUtils.java
+++ b/integration/src/main/java/scripts/utils/NotebookUtils.java
@@ -205,6 +205,7 @@ public class NotebookUtils {
                 if (e.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
                   throw e;
                 }
+              } catch (IOException ignored) {
               }
               return null;
             });

--- a/integration/src/main/java/scripts/utils/NotebookUtils.java
+++ b/integration/src/main/java/scripts/utils/NotebookUtils.java
@@ -199,8 +199,12 @@ public class NotebookUtils {
                   throw new NullPointerException();
                 }
                 return p;
-                // Do not retry if it's an IO exception.
-              } catch (IOException ignored) {
+                // Retry 403s as permissions may take time to propagate, but do not retry if it's
+                // any other IO exception.
+              } catch (GoogleJsonResponseException e) {
+                if (e.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+                  throw e;
+                }
               }
               return null;
             });


### PR DESCRIPTION
`PrivateControlledAiNotebookInstancePostStartup` has been failing due to IAM propagation delay, this adds retry support.