### PR TITLE
Use the right validation for existing bucket name

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -134,14 +134,14 @@ public class ResourceValidationUtils {
     this.gitRepoReferencedResourceConfiguration = gitRepoReferencedResourceConfiguration;
   }
 
-  public static void validateControlledBucketName(String name) {
+  public static void validateBucketNameDisallowUnderscore(String name) {
     validateBucketName(
         name,
         CONTROLLED_BUCKET_NAME_VALIDATION_PATTERN,
         CONTROLLED_BUCKET_NAME_VALIDATION_FAILURE_ERROR);
   }
 
-  public static void validateReferencedBucketName(String name) {
+  public static void validateBucketNameAllowsUnderscore(String name) {
     validateBucketName(
         name,
         REFERENCED_BUCKET_NAME_VALIDATION_PATTERN,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 
+import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
@@ -7,6 +8,7 @@ import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.common.base.Preconditions;
 import java.util.UUID;
 import javax.annotation.PostConstruct;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -33,7 +35,13 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
-    return new ControlledGcsBucketResource(dbResource);
+    ControlledGcsBucketAttributes attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledGcsBucketAttributes.class);
+    var bucketName =
+        StringUtils.isEmpty(attributes.getBucketName())
+            ? generateCloudName(dbResource.getWorkspaceId(), dbResource.getName())
+            : attributes.getBucketName();
+    return new ControlledGcsBucketResource(dbResource, bucketName);
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -36,19 +36,7 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
   /** {@inheritDoc} */
   @Override
   public WsmResource makeResourceFromDb(DbResource dbResource) {
-    ControlledGcsBucketAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ControlledGcsBucketAttributes.class);
-    ControlledResourceFields commonFields = new ControlledResourceFields(dbResource);
-    var resource =
-        ControlledGcsBucketResource.builder()
-            .bucketName(
-                StringUtils.isEmpty(attributes.getBucketName())
-                    ? ControlledGcsBucketHandler.getHandler()
-                        .generateCloudName(commonFields.getWorkspaceId(), commonFields.getName())
-                    : attributes.getBucketName())
-            .common(commonFields)
-            .build();
-    return resource;
+    return new ControlledGcsBucketResource(dbResource);
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -1,15 +1,12 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 
-import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
-import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.common.base.Preconditions;
 import java.util.UUID;
 import javax.annotation.PostConstruct;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -97,10 +97,11 @@ public class ControlledGcsBucketResource extends ControlledResource {
     super(dbResource);
     ControlledGcsBucketAttributes attributes =
         DbSerDes.fromJson(dbResource.getAttributes(), ControlledGcsBucketAttributes.class);
-    this.bucketName = StringUtils.isEmpty(attributes.getBucketName())
-        ? ControlledGcsBucketHandler.getHandler()
-        .generateCloudName(dbResource.getWorkspaceId(), dbResource.getName())
-        : attributes.getBucketName();
+    this.bucketName =
+        StringUtils.isEmpty(attributes.getBucketName())
+            ? ControlledGcsBucketHandler.getHandler()
+                .generateCloudName(dbResource.getWorkspaceId(), dbResource.getName())
+            : attributes.getBucketName();
   }
 
   public static ControlledGcsBucketResource.Builder builder() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 public class ControlledGcsBucketResource extends ControlledResource {
@@ -93,15 +92,9 @@ public class ControlledGcsBucketResource extends ControlledResource {
     validate();
   }
 
-  public ControlledGcsBucketResource(DbResource dbResource) {
+  public ControlledGcsBucketResource(DbResource dbResource, String bucketName) {
     super(dbResource);
-    ControlledGcsBucketAttributes attributes =
-        DbSerDes.fromJson(dbResource.getAttributes(), ControlledGcsBucketAttributes.class);
-    this.bucketName =
-        StringUtils.isEmpty(attributes.getBucketName())
-            ? ControlledGcsBucketHandler.getHandler()
-                .generateCloudName(dbResource.getWorkspaceId(), dbResource.getName())
-            : attributes.getBucketName();
+    this.bucketName = bucketName;
   }
 
   public static ControlledGcsBucketResource.Builder builder() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
@@ -148,7 +148,7 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
     }
     // Validate in case there's a typo and user gave wrong name. This gives a slightly more usable
     // error message than "You do not have access to bucket".
-    ResourceValidationUtils.validateReferencedBucketName(getBucketName());
+    ResourceValidationUtils.validateBucketNameAllowsUnderscore(getBucketName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
@@ -157,7 +157,7 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
       throw new MissingRequiredFieldException(
           "Missing required field for ReferenceGcsObjectResource.");
     }
-    ResourceValidationUtils.validateReferencedBucketName(getBucketName());
+    ResourceValidationUtils.validateBucketNameAllowsUnderscore(getBucketName());
     ResourceValidationUtils.validateGcsObjectName(getObjectName());
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -136,29 +136,29 @@ public class ValidationUtilsTest extends BaseUnitTest {
   public void validateReferencedBucketName_nameHas64Character_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateReferencedBucketName(INVALID_STRING));
+        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore(INVALID_STRING));
   }
 
   @Test
   public void validateReferencedBucketName_nameHas63Character_OK() {
-    ResourceValidationUtils.validateReferencedBucketName(MAX_VALID_STRING);
+    ResourceValidationUtils.validateBucketNameAllowsUnderscore(MAX_VALID_STRING);
   }
 
   @Test
   public void validateReferencedBucketName_nameHas2Character_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateReferencedBucketName("aa"));
+        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("aa"));
   }
 
   @Test
   public void validateReferencedBucketName_nameHas3Character_OK() {
-    ResourceValidationUtils.validateReferencedBucketName("123");
+    ResourceValidationUtils.validateBucketNameAllowsUnderscore("123");
   }
 
   @Test
   public void validateReferencedBucketName_nameHas222CharacterWithDotSeparator_OK() {
-    ResourceValidationUtils.validateReferencedBucketName(MAX_VALID_STRING_WITH_DOTS);
+    ResourceValidationUtils.validateBucketNameAllowsUnderscore(MAX_VALID_STRING_WITH_DOTS);
   }
 
   @Test
