### PR TITLE
[PF-2363] Check correct Sam action when enabling/disabling application.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -724,7 +724,7 @@ public class SamService {
       return resourcesApi.resourceActionV2(
           SamConstants.SamResource.WORKSPACE,
           workspaceUuid.toString(),
-          SamConstants.SamWorkspaceAction.CREATE_CONTROLLED_USER_PRIVATE,
+          SamConstants.SamWorkspaceAction.CREATE_CONTROLLED_APPLICATION_PRIVATE,
           email);
     } catch (ApiException apiException) {
       throw SamExceptionFactory.create("Sam error querying role in Sam", apiException);


### PR DESCRIPTION
Currently method `isApplicationEnabledInSam()` in class `SamService` is checking the wrong Sam action.

Surprisingly, this is not causing failures when Leo enables applications currently.

Upon further analysis, this method is only ever called in the precheck step of the application [en|dis]able flight, and is used to determine whether Sam and the DAO are in sync.  Subsequent steps then use this info to bring Sam and DAO into sync.

Thus my read is that:
* If the caller has permissions for `CREATE_CONTROLLED_USER_PRIVATE`:
  * On enable, the subsequent "enable" step would **always** result in the app being enabled (from a Sam perspective).
  * On disable, the subsequent "disable" step would **never** result in the app being disabled (from a Sam perspective).
* If caller does not have permissions for `CREATE_CONTROLLED_USER_PRIVATE`:
  * On enable, the subsequent "enable" step would **never** result in the app being enabled (from a Sam perspective).
  * On disable, the subsequent "disable" step would **always** result in the app being disabled (from a Sam perspective).