### PR TITLE
[no ticket] No policy usage in integration tests

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -68,9 +68,9 @@ import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
 import scripts.utils.GcsBucketObjectUtils;
 import scripts.utils.GcsBucketUtils;
-import scripts.utils.WorkspaceAllocateWithPolicyTestScriptBase;
+import scripts.utils.WorkspaceAllocateTestScriptBase;
 
-public class CloneWorkspace extends WorkspaceAllocateWithPolicyTestScriptBase {
+public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
   private static final Logger logger = LoggerFactory.getLogger(CloneWorkspace.class);
   private ControlledGcpResourceApi cloningUserResourceApi;
   private FolderApi cloningUserFolderApi;


### PR DESCRIPTION
The CloneWorkspace integration test was using TPS, even in environments where TPS was disabled. That led to failures.
This change removes the use of policy in that test.