### PR TITLE
[PF-2360] Disable cloneAzureWorkspaceWithContainer test

### DIFF
--- a/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AzureWorkspaceTest.java
@@ -42,6 +42,7 @@ import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -99,6 +100,8 @@ public class AzureWorkspaceTest extends BaseAzureConnectedTest {
   }
 
   @Test
+  @Disabled
+  // TODO: TOAZ-286 - problem with LZ configuration
   void cloneAzureWorkspaceWithContainer() throws InterruptedException {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     Mockito.when(mockSamService.getUserEmailFromSamAndRethrowOnInterrupt(any()))


### PR DESCRIPTION
The hardcoded LZ is broken, so disable the test. Ticket TOAZ-286 is tracking the problem.