### PR TITLE
[PF-2408] Wait for project permission propagation before returning from create GCP cloud context

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -38,7 +38,6 @@ import bio.terra.workspace.model.GcpBigQueryDatasetResource;
 import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.GcpGcsObjectAttributes;
 import bio.terra.workspace.model.GcpGcsObjectResource;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.ResourceCloneDetails;
@@ -72,6 +71,9 @@ import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
   private static final Logger logger = LoggerFactory.getLogger(CloneWorkspace.class);
+  private static final int EXPECTED_NUM_CLONED_RESOURCES = 11;
+  private static final String TERRA_FOLDER_ID = "terra-folder-id";
+  private static final String FOLDER_DISPLAY_NAME = "folderDisplayName";
   private ControlledGcpResourceApi cloningUserResourceApi;
   private FolderApi cloningUserFolderApi;
   private FolderApi ownerFolderApi;
@@ -98,9 +100,33 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
   private String controlledBucketFolderName;
   private String referenceBucketFolderName;
 
-  private static final int EXPECTED_NUM_CLONED_RESOURCES = 11;
-  private static final String TERRA_FOLDER_ID = "terra-folder-id";
-  private static final String FOLDER_DISPLAY_NAME = "folderDisplayName";
+  private static void assertDatasetHasNoTables(
+      String destinationProjectId, BigQuery bigQueryClient, String datasetName) throws Exception {
+    // The result table will not be created if there are no results.
+    TableId resultTableId = TableId.of(destinationProjectId, datasetName, "FAKE TABLE NAME");
+    final QueryJobConfiguration listTablesQuery =
+        QueryJobConfiguration.newBuilder(
+                "SELECT * FROM `"
+                    + destinationProjectId
+                    + "."
+                    + datasetName
+                    + ".INFORMATION_SCHEMA.TABLES`;")
+            .setDestinationTable(resultTableId)
+            .setWriteDisposition(WriteDisposition.WRITE_TRUNCATE)
+            .build();
+    // Will throw not found if the dataset doesn't exist
+    // Retry because in rare cases, it can take a while for bigquery.jobs.create to propagate
+    // TODO(PF-2335): Delete retry after PF-2335 is fixed
+    final TableResult listTablesResult =
+        ClientTestUtils.getWithRetryOnException(() -> bigQueryClient.query(listTablesQuery));
+    final long numRows =
+        StreamSupport.stream(listTablesResult.getValues().spliterator(), false).count();
+    assertEquals(0, numRows, "Expected zero tables for COPY_DEFINITION dataset");
+    logger.info(
+        "BQ Dataset {} in project {} has no tables, as expected.",
+        datasetName,
+        destinationProjectId);
+  }
 
   @Override
   protected void doSetup(
@@ -116,21 +142,23 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
     cloningUser = testUsers.get(1);
     logger.info(
         "Owning user: {}, Cloning user: {}", sourceOwnerUser.userEmail, cloningUser.userEmail);
-    // Build source GCP project in main test workspace
-    sourceProjectId =
-        CloudContextMaker.createGcpCloudContext(getWorkspaceId(), sourceOwnerWorkspaceApi);
-    logger.info("Created source project {} in workspace {}", sourceProjectId, getWorkspaceId());
 
     // Add cloning user as reader on the workspace
-    sourceOwnerWorkspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(cloningUser.userEmail),
-        getWorkspaceId(),
-        IamRole.READER);
+    ClientTestUtils.grantRole(
+        sourceOwnerWorkspaceApi, getWorkspaceId(), cloningUser, IamRole.READER);
     logger.info(
         "Granted role {} for user {} on workspace {}",
         IamRole.READER,
         cloningUser.userEmail,
         getWorkspaceId());
+
+    // Build source GCP project in main test workspace
+    sourceProjectId =
+        CloudContextMaker.createGcpCloudContext(getWorkspaceId(), sourceOwnerWorkspaceApi);
+    logger.info("Created source project {} in workspace {}", sourceProjectId, getWorkspaceId());
+
+    // Wait for reader to have permissions on the project
+    ClientTestUtils.workspaceRoleWaitForPropagation(cloningUser, sourceProjectId);
 
     // Give users resource APIs
     final ControlledGcpResourceApi sourceOwnerResourceApi =
@@ -931,34 +959,6 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
             .filter(x -> x.getId().equals(folderId))
             .collect(onlyElement());
     assertNotNull(actualFolder);
-  }
-
-  private static void assertDatasetHasNoTables(
-      String destinationProjectId, BigQuery bigQueryClient, String datasetName) throws Exception {
-    // The result table will not be created if there are no results.
-    TableId resultTableId = TableId.of(destinationProjectId, datasetName, "FAKE TABLE NAME");
-    final QueryJobConfiguration listTablesQuery =
-        QueryJobConfiguration.newBuilder(
-                "SELECT * FROM `"
-                    + destinationProjectId
-                    + "."
-                    + datasetName
-                    + ".INFORMATION_SCHEMA.TABLES`;")
-            .setDestinationTable(resultTableId)
-            .setWriteDisposition(WriteDisposition.WRITE_TRUNCATE)
-            .build();
-    // Will throw not found if the dataset doesn't exist
-    // Retry because in rare cases, it can take a while for bigquery.jobs.create to propagate
-    // TODO(PF-2335): Delete retry after PF-2335 is fixed
-    final TableResult listTablesResult =
-        ClientTestUtils.getWithRetryOnException(() -> bigQueryClient.query(listTablesQuery));
-    final long numRows =
-        StreamSupport.stream(listTablesResult.getValues().spliterator(), false).count();
-    assertEquals(0, numRows, "Expected zero tables for COPY_DEFINITION dataset");
-    logger.info(
-        "BQ Dataset {} in project {} has no tables, as expected.",
-        datasetName,
-        destinationProjectId);
   }
 
   private void assertEmptyBucket(String bucketName, String destinationProjectId)

--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
@@ -16,7 +16,6 @@ import bio.terra.workspace.model.ApplicationState;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.ControlledResourceIamRole;
 import bio.terra.workspace.model.CreatedControlledGcpGcsBucket;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.PrivateResourceUser;
 import bio.terra.workspace.model.ResourceList;
@@ -84,17 +83,17 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
     ControlledGcpResourceApi wsmappResourceApi = new ControlledGcpResourceApi(wsmappApiClient);
 
     // Owner adds a reader and a writer to the workspace
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(reader.userEmail), getWorkspaceId(), IamRole.READER);
-    logger.info("Added {} as a reader to workspace {}", reader.userEmail, getWorkspaceId());
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(writer.userEmail), getWorkspaceId(), IamRole.WRITER);
-    logger.info("Added {} as a writer to workspace {}", writer.userEmail, getWorkspaceId());
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), reader, IamRole.READER);
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), writer, IamRole.WRITER);
 
     // Create the cloud context
     String projectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
     assertNotNull(projectId);
     logger.info("Created project {}", projectId);
+
+    // Wait for grantees to have permission
+    ClientTestUtils.workspaceRoleWaitForPropagation(reader, projectId);
+    ClientTestUtils.workspaceRoleWaitForPropagation(writer, projectId);
 
     // Enable the application in the workspace
     WorkspaceApplicationDescription applicationDescription =

--- a/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -17,7 +17,6 @@ import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
 import bio.terra.workspace.model.GcpBigQueryDatasetUpdateParameters;
 import bio.terra.workspace.model.GenerateGcpBigQueryDatasetCloudIDRequestBody;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.ResourceType;
@@ -89,9 +88,8 @@ public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScr
         ClientTestUtils.getControlledGcpResourceClient(testUser, server);
 
     // Add a writer the source workspace. Reader is already added by the base class
-    logger.info("Adding {} as writer to workspace {}", writer.userEmail, getWorkspaceId());
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(writer.userEmail), getWorkspaceId(), IamRole.WRITER);
+    ClientTestUtils.grantRoleWaitForPropagation(
+        workspaceApi, getWorkspaceId(), getSourceProjectId(), writer, IamRole.WRITER);
 
     SamClientUtils.dumpResourcePolicy(testUser, server, "workspace", getWorkspaceId().toString());
 

--- a/integration/src/main/java/scripts/testscripts/EnablePet.java
+++ b/integration/src/main/java/scripts/testscripts/EnablePet.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.common.sam.SamRetry;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.WorkspaceApi;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import com.google.api.services.iam.v1.Iam;
 import com.google.api.services.iam.v1.model.TestIamPermissionsRequest;
@@ -64,10 +63,9 @@ public class EnablePet extends WorkspaceAllocateTestScriptBase {
     petSaWorkspaceApi.enablePet(getWorkspaceId());
 
     // Add second user to the workspace as a reader.
-    userWorkspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(secondUser.userEmail),
-        getWorkspaceId(),
-        IamRole.READER);
+    ClientTestUtils.grantRoleWaitForPropagation(
+        userWorkspaceApi, getWorkspaceId(), projectId, secondUser, IamRole.READER);
+
     // Validate the second user cannot impersonate either user's pet.
     GoogleApi secondUserSamGoogleApi = SamClientUtils.samGoogleApi(secondUser, server);
     String secondUserPetSaEmail =

--- a/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/FolderLifecycle.java
@@ -19,7 +19,6 @@ import bio.terra.workspace.model.CreatedControlledGcpGcsBucket;
 import bio.terra.workspace.model.Folder;
 import bio.terra.workspace.model.GcpBigQueryDatasetAttributes;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.JobReport.StatusEnum;
@@ -59,11 +58,7 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
 
     ApiClient ownerApiClient = ClientTestUtils.getClientForTestUser(workspaceOwner, server);
     ApiClient writerApiClient = ClientTestUtils.getClientForTestUser(secondUser, server);
-
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(secondUser.userEmail),
-        getWorkspaceId(),
-        IamRole.WRITER);
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), secondUser, IamRole.WRITER);
 
     folderOwnerApi = new FolderApi(ownerApiClient);
     folderWriterApi = new FolderApi(writerApiClient);
@@ -85,6 +80,10 @@ public class FolderLifecycle extends WorkspaceAllocateTestScriptBase {
     assertEquals(displayName, folderFoo.getDisplayName());
     assertEquals(description, folderFoo.getDescription());
     assertNull(folderFoo.getParentFolderId());
+
+    // THIS TEST IS BROKEN AND NOT RUN: YOU NEED TO MAKE A CLOUD CONTEXT TO
+    // BE ABLE TO MAKE CONTROLLED RESOURCES. AND NEED TO WAIT FOR PERMISSIONS
+    // TO BE GRANTED AFTER THE CLOUD CONTEXT IS CREATED
 
     // Add a bucket to foo.
     CreatedControlledGcpGcsBucket controlledGcsBucketInFoo =

--- a/integration/src/main/java/scripts/testscripts/GetRoles.java
+++ b/integration/src/main/java/scripts/testscripts/GetRoles.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.equalTo;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiException;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.RoleBindingList;
 import bio.terra.workspace.model.WorkspaceStageModel;
@@ -26,14 +25,7 @@ public class GetRoles extends WorkspaceAllocateTestScriptBase {
     super.doSetup(testUsers, workspaceApi);
 
     for (TestUserSpecification testUser : testUsers) {
-      logger.info(
-          "Granting role {} for user {} on workspace id {}",
-          IAM_ROLE.toString(),
-          testUser.userEmail,
-          getWorkspaceId().toString());
-      final var body = new GrantRoleRequestBody().memberEmail(testUser.userEmail);
-      // grant the role
-      workspaceApi.grantRole(body, getWorkspaceId(), IAM_ROLE);
+      ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), testUser, IAM_ROLE);
     }
   }
 

--- a/integration/src/main/java/scripts/testscripts/ListWorkspaces.java
+++ b/integration/src/main/java/scripts/testscripts/ListWorkspaces.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.WorkspaceApi;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.WorkspaceDescription;
 import bio.terra.workspace.model.WorkspaceDescriptionList;
@@ -37,10 +36,7 @@ public class ListWorkspaces extends WorkspaceAllocateTestScriptBase {
     workspaceId2 = UUID.randomUUID();
     createWorkspace(workspaceId2, getSpendProfileId(), secondUserApi);
     // Add first user as workspace reader
-    secondUserApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(testUsers.get(0).userEmail),
-        workspaceId2,
-        IamRole.READER);
+    ClientTestUtils.grantRole(secondUserApi, workspaceId2, testUsers.get(0), IamRole.READER);
   }
 
   @Override

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstancePostStartup.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstancePostStartup.java
@@ -8,7 +8,6 @@ import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.CreatedControlledGcpAiNotebookInstanceResult;
 import bio.terra.workspace.model.GcpAiNotebookInstanceResource;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import com.google.api.services.notebooks.v1.AIPlatformNotebooks;
 import java.util.List;
@@ -36,11 +35,10 @@ public class PrivateControlledAiNotebookInstancePostStartup
   @Override
   protected void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
       throws Exception {
-    CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(resourceUser.userEmail),
-        getWorkspaceId(),
-        IamRole.WRITER);
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), resourceUser, IamRole.WRITER);
+    String projectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
+    ClientTestUtils.workspaceRoleWaitForPropagation(resourceUser, projectId);
+
     ControlledGcpResourceApi resourceUserApi =
         ClientTestUtils.getControlledGcpResourceClient(resourceUser, server);
     String testValue = RandomStringUtils.random(5, /*letters=*/ true, /*numbers=*/ true);

--- a/integration/src/main/java/scripts/testscripts/ReferencedBigQueryResourceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedBigQueryResourceLifecycle.java
@@ -19,7 +19,6 @@ import bio.terra.workspace.model.GcpBigQueryDataTableAttributes;
 import bio.terra.workspace.model.GcpBigQueryDataTableResource;
 import bio.terra.workspace.model.GcpBigQueryDatasetAttributes;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.ResourceType;
@@ -71,14 +70,8 @@ public class ReferencedBigQueryResourceLifecycle extends WorkspaceAllocateTestSc
     ReferencedGcpResourceApi referencedGcpResourceApi =
         ClientTestUtils.getReferencedGcpResourceClient(testUser, server);
     // Grant secondary users READER permission in the workspace.
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(partialAccessUser.userEmail),
-        getWorkspaceId(),
-        IamRole.READER);
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(noAccessUser.userEmail),
-        getWorkspaceId(),
-        IamRole.READER);
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), partialAccessUser, IamRole.READER);
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), noAccessUser, IamRole.READER);
 
     // Create the references
     GcpBigQueryDatasetResource referencedDataset =

--- a/integration/src/main/java/scripts/testscripts/ReferencedDataRepoSnapshotLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedDataRepoSnapshotLifecycle.java
@@ -16,7 +16,6 @@ import bio.terra.workspace.model.CloneReferencedGcpDataRepoSnapshotResourceResul
 import bio.terra.workspace.model.CloneReferencedResourceRequestBody;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.DataRepoSnapshotResource;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.ResourceType;
@@ -67,10 +66,7 @@ public class ReferencedDataRepoSnapshotLifecycle extends WorkspaceAllocateTestSc
         ClientTestUtils.getReferencedGcpResourceClient(testUser, server);
     // Add the "partial access" user as a workspace reader. This does not give them access to any
     // underlying referenced resources.
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(partialAccessUser.userEmail),
-        getWorkspaceId(),
-        IamRole.READER);
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), partialAccessUser, IamRole.READER);
 
     // Create the reference
     DataRepoSnapshotResource snapshotResource =

--- a/integration/src/main/java/scripts/testscripts/ReferencedGcsResourceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedGcsResourceLifecycle.java
@@ -19,7 +19,6 @@ import bio.terra.workspace.model.GcpGcsBucketAttributes;
 import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.GcpGcsObjectAttributes;
 import bio.terra.workspace.model.GcpGcsObjectResource;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.ResourceType;
