### PR TITLE
[PF-2168] Move from terra-kernel-k8s to broad-dsp-gcr-public

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -44,8 +44,6 @@ on:
         default: 'main'
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
-  GOOGLE_PROJECT: terra-kernel-k8s
-  GKE_CLUSTER: terra-kernel-k8s
 jobs:
   tag-publish-job:
     runs-on: ubuntu-latest
@@ -131,7 +129,7 @@ jobs:
       id: image-name
       run: |
         DOCKER_TAG=${{ steps.tag.outputs.tag }}
-        echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${DOCKER_TAG} >> $GITHUB_OUTPUT
+        echo name=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${DOCKER_TAG} >> $GITHUB_OUTPUT
     - name: Build image locally with jib
       if: steps.skiptest.outputs.is-bump == 'no'
       run: "./gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain"

--- a/HOTFIX.md
+++ b/HOTFIX.md
@@ -20,14 +20,14 @@ branch name for the `branch` input.
 
 ## Delivering The Hotfix
 
-1) `gcloud auth login` as an account that has push access to gcr.io/terra-kernel-k8s, likely your @broadinstitute.org account
+1) `gcloud auth login` as an account that has push access to gcr.io/broad-dsp-gcr-public, likely your @broadinstitute.org account
 
 2) Run `gcloud auth configure-docker`
 
 3) Build and push the image that you would like to use for your hotfix:
 
 ```sh
-./gradlew jib --image=gcr.io/terra-kernel-k8s/terra-workspace-manager:hotfix-<DATE>
+./gradlew jib --image=gcr.io/broad-dsp-gcr-public/terra-workspace-manager:hotfix-<DATE>
 ```
 
 4) Follow Step 1 in terra-helmfile/[HOTFIX.md](https://github.com/broadinstitute/terra-helmfile/blob/master/docs/HOTFIX.md)

--- a/service/local-dev/skaffold.yaml.template
+++ b/service/local-dev/skaffold.yaml.template
@@ -3,7 +3,7 @@ apiVersion: skaffold/v2beta17
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/terra-kernel-k8s/terra-workspace-manager
+  - image: gcr.io/broad-dsp-gcr-public/terra-workspace-manager
     context: ../../
     jib:
       project: service


### PR DESCRIPTION
This needs to be merged (and a new image needs to be published) before the equivalent helmfile change can merge