### PR TITLE
Log exception so we can get to the underlying cause [WOR-727]

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/VerifyAzureStorageContainerCanBeCreatedStep.java
@@ -169,6 +169,8 @@ public class VerifyAzureStorageContainerCanBeCreatedStep implements Step {
                   "Shared storage account not found in landing zone. Landing zone ID='%s'.",
                   landingZoneId)));
     } catch (IllegalStateException illegalStateException) { // Thrown by landingZoneApiDispatch
+      logger.error(
+          "Landing zone associated with the billing profile not found.", illegalStateException);
       return new StepResult(
           StepStatus.STEP_RESULT_FAILURE_FATAL,
           new LandingZoneNotFoundException(


### PR DESCRIPTION
We are getting an exception creating a workspace in staging, but the underlying IllegalStateException is being swallowed. This PR logs the exception to aid debugging. 