@@ -75,14 +74,8 @@ public class ReferencedGcsResourceLifecycle extends WorkspaceAllocateTestScriptB
     ReferencedGcpResourceApi referencedGcpResourceApi =
         ClientTestUtils.getReferencedGcpResourceClient(testUser, server);
     // Grant secondary users READER permission in the workspace.
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(partialAccessUser.userEmail),
-        getWorkspaceId(),
-        IamRole.READER);
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(noAccessUser.userEmail),
-        getWorkspaceId(),
-        IamRole.READER);
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), partialAccessUser, IamRole.READER);
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), noAccessUser, IamRole.READER);
 
     // Create the references
     GcpGcsBucketResource referencedBucket =

--- a/integration/src/main/java/scripts/testscripts/RemoveUser.java
+++ b/integration/src/main/java/scripts/testscripts/RemoveUser.java
@@ -199,7 +199,7 @@ public class RemoveUser extends WorkspaceAllocateTestScriptBase {
     } catch (StorageException googleError) {
       // If this is a 403 error, the user was successfully removed from the bucket.
       assertEquals(SC_FORBIDDEN, googleError.getCode());
-    } catch (IOException e) {
+    } catch (Exception e) {
       // Unexpected error, rethrow
       throw new RuntimeException("Error checking user is removed from bucket", e);
     }

--- a/integration/src/main/java/scripts/testscripts/RemoveUser.java
+++ b/integration/src/main/java/scripts/testscripts/RemoveUser.java
@@ -77,21 +77,17 @@ public class RemoveUser extends WorkspaceAllocateTestScriptBase {
         new GrantRoleRequestBody().memberEmail(groupEmail), getWorkspaceId(), IamRole.READER);
 
     // Add one user as a reader, and one as both a reader and writer.
-    ownerWorkspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(privateResourceUser.userEmail),
-        getWorkspaceId(),
-        IamRole.READER);
-    ownerWorkspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(privateResourceUser.userEmail),
-        getWorkspaceId(),
-        IamRole.WRITER);
-    ownerWorkspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(sharedResourceUser.userEmail),
-        getWorkspaceId(),
-        IamRole.WRITER);
+    ClientTestUtils.grantRole(
+        ownerWorkspaceApi, getWorkspaceId(), privateResourceUser, IamRole.READER);
+    ClientTestUtils.grantRole(
+        ownerWorkspaceApi, getWorkspaceId(), privateResourceUser, IamRole.WRITER);
+    ClientTestUtils.grantRole(
+        ownerWorkspaceApi, getWorkspaceId(), sharedResourceUser, IamRole.WRITER);
 
     // Create a GCP cloud context.
     projectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), ownerWorkspaceApi);
+    ClientTestUtils.workspaceRoleWaitForPropagation(privateResourceUser, projectId);
+    ClientTestUtils.workspaceRoleWaitForPropagation(sharedResourceUser, projectId);
 
     // Create a shared GCS bucket with one object inside.
     ControlledGcpResourceApi ownerResourceApi =

--- a/integration/src/main/java/scripts/utils/BqDatasetUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDatasetUtils.java
@@ -227,13 +227,14 @@ public class BqDatasetUtils {
         accessScope.name(),
         datasetId,
         workspaceUuid);
-    GcpBigQueryDatasetResource result = resourceApi.createBigQueryDataset(body, workspaceUuid).getBigQueryDataset();
+    GcpBigQueryDatasetResource result =
+        resourceApi.createBigQueryDataset(body, workspaceUuid).getBigQueryDataset();
     logger.info(
-      "Created {} {} BQ dataset {} workspace {}",
-      managedBy.name(),
-      accessScope.name(),
-      datasetId,
-      workspaceUuid);
+        "Created {} {} BQ dataset {} workspace {}",
+        managedBy.name(),
+        accessScope.name(),
+        datasetId,
+        workspaceUuid);
     return result;
   }
 
@@ -322,31 +323,33 @@ public class BqDatasetUtils {
                     .build()));
 
     ClientTestUtils.getWithRetryOnException(
-      () -> bigQueryClient.query(
-        QueryJobConfiguration.newBuilder(
-                "INSERT INTO `"
-                    + projectId
-                    + "."
-                    + dataset.getAttributes().getDatasetId()
-                    + ".department` (department_id, manager_id, name) "
-                    + "VALUES(201, 101, 'ocean'), (202, 102, 'sky');")
-            .build()));
+        () ->
+            bigQueryClient.query(
+                QueryJobConfiguration.newBuilder(
+                        "INSERT INTO `"
+                            + projectId
+                            + "."
+                            + dataset.getAttributes().getDatasetId()
+                            + ".department` (department_id, manager_id, name) "
+                            + "VALUES(201, 101, 'ocean'), (202, 102, 'sky');")
+                    .build()));
 
     // double-check the rows are there
     TableResult employeeTableResult =
-      ClientTestUtils.getWithRetryOnException(
-        () -> bigQueryClient.query(
-            QueryJobConfiguration.newBuilder(
-                    "SELECT * FROM `"
-                        + projectId
-                        + "."
-                        + dataset.getAttributes().getDatasetId()
-                        + "."
-                        + BQ_EMPLOYEE_TABLE_NAME
-                        + "`;")
-                .setDestinationTable(resultTableId)
-                .setWriteDisposition(WriteDisposition.WRITE_TRUNCATE)
-                .build()));
+        ClientTestUtils.getWithRetryOnException(
+            () ->
+                bigQueryClient.query(
+                    QueryJobConfiguration.newBuilder(
+                            "SELECT * FROM `"
+                                + projectId
+                                + "."
+                                + dataset.getAttributes().getDatasetId()
+                                + "."
+                                + BQ_EMPLOYEE_TABLE_NAME
+                                + "`;")
+                        .setDestinationTable(resultTableId)
+                        .setWriteDisposition(WriteDisposition.WRITE_TRUNCATE)
+                        .build()));
     long numRows =
         StreamSupport.stream(employeeTableResult.getValues().spliterator(), false).count();
     assertThat(numRows, is(greaterThanOrEqualTo(2L)));

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -270,7 +270,8 @@ public class ClientTestUtils {
    */
   public static @Nullable <T> T getWithRetryOnException(SupplierWithException<T> supplier)
       throws Exception {
-    return getWithRetryOnException(supplier, DEFAULT_RETRY_TOTAL_DURATION, DEFAULT_SLEEP_DURATION, null);
+    return getWithRetryOnException(
+        supplier, DEFAULT_RETRY_TOTAL_DURATION, DEFAULT_SLEEP_DURATION, null);
   }
 
   public static void runWithRetryOnException(Runnable fn) throws Exception {
@@ -289,17 +290,18 @@ public class ClientTestUtils {
    * @param supplier - code returning the result or throwing an exception
    * @param totalDuration - total amount of time to retry
    * @param sleepDuration - amount of time to sleep between retries
-   * @param retryExceptionList - nullable; a list of exception classes. If null, any exception is retried
+   * @param retryExceptionList - nullable; a list of exception classes. If null, any exception is
+   *     retried
    * @param <T> - type of result
    * @return - result from supplier, if no exception
    * @throws InterruptedException if the sleep is interrupted
    */
   public static <T> T getWithRetryOnException(
-    SupplierWithException<T> supplier,
-    Duration totalDuration,
-    Duration sleepDuration,
-    @Nullable List<Class<? extends Exception>> retryExceptionList
-    ) throws Exception {
+      SupplierWithException<T> supplier,
+      Duration totalDuration,
+      Duration sleepDuration,
+      @Nullable List<Class<? extends Exception>> retryExceptionList)
+      throws Exception {
 
     T result = null;
     Instant endTime = Instant.now().plus(totalDuration);
@@ -314,17 +316,18 @@ public class ClientTestUtils {
           throw e;
         }
         logger.info(
-          "Exception \"{}\". Waiting {} seconds. End time is {}",
-          e.getMessage(),
-          sleepDuration.toSeconds(),
-          endTime);
+            "Exception \"{}\". Waiting {} seconds. End time is {}",
+            e.getMessage(),
+            sleepDuration.toSeconds(),
+            endTime);
         TimeUnit.MILLISECONDS.sleep(sleepDuration.toMillis());
       }
     }
     return result;
   }
 
