### PR TITLE
[PF-2432] Fix PrivateControlledGcsBucketLifecycle

### DIFF
--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -125,8 +125,8 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
         new GcsBucketAccessTester(privateResourceUser, bucketName, projectId)) {
       tester.checkAccessWait(privateResourceUser, ControlledResourceIamRole.EDITOR);
       // workspace owner can do nothing
-      tester.checkAccess(testUser, null);
-      tester.checkAccess(workspaceReader, null);
+      tester.checkAccessWait(testUser, null);
+      tester.checkAccessWait(workspaceReader, null);
     }
 
     // Any workspace user should be able to enumerate all buckets, even though they can't access

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -13,6 +13,7 @@
     "integration/Jobs.json",
     "integration/ListWorkspaces.json",
     "integration/PrivateControlledAiNotebookInstanceLifecycle.json",
+    "integration/PrivateControlledGcsBucketLifecycle.json",
     "integration/ReferencedBigQueryResourceLifecycle.json",
     "integration/ReferencedDataRepoSnapshotLifecycle.json",
     "integration/ReferencedGcsResourceLifecycle.json",


### PR DESCRIPTION
Another integration test which needed retries.

Also interesting: I've seen a number of failures where the primary test user could delete one blob from a bucket but later could not delete a different one. This might have been an issue of deleting an object immediately after it was created, but still odd.