### PR TITLE
PF-2445: use the create date when there's no log for an old resource in terra

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
@@ -226,8 +226,6 @@ public class FolderApiController extends ControllerBase implements FolderApi {
             lastUpdatedDetail
                 .map(ActivityLogChangeDetails::actorEmail)
                 .orElse(folder.createdByEmail()))
-        // should only return MIN if the log doesn't exist which means the folder was last updated
-        // before the implementation of change subject id logging.
         .lastUpdatedDate(
             lastUpdatedDetail
                 .map(ActivityLogChangeDetails::changeDate)

--- a/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
@@ -26,7 +26,6 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.logging.WorkspaceActivityLogService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.OperationType;
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -86,7 +85,8 @@ public class FolderApiController extends ControllerBase implements FolderApi {
         OperationType.CREATE,
         folderId.toString(),
         ActivityLogChangedTarget.FOLDER);
-    return new ResponseEntity<>(buildFolder(folder, workspaceId), HttpStatus.OK);
+    return new ResponseEntity<>(
+        buildFolder(folderService.getFolder(workspaceId, folderId), workspaceId), HttpStatus.OK);
   }
 
   @Override
@@ -222,10 +222,15 @@ public class FolderApiController extends ControllerBase implements FolderApi {
         .properties(convertMapToApiProperties(folder.properties()))
         .createdBy(folder.createdByEmail())
         .createdDate(folder.createdDate())
-        .lastUpdatedBy(lastUpdatedDetail.map(detail -> detail.actorEmail()).orElse("unknown"))
+        .lastUpdatedBy(
+            lastUpdatedDetail
+                .map(ActivityLogChangeDetails::actorEmail)
+                .orElse(folder.createdByEmail()))
         // should only return MIN if the log doesn't exist which means the folder was last updated
         // before the implementation of change subject id logging.
         .lastUpdatedDate(
-            lastUpdatedDetail.map(detail -> detail.changeDate()).orElse(OffsetDateTime.MIN));
+            lastUpdatedDetail
+                .map(ActivityLogChangeDetails::changeDate)
+                .orElse(folder.createdDate()));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -70,7 +70,6 @@ import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceAndHighestRole;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import io.opencensus.contrib.spring.aop.Traced;
-import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -286,9 +285,11 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
         .lastUpdatedDate(
             lastChangeDetailsOptional
                 .map(ActivityLogChangeDetails::changeDate)
-                .orElse(OffsetDateTime.MIN))
+                .orElse(workspace.createdDate()))
         .lastUpdatedBy(
-            lastChangeDetailsOptional.map(ActivityLogChangeDetails::actorEmail).orElse("unknown"))
+            lastChangeDetailsOptional
+                .map(ActivityLogChangeDetails::actorEmail)
+                .orElse(workspace.createdByEmail()))
         .policies(workspacePolicies);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/logging/WorkspaceActivityLogService.java
+++ b/service/src/main/java/bio/terra/workspace/service/logging/WorkspaceActivityLogService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Component;
 /** This component is a service for logging workspace activities. */
 @Component
 public class WorkspaceActivityLogService {
-
   private final SamService samService;
   private final WorkspaceActivityLogDao workspaceActivityLogDao;
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
@@ -101,6 +101,21 @@ public class FolderApiControllerTest extends BaseUnitTest {
   }
 
   @Test
+  public void createFolder_dateAndActorFieldsSet() throws Exception {
+    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+
+    ApiFolder folder =
+        createFolder(workspaceId, "foo", "This is folder foo", null, Map.of("foo", "bar"));
+
+    assertNotNull(folder.getId());
+    assertNull(folder.getParentFolderId());
+    assertEquals(USER_REQUEST.getEmail(), folder.getCreatedBy());
+    assertNotNull(folder.getCreatedDate());
+    assertEquals(USER_REQUEST.getEmail(), folder.getLastUpdatedBy());
+    assertNotNull(folder.getLastUpdatedDate());
+  }
+
+  @Test
   public void createFolder_doesNotHaveWriteAccess_throws403() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     doThrow(new ForbiddenException("User has no write access"))

--- a/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
@@ -244,14 +244,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
     ApiFolder secondFolder =
         createFolder(workspaceId, displayName, /*parentFolderId=*/ firstFolder.getId());
 
-    List<ApiFolder> retrievedFolders =
-        listFolders(workspaceId).getFolders().stream()
-            .filter(folder -> folder.getCreatedDate() != null)
-            .map(
-                // Only the retrivedFolders will have created date set. To assert equals, remove the
-                // created date.
-                folder -> folder.createdDate(null))
-            .toList();
+    List<ApiFolder> retrievedFolders = listFolders(workspaceId).getFolders().stream().toList();
 
     assertThat(retrievedFolders, containsInAnyOrder(firstFolder, secondFolder));
   }


### PR DESCRIPTION
We backfilled the create date already. 