-  private static boolean isRetryable(Exception e, @Nullable List<Class<? extends Exception>> retryExceptionList) {
+  private static boolean isRetryable(
+      Exception e, @Nullable List<Class<? extends Exception>> retryExceptionList) {
     // If we didn't get a list, then all exceptions are considered retryable
     if (retryExceptionList == null) {
       return true;

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -259,9 +259,9 @@ public class ClientTestUtils {
   }
 
   /**
-   * Get a result from a call that might throw an exception. Treat the exception as retry-able.
-   * This structure is useful for situations where we are
-   * waiting on a cloud IAM permission change to take effect.
+   * Get a result from a call that might throw an exception. Treat the exception as retry-able. This
+   * structure is useful for situations where we are waiting on a cloud IAM permission change to
+   * take effect.
    *
    * @param supplier - code returning the result or throwing an exception
    * @param <T> - type of result

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -259,8 +259,8 @@ public class ClientTestUtils {
   }
 
   /**
-   * Get a result from a call that might throw an exception. Treat the exception as retryable, sleep
-   * for 15 seconds, and retry up to 60 times. This structure is useful for situations where we are
+   * Get a result from a call that might throw an exception. Treat the exception as retry-able.
+   * This structure is useful for situations where we are
    * waiting on a cloud IAM permission change to take effect.
    *
    * @param supplier - code returning the result or throwing an exception

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -421,7 +421,6 @@ public class ClientTestUtils {
   /** An interface for an arbitrary workspace operation that throws an {@link ApiException}. */
   @FunctionalInterface
   public interface WorkspaceOperation<T> {
-
     T apply() throws ApiException;
   }
 

--- a/integration/src/main/java/scripts/utils/CloudContextMaker.java
+++ b/integration/src/main/java/scripts/utils/CloudContextMaker.java
@@ -11,7 +11,6 @@ import bio.terra.workspace.model.JobReport.StatusEnum;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/integration/src/main/java/scripts/utils/CloudContextMaker.java
+++ b/integration/src/main/java/scripts/utils/CloudContextMaker.java
@@ -10,13 +10,15 @@ import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport.StatusEnum;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Utilities for creating/deleting cloud contexts for client tests */
 public class CloudContextMaker {
   private static final Logger logger = LoggerFactory.getLogger(CloudContextMaker.class);
-  private static final Duration CREATE_CONTEXT_POLL_INTERVAL = Duration.ofSeconds(10);
+  private static final Duration CREATE_CONTEXT_POLL_INTERVAL = Duration.ofSeconds(60);
 
   private CloudContextMaker() {}
 
@@ -64,7 +66,7 @@ public class CloudContextMaker {
     CreateCloudContextResult contextResult =
         workspaceApi.createCloudContext(createContext, workspaceUuid);
     while (ClientTestUtils.jobIsRunning(contextResult.getJobReport())) {
-      Thread.sleep(CREATE_CONTEXT_POLL_INTERVAL.toMillis());
+      TimeUnit.SECONDS.sleep(CREATE_CONTEXT_POLL_INTERVAL.toSeconds());
       contextResult = workspaceApi.getCreateCloudContextResult(workspaceUuid, contextJobId);
     }
     logger.info(

--- a/integration/src/main/java/scripts/utils/GcpWorkspaceCloneTestScriptBase.java
+++ b/integration/src/main/java/scripts/utils/GcpWorkspaceCloneTestScriptBase.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import bio.terra.workspace.api.WorkspaceApi;
-import bio.terra.workspace.model.GrantRoleRequestBody;
 import bio.terra.workspace.model.IamRole;
 import java.util.List;
 import java.util.UUID;
@@ -57,8 +56,7 @@ public abstract class GcpWorkspaceCloneTestScriptBase extends WorkspaceAllocateT
         "There must be at least two test users defined for this test.",
         testUsers != null && testUsers.size() > 1);
     reader = testUsers.get(1);
-    workspaceApi.grantRole(
-        new GrantRoleRequestBody().memberEmail(reader.userEmail), getWorkspaceId(), IamRole.READER);
+    ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), reader, IamRole.READER);
     sourceProjectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
     destinationWorkspaceId = UUID.randomUUID();
     WorkspaceApi secondUserWorkspaceApi = ClientTestUtils.getWorkspaceClient(reader, server);

--- a/integration/src/main/java/scripts/utils/GcpWorkspaceCloneTestScriptBase.java
+++ b/integration/src/main/java/scripts/utils/GcpWorkspaceCloneTestScriptBase.java
@@ -58,6 +58,7 @@ public abstract class GcpWorkspaceCloneTestScriptBase extends WorkspaceAllocateT
     reader = testUsers.get(1);
     ClientTestUtils.grantRole(workspaceApi, getWorkspaceId(), reader, IamRole.READER);
     sourceProjectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
+    ClientTestUtils.workspaceRoleWaitForPropagation(reader, sourceProjectId);
     destinationWorkspaceId = UUID.randomUUID();
     WorkspaceApi secondUserWorkspaceApi = ClientTestUtils.getWorkspaceClient(reader, server);
     createWorkspace(destinationWorkspaceId, getSpendProfileId(), secondUserWorkspaceApi);

--- a/integration/src/main/java/scripts/utils/GcsBucketObjectUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketObjectUtils.java
@@ -12,7 +12,6 @@ import bio.terra.workspace.model.GcpGcsObjectResource;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
-import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -27,13 +26,12 @@ public class GcsBucketObjectUtils {
   private static final Pattern GCS_OBJECT_PATTERN = Pattern.compile("^gs://([^/]+)/(.+)$");
 
   public static Blob retrieveBucketFile(
-      String bucketName, String gcpProjectId, TestUserSpecification bucketReader)
-      throws IOException {
+      String bucketName, String gcpProjectId, TestUserSpecification bucketReader) throws Exception {
     Storage cloningUserStorageClient =
         ClientTestUtils.getGcpStorageClient(bucketReader, gcpProjectId);
     BlobId blobId = BlobId.of(bucketName, GcsBucketUtils.GCS_BLOB_NAME);
-
-    final Blob retrievedFile = cloningUserStorageClient.get(blobId);
+    Blob retrievedFile =
+        ClientTestUtils.getWithRetryOnException(() -> cloningUserStorageClient.get(blobId));
     logger.info("Retrieved file {} from bucket {}", GcsBucketUtils.GCS_BLOB_NAME, bucketName);
     assertNotNull(retrievedFile);
     assertEquals(blobId.getName(), retrievedFile.getBlobId().getName());

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -172,11 +172,11 @@ public class GcsBucketUtils {
                     .lifecycle(new GcpGcsBucketLifecycle().rules(BUCKET_LIFECYCLE_RULES)));
 
     logger.info(
-      "Creating {} {} bucket {} in workspace {}",
-      managedBy.name(),
-      accessScope.name(),
-      bucketName,
-      workspaceUuid);
+        "Creating {} {} bucket {} in workspace {}",
+        managedBy.name(),
+        accessScope.name(),
+        bucketName,
+        workspaceUuid);
     CreatedControlledGcpGcsBucket result = resourceApi.createBucket(body, workspaceUuid);
     logger.info(
         "Created {} {} bucket {} resource ID {} in workspace {}",

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -171,9 +171,15 @@ public class GcsBucketUtils {
                     .defaultStorageClass(GcpGcsBucketDefaultStorageClass.STANDARD)
                     .lifecycle(new GcpGcsBucketLifecycle().rules(BUCKET_LIFECYCLE_RULES)));
 
+    logger.info(
+      "Creating {} {} bucket {} in workspace {}",
+      managedBy.name(),
+      accessScope.name(),
+      bucketName,
+      workspaceUuid);
     CreatedControlledGcpGcsBucket result = resourceApi.createBucket(body, workspaceUuid);
     logger.info(
-        "Creating {} {} bucket {} resource ID {} in workspace {}",
+        "Created {} {} bucket {} resource ID {} in workspace {}",
         managedBy.name(),
         accessScope.name(),
         bucketName,

--- a/integration/src/main/resources/configs/integration/BasicAuthenticated.json
+++ b/integration/src/main/resources/configs/integration/BasicAuthenticated.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["liam.json"]
+  "testUserFiles": ["liam.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/BasicUnauthenticated.json
+++ b/integration/src/main/resources/configs/integration/BasicUnauthenticated.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": []
+  "testUserFiles": [],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/CloneWorkspace.json
+++ b/integration/src/main/resources/configs/integration/CloneWorkspace.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "elijah.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/CloneWorkspace.json
+++ b/integration/src/main/resources/configs/integration/CloneWorkspace.json
@@ -9,13 +9,13 @@
       "name": "CloneWorkspace",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 15,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"],
+  "testUserFiles": ["bella.json", "levi.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/CloneWorkspace.json
+++ b/integration/src/main/resources/configs/integration/CloneWorkspace.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json"],
+  "testUserFiles": ["bella.json", "elijah.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/CloneWorkspace.json
+++ b/integration/src/main/resources/configs/integration/CloneWorkspace.json
@@ -9,7 +9,7 @@
       "name": "CloneWorkspace",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/ControlledApplicationPrivateGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledApplicationPrivateGcsBucketLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ControlledApplicationPrivateGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/ControlledApplicationPrivateGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledApplicationPrivateGcsBucketLifecycle.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json", "wsmapp.json"]
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json", "wsmapp.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledApplicationPrivateGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledApplicationPrivateGcsBucketLifecycle.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json", "liam.json", "wsmapp.json"],
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json", "wsmapp.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledApplicationPrivateGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledApplicationPrivateGcsBucketLifecycle.json
@@ -9,13 +9,13 @@
       "name": "ControlledApplicationPrivateGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 10,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json", "wsmapp.json"],
+  "testUserFiles": ["bella.json", "levi.json", "liam.json", "wsmapp.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
@@ -9,13 +9,13 @@
       "name": "ControlledApplicationSharedGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 10,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json", "wsmapp.json"],
+  "testUserFiles": ["bella.json", "levi.json", "liam.json", "wsmapp.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ControlledApplicationSharedGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json", "wsmapp.json"]
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json", "wsmapp.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledApplicationSharedGcsBucketLifecycle.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json", "liam.json", "wsmapp.json"],
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json", "wsmapp.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledAzureVmNoPublicIpLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledAzureVmNoPublicIpLifecycle.json
@@ -19,5 +19,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json"]
+  "testUserFiles": ["bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledAzureVmWithCustomScriptExtensionNoPublicIpLifecycle.json
@@ -19,5 +19,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json"]
+  "testUserFiles": ["bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledAzureVmWithPublicIpLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledAzureVmWithPublicIpLifecycle.json
@@ -19,5 +19,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json"]
+  "testUserFiles": ["bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledAzureVmWithWrongCredentialsLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledAzureVmWithWrongCredentialsLifecycle.json
@@ -19,5 +19,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json"]
+  "testUserFiles": ["bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ControlledBigQueryDatasetLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
+  "testUserFiles": ["bella.json", "levi.json", "liam.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json"]
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledBigQueryDatasetLifecycle.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json", "liam.json"],
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "elijah.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json"],
+  "testUserFiles": ["bella.json", "elijah.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ControlledGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ControlledGcsBucketLifecycle.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"],
+  "testUserFiles": ["bella.json", "levi.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/DeleteWorkspaceWithControlledResource.json
+++ b/integration/src/main/resources/configs/integration/DeleteWorkspaceWithControlledResource.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json"]
+  "testUserFiles": ["bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/DeleteWorkspaceWithControlledResource.json
+++ b/integration/src/main/resources/configs/integration/DeleteWorkspaceWithControlledResource.json
@@ -9,7 +9,7 @@
       "name": "DeleteWorkspaceWithControlledResource",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/DeleteWorkspaceWithControlledResource.json
+++ b/integration/src/main/resources/configs/integration/DeleteWorkspaceWithControlledResource.json
@@ -9,7 +9,7 @@
       "name": "DeleteWorkspaceWithControlledResource",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/EnablePet.json
+++ b/integration/src/main/resources/configs/integration/EnablePet.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["levi.json", "bella.json"],
+  "testUserFiles": ["elijah.json", "bella.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/EnablePet.json
+++ b/integration/src/main/resources/configs/integration/EnablePet.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["elijah.json", "bella.json"]
+  "testUserFiles": ["elijah.json", "bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/EnablePet.json
+++ b/integration/src/main/resources/configs/integration/EnablePet.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["elijah.json", "bella.json"],
+  "testUserFiles": ["levi.json", "bella.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/EnablePet.json
+++ b/integration/src/main/resources/configs/integration/EnablePet.json
@@ -9,7 +9,7 @@
       "name": "EnablePet",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 3,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/EnumerateJobs.json
+++ b/integration/src/main/resources/configs/integration/EnumerateJobs.json
@@ -9,7 +9,7 @@
       "name": "EnumerateJobs",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/EnumerateJobs.json
+++ b/integration/src/main/resources/configs/integration/EnumerateJobs.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json"]
+  "testUserFiles": ["bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/EnumerateJobs.json
+++ b/integration/src/main/resources/configs/integration/EnumerateJobs.json
@@ -9,7 +9,7 @@
       "name": "EnumerateJobs",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 10,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/EnumerateResources.json
+++ b/integration/src/main/resources/configs/integration/EnumerateResources.json
@@ -9,7 +9,7 @@
       "name": "EnumerateResources",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/EnumerateResources.json
+++ b/integration/src/main/resources/configs/integration/EnumerateResources.json
@@ -9,7 +9,7 @@
       "name": "EnumerateResources",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/EnumerateResources.json
+++ b/integration/src/main/resources/configs/integration/EnumerateResources.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "liam.json"]
+  "testUserFiles": ["bella.json", "liam.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/FolderLifecycle.json
+++ b/integration/src/main/resources/configs/integration/FolderLifecycle.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["liam.json", "bella.json"]
+  "testUserFiles": ["liam.json", "bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/GetRoles.json
+++ b/integration/src/main/resources/configs/integration/GetRoles.json
@@ -9,7 +9,7 @@
       "name": "GetRoles",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/GetRoles.json
+++ b/integration/src/main/resources/configs/integration/GetRoles.json
@@ -9,8 +9,8 @@
       "name": "GetRoles",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
-      "expectedTimeForEachUnit": "SECONDS",
+      "expectedTimeForEach": 30,
+      "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }

--- a/integration/src/main/resources/configs/integration/GetRoles.json
+++ b/integration/src/main/resources/configs/integration/GetRoles.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["liam.json"]
+  "testUserFiles": ["liam.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/Jobs.json
+++ b/integration/src/main/resources/configs/integration/Jobs.json
@@ -9,7 +9,7 @@
       "name": "Jobs",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/Jobs.json
+++ b/integration/src/main/resources/configs/integration/Jobs.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "elijah.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/Jobs.json
+++ b/integration/src/main/resources/configs/integration/Jobs.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json"],
+  "testUserFiles": ["bella.json", "elijah.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/Jobs.json
+++ b/integration/src/main/resources/configs/integration/Jobs.json
@@ -9,13 +9,13 @@
       "name": "Jobs",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 10,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"],
+  "testUserFiles": ["bella.json", "levi.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ListWorkspaces.json
+++ b/integration/src/main/resources/configs/integration/ListWorkspaces.json
@@ -9,7 +9,7 @@
       "name": "ListWorkspaces",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/ListWorkspaces.json
+++ b/integration/src/main/resources/configs/integration/ListWorkspaces.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "liam.json"]
+  "testUserFiles": ["bella.json", "liam.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ListWorkspaces.json
+++ b/integration/src/main/resources/configs/integration/ListWorkspaces.json
@@ -9,8 +9,8 @@
       "name": "ListWorkspaces",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
-      "expectedTimeForEachUnit": "SECONDS",
+      "expectedTimeForEach": 30,
+      "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }

--- a/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
@@ -9,7 +9,7 @@
       "name": "PrivateControlledAiNotebookInstanceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json"]
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
@@ -9,13 +9,13 @@
       "name": "PrivateControlledAiNotebookInstanceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 16,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
+  "testUserFiles": ["bella.json", "levi.json", "liam.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstanceLifecycle.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json", "liam.json"],
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstancePostStartup.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstancePostStartup.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "elijah.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstancePostStartup.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstancePostStartup.json
@@ -9,13 +9,13 @@
       "name": "PrivateControlledAiNotebookInstancePostStartup",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 16,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"],
+  "testUserFiles": ["bella.json", "levi.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstancePostStartup.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstancePostStartup.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json"],
+  "testUserFiles": ["bella.json", "elijah.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstancePostStartup.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledAiNotebookInstancePostStartup.json
@@ -9,7 +9,7 @@
       "name": "PrivateControlledAiNotebookInstancePostStartup",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
@@ -9,13 +9,13 @@
       "name": "PrivateControlledGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
+  "testUserFiles": ["bella.json", "levi.json", "liam.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
@@ -9,7 +9,7 @@
       "name": "PrivateControlledGcsBucketLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json"]
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
+++ b/integration/src/main/resources/configs/integration/PrivateControlledGcsBucketLifecycle.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json", "liam.json"],
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedBigQueryResourceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedBigQueryResourceLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ReferencedBigQueryResourceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile",
@@ -19,6 +19,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "liam.json", "elijah.json"],
+  "testUserFiles": ["bella.json", "liam.json", "levi.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedBigQueryResourceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedBigQueryResourceLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ReferencedBigQueryResourceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile",
@@ -19,6 +19,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "liam.json", "levi.json"],
+  "testUserFiles": ["bella.json", "liam.json", "elijah.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedBigQueryResourceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedBigQueryResourceLifecycle.json
@@ -19,5 +19,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "liam.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "liam.json", "elijah.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ReferencedDataRepoSnapshotLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile",
@@ -19,6 +19,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"],
+  "testUserFiles": ["bella.json", "levi.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
@@ -19,5 +19,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "elijah.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
@@ -15,7 +15,7 @@
         "spend-profile-id": "wm-default-spend-profile",
         "data-repo-instance": "terra",
         "snapshot-id":"220a2d18-56f7-492a-b7b3-2bc7d79e54b2",
-        "snapshot-id-2":"3d3d6fde-0a66-4807-b03e-f75e67eb0fe9"
+        "snapshot-id-2":"3d3d6fde-0a66-4807-b03e-f30e67eb0fe9"
       }
     }
   ],

--- a/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedDataRepoSnapshotLifecycle.json
@@ -9,16 +9,16 @@
       "name": "ReferencedDataRepoSnapshotLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile",
         "data-repo-instance": "terra",
         "snapshot-id":"220a2d18-56f7-492a-b7b3-2bc7d79e54b2",
-        "snapshot-id-2":"3d3d6fde-0a66-4807-b03e-f30e67eb0fe9"
+        "snapshot-id-2":"3d3d6fde-0a66-4807-b03e-f75e67eb0fe9"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json"],
+  "testUserFiles": ["bella.json", "elijah.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedGcsResourceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedGcsResourceLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ReferencedGcsResourceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile",
@@ -20,6 +20,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "liam.json", "elijah.json"],
+  "testUserFiles": ["bella.json", "liam.json", "levi.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedGcsResourceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedGcsResourceLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ReferencedGcsResourceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile",
@@ -20,6 +20,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "liam.json", "levi.json"],
+  "testUserFiles": ["bella.json", "liam.json", "elijah.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedGcsResourceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedGcsResourceLifecycle.json
@@ -20,5 +20,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "liam.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "liam.json", "elijah.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedGitRepoLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedGitRepoLifecycle.json
@@ -17,5 +17,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json"]
+  "testUserFiles": ["bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedGitRepoLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedGitRepoLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ReferencedGitRepoLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile",

--- a/integration/src/main/resources/configs/integration/ReferencedGitRepoLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedGitRepoLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ReferencedGitRepoLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile",

--- a/integration/src/main/resources/configs/integration/ReferencedTerraWorkspaceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedTerraWorkspaceLifecycle.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "elijah.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedTerraWorkspaceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedTerraWorkspaceLifecycle.json
@@ -9,7 +9,7 @@
       "name": "ReferencedTerraWorkspaceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/ReferencedTerraWorkspaceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedTerraWorkspaceLifecycle.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json"],
+  "testUserFiles": ["bella.json", "elijah.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ReferencedTerraWorkspaceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/ReferencedTerraWorkspaceLifecycle.json
@@ -9,13 +9,13 @@
       "name": "ReferencedTerraWorkspaceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"],
+  "testUserFiles": ["bella.json", "levi.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/RemoveUser.json
+++ b/integration/src/main/resources/configs/integration/RemoveUser.json
@@ -9,13 +9,13 @@
       "name": "RemoveUser",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 10,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
+  "testUserFiles": ["bella.json", "levi.json", "liam.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/RemoveUser.json
+++ b/integration/src/main/resources/configs/integration/RemoveUser.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json", "liam.json"]
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/RemoveUser.json
+++ b/integration/src/main/resources/configs/integration/RemoveUser.json
@@ -16,6 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json", "liam.json"],
+  "testUserFiles": ["bella.json", "elijah.json", "liam.json"],
   "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/RemoveUser.json
+++ b/integration/src/main/resources/configs/integration/RemoveUser.json
@@ -9,7 +9,7 @@
       "name": "RemoveUser",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/ResourceLineage.json
+++ b/integration/src/main/resources/configs/integration/ResourceLineage.json
@@ -9,7 +9,7 @@
       "name": "ResourceLineage",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 15,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/ResourceLineage.json
+++ b/integration/src/main/resources/configs/integration/ResourceLineage.json
@@ -16,5 +16,6 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json"]
+  "testUserFiles": ["bella.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/ResourceLineage.json
+++ b/integration/src/main/resources/configs/integration/ResourceLineage.json
@@ -9,7 +9,7 @@
       "name": "ResourceLineage",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "MINUTES",
       "parametersMap": {
         "spend-profile-id": "wm-default-spend-profile"

--- a/integration/src/main/resources/configs/integration/WorkspaceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/WorkspaceLifecycle.json
@@ -9,7 +9,7 @@
       "name": "WorkspaceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 10,
+      "expectedTimeForEach": 30,
       "expectedTimeForEachUnit": "SECONDS"
     }
   ],

--- a/integration/src/main/resources/configs/integration/WorkspaceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/WorkspaceLifecycle.json
@@ -13,5 +13,6 @@
       "expectedTimeForEachUnit": "SECONDS"
     }
   ],
-  "testUserFiles": ["liam.json"]
+  "testUserFiles": ["liam.json"],
+  "maxRetries" : 0
 }

--- a/integration/src/main/resources/configs/integration/WorkspaceLifecycle.json
+++ b/integration/src/main/resources/configs/integration/WorkspaceLifecycle.json
@@ -9,7 +9,7 @@
       "name": "WorkspaceLifecycle",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
-      "expectedTimeForEach": 30,
+      "expectedTimeForEach": 75,
       "expectedTimeForEachUnit": "SECONDS"
     }
   ],

--- a/integration/src/main/resources/configs/integration/alpha/ReferencedDataRepoSnapshotLifecycle.json
+++ b/integration/src/main/resources/configs/integration/alpha/ReferencedDataRepoSnapshotLifecycle.json
@@ -19,5 +19,5 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "levi.json"]
 }

--- a/integration/src/main/resources/configs/integration/alpha/ReferencedDataRepoSnapshotLifecycle.json
+++ b/integration/src/main/resources/configs/integration/alpha/ReferencedDataRepoSnapshotLifecycle.json
@@ -19,5 +19,5 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json"]
+  "testUserFiles": ["bella.json", "elijah.json"]
 }

--- a/integration/src/main/resources/configs/integration/staging/ReferencedDataRepoSnapshotLifecycle.json
+++ b/integration/src/main/resources/configs/integration/staging/ReferencedDataRepoSnapshotLifecycle.json
@@ -19,5 +19,5 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "elijah.json"]
+  "testUserFiles": ["bella.json", "levi.json"]
 }

--- a/integration/src/main/resources/configs/integration/staging/ReferencedDataRepoSnapshotLifecycle.json
+++ b/integration/src/main/resources/configs/integration/staging/ReferencedDataRepoSnapshotLifecycle.json
@@ -19,5 +19,5 @@
       }
     }
   ],
-  "testUserFiles": ["bella.json", "levi.json"]
+  "testUserFiles": ["bella.json", "elijah.json"]
 }

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -5,7 +5,6 @@
   "testConfigurationFiles": [
     "integration/BasicAuthenticated.json",
     "integration/BasicUnauthenticated.json",
-    "integration/CloneWorkspace.json",
     "integration/ControlledBigQueryDatasetLifecycle.json",
     "integration/ControlledGcsBucketLifecycle.json",
     "integration/DeleteWorkspaceWithControlledResource.json",

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -5,9 +5,6 @@
   "testConfigurationFiles": [
     "integration/BasicAuthenticated.json",
     "integration/BasicUnauthenticated.json",
-    "integration/CloneWorkspace.json",
-    "integration/ControlledBigQueryDatasetLifecycle.json",
-    "integration/ControlledGcsBucketLifecycle.json",
     "integration/DeleteWorkspaceWithControlledResource.json",
     "integration/EnablePet.json",
     "integration/EnumerateResources.json",
@@ -21,7 +18,6 @@
     "integration/ReferencedGcsResourceLifecycle.json",
     "integration/ReferencedGitRepoLifecycle.json",
     "integration/ReferencedTerraWorkspaceLifecycle.json",
-    "integration/RemoveUser.json",
     "integration/ResourceLineage.json",
     "integration/WorkspaceLifecycle.json"
   ]

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -5,6 +5,7 @@
   "testConfigurationFiles": [
     "integration/BasicAuthenticated.json",
     "integration/BasicUnauthenticated.json",
+    "integration/CloneWorkspace.json",
     "integration/ControlledBigQueryDatasetLifecycle.json",
     "integration/ControlledGcsBucketLifecycle.json",
     "integration/DeleteWorkspaceWithControlledResource.json",

--- a/integration/src/main/resources/testusers/levi.json
+++ b/integration/src/main/resources/testusers/levi.json
@@ -1,5 +1,5 @@
 {
   "name": "levi",
-  "userEmail": "Levi.Bonechewer@test.firecloud.org",
+  "userEmail": "levi.bonechewer@test.firecloud.org",
   "delegatorServiceAccountFile": "delegate-user-sa.json"
 }

--- a/integration/src/main/resources/testusers/levi.json
+++ b/integration/src/main/resources/testusers/levi.json
@@ -1,0 +1,5 @@
+{
+  "name": "levi",
+  "userEmail": "Levi.Bonechewer@test.firecloud.org",
+  "delegatorServiceAccountFile": "delegate-user-sa.json"
+}

--- a/service/src/main/java/bio/terra/workspace/common/utils/FlightUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/FlightUtils.java
@@ -180,7 +180,11 @@ public final class FlightUtils {
    * @param maxWait maximum time to wait
    */
   public static FlightState waitForFlightExponential(
-      Stairway stairway, String flightId, Duration initialInterval, Duration maxInterval, Duration maxWait)
+      Stairway stairway,
+      String flightId,
+      Duration initialInterval,
+      Duration maxInterval,
+      Duration maxWait)
       throws InterruptedException {
     final Instant endTime = Instant.now().plus(maxWait);
     Duration sleepInterval = initialInterval;

--- a/service/src/main/java/bio/terra/workspace/common/utils/GcpUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/GcpUtils.java
@@ -6,10 +6,12 @@ import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.workspace.exceptions.SaCredentialsMissingException;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import com.google.auth.ServiceAccountSigner;
+import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import io.grpc.Status.Code;
@@ -138,5 +140,12 @@ public class GcpUtils {
       throw new SaCredentialsMissingException(
           "Unable to find WSM service account credentials. Ensure WSM is actually running as a service account");
     }
+  }
+
+  public static GoogleCredentials getGoogleCredentialsFromUserRequest(
+      AuthenticatedUserRequest userRequest) {
+    // The expirationTime argument is only used for refresh tokens, not access tokens.
+    AccessToken accessToken = new AccessToken(userRequest.getRequiredToken(), null);
+    return GoogleCredentials.create(accessToken);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/common/utils/RetryUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/RetryUtils.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 /** RetryUtils provides static methods for waiting and retrying. */
 public class RetryUtils {
   // Retry duration defaults - defaults are set for IAM propagation
-  public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(7);
+  public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(30);
   public static final Duration DEFAULT_RETRY_SLEEP_DURATION = Duration.ofSeconds(15);
   public static final double DEFAULT_RETRY_FACTOR_INCREASE = 0.0;
   public static final Duration DEFAULT_RETRY_SLEEP_DURATION_MAX = Duration.ofMinutes(3);

--- a/service/src/main/java/bio/terra/workspace/common/utils/RetryUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/RetryUtils.java
@@ -1,13 +1,12 @@
 package bio.terra.workspace.common.utils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** RetryUtils provides static methods for waiting and retrying. */
 public class RetryUtils {

--- a/service/src/main/java/bio/terra/workspace/common/utils/RetryUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/RetryUtils.java
@@ -1,0 +1,100 @@
+package bio.terra.workspace.common.utils;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** RetryUtils provides static methods for waiting and retrying. */
+public class RetryUtils {
+  // Retry duration defaults - defaults are set for IAM propagation
+  public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(7);
+  public static final Duration DEFAULT_SLEEP_DURATION = Duration.ofSeconds(15);
+
+  private static final Logger logger = LoggerFactory.getLogger(RetryUtils.class);
+
+  /**
+   * Supplier that can throw
+   *
+   * @param <T> return type for the non-throw case
+   */
+  @FunctionalInterface
+  public interface SupplierWithException<T> {
+    T get() throws Exception;
+  }
+
+  /**
+   * Get a result from a call that might throw an exception. If the supplier finishes, the result is
+   * returned. If the supplier continues to throw, when totalDuration has elapsed, this method will
+   * throw that exception.
+   *
+   * @param supplier - code returning the result or throwing an exception
+   * @param totalDuration - total amount of time to retry
+   * @param sleepDuration - amount of time to sleep between retries
+   * @param retryExceptionList - nullable; a list of exception classes. If null, any exception is
+   *     retried
+   * @param <T> - type of result
+   * @return - result from supplier, if no exception
+   * @throws InterruptedException if the sleep is interrupted
+   */
+  public static <T> T getWithRetryOnException(
+      SupplierWithException<T> supplier,
+      Duration totalDuration,
+      Duration sleepDuration,
+      @Nullable List<Class<? extends Exception>> retryExceptionList)
+      throws Exception {
+
+    T result;
+    Instant endTime = Instant.now().plus(totalDuration);
+
+    while (true) {
+      try {
+        result = supplier.get();
+        break;
+      } catch (Exception e) {
+        // If we are out of time or the exception is not retryable
+        if (Instant.now().isAfter(endTime) || !isRetryable(e, retryExceptionList)) {
+          throw e;
+        }
+        logger.info(
+            "Exception \"{}\". Waiting {} seconds. End time is {}",
+            e.getMessage(),
+            sleepDuration.toSeconds(),
+            endTime);
+        TimeUnit.MILLISECONDS.sleep(sleepDuration.toMillis());
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Default version of getWithRetryOnException. It retries all exceptions and uses the default
+   * total duration and sleep duration.
+   *
+   * @param supplier - code returning the result or throwing an exception
+   * @param <T> - type of result
+   * @return - result from supplier
+   * @throws InterruptedException if the sleep is interrupted
+   */
+  public static <T> T getWithRetryOnException(SupplierWithException<T> supplier) throws Exception {
+    return getWithRetryOnException(
+        supplier, DEFAULT_RETRY_TOTAL_DURATION, DEFAULT_SLEEP_DURATION, null);
+  }
+
+  private static boolean isRetryable(
+      Exception e, @Nullable List<Class<? extends Exception>> retryExceptionList) {
+    // If we didn't get a list, then all exceptions are considered retryable
+    if (retryExceptionList == null) {
+      return true;
+    }
+    for (Class<? extends Exception> clazz : retryExceptionList) {
+      if (clazz.isInstance(e)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCreateCloudContextFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCreateCloudContextFlightStep.java
@@ -1,8 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.workspace;
 
-import static bio.terra.workspace.common.utils.FlightUtils.FLIGHT_POLL_CYCLES;
-import static bio.terra.workspace.common.utils.FlightUtils.FLIGHT_POLL_SECONDS;
-
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
@@ -13,7 +10,6 @@ import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.FlightWaitTimedOutException;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
-
 import java.time.Duration;
 
 public class AwaitCreateCloudContextFlightStep implements Step {
@@ -29,12 +25,13 @@ public class AwaitCreateCloudContextFlightStep implements Step {
     FlightUtils.validateRequiredEntries(context.getWorkingMap(), flightIdKey);
     var jobId = context.getWorkingMap().get(flightIdKey, String.class);
     try {
-      FlightState subflightState = FlightUtils.waitForFlightExponential(
-        context.getStairway(),
-        jobId,
-        Duration.ofSeconds(15), // Initial interval
-        Duration.ofMinutes(3),  // Max interval
-        Duration.ofMinutes(30)); // Max flight duration
+      FlightState subflightState =
+          FlightUtils.waitForFlightExponential(
+              context.getStairway(),
+              jobId,
+              Duration.ofSeconds(15), // Initial interval
+              Duration.ofMinutes(3), // Max interval
+              Duration.ofMinutes(30)); // Max flight duration
       if (FlightStatus.SUCCESS != subflightState.getFlightStatus()) {
         // no point in retrying the await step
         return new StepResult(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
@@ -75,11 +75,13 @@ public class CreateGcpContextFlightV2 extends Flight {
     addStep(new SetProjectBillingStep(crl.getCloudBillingClientCow()), cloudRetry);
     addStep(new GrantWsmRoleAdminStep(crl), shortRetry);
     addStep(new CreateCustomGcpRolesStep(crl.getIamCow()), shortRetry);
+    // Try creating the pet before sync'ing, so the proxy group is configured before we
+    // make do the Sam sync and create the role-based Google groups.
+    addStep(new CreatePetSaStep(appContext.getSamService(), userRequest), shortRetry);
     addStep(
         new SyncSamGroupsStep(appContext.getSamService(), workspaceUuid, userRequest), shortRetry);
     // TODO(PF-1227): When IAM performance issue is fixed, change back to cloudRetry.
     addStep(new GcpCloudSyncStep(crl.getCloudResourceManagerCow()), bufferRetry);
-    addStep(new CreatePetSaStep(appContext.getSamService(), userRequest), shortRetry);
 
     // Wait for the project permissions to propagate.
     // The SLO is 99.5% of the time it finishes in under 7 minutes.

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
@@ -82,7 +82,7 @@ public class CreateGcpContextFlightV2 extends Flight {
     addStep(new CreatePetSaStep(appContext.getSamService(), userRequest), shortRetry);
 
     // Wait for the project permissions to propagate.
-    // The SLA is 99.5% of the time it finishes in under 7 minutes.
+    // The SLO is 99.5% of the time it finishes in under 7 minutes.
     addStep(new WaitForProjectPermissionsStep(userRequest));
 
     // Store the cloud context data and unlock the database row

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
@@ -81,6 +81,10 @@ public class CreateGcpContextFlightV2 extends Flight {
     addStep(new GcpCloudSyncStep(crl.getCloudResourceManagerCow()), bufferRetry);
     addStep(new CreatePetSaStep(appContext.getSamService(), userRequest), shortRetry);
 
+    // Wait for the project permissions to propagate.
+    // The SLA is 99.5% of the time it finishes in under 7 minutes.
+    addStep(new WaitForProjectPermissionsStep(userRequest));
+
     // Store the cloud context data and unlock the database row
     // This must be the last step, since it clears the lock. So this step also
     // sets the flight response.

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
@@ -62,7 +62,7 @@ public class WaitForProjectPermissionsStep implements Step {
     try {
       RetryUtils.getWithRetryOnException(
           () -> testIam(storage),
-          Duration.ofMinutes(75), /* total allowed duration */
+          Duration.ofMinutes(30), /* total allowed duration */
           RetryUtils.DEFAULT_RETRY_SLEEP_DURATION,
           0.5, /* increase wait by half again as much */
           RetryUtils.DEFAULT_RETRY_SLEEP_DURATION_MAX,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
@@ -62,7 +62,7 @@ public class WaitForProjectPermissionsStep implements Step {
     try {
       RetryUtils.getWithRetryOnException(
           () -> testIam(storage),
-          Duration.ofMinutes(30), /* total allowed duration */
+          Duration.ofMinutes(15), /* total allowed duration */
           RetryUtils.DEFAULT_RETRY_SLEEP_DURATION,
           0.5, /* increase wait by half again as much */
           RetryUtils.DEFAULT_RETRY_SLEEP_DURATION_MAX,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
@@ -60,8 +60,10 @@ public class WaitForProjectPermissionsStep implements Step {
 
     try {
       RetryUtils.getWithRetryOnException(() -> testIam(storage),
-        Duration.ofMinutes(20), /* total duration */
-        RetryUtils.DEFAULT_SLEEP_DURATION,
+        Duration.ofMinutes(15), /* total allowed duration */
+        RetryUtils.DEFAULT_RETRY_SLEEP_DURATION,
+        0.5, /* increase wait by half again as much */
+        RetryUtils.DEFAULT_RETRY_SLEEP_DURATION_MAX,
         null /* all exceptions are retried */);
     } catch (Exception e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
@@ -62,7 +62,7 @@ public class WaitForProjectPermissionsStep implements Step {
     try {
       RetryUtils.getWithRetryOnException(
           () -> testIam(storage),
-          Duration.ofMinutes(15), /* total allowed duration */
+          Duration.ofMinutes(75), /* total allowed duration */
           RetryUtils.DEFAULT_RETRY_SLEEP_DURATION,
           0.5, /* increase wait by half again as much */
           RetryUtils.DEFAULT_RETRY_SLEEP_DURATION_MAX,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
@@ -62,7 +62,7 @@ public class WaitForProjectPermissionsStep implements Step {
     try {
       RetryUtils.getWithRetryOnException(
           () -> testIam(storage),
-          Duration.ofMinutes(15), /* total allowed duration */
+          RetryUtils.DEFAULT_RETRY_TOTAL_DURATION,
           RetryUtils.DEFAULT_RETRY_SLEEP_DURATION,
           0.5, /* increase wait by half again as much */
           RetryUtils.DEFAULT_RETRY_SLEEP_DURATION_MAX,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
@@ -1,0 +1,77 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.GCP_PROJECT_ID;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.GcpUtils;
+import bio.terra.workspace.common.utils.RetryUtils;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+
+/** Do not complete the cloud context creation until the project permissions have propagated. */
+public class WaitForProjectPermissionsStep implements Step {
+  private final Logger logger = LoggerFactory.getLogger(WaitForProjectPermissionsStep.class);
+  private final AuthenticatedUserRequest userRequest;
+
+  public WaitForProjectPermissionsStep(AuthenticatedUserRequest userRequest) {
+    this.userRequest = userRequest;
+  }
+
+  /**
+   * CRL doesn't support list-bucket. For now we call GCP directly.
+   *
+   * @param userRequest user creating the cloud contxt
+   * @param gcpProjectId project that got created
+   * @return GCS Storage object
+   */
+  private Storage getStorage(AuthenticatedUserRequest userRequest, String gcpProjectId) {
+    StorageOptions.Builder optionsBuilder = StorageOptions.newBuilder();
+    optionsBuilder.setCredentials(GcpUtils.getGoogleCredentialsFromUserRequest(userRequest));
+    optionsBuilder.setProjectId(gcpProjectId);
+    return optionsBuilder.build().getService();
+  }
+
+  /**
+   * Method to be used for testing that project permissions have propagated. We are assuming that if
+   * one permission is working, they all have been sync'd. As far as we know, that is the case.
+   *
+   * @param storage the storage object we are trying to list
+   * @return useless boolean to match the function signature
+   */
+  private Boolean testIam(Storage storage) {
+    storage.list();
+    return true;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    String gcpProjectId = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
+    Storage storage = getStorage(userRequest, gcpProjectId);
+
+    try {
+      RetryUtils.getWithRetryOnException(() -> testIam(storage),
+        Duration.ofMinutes(20), /* total duration */
+        RetryUtils.DEFAULT_SLEEP_DURATION,
+        null /* all exceptions are retried */);
+    } catch (Exception e) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  /** This is a read-only step, so nothing to undo */
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -135,11 +135,11 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
    */
   @AfterEach
   public void resetFlightDebugInfo() {
+    jobService.setFlightDebugInfoForTest(null);
     StairwayTestUtils.enumerateJobsDump(
         jobService, workspaceId, userAccessUtils.defaultUserAuthRequest());
     StairwayTestUtils.enumerateJobsDump(
         jobService, workspaceId2, userAccessUtils.defaultUserAuthRequest());
-    jobService.setFlightDebugInfoForTest(null);
   }
 
   @AfterAll

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
@@ -151,11 +151,11 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
    */
   @AfterEach
   public void resetFlightDebugInfo() {
+    jobService.setFlightDebugInfoForTest(null);
     StairwayTestUtils.enumerateJobsDump(
         jobService, workspaceId, userAccessUtils.defaultUserAuthRequest());
     StairwayTestUtils.enumerateJobsDump(
         jobService, workspaceId2, userAccessUtils.defaultUserAuthRequest());
-    jobService.setFlightDebugInfoForTest(null);
   }
 
   @AfterAll

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -57,6 +58,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * <p>Use this instead of WorkspaceApiControllerTest, if you want to use real
  * bio.terra.workspace.service.iam.SamService.
  */
+
 @TestInstance(Lifecycle.PER_CLASS)
 public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
@@ -215,6 +217,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     assertStrippedWorkspace(gotWorkspace);
   }
 
+  @Disabled("Assert by list size is not reliable if other tests have failed")
+  // TODO: PF-2413 Assert by list size is not reliable if other tests have failed
   @Test
   public void listWorkspaces_requesterIsOwner_returnsFullWorkspace() throws Exception {
     List<ApiWorkspaceDescription> listedWorkspaces =
@@ -228,6 +232,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     assertFullWorkspace(listedWorkspaces.get(0));
   }
 
+  @Disabled("Assert by list size is not reliable if other tests have failed")
+  // TODO: PF-2413 Assert by list size is not reliable if other tests have failed
   @Test
   public void listWorkspaces_requesterIsDiscoverer_requestMinHighestRoleNotSet_returnsNoWorkspaces()
       throws Exception {
@@ -242,6 +248,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     assertTrue(listedWorkspaces.isEmpty());
   }
 
+  @Disabled("Assert by list size is not reliable if other tests have failed")
+  // TODO: PF-2413 Assert by list size is not reliable if other tests have failed
   @Test
   public void
       listWorkspaces_requesterIsDiscoverer_requestMinHighestRoleSetToReader_returnsNoWorkspaces()

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -58,7 +58,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * <p>Use this instead of WorkspaceApiControllerTest, if you want to use real
  * bio.terra.workspace.service.iam.SamService.
  */
-
 @TestInstance(Lifecycle.PER_CLASS)
 public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 

--- a/service/src/test/java/bio/terra/workspace/common/GcpCloudUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/GcpCloudUtils.java
@@ -42,7 +42,6 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 /** Utils for working with cloud objects. */
@@ -131,7 +130,7 @@ public class GcpCloudUtils {
 
     // Create a blob with retry to allow permission propagation
     RetryUtils.getWithRetryOnException(
-      () -> storageClient.create(blobInfo, GCS_FILE_CONTENTS.getBytes(StandardCharsets.UTF_8)));
+        () -> storageClient.create(blobInfo, GCS_FILE_CONTENTS.getBytes(StandardCharsets.UTF_8)));
   }
 
   /** Asserts bucket has file as per addFileToBucket(). */

--- a/service/src/test/java/bio/terra/workspace/common/GcpCloudUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/GcpCloudUtils.java
@@ -119,8 +119,8 @@ public class GcpCloudUtils {
       AuthenticatedUserRequest userRequest, String projectId, String datasetId) throws Exception {
     BigQueryCow bigQueryCow = crlService.createBigQueryCow(userRequest);
     List<com.google.api.services.bigquery.model.TableList.Tables> actualTables =
-      RetryUtils.getWithRetryOnException(() ->
-        bigQueryCow.tables().list(projectId, datasetId).execute().getTables());
+        RetryUtils.getWithRetryOnException(
+            () -> bigQueryCow.tables().list(projectId, datasetId).execute().getTables());
     assertNull(actualTables);
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/StairwayTestUtils.java
@@ -18,12 +18,11 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.model.EnumeratedJob;
 import bio.terra.workspace.service.job.model.EnumeratedJobs;
 import bio.terra.workspace.service.resource.model.WsmResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Test utilities for working with Stairway. */
 public class StairwayTestUtils {

--- a/service/src/test/java/bio/terra/workspace/common/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/StairwayTestUtils.java
@@ -43,9 +43,10 @@ public class StairwayTestUtils {
       throws DatabaseOperationException, StairwayExecutionException, InterruptedException,
           DuplicateFlightIdException {
     String flightId = stairway.createFlightId();
-    // TODO(dd): Remove this before merge
+    // TODO(PF-1408): Remove/adjust this when all fixes are in
     // ^^^^^^^^^^^^^^^
-    // To see whether GCP propagation ever completes, force this timeout very high.
+    // Allow for GCP propagation to complete. In the second part of the PF-1408 work, we can decide
+    // the appropriate timeout for those cases and restore timeout control to the tests.
     logger.warn("--> Overriding poll timeout for GCP permission propagation diagnosis <--");
     timeout = Duration.ofMinutes(75);
     // ^^^^^^^^^^^^^^^

--- a/service/src/test/java/bio/terra/workspace/common/StairwayTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/StairwayTestUtils.java
@@ -18,12 +18,17 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.model.EnumeratedJob;
 import bio.terra.workspace.service.job.model.EnumeratedJobs;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
 
 /** Test utilities for working with Stairway. */
 public class StairwayTestUtils {
+  private static final Logger logger = LoggerFactory.getLogger(StairwayTestUtils.class);
+
   private StairwayTestUtils() {}
 
   /**
@@ -39,6 +44,13 @@ public class StairwayTestUtils {
       throws DatabaseOperationException, StairwayExecutionException, InterruptedException,
           DuplicateFlightIdException {
     String flightId = stairway.createFlightId();
+    // TODO(dd): Remove this before merge
+    // ^^^^^^^^^^^^^^^
+    // To see whether GCP propagation ever completes, force this timeout very high.
+    logger.warn("--> Overriding poll timeout for GCP permission propagation diagnosis <--");
+    timeout = Duration.ofMinutes(75);
+    // ^^^^^^^^^^^^^^^
+
     stairway.submitWithDebugInfo(
         flightId, flightClass, inputParameters, /* shouldQueue= */ false, debugInfo);
     return pollUntilComplete(flightId, stairway, timeout.dividedBy(20), timeout);

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -187,9 +187,9 @@ public class MockMvcUtils {
   public static final String CREATE_CLOUD_CONTEXT_PATH_FORMAT =
       "/api/workspaces/v1/%s/cloudcontexts";
   public static final String DELETE_GCP_CLOUD_CONTEXT_PATH_FORMAT =
-    "/api/workspaces/v1/%s/cloudcontexts/gcp";
+      "/api/workspaces/v1/%s/cloudcontexts/gcp";
   public static final String GET_CLOUD_CONTEXT_PATH_FORMAT =
-    "/api/workspaces/v1/%s/cloudcontexts/result/%s";
+      "/api/workspaces/v1/%s/cloudcontexts/result/%s";
   public static final String CREATE_AZURE_IP_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/ip";
   public static final String CREATE_AZURE_DISK_PATH_FORMAT =
@@ -442,11 +442,13 @@ public class MockMvcUtils {
     return objectMapper.readValue(serializedResponse, ApiCreateCloudContextResult.class);
   }
 
-  public void deleteGcpCloudContext(
-    AuthenticatedUserRequest userRequest, UUID workspaceId) throws Exception {
+  public void deleteGcpCloudContext(AuthenticatedUserRequest userRequest, UUID workspaceId)
+      throws Exception {
     mockMvc
-      .perform(addAuth(delete(DELETE_GCP_CLOUD_CONTEXT_PATH_FORMAT.formatted(workspaceId)), userRequest))
-      .andExpect(status().isNoContent());
+        .perform(
+            addAuth(
+                delete(DELETE_GCP_CLOUD_CONTEXT_PATH_FORMAT.formatted(workspaceId)), userRequest))
+        .andExpect(status().isNoContent());
   }
 
   public ApiCloneWorkspaceResult getCloneWorkspaceResult(

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -148,6 +148,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 /**
@@ -532,6 +533,19 @@ public class MockMvcUtils {
             addAuth(
                 get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceId)), userRequest))
         .andExpect(status().is(HttpStatus.SC_NOT_FOUND));
+  }
+
+  // Delete Workspace variant when we don't know if workspaceId exists.
+  public int deleteWorkspaceNoCheck(AuthenticatedUserRequest userRequest, UUID workspaceId)
+      throws Exception {
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                addAuth(
+                    delete(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, workspaceId)),
+                    userRequest))
+            .andReturn();
+    return mvcResult.getResponse().getStatus();
   }
 
   public ApiWsmPolicyUpdateResult updatePolicies(

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -186,8 +186,10 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/referenced/datarepo/snapshots";
   public static final String CREATE_CLOUD_CONTEXT_PATH_FORMAT =
       "/api/workspaces/v1/%s/cloudcontexts";
+  public static final String DELETE_GCP_CLOUD_CONTEXT_PATH_FORMAT =
+    "/api/workspaces/v1/%s/cloudcontexts/gcp";
   public static final String GET_CLOUD_CONTEXT_PATH_FORMAT =
-      "/api/workspaces/v1/%s/cloudcontexts/result/%s";
+    "/api/workspaces/v1/%s/cloudcontexts/result/%s";
   public static final String CREATE_AZURE_IP_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/ip";
   public static final String CREATE_AZURE_DISK_PATH_FORMAT =
@@ -438,6 +440,13 @@ public class MockMvcUtils {
         getSerializedResponseForGetJobResult(
             userRequest, GET_CLOUD_CONTEXT_PATH_FORMAT, workspaceId, jobId);
     return objectMapper.readValue(serializedResponse, ApiCreateCloudContextResult.class);
+  }
+
+  public void deleteGcpCloudContext(
+    AuthenticatedUserRequest userRequest, UUID workspaceId) throws Exception {
+    mockMvc
+      .perform(addAuth(delete(DELETE_GCP_CLOUD_CONTEXT_PATH_FORMAT.formatted(workspaceId)), userRequest))
+      .andExpect(status().isNoContent());
   }
 
   public ApiCloneWorkspaceResult getCloneWorkspaceResult(

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -188,7 +188,7 @@ public class MockMvcUtils {
   public static final String CREATE_CLOUD_CONTEXT_PATH_FORMAT =
       "/api/workspaces/v1/%s/cloudcontexts";
   public static final String DELETE_GCP_CLOUD_CONTEXT_PATH_FORMAT =
-      "/api/workspaces/v1/%s/cloudcontexts/gcp";
+      "/api/workspaces/v1/%s/cloudcontexts/GCP";
   public static final String GET_CLOUD_CONTEXT_PATH_FORMAT =
       "/api/workspaces/v1/%s/cloudcontexts/result/%s";
   public static final String CREATE_AZURE_IP_PATH_FORMAT =

--- a/service/src/test/java/bio/terra/workspace/connected/UserAccessUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/UserAccessUtils.java
@@ -41,6 +41,12 @@ public class UserAccessUtils {
   @Value("${workspace.connected-test.billing-user-email}")
   private String billingUserEmail;
 
+  /**
+   * Email of user with no access to the billing profile
+   */
+  @Value("${workspace.connected-test.no-billing-access-user-email}")
+  private String noBillingAccessUserEmail;
+
   /** Creates Google credentials for the user. Relies on domain delegation. */
   public GoogleCredentials generateCredentials(String userEmail) {
     try {
@@ -80,6 +86,11 @@ public class UserAccessUtils {
     return generateAccessToken(billingUserEmail);
   }
 
+  /** Generates an OAuth access token for the billing test user. */
+  public AccessToken noBillingAccessUserAccessToken() {
+    return generateAccessToken(noBillingAccessUserEmail);
+  }
+
   /** Expose the default test user email. */
   public String getDefaultUserEmail() {
     return defaultUserEmail;
@@ -93,6 +104,11 @@ public class UserAccessUtils {
   /** Expose the billing test user email. */
   public String getBillingUserEmail() {
     return billingUserEmail;
+  }
+
+  /** Expose the no-billing-access test user email */
+  public String getNoBillingAccessUserEmail() {
+    return noBillingAccessUserEmail;
   }
 
   /** Provides an AuthenticatedUserRequest using the default user's email and access token. */
@@ -113,6 +129,12 @@ public class UserAccessUtils {
     return new AuthenticatedUserRequest()
         .email(getBillingUserEmail())
         .token(Optional.of(billingUserAccessToken().getTokenValue()));
+  }
+
+  public AuthenticatedUserRequest noBillingAccessUserAuthRequest() {
+    return new AuthenticatedUserRequest()
+      .email(getNoBillingAccessUserEmail())
+      .token(Optional.of(noBillingAccessUserAccessToken().getTokenValue()));
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/connected/UserAccessUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/UserAccessUtils.java
@@ -41,9 +41,7 @@ public class UserAccessUtils {
   @Value("${workspace.connected-test.billing-user-email}")
   private String billingUserEmail;
 
-  /**
-   * Email of user with no access to the billing profile
-   */
+  /** Email of user with no access to the billing profile */
   @Value("${workspace.connected-test.no-billing-access-user-email}")
   private String noBillingAccessUserEmail;
 
@@ -133,8 +131,8 @@ public class UserAccessUtils {
 
   public AuthenticatedUserRequest noBillingAccessUserAuthRequest() {
     return new AuthenticatedUserRequest()
-      .email(getNoBillingAccessUserEmail())
-      .token(Optional.of(noBillingAccessUserAccessToken().getTokenValue()));
+        .email(getNoBillingAccessUserEmail())
+        .token(Optional.of(noBillingAccessUserAccessToken().getTokenValue()));
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -10,9 +10,8 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import java.util.UUID;
-
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/connected/WorkspaceConnectedTestUtils.java
@@ -1,14 +1,18 @@
 package bio.terra.workspace.connected;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import java.util.UUID;
+
+import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +22,7 @@ public class WorkspaceConnectedTestUtils {
   private @Autowired WorkspaceService workspaceService;
   private @Autowired JobService jobService;
   private @Autowired SpendConnectedTestUtils spendUtils;
+  private @Autowired CrlService crlService;
 
   /**
    * Creates a workspace with a GCP cloud context.
@@ -49,5 +54,23 @@ public class WorkspaceConnectedTestUtils {
 
   public void deleteWorkspaceAndGcpContext(AuthenticatedUserRequest userRequest, UUID workspaceId) {
     workspaceService.deleteWorkspace(workspaceService.getWorkspace(workspaceId), userRequest);
+  }
+
+  public void assertProjectIsBeingDeleted(String projectId) throws Exception {
+    assertProjectState(projectId, "DELETE_REQUESTED");
+  }
+
+  public void assertProjectIsActive(String projectId) throws Exception {
+    assertProjectState(projectId, "ACTIVE");
+  }
+
+  public void assertProjectExist(String projectId) throws Exception {
+    // Verify project exists by retrieving it - will throw if non-existent
+    crlService.getCloudResourceManagerCow().projects().get(projectId).execute();
+  }
+
+  private void assertProjectState(String projectId, String state) throws Exception {
+    Project project = crlService.getCloudResourceManagerCow().projects().get(projectId).execute();
+    assertEquals(state, project.getState());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -199,8 +199,8 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
    */
   @AfterEach
   public void resetFlightDebugInfo() {
-    StairwayTestUtils.enumerateJobsDump(jobService, workspaceId, user.getAuthenticatedRequest());
     jobService.setFlightDebugInfoForTest(null);
+    StairwayTestUtils.enumerateJobsDump(jobService, workspaceId, user.getAuthenticatedRequest());
   }
 
   /** After running all tests, delete the shared workspace. */

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -19,6 +19,7 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.db.FolderDao;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceActivityLogDao;
@@ -30,7 +31,6 @@ import bio.terra.workspace.generated.model.ApiGcpGcsBucketDefaultStorageClass;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiResourceCloneDetails;
 import bio.terra.workspace.generated.model.ApiResourceType;
-import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.datarepo.DataRepoService;
 import bio.terra.workspace.service.folder.model.Folder;
 import bio.terra.workspace.service.iam.SamService;
@@ -72,9 +72,9 @@ import org.springframework.test.web.servlet.MockMvc;
 // Use application configuration profile in addition to the standard connected test profile
 // inherited from the base class.
 @ActiveProfiles({"app-test"})
-class GcpCloundContextConnectedTest extends BaseConnectedTest {
+class GcpCloudContextConnectedTest extends BaseConnectedTest {
   public static final String SPEND_PROFILE_ID = "wm-default-spend-profile";
-  private static final Logger logger = LoggerFactory.getLogger(GcpCloundContextConnectedTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(GcpCloudContextConnectedTest.class);
   // Name of the test WSM application. This must match the identifier in the
   // application-app-test.yml file.
   private static final String TEST_WSM_APP = "TestWsmApp";
@@ -85,7 +85,6 @@ class GcpCloundContextConnectedTest extends BaseConnectedTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private ControlledResourceService controlledResourceService;
-  @Autowired private CrlService crl;
   @Autowired private FolderDao folderDao;
   @Autowired private GcpCloudContextService gcpCloudContextService;
   @Autowired private JobService jobService;
@@ -99,6 +98,7 @@ class GcpCloundContextConnectedTest extends BaseConnectedTest {
   @Autowired private WorkspaceService workspaceService;
   @Autowired private WorkspaceActivityLogDao workspaceActivityLogDao;
   @Autowired private WsmApplicationService appService;
+  @Autowired private WorkspaceConnectedTestUtils workspaceConnectedTestUtils;
 
   private UUID workspaceId;
   private UUID workspaceId2;
@@ -138,15 +138,14 @@ class GcpCloundContextConnectedTest extends BaseConnectedTest {
     // Reach in and find the project id
     String projectId = gcpCloudContextService.getRequiredGcpProject(workspaceId);
 
-    // Verify project exists by retrieving it.
-    crl.getCloudResourceManagerCow().projects().get(projectId).execute();
+    // Verify project exists
+    workspaceConnectedTestUtils.assertProjectExist(projectId);
 
     mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     workspaceId = null;
 
     // Check that project is now being deleted.
-    Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
-    assertEquals("DELETE_REQUESTED", project.getState());
+    workspaceConnectedTestUtils.assertProjectIsBeingDeleted(projectId);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -65,6 +65,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -123,10 +124,20 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
     jobService.setFlightDebugInfoForTest(null);
     try {
       if (workspaceId != null) {
-        mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+        int status =
+            mockMvcUtils.deleteWorkspaceNoCheck(
+                userAccessUtils.defaultUserAuthRequest(), workspaceId);
+        assertTrue(
+            status == HttpStatus.NO_CONTENT.value() || status == HttpStatus.NOT_FOUND.value());
+        workspaceId = null;
       }
       if (workspaceId2 != null) {
-        mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        int status =
+            mockMvcUtils.deleteWorkspaceNoCheck(
+                userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        assertTrue(
+            status == HttpStatus.NO_CONTENT.value() || status == HttpStatus.NOT_FOUND.value());
+        workspaceId2 = null;
       }
     } catch (Exception ex) {
       logger.warn("Failed to delete workspaces after test");

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -54,7 +54,6 @@ import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -105,6 +104,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
 
   @BeforeEach
   void setup() throws Exception {
+    jobService.setFlightDebugInfoForTest(null);
     doReturn(true).when(mockDataRepoService).snapshotReadable(any(), any(), any());
     workspaceId =
         mockMvcUtils
@@ -118,6 +118,9 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
    */
   @AfterEach
   public void resetFlightDebugInfo() {
+    // Reset the debug info before trying to delete. Otherwise, the delete flight can have
+    // unexpected retry failures.
+    jobService.setFlightDebugInfoForTest(null);
     try {
       if (workspaceId != null) {
         mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
@@ -128,8 +131,6 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
     } catch (Exception ex) {
       logger.warn("Failed to delete workspaces after test");
     }
-
-    jobService.setFlightDebugInfoForTest(null);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloundContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloundContextConnectedTest.java
@@ -1,0 +1,355 @@
+package bio.terra.workspace.service.workspace;
+
+import bio.terra.stairway.FlightDebugInfo;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.common.BaseConnectedTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
+import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.db.FolderDao;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.db.WorkspaceActivityLogDao;
+import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
+import bio.terra.workspace.generated.model.ApiCloneResourceResult;
+import bio.terra.workspace.generated.model.ApiClonedWorkspace;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketDefaultStorageClass;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
+import bio.terra.workspace.generated.model.ApiResourceCloneDetails;
+import bio.terra.workspace.generated.model.ApiResourceType;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.datarepo.DataRepoService;
+import bio.terra.workspace.service.folder.model.Folder;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.job.JobService.JobResultOrException;
+import bio.terra.workspace.service.job.exception.InvalidResultStateException;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
+import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.AwaitCloneAllResourcesFlightStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.AwaitCreateCloudContextFlightStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.CloneAllFoldersStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.FindResourcesToCloneStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.LaunchCloneAllResourcesFlightStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.LaunchCreateCloudContextFlightStep;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
+import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
+import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import bio.terra.workspace.service.workspace.model.WorkspaceStage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.services.cloudresourcemanager.v3.model.Project;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.defaultWorkspaceBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+// Use application configuration profile in addition to the standard connected test profile
+// inherited from the base class.
+@ActiveProfiles({"app-test"})
+class GcpCloundContextConnectedTest extends BaseConnectedTest {
+  public static final String SPEND_PROFILE_ID = "wm-default-spend-profile";
+  private static final Logger logger = LoggerFactory.getLogger(GcpCloundContextConnectedTest.class);
+  // Name of the test WSM application. This must match the identifier in the
+  // application-app-test.yml file.
+  private static final String TEST_WSM_APP = "TestWsmApp";
+  private static final String FOLDER_NAME = "FolderName";
+  private static final UUID FOLDER_ID = UUID.randomUUID();
+
+  @MockBean private DataRepoService mockDataRepoService;
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ControlledResourceService controlledResourceService;
+  @Autowired private CrlService crl;
+  @Autowired private FolderDao folderDao;
+  @Autowired private GcpCloudContextService gcpCloudContextService;
+  @Autowired private JobService jobService;
+  @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private ReferencedResourceService referenceResourceService;
+  @Autowired private ResourceDao resourceDao;
+  @Autowired private SamService samService;
+  @Autowired private SpendConnectedTestUtils spendUtils;
+  @Autowired private UserAccessUtils userAccessUtils;
+  @Autowired private WorkspaceService workspaceService;
+  @Autowired private WorkspaceActivityLogDao workspaceActivityLogDao;
+  @Autowired private WsmApplicationService appService;
+
+  private UUID workspaceId;
+  private UUID workspaceId2;
+
+  @BeforeEach
+  void setup() throws Exception {
+    doReturn(true).when(mockDataRepoService).snapshotReadable(any(), any(), any());
+    workspaceId =
+        mockMvcUtils
+            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .getId();
+    workspaceId2 = null;
+  }
+
+  /**
+   * Reset the {@link FlightDebugInfo} on the {@link JobService} to not interfere with other tests.
+   */
+  @AfterEach
+  public void resetFlightDebugInfo() {
+    try {
+      if (workspaceId != null) {
+        mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+      }
+      if (workspaceId2 != null) {
+        mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+      }
+    } catch (Exception ex) {
+      logger.warn("Failed to delete workspaces after test");
+    }
+
+    jobService.setFlightDebugInfoForTest(null);
+  }
+
+  @Test
+  @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
+  void deleteWorkspaceWithGoogleContext() throws Exception {
+    // Reach in and find the project id
+    String projectId = gcpCloudContextService.getRequiredGcpProject(workspaceId);
+
+    // Verify project exists by retrieving it.
+    crl.getCloudResourceManagerCow().projects().get(projectId).execute();
+
+    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    workspaceId = null;
+
+    // Check that project is now being deleted.
+    Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
+    assertEquals("DELETE_REQUESTED", project.getState());
+  }
+
+  @Test
+  @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
+  void createGetDeleteGoogleContext() throws Exception {
+    assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceId).isPresent());
+    mockMvcUtils.deleteGcpCloudContext(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceId).isEmpty());
+  }
+
+  @Test
+  public void cloneGcpWorkspace() throws Exception {
+    // Add a bucket resource
+    String bucketName = "terra-test-" + UUID.randomUUID().toString().toLowerCase();
+    ApiGcpGcsBucketResource bucketResource =
+        mockMvcUtils
+            .createControlledGcsBucket(
+                userAccessUtils.defaultUserAuthRequest(),
+                workspaceId,
+                "bucket_1", /* resource name */
+                bucketName,
+                "us-west4",
+                ApiGcpGcsBucketDefaultStorageClass.STANDARD,
+                null) /* lifecycle */
+            .getGcpBucket();
+
+    // Enable an application
+    Workspace sourceWorkspace = workspaceService.getWorkspace(workspaceId);
+    appService.enableWorkspaceApplication(
+        userAccessUtils.defaultUserAuthRequest(), sourceWorkspace, TEST_WSM_APP);
+
+    // Create a folder
+    Folder sourceFolder =
+        new Folder(
+            FOLDER_ID,
+            workspaceId,
+            FOLDER_NAME,
+            /*description=*/ null,
+            /*parentFolderId=*/ null,
+            /*properties=*/ Map.of(),
+            "foo@gmail.com",
+            null);
+    folderDao.createFolder(sourceFolder);
+
+    workspaceId2 = UUID.randomUUID();
+    Workspace destinationWorkspace =
+        defaultWorkspaceBuilder(workspaceId2)
+            .userFacingId("dest-user-facing-id")
+            .displayName("Destination Workspace")
+            .description("Copied from source")
+            .spendProfileId(new SpendProfileId(SPEND_PROFILE_ID))
+            .build();
+
+    final String destinationLocation = "us-east1";
+    final String cloneJobId =
+        workspaceService.cloneWorkspace(
+            sourceWorkspace,
+            userAccessUtils.defaultUserAuthRequest(),
+            destinationLocation,
+            destinationWorkspace,
+            null);
+    jobService.waitForJob(cloneJobId);
+    final JobResultOrException<ApiClonedWorkspace> cloneResultOrException =
+        jobService.retrieveJobResult(cloneJobId, ApiClonedWorkspace.class);
+    assertNull(cloneResultOrException.getException());
+    final ApiClonedWorkspace cloneResult = cloneResultOrException.getResult();
+    assertEquals(destinationWorkspace.getWorkspaceId(), cloneResult.getDestinationWorkspaceId());
+    assertThat(cloneResult.getResources(), hasSize(1));
+
+    final ApiResourceCloneDetails bucketCloneDetails = cloneResult.getResources().get(0);
+    assertEquals(ApiCloneResourceResult.SUCCEEDED, bucketCloneDetails.getResult());
+    assertNull(bucketCloneDetails.getErrorMessage());
+    assertEquals(ApiResourceType.GCS_BUCKET, bucketCloneDetails.getResourceType());
+    assertEquals(
+        bucketResource.getMetadata().getResourceId(), bucketCloneDetails.getSourceResourceId());
+
+    // destination WS should exist
+    final Workspace retrievedDestinationWorkspace =
+        workspaceService.getWorkspace(destinationWorkspace.getWorkspaceId());
+    assertEquals(
+        "Destination Workspace", retrievedDestinationWorkspace.getDisplayName().orElseThrow());
+    assertEquals(
+        "Copied from source", retrievedDestinationWorkspace.getDescription().orElseThrow());
+    assertEquals(WorkspaceStage.MC_WORKSPACE, retrievedDestinationWorkspace.getWorkspaceStage());
+
+    // Destination Workspace should have a GCP context
+    assertNotNull(
+        gcpCloudContextService
+            .getGcpCloudContext(destinationWorkspace.getWorkspaceId())
+            .orElseThrow());
+
+    // Destination workspace should have an enabled application
+    assertTrue(appService.getWorkspaceApplication(destinationWorkspace, TEST_WSM_APP).isEnabled());
+
+    // Destination workspace should have 1 cloned folder with the relations
+    assertThat(folderDao.listFoldersInWorkspace(destinationWorkspace.getWorkspaceId()), hasSize(1));
+    assertFalse(
+        folderDao
+            .listFoldersInWorkspace(destinationWorkspace.getWorkspaceId())
+            .contains(sourceFolder));
+  }
+
+  @Test
+  public void cloneGcpWorkspaceUndoSteps() {
+    Workspace sourceWorkspace = workspaceService.getWorkspace(workspaceId);
+    // Enable an application
+    appService.enableWorkspaceApplication(
+        userAccessUtils.defaultUserAuthRequest(), sourceWorkspace, TEST_WSM_APP);
+
+    // Create a folder
+    folderDao.createFolder(
+        new Folder(
+            FOLDER_ID,
+            workspaceId,
+            FOLDER_NAME,
+            /*description=*/ null,
+            /*parentFolderId=*/ null,
+            /*properties=*/ Map.of(),
+            "foo@gmail.com",
+            null));
+
+    // Create a referenced resource
+    ReferencedBigQueryDatasetResource datasetReference =
+        referenceResourceService
+            .createReferenceResource(
+                ReferenceResourceFixtures.makeReferencedBqDatasetResource(
+                    sourceWorkspace.getWorkspaceId(), "my-project", "fake_dataset"),
+                userAccessUtils.defaultUserAuthRequest())
+            .castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET);
+    ApiGcpBigQueryDatasetCreationParameters creationParameters =
+        new ApiGcpBigQueryDatasetCreationParameters()
+            .datasetId("my_awesome_dataset")
+            .location("us-central1");
+    ControlledBigQueryDatasetResource resource =
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(
+                sourceWorkspace.getWorkspaceId())
+            .datasetName("my_awesome_dataset")
+            .build();
+
+    // Create a controlled resource
+    ControlledBigQueryDatasetResource createdDataset =
+        controlledResourceService
+            .createControlledResourceSync(
+                resource, null, userAccessUtils.defaultUserAuthRequest(), creationParameters)
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
+
+    workspaceId2 = UUID.randomUUID();
+    Workspace destinationWorkspace =
+        defaultWorkspaceBuilder(workspaceId2)
+            .userFacingId("dest-user-facing-id")
+            .displayName("Destination Workspace")
+            .description("Copied from source")
+            .spendProfileId(new SpendProfileId(SPEND_PROFILE_ID))
+            .build();
+
+    final String destinationLocation = "us-east1";
+    // Retry undo steps once and fail at the end of the flight.
+    Map<String, StepStatus> retrySteps = new HashMap<>();
+    retrySteps.put(CloneAllFoldersStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    retrySteps.put(FindResourcesToCloneStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    retrySteps.put(
+        LaunchCreateCloudContextFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    retrySteps.put(
+        AwaitCreateCloudContextFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    retrySteps.put(
+        LaunchCloneAllResourcesFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    retrySteps.put(
+        AwaitCloneAllResourcesFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    FlightDebugInfo debugInfo =
+        FlightDebugInfo.newBuilder().undoStepFailures(retrySteps).lastStepFailure(true).build();
+    // TODO(PF-2259): This test is not actually testing the undo of CloneGcpWorkspaceFlight. It is
+    // testing the undo of WorkspaceCreateFlight.
+    jobService.setFlightDebugInfoForTest(debugInfo);
+
+    assertThrows(
+        InvalidResultStateException.class,
+        () ->
+            workspaceService.cloneWorkspace(
+                sourceWorkspace,
+                userAccessUtils.defaultUserAuthRequest(),
+                destinationLocation,
+                destinationWorkspace,
+                null));
+    assertThrows(
+        WorkspaceNotFoundException.class,
+        () -> workspaceService.getWorkspace(destinationWorkspace.getWorkspaceId()));
+
+    // Destination Workspace should not have a GCP context
+    assertTrue(
+        gcpCloudContextService.getGcpCloudContext(destinationWorkspace.getWorkspaceId()).isEmpty());
+
+    // Destination workspace should not have folder
+    assertTrue(folderDao.listFoldersInWorkspace(destinationWorkspace.getWorkspaceId()).isEmpty());
+    assertThrows(
+        ResourceNotFoundException.class,
+        () ->
+            resourceDao.getResource(
+                destinationWorkspace.getWorkspaceId(), createdDataset.getResourceId()));
+    assertThrows(
+        ResourceNotFoundException.class,
+        () ->
+            resourceDao.getResource(
+                destinationWorkspace.getWorkspaceId(), datasetReference.getResourceId()));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloundContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloundContextConnectedTest.java
@@ -1,5 +1,17 @@
 package bio.terra.workspace.service.workspace;
 
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.defaultWorkspaceBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.BaseConnectedTest;
@@ -43,6 +55,9 @@ import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,22 +68,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.defaultWorkspaceBuilder;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 
 // Use application configuration profile in addition to the standard connected test profile
 // inherited from the base class.

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -1,30 +1,5 @@
 package bio.terra.workspace.service.workspace;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.defaultWorkspaceBuilder;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UFID_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UUID_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
-import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import bio.terra.common.exception.ErrorReportException;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.MissingRequiredFieldException;
@@ -33,61 +8,28 @@ import bio.terra.common.sam.exception.SamInternalServerErrorException;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.BaseConnectedTest;
-import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
-import bio.terra.workspace.db.FolderDao;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
-import bio.terra.workspace.generated.model.ApiCloneResourceResult;
-import bio.terra.workspace.generated.model.ApiClonedWorkspace;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiCreateCloudContextRequest;
-import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketDefaultStorageClass;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycle;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycleRule;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycleRuleAction;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycleRuleActionType;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycleRuleCondition;
 import bio.terra.workspace.generated.model.ApiJobControl;
-import bio.terra.workspace.generated.model.ApiResourceCloneDetails;
-import bio.terra.workspace.generated.model.ApiResourceType;
-import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.datarepo.DataRepoService;
-import bio.terra.workspace.service.folder.model.Folder;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
+import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.SamConstants.SamResource;
 import bio.terra.workspace.service.iam.model.SamConstants.SamSpendProfileAction;
-import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.job.JobService.JobResultOrException;
 import bio.terra.workspace.service.job.exception.InvalidResultStateException;
-import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
-import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.AwaitCloneAllResourcesFlightStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.AwaitCreateCloudContextFlightStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.CloneAllFoldersStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.FindResourcesToCloneStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.LaunchCloneAllResourcesFlightStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.LaunchCreateCloudContextFlightStep;
-import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
-import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
-import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
-import bio.terra.workspace.service.resource.model.CloningInstructions;
-import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
 import bio.terra.workspace.service.resource.referenced.cloud.any.datareposnapshot.ReferencedDataRepoSnapshotResource;
-import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
-import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateUserFacingIdException;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateWorkspaceException;
@@ -98,8 +40,18 @@ import bio.terra.workspace.service.workspace.flight.CreateWorkspaceStep;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import com.google.common.collect.ImmutableList;
+import org.apache.http.HttpStatus;
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -107,47 +59,43 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.http.HttpStatus;
-import org.broadinstitute.dsde.workbench.client.sam.ApiException;
-import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
+
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.defaultWorkspaceBuilder;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UFID_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UUID_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 // Use application configuration profile in addition to the standard connected test profile
 // inherited from the base class.
 @ActiveProfiles({"app-test"})
 class WorkspaceServiceTest extends BaseConnectedTest {
-
-  public static final String SPEND_PROFILE_ID = "wm-default-spend-profile";
-  // Name of the test WSM application. This must match the identifier in the
-  // application-app-test.yml file.
-  private static final String TEST_WSM_APP = "TestWsmApp";
-  private static final String FOLDER_NAME = "FolderName";
-  private static final UUID FOLDER_ID = UUID.randomUUID();
-
   @MockBean private DataRepoService mockDataRepoService;
   /** Mock SamService does nothing for all calls that would throw if unauthorized. */
   @MockBean private SamService mockSamService;
 
   @Autowired private MockMvc mockMvc;
-  @Autowired private ControlledResourceService controlledResourceService;
-  @Autowired private CrlService crl;
-  @Autowired private GcpCloudContextService gcpCloudContextService;
   @Autowired private JobService jobService;
+  @Autowired private ObjectMapper objectMapper;
   @Autowired private ReferencedResourceService referenceResourceService;
   @Autowired private ResourceDao resourceDao;
-  @Autowired private SpendConnectedTestUtils spendUtils;
   @Autowired private WorkspaceService workspaceService;
-  @Autowired private ObjectMapper objectMapper;
   @Autowired private WorkspaceActivityLogDao workspaceActivityLogDao;
-  @Autowired private WsmApplicationService appService;
-  @Autowired private FolderDao folderDao;
 
   @BeforeEach
   void setup() throws Exception {
@@ -158,7 +106,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
             any(), eq(SamResource.SPEND_PROFILE), any(), eq(SamSpendProfileAction.LINK)))
         .thenReturn(true);
     final String policyGroup = "terra-workspace-manager-test-group@googlegroups.com";
-    // Return a valid google group for cloud sync, as Google validates groups added to GCP projects.
+    // Return a valid Google group for cloud sync, as Google validates groups added to GCP projects.
     when(mockSamService.syncWorkspacePolicy(any(), any(), any())).thenReturn(policyGroup);
 
     doReturn(policyGroup)
@@ -699,313 +647,32 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   }
 
   @Test
-  @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void deleteWorkspaceWithGoogleContext() throws Exception {
-    Workspace request =
-        defaultWorkspaceBuilder(null).spendProfileId(spendUtils.defaultSpendId()).build();
-    workspaceService.createWorkspace(request, null, null, USER_REQUEST);
-    String jobId = UUID.randomUUID().toString();
-    workspaceService.createGcpCloudContext(request, jobId, USER_REQUEST, "/fake/value");
-    jobService.waitForJob(jobId);
-    assertNull(jobService.retrieveJobResult(jobId, Object.class).getException());
-    Workspace workspace = workspaceService.getWorkspace(request.getWorkspaceId());
-    String projectId = gcpCloudContextService.getRequiredGcpProject(workspace.getWorkspaceId());
-
-    // Verify project exists by retrieving it.
-    crl.getCloudResourceManagerCow().projects().get(projectId).execute();
-
-    workspaceService.deleteWorkspace(request, USER_REQUEST);
-
-    // Check that project is now being deleted.
-    Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
-    assertEquals("DELETE_REQUESTED", project.getState());
-  }
-
-  @Test
-  @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void createGetDeleteGoogleContext() {
-    Workspace request =
-        defaultWorkspaceBuilder(null).spendProfileId(spendUtils.defaultSpendId()).build();
-    workspaceService.createWorkspace(request, null, null, USER_REQUEST);
-
-    String jobId = UUID.randomUUID().toString();
-    workspaceService.createGcpCloudContext(request, jobId, USER_REQUEST, "/fake/value");
-    jobService.waitForJob(jobId);
-    assertNull(jobService.retrieveJobResult(jobId, Object.class).getException());
-    assertTrue(gcpCloudContextService.getGcpCloudContext(request.getWorkspaceId()).isPresent());
-    workspaceService.deleteGcpCloudContext(request, USER_REQUEST);
-    assertTrue(gcpCloudContextService.getGcpCloudContext(request.getWorkspaceId()).isEmpty());
-  }
-
-  @Test
   void createGoogleContextRawlsStageThrows() throws Exception {
     // RAWLS_WORKSPACE stage workspaces use existing Sam resources instead of owning them, so the
     // mock pretends our user has access to any workspace we ask about.
     when(mockSamService.isAuthorized(
-            any(), eq(SamResource.WORKSPACE), any(), eq(SamWorkspaceAction.READ)))
-        .thenReturn(true);
+      any(), eq(SamResource.WORKSPACE), any(), eq(SamConstants.SamWorkspaceAction.READ)))
+      .thenReturn(true);
     UUID workspaceId = UUID.randomUUID();
     Workspace request =
-        defaultWorkspaceBuilder(workspaceId).workspaceStage(WorkspaceStage.RAWLS_WORKSPACE).build();
+      defaultWorkspaceBuilder(workspaceId).workspaceStage(WorkspaceStage.RAWLS_WORKSPACE).build();
     workspaceService.createWorkspace(request, null, null, USER_REQUEST);
     String jobId = UUID.randomUUID().toString();
     ApiCreateCloudContextRequest contextRequest =
-        new ApiCreateCloudContextRequest()
-            .cloudPlatform(ApiCloudPlatform.GCP)
-            .jobControl(new ApiJobControl().id(jobId));
+      new ApiCreateCloudContextRequest()
+        .cloudPlatform(ApiCloudPlatform.GCP)
+        .jobControl(new ApiJobControl().id(jobId));
     // Validation happens in the controller, so make this request through the mock MVC object rather
     // than calling the service directly.
     mockMvc
-        .perform(
-            addJsonContentType(
-                    addAuth(
-                        post(String.format(CREATE_CLOUD_CONTEXT_PATH_FORMAT, workspaceId)),
-                        USER_REQUEST))
-                .content(objectMapper.writeValueAsString(contextRequest)))
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+      .perform(
+        addJsonContentType(
+          addAuth(
+            post(String.format(CREATE_CLOUD_CONTEXT_PATH_FORMAT, workspaceId)),
+            USER_REQUEST))
+          .content(objectMapper.writeValueAsString(contextRequest)))
+      .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
   }
 
-  @Test
-  public void cloneGcpWorkspace() {
-    // Create a workspace
-    final Workspace sourceWorkspace =
-        defaultWorkspaceBuilder(null)
-            .userFacingId("source-user-facing-id")
-            .displayName("Source Workspace")
-            .description("The original workspace.")
-            .spendProfileId(new SpendProfileId(SPEND_PROFILE_ID))
-            .build();
-    final UUID sourceWorkspaceId =
-        workspaceService.createWorkspace(sourceWorkspace, null, null, USER_REQUEST);
 
-    // Create a cloud context
-    final String createCloudContextJobId = UUID.randomUUID().toString();
-    workspaceService.createGcpCloudContext(sourceWorkspace, createCloudContextJobId, USER_REQUEST);
-    jobService.waitForJob(createCloudContextJobId);
-    assertNull(jobService.retrieveJobResult(createCloudContextJobId, Object.class).getException());
-
-    // Add a bucket resource
-    final ControlledGcsBucketResource bucketResource =
-        ControlledGcsBucketResource.builder()
-            .bucketName("terra-test-" + UUID.randomUUID().toString().toLowerCase())
-            .common(
-                ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
-                    .name("bucket_1")
-                    .description("Just a plain bucket.")
-                    .cloningInstructions(CloningInstructions.COPY_RESOURCE)
-                    .resourceId(UUID.randomUUID())
-                    .workspaceUuid(sourceWorkspaceId)
-                    .managedBy(ManagedByType.MANAGED_BY_USER)
-                    .privateResourceState(PrivateResourceState.INITIALIZING)
-                    .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
-                    .applicationId(null)
-                    .iamRole(ControlledResourceIamRole.OWNER)
-                    .build())
-            .build();
-    final ApiGcpGcsBucketCreationParameters creationParameters =
-        new ApiGcpGcsBucketCreationParameters()
-            .name("foo")
-            .defaultStorageClass(ApiGcpGcsBucketDefaultStorageClass.NEARLINE)
-            .lifecycle(
-                new ApiGcpGcsBucketLifecycle()
-                    .addRulesItem(
-                        new ApiGcpGcsBucketLifecycleRule()
-                            .condition(new ApiGcpGcsBucketLifecycleRuleCondition().age(90))
-                            .action(
-                                new ApiGcpGcsBucketLifecycleRuleAction()
-                                    .type(ApiGcpGcsBucketLifecycleRuleActionType.SET_STORAGE_CLASS)
-                                    .storageClass(ApiGcpGcsBucketDefaultStorageClass.STANDARD))));
-
-    final ControlledResource createdResource =
-        controlledResourceService.createControlledResourceSync(
-            bucketResource, ControlledResourceIamRole.OWNER, USER_REQUEST, creationParameters);
-
-    // Enable an application
-    appService.enableWorkspaceApplication(USER_REQUEST, sourceWorkspace, TEST_WSM_APP);
-
-    // Create a folder
-    Folder sourceFolder =
-        new Folder(
-            FOLDER_ID,
-            sourceWorkspaceId,
-            FOLDER_NAME,
-            /*description=*/ null,
-            /*parentFolderId=*/ null,
-            /*properties=*/ Map.of(),
-            "foo@gmail.com",
-            null);
-    folderDao.createFolder(sourceFolder);
-
-    final ControlledGcsBucketResource createdBucketResource =
-        createdResource.castByEnum(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
-    final Workspace destinationWorkspace =
-        defaultWorkspaceBuilder(null)
-            .userFacingId("dest-user-facing-id")
-            .displayName("Destination Workspace")
-            .description("Copied from source")
-            .spendProfileId(new SpendProfileId(SPEND_PROFILE_ID))
-            .build();
-    final String destinationLocation = "us-east1";
-    final String cloneJobId =
-        workspaceService.cloneWorkspace(
-            sourceWorkspace, USER_REQUEST, destinationLocation, destinationWorkspace, null);
-    jobService.waitForJob(cloneJobId);
-    final JobResultOrException<ApiClonedWorkspace> cloneResultOrException =
-        jobService.retrieveJobResult(cloneJobId, ApiClonedWorkspace.class);
-    assertNull(cloneResultOrException.getException());
-    final ApiClonedWorkspace cloneResult = cloneResultOrException.getResult();
-    assertEquals(destinationWorkspace.getWorkspaceId(), cloneResult.getDestinationWorkspaceId());
-    assertThat(cloneResult.getResources(), hasSize(1));
-
-    final ApiResourceCloneDetails bucketCloneDetails = cloneResult.getResources().get(0);
-    assertEquals(ApiCloneResourceResult.SUCCEEDED, bucketCloneDetails.getResult());
-    assertNull(bucketCloneDetails.getErrorMessage());
-    assertEquals(ApiResourceType.GCS_BUCKET, bucketCloneDetails.getResourceType());
-    assertEquals(createdBucketResource.getResourceId(), bucketCloneDetails.getSourceResourceId());
-
-    // destination WS should exist
-    final Workspace retrievedDestinationWorkspace =
-        workspaceService.getWorkspace(destinationWorkspace.getWorkspaceId());
-    assertEquals(
-        "Destination Workspace", retrievedDestinationWorkspace.getDisplayName().orElseThrow());
-    assertEquals(
-        "Copied from source", retrievedDestinationWorkspace.getDescription().orElseThrow());
-    assertEquals(WorkspaceStage.MC_WORKSPACE, retrievedDestinationWorkspace.getWorkspaceStage());
-
-    // Destination Workspace should have a GCP context
-    assertNotNull(
-        gcpCloudContextService
-            .getGcpCloudContext(destinationWorkspace.getWorkspaceId())
-            .orElseThrow());
-
-    // Destination workspace should have an enabled application
-    assertTrue(appService.getWorkspaceApplication(destinationWorkspace, TEST_WSM_APP).isEnabled());
-
-    // Destination workspace should have 1 cloned folder with the relations
-    assertThat(folderDao.listFoldersInWorkspace(destinationWorkspace.getWorkspaceId()), hasSize(1));
-    assertFalse(
-        folderDao
-            .listFoldersInWorkspace(destinationWorkspace.getWorkspaceId())
-            .contains(sourceFolder));
-
-    // Clean up
-    workspaceService.deleteWorkspace(sourceWorkspace, USER_REQUEST);
-    workspaceService.deleteWorkspace(destinationWorkspace, USER_REQUEST);
-  }
-
-  @Test
-  public void cloneGcpWorkspaceUndoSteps() {
-    // Create a workspace
-    final Workspace sourceWorkspace =
-        defaultWorkspaceBuilder(null)
-            .userFacingId("source-user-facing-id")
-            .displayName("Source Workspace")
-            .description("The original workspace.")
-            .spendProfileId(new SpendProfileId(SPEND_PROFILE_ID))
-            .build();
-
-    workspaceService.createWorkspace(sourceWorkspace, null, null, USER_REQUEST);
-
-    // Create a cloud context
-    final String createCloudContextJobId = UUID.randomUUID().toString();
-    workspaceService.createGcpCloudContext(sourceWorkspace, createCloudContextJobId, USER_REQUEST);
-    jobService.waitForJob(createCloudContextJobId);
-    assertNull(jobService.retrieveJobResult(createCloudContextJobId, Object.class).getException());
-
-    // Enable an application
-    appService.enableWorkspaceApplication(USER_REQUEST, sourceWorkspace, TEST_WSM_APP);
-
-    // Create a folder
-    folderDao.createFolder(
-        new Folder(
-            FOLDER_ID,
-            sourceWorkspace.getWorkspaceId(),
-            FOLDER_NAME,
-            /*description=*/ null,
-            /*parentFolderId=*/ null,
-            /*properties=*/ Map.of(),
-            "foo@gmail.com",
-            null));
-
-    // Create a referenced resource
-    ReferencedBigQueryDatasetResource datasetReference =
-        referenceResourceService
-            .createReferenceResource(
-                ReferenceResourceFixtures.makeReferencedBqDatasetResource(
-                    sourceWorkspace.getWorkspaceId(), "my-project", "fake_dataset"),
-                USER_REQUEST)
-            .castByEnum(WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET);
-    ApiGcpBigQueryDatasetCreationParameters creationParameters =
-        new ApiGcpBigQueryDatasetCreationParameters()
-            .datasetId("my_awesome_dataset")
-            .location("us-central1");
-    ControlledBigQueryDatasetResource resource =
-        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(
-                sourceWorkspace.getWorkspaceId())
-            .datasetName("my_awesome_dataset")
-            .build();
-
-    // Create a controlled resource
-    ControlledBigQueryDatasetResource createdDataset =
-        controlledResourceService
-            .createControlledResourceSync(resource, null, USER_REQUEST, creationParameters)
-            .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
-
-    final Workspace destinationWorkspace =
-        defaultWorkspaceBuilder(null)
-            .userFacingId("dest-user-facing-id")
-            .displayName("Destination Workspace")
-            .description("Copied from source")
-            .spendProfileId(new SpendProfileId(SPEND_PROFILE_ID))
-            .build();
-    final String destinationLocation = "us-east1";
-    // Retry undo steps once and fail at the end of the flight.
-    Map<String, StepStatus> retrySteps = new HashMap<>();
-    retrySteps.put(CloneAllFoldersStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    retrySteps.put(FindResourcesToCloneStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    retrySteps.put(
-        LaunchCreateCloudContextFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    retrySteps.put(
-        AwaitCreateCloudContextFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    retrySteps.put(
-        LaunchCloneAllResourcesFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    retrySteps.put(
-        AwaitCloneAllResourcesFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    FlightDebugInfo debugInfo =
-        FlightDebugInfo.newBuilder().undoStepFailures(retrySteps).lastStepFailure(true).build();
-    // TODO(PF-2259): This test is not actually testing the undo of CloneGcpWorkspaceFlight. It is
-    // testing the undo of WorkspaceCreateFlight.
-    jobService.setFlightDebugInfoForTest(debugInfo);
-
-    assertThrows(
-        InvalidResultStateException.class,
-        () ->
-            workspaceService.cloneWorkspace(
-                sourceWorkspace, USER_REQUEST, destinationLocation, destinationWorkspace, null));
-    assertThrows(
-        WorkspaceNotFoundException.class,
-        () -> workspaceService.getWorkspace(destinationWorkspace.getWorkspaceId()));
-
-    // Destination Workspace should not have a GCP context
-    assertTrue(
-        gcpCloudContextService.getGcpCloudContext(destinationWorkspace.getWorkspaceId()).isEmpty());
-
-    // Destination workspace should not have folder
-    assertTrue(folderDao.listFoldersInWorkspace(destinationWorkspace.getWorkspaceId()).isEmpty());
-    assertThrows(
-        ResourceNotFoundException.class,
-        () ->
-            resourceDao.getResource(
-                destinationWorkspace.getWorkspaceId(), createdDataset.getResourceId()));
-    assertThrows(
-        ResourceNotFoundException.class,
-        () ->
-            resourceDao.getResource(
-                destinationWorkspace.getWorkspaceId(), datasetReference.getResourceId()));
-
-    // Remove the effect of lastStepFailure, and clean up the created workspace
-    jobService.setFlightDebugInfoForTest(null);
-    workspaceService.deleteWorkspace(sourceWorkspace, USER_REQUEST);
-    workspaceService.deleteWorkspace(destinationWorkspace, USER_REQUEST);
-  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
@@ -63,8 +63,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 class CreateGcpContextFlightV2Test extends BaseConnectedTest {
 
-  /** How long to wait for a Stairway flight to complete before timing out the test. */
-  private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(3);
+  /**
+   * How long to wait for a Stairway flight to complete before timing out the test.
+   * This is set to 20 minutes to allow tests to ride through service outages,
+   * cloud retries, and IAM propagation.
+   */
+  private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(20);
 
   @Autowired private WorkspaceService workspaceService;
   @Autowired private CrlService crl;

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
@@ -64,9 +64,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 class CreateGcpContextFlightV2Test extends BaseConnectedTest {
 
   /**
-   * How long to wait for a Stairway flight to complete before timing out the test.
-   * This is set to 20 minutes to allow tests to ride through service outages,
-   * cloud retries, and IAM propagation.
+   * How long to wait for a Stairway flight to complete before timing out the test. This is set to
+   * 20 minutes to allow tests to ride through service outages, cloud retries, and IAM propagation.
    */
   private static final Duration STAIRWAY_FLIGHT_TIMEOUT = Duration.ofMinutes(20);
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2Test.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.stairway.FlightMap;
@@ -21,8 +20,6 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
-import bio.terra.workspace.service.iam.model.SamConstants.SamResource;
-import bio.terra.workspace.service.iam.model.SamConstants.SamSpendProfileAction;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.job.JobService;
@@ -54,12 +51,9 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 class CreateGcpContextFlightV2Test extends BaseConnectedTest {
 
@@ -78,11 +72,6 @@ class CreateGcpContextFlightV2Test extends BaseConnectedTest {
   @Autowired private UserAccessUtils userAccessUtils;
   @Autowired private WorkspaceConnectedTestUtils testUtils;
   @Autowired private GcpCloudContextService gcpCloudContextService;
-
-  @BeforeEach
-  void setUp() throws InterruptedException {
-
-  }
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
@@ -163,7 +152,8 @@ class CreateGcpContextFlightV2Test extends BaseConnectedTest {
   void createsProjectAndContext_unauthorizedSpendProfile_flightFailsAndGcpProjectNotCreated()
       throws Exception {
     UUID workspaceUuid = createWorkspace(spendUtils.defaultSpendId());
-    AuthenticatedUserRequest unauthorizedUserRequest = userAccessUtils.noBillingAccessUserAuthRequest();
+    AuthenticatedUserRequest unauthorizedUserRequest =
+        userAccessUtils.noBillingAccessUserAuthRequest();
 
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlightTest.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
-import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.job.JobService;
@@ -23,7 +23,6 @@ import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,7 +45,7 @@ class DeleteGcpContextFlightTest extends BaseConnectedTest {
   private static final Duration CREATION_FLIGHT_TIMEOUT = Duration.ofMinutes(3);
 
   @Autowired private WorkspaceService workspaceService;
-  @Autowired private CrlService crl;
+  @Autowired private WorkspaceConnectedTestUtils workspaceConnectedTestUtils;
   @Autowired private JobService jobService;
   @Autowired private SpendConnectedTestUtils spendUtils;
   @Autowired private UserAccessUtils userAccessUtils;
@@ -98,8 +97,7 @@ class DeleteGcpContextFlightTest extends BaseConnectedTest {
     String projectId2 = gcpCloudContextService.getRequiredGcpProject(workspaceUuid);
     assertEquals(projectId, projectId2);
 
-    Project project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
-    assertEquals("ACTIVE", project.getState());
+    workspaceConnectedTestUtils.assertProjectIsActive(projectId);
 
     // Delete the google context.
     FlightMap deleteParameters = new FlightMap();
@@ -131,8 +129,7 @@ class DeleteGcpContextFlightTest extends BaseConnectedTest {
         CloudContextRequiredException.class,
         () -> gcpCloudContextService.getRequiredGcpProject(workspaceUuid));
 
-    project = crl.getCloudResourceManagerCow().projects().get(projectId).execute();
-    assertEquals("DELETE_REQUESTED", project.getState());
+    workspaceConnectedTestUtils.assertProjectIsBeingDeleted(projectId);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteGcpContextFlightTest.java
@@ -42,7 +42,7 @@ class DeleteGcpContextFlightTest extends BaseConnectedTest {
   /**
    * How long to wait for a create context Stairway flight to complete before timing out the test.
    */
-  private static final Duration CREATION_FLIGHT_TIMEOUT = Duration.ofMinutes(3);
+  private static final Duration CREATION_FLIGHT_TIMEOUT = Duration.ofMinutes(20);
 
   @Autowired private WorkspaceService workspaceService;
   @Autowired private WorkspaceConnectedTestUtils workspaceConnectedTestUtils;

--- a/service/src/test/resources/application-connected-test.yml
+++ b/service/src/test/resources/application-connected-test.yml
@@ -4,7 +4,7 @@ workspace:
 
   connected-test:
     user-delegated-service-account-path: ../config/user-delegated-sa.json
-    default-user-email: elijah.thunderlord@test.firecloud.org
+    default-user-email: avery.stormreaver@test.firecloud.org
     second-user-email: liam.dragonmaw@test.firecloud.org
     billing-user-email: hermione.owner@test.firecloud.org
 

--- a/service/src/test/resources/application-connected-test.yml
+++ b/service/src/test/resources/application-connected-test.yml
@@ -7,6 +7,7 @@ workspace:
     default-user-email: avery.stormreaver@test.firecloud.org
     second-user-email: liam.dragonmaw@test.firecloud.org
     billing-user-email: hermione.owner@test.firecloud.org
+    no-billing-access-user-email: harper.thunderlord@test.firecloud.org
 
   crl:
     use-crl: true


### PR DESCRIPTION
### Motivation
GCP permission propagation from Google Groups has gotten slower, breaking tests.

### Remove conflicting timeouts and use long ones
I made several changes to timeouts so that I could more centrally control when things failed:
- Disabled TestRunner retries (that always fail)
- Extend all TestRunner dev configs to have 75 minute test timeouts, so TestRunner doesn't kill tests
- Change integration test `getWithRetryOnException` to be duration based instead of number of retries based. Default to 30 minutes.
- Implement `RetryUtils` in service project as a duration based retry and use it uniformly (I think). Set its default timeout to 30 minutes.

### Wait for permissions to propagate
- Changed `createGcpCloudContext` to wait until the owner has `storage.bucket.list` permission on the project.
- Added workspace `grant` support in ClientTestUtils with waiting until the granted user has `storage.bucket.list` permission on the project. Changed all grants to use it, so we always wait for the grantee to have permission before running more of the test.
- Reordered where grants are done. We had code that would do:
  - create cloud context
  - grant role
  - use granted role
I changed those to be:
  - grant role
  - create cloud context
  - wait for role grant
The hope being that by granting the role and updating the Google Group before the project create, we could overlap the propagation.

### Misc Changes
There were a few other spots where I put additional `getWithRetryOnException` to wait for permissions.


