### PR TITLE
PF-2217: policy merge saves to target

### DIFF
--- a/service/src/main/java/bio/terra/workspace/amalgam/tps/TpsApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/tps/TpsApiDispatch.java
@@ -249,7 +249,7 @@ public class TpsApiDispatch {
     features.tpsEnabledCheck();
     PolicyUpdateResult result =
         paoService.mergeFromPao(
-            objectId, body.getSourceObjectId(), updateModeFromApi(body.getUpdateMode()));
+            body.getSourceObjectId(), objectId, updateModeFromApi(body.getUpdateMode()));
 
     return updateResultToApi(result);
   }


### PR DESCRIPTION
Policy merge wasn't writing to the target policy.
Probably should have an integration test for this which we can add after the separate service is available.