### PR TITLE
[PF-2341] Recode proxyUrl retry loop

### DIFF
--- a/integration/src/main/java/scripts/utils/NotebookUtils.java
+++ b/integration/src/main/java/scripts/utils/NotebookUtils.java
@@ -1,7 +1,6 @@
 package scripts.utils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static scripts.utils.CommonResourceFieldsUtil.makeControlledResourceCommonFields;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
@@ -28,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -186,36 +186,43 @@ public class NotebookUtils {
    */
   public static void assertInstanceHasProxyUrl(
       AIPlatformNotebooks userNotebooks, String instanceName) throws Exception {
-    String proxyUrl =
-        ClientTestUtils.getWithRetryOnException(
-            () -> {
-              try {
-                String p =
-                    userNotebooks
-                        .projects()
-                        .locations()
-                        .instances()
-                        .get(instanceName)
-                        .execute()
-                        .getProxyUri();
-                if (p == null) {
-                  logger.info("Notebook proxy url is null, retry");
-                  throw new NullPointerException();
-                }
-                return p;
-                // Retry 403s as permissions may take time to propagate, but do not retry if it's
-                // any other IO exception.
-              } catch (GoogleJsonResponseException e) {
-                if (e.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
-                  logger.info("Fails to fetch notebook proxy url due to 403, retry", e);
-                  throw e;
-                }
-                logger.info("Fails to fetch notebook proxy url, do not retry", e);
-              } catch (Exception ignored) {
-                logger.info("Fails to fetch notebook proxy url, do not retry", ignored);
-              }
-              return null;
-            });
-    assertNotNull(proxyUrl);
+    final int retryMax = 40;
+    final int retrySeconds = 15;
+    for (int retryCount = 0; retryCount < retryMax; retryCount++) {
+      try {
+        String proxyUrl =
+            userNotebooks
+                .projects()
+                .locations()
+                .instances()
+                .get(instanceName)
+                .execute()
+                .getProxyUri();
+        if (proxyUrl != null) {
+          return;
+        }
+        logger.info("Notebook proxy url is null, retry");
+      } catch (GoogleJsonResponseException e) {
+        // Retry 403s as permissions may take time to propagate, but do not retry if it's
+        // any other IO exception.
+        if (e.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+          logger.info("Fails to fetch notebook proxy url due to 403, retry", e);
+        } else {
+          logger.info("Fails to fetch notebook proxy url, do not retry", e);
+          throw e;
+        }
+      } catch (Exception e) {
+        logger.info("Fails to fetch notebook proxy url, do not retry", e);
+        throw e;
+      }
+      // If we are here, we are retrying
+      logger.info(
+          "Retrying getProxyUrl after {} seconds; retry {} of {}",
+          retrySeconds,
+          retryCount + 1,
+          retryMax);
+      TimeUnit.SECONDS.sleep(retrySeconds);
+    }
+    throw new RuntimeException("Retries of getProxyUrl are exhausted");
   }
 }


### PR DESCRIPTION
Moved the retry loop into the NotebookUtil code. This simplifies things and eliminates a bug, since non-exception cases are also retried.