### PR TITLE
[TERRA-192] Update 'GET' endpoint names from 'get*' to '*"

### DIFF
--- a/openapi/src/parts/controlled_aws_bucket.yaml
+++ b/openapi/src/parts/controlled_aws_bucket.yaml
@@ -38,7 +38,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/buckets/{resourceId}/getConsoleLink:
+  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/buckets/{resourceId}/consoleLink:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
       - $ref: '#/components/parameters/ResourceId'
@@ -58,7 +58,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/buckets/{resourceId}/getCredential:
+  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/buckets/{resourceId}/credential:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
       - $ref: '#/components/parameters/ResourceId'

--- a/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
+++ b/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
@@ -56,7 +56,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/getConsoleLink:
+  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/consoleLink:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
       - $ref: '#/components/parameters/ResourceId'
@@ -76,7 +76,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/getCredential:
+  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/credential:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
       - $ref: '#/components/parameters/ResourceId'
@@ -96,7 +96,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/getProxyUrl:
+  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/proxyUrl:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
       - $ref: '#/components/parameters/ResourceId'


### PR DESCRIPTION
Current endpoint - 

- /api/workspaces/v1/{workspaceId}/resources/controlled/aws/buckets/{resourceId}/getConsoleLink
- /api/workspaces/v1/{workspaceId}/resources/controlled/aws/buckets/{resourceId}/getCredential
- /api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/getConsoleLink
- /api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/getCredential
- /api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/getProxyUrl

Reason for change - 

- https://restfulapi.net/
- https://blog.dreamfactory.com/best-practices-for-naming-rest-api-endpoints/

Recommended to omit the operation name ‘get’

No other changes in java code are needed since operationId remain the same