### PR TITLE
Fix CloneWorkspace integration test flakiness

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -934,8 +934,7 @@ public class CloneWorkspace extends WorkspaceAllocateWithPolicyTestScriptBase {
   }
 
   private static void assertDatasetHasNoTables(
-      String destinationProjectId, BigQuery bigQueryClient, String datasetName)
-      throws Exception {
+      String destinationProjectId, BigQuery bigQueryClient, String datasetName) throws Exception {
     // The result table will not be created if there are no results.
     TableId resultTableId = TableId.of(destinationProjectId, datasetName, "FAKE TABLE NAME");
     final QueryJobConfiguration listTablesQuery =
@@ -951,8 +950,8 @@ public class CloneWorkspace extends WorkspaceAllocateWithPolicyTestScriptBase {
     // Will throw not found if the dataset doesn't exist
     // Retry because in rare cases, it can take a while for bigquery.jobs.create to propagate
     // TODO(PF-2335): Delete retry after PF-2335 is fixed
-    final TableResult listTablesResult = ClientTestUtils.getWithRetryOnException(
-        () -> bigQueryClient.query(listTablesQuery));
+    final TableResult listTablesResult =
+        ClientTestUtils.getWithRetryOnException(() -> bigQueryClient.query(listTablesQuery));
     final long numRows =
         StreamSupport.stream(listTablesResult.getValues().spliterator(), false).count();
     assertEquals(0, numRows, "Expected zero tables for COPY_DEFINITION dataset");


### PR DESCRIPTION
I'm no longer seeing the CloneWorkspace failure from https://github.com/DataBiosphere/terra-workspace-manager/pull/950 . Now I'm seeing a flaky failure that is fixable.

Example flake:

https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/3679977850/jobs/6225047800

Relevant error:

```
2022-12-12T21:40:34.6177620Z com.google.cloud.bigquery.BigQueryException: Access Denied: Project terra-wsm-t-snappy-gourd-637: User does not have bigquery.jobs.create permission in project terra-wsm-t-snappy-gourd-637.
2022-12-12T21:40:34.6179398Z 	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.translate(HttpBigQueryRpc.java:115)
2022-12-12T21:40:34.6180273Z 2022-12-12 21:40:34.587   INFO   --- [pool-3-thread-1] bio.terra.testrunner.runner.RetryLogic   : Retry attempt 1.
2022-12-12T21:40:34.6181290Z 	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.create(HttpBigQueryRpc.java:220)
2022-12-12T21:40:34.6182361Z 	at com.google.cloud.bigquery.BigQueryImpl$5.call(BigQueryImpl.java:369)
2022-12-12T21:40:34.6182970Z 	at com.google.cloud.bigquery.BigQueryImpl$5.call(BigQueryImpl.java:366)
2022-12-12T21:40:34.6183638Z 	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
2022-12-12T21:40:34.6184246Z 	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
2022-12-12T21:40:34.6184783Z 	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
2022-12-12T21:40:34.6185391Z 	at com.google.cloud.bigquery.BigQueryImpl.create(BigQueryImpl.java:365)
2022-12-12T21:40:34.6185974Z 	at com.google.cloud.bigquery.BigQueryImpl.create(BigQueryImpl.java:340)
2022-12-12T21:40:34.6186554Z 	at com.google.cloud.bigquery.BigQueryImpl.query(BigQueryImpl.java:1242)
2022-12-12T21:40:34.6187206Z 	at scripts.testscripts.CloneWorkspace.assertDatasetHasNoTables(CloneWorkspace.java:952)
2022-12-12T21:40:34.6187874Z 	at scripts.testscripts.CloneWorkspace.doUserJourney(CloneWorkspace.java:596)
2022-12-12T21:40:34.6188565Z 	at scripts.utils.WorkspaceApiTestScriptBase.userJourney(WorkspaceApiTestScriptBase.java:40)
```