@@ -167,53 +167,53 @@ public class ValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InvalidNameException.class,
         () ->
-            ResourceValidationUtils.validateReferencedBucketName(
+            ResourceValidationUtils.validateBucketNameAllowsUnderscore(
                 INVALID_STRING + "." + MAX_VALID_STRING));
   }
 
   @Test
   public void validateReferencedBucketName_nameStartAndEndWithNumber_OK() {
-    ResourceValidationUtils.validateReferencedBucketName("1-bucket-1");
+    ResourceValidationUtils.validateBucketNameAllowsUnderscore("1-bucket-1");
   }
 
   @Test
   public void validateReferencedBucketName_nameStartAndEndWithDot_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateReferencedBucketName(".bucket-name."));
+        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore(".bucket-name."));
   }
 
   @Test
   public void validateReferencedBucketName_nameWithGoogPrefix_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateReferencedBucketName("goog-bucket-name1"));
+        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("goog-bucket-name1"));
   }
 
   @Test
   public void validateReferencedBucketName_nameContainsGoogle_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateReferencedBucketName("bucket-google-name"));
+        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("bucket-google-name"));
   }
 
   @Test
   public void validateReferencedBucketName_nameContainsG00gle_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateReferencedBucketName("bucket-g00gle-name"));
+        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("bucket-g00gle-name"));
   }
 
   @Test
   public void validateReferencedBucketName_nameContainsUnderscore_OK() {
-    ResourceValidationUtils.validateReferencedBucketName("bucket_name");
+    ResourceValidationUtils.validateBucketNameAllowsUnderscore("bucket_name");
   }
 
   @Test
   public void validateControlledBucketName_nameContainsUnderscore_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateControlledBucketName("bucket_name"));
+        () -> ResourceValidationUtils.validateBucketNameDisallowUnderscore("bucket_name"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferenceValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferenceValidationUtilsTest.java
@@ -14,12 +14,12 @@ public class ReferenceValidationUtilsTest extends BaseUnitTest {
   public void testInvalidCharInBucketName() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateReferencedBucketName("INVALIDBUCKETNAME"));
+        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("INVALIDBUCKETNAME"));
   }
 
   @Test
   public void validBucketNameOk() {
-    ResourceValidationUtils.validateReferencedBucketName("valid-bucket_name.1");
+    ResourceValidationUtils.validateBucketNameAllowsUnderscore("valid-bucket_name.1");
   }
 
   @Test


### PR DESCRIPTION
Our current database has bucket with name that has underscore in it. It is *allowed* in gcp so they likely has a gcs bucket cloud instance associated with. However, we imposed a rule to not allow underscore for some nextflow reason. that change is *not* backward compatible and makes all those previous workspace with underscore bucket unusable.

Now when those workspaces are not able to be get, delete, update because of this validation error. 

I don't want to just clean up the row in the db because the cloud bucket is still there. 