### PR TITLE
[PF-2333] Remove cloud-platform requirement for creating context

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateGcpContextFlightV2.java
@@ -85,7 +85,7 @@ public class CreateGcpContextFlightV2 extends Flight {
 
     // Wait for the project permissions to propagate.
     // The SLO is 99.5% of the time it finishes in under 7 minutes.
-    addStep(new WaitForProjectPermissionsStep(userRequest));
+    addStep(new WaitForProjectPermissionsStep());
 
     // Store the cloud context data and unlock the database row
     // This must be the last step, since it clears the lock. So this step also

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreatePetSaStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreatePetSaStep.java
@@ -3,7 +3,6 @@ package bio.terra.workspace.service.workspace.flight;
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.GCP_PROJECT_ID;
 
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
@@ -28,11 +27,10 @@ public class CreatePetSaStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    FlightMap workingMap = context.getWorkingMap();
     String projectId = context.getWorkingMap().get(GCP_PROJECT_ID, String.class);
     AuthenticatedUserRequest petSaCredentials =
         samService.getOrCreatePetSaCredentials(projectId, userRequest);
-    workingMap.put(WorkspaceFlightMapKeys.PET_SA_CREDENTIALS, petSaCredentials);
+    context.getWorkingMap().put(WorkspaceFlightMapKeys.PET_SA_CREDENTIALS, petSaCredentials);
     return StepResult.getStepResultSuccess();
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreatePetSaStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreatePetSaStep.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.workspace.flight;
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.GCP_PROJECT_ID;
 
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
@@ -27,8 +28,11 @@ public class CreatePetSaStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
     String projectId = context.getWorkingMap().get(GCP_PROJECT_ID, String.class);
-    samService.getOrCreatePetSaEmail(projectId, userRequest.getRequiredToken());
+    AuthenticatedUserRequest petSaCredentials =
+        samService.getOrCreatePetSaCredentials(projectId, userRequest);
+    workingMap.put(WorkspaceFlightMapKeys.PET_SA_CREDENTIALS, petSaCredentials);
     return StepResult.getStepResultSuccess();
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
@@ -51,8 +51,7 @@ public class WaitForProjectPermissionsStep implements Step {
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
     // Test permissions using the user's pet SA instead of their actual account as their access
-    // token
-    // may not have the cloud-platform scope required to access cloud resources.
+    // token may not have the cloud-platform scope required to access cloud resources.
     AuthenticatedUserRequest petSaCredentials =
         flightContext
             .getWorkingMap()

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WaitForProjectPermissionsStep.java
@@ -20,11 +20,6 @@ import org.slf4j.LoggerFactory;
 /** Do not complete the cloud context creation until the project permissions have propagated. */
 public class WaitForProjectPermissionsStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(WaitForProjectPermissionsStep.class);
-  private final AuthenticatedUserRequest userRequest;
-
-  public WaitForProjectPermissionsStep(AuthenticatedUserRequest userRequest) {
-    this.userRequest = userRequest;
-  }
 
   /**
    * CRL doesn't support list-bucket. For now we call GCP directly.
@@ -55,8 +50,15 @@ public class WaitForProjectPermissionsStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
+    // Test permissions using the user's pet SA instead of their actual account as their access
+    // token
+    // may not have the cloud-platform scope required to access cloud resources.
+    AuthenticatedUserRequest petSaCredentials =
+        flightContext
+            .getWorkingMap()
+            .get(WorkspaceFlightMapKeys.PET_SA_CREDENTIALS, AuthenticatedUserRequest.class);
     String gcpProjectId = flightContext.getWorkingMap().get(GCP_PROJECT_ID, String.class);
-    Storage storage = getStorage(userRequest, gcpProjectId);
+    Storage storage = getStorage(petSaCredentials, gcpProjectId);
 
     var startTime = Instant.now();
     try {

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -19,6 +19,7 @@ public final class WorkspaceFlightMapKeys {
   public static final String IS_WET_RUN = "isWetRun";
   public static final String UPDATED_WORKSPACES = "updatedWorkspaces";
   public static final String SPEND_PROFILE = "spendProfile";
+  public static final String PET_SA_CREDENTIALS = "petSaCredentials";
 
   private WorkspaceFlightMapKeys() {}
 


### PR DESCRIPTION
Currently, creating a GCP cloud context involves polling GCP using the user's credentials to determine when cloud permissions are fully synchronized. However, this means that the user provided credentials must have the `cloud-platform` OAuth scope. This breaks the CLI, which intentionally does not include this scope for user auth tokens (as it gives broader permissions than we want for Terra).

I've switched this polling to use the calling user's pet SA instead, as we always generate pet tokens with cloud-platform scope. There was already a step in the flight to create the pet SA for the calling user, so the account is guaranteed to exist.