### PR TITLE
[PF-2333] Read Janitor SA key properly

### DIFF
--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -218,7 +218,7 @@ vaultgetb64 "secret/dsde/terra/kernel/${k8senv}/${namespace}/workspace/app-sa" "
 
 # Janitor SA is only available in integration
 if [ "${k8senv}" = "integration" ]; then
-    vaultgetb64 "secret/dsde/terra/kernel/integration/tools/crl_janitor/client-sa" "${outputdir}/janitor-client-sa.json"
+    vaultget "secret/dsde/terra/kernel/integration/tools/crl_janitor/client-sa" "${outputdir}/janitor-client-sa.json"
 else
     echo "No janitor credentials for target ${target}"
 fi


### PR DESCRIPTION
Yesterday I updated the Janitor SA key in Vault to no longer be base64 encoded so that it's readable by the terraform-GHA mechanism for the CLI but forgot to update other users. Sorry!