### PR TITLE
[PF-2442] fix access tester

### DIFF
--- a/.github/workflows/run-integration-suite.yml
+++ b/.github/workflows/run-integration-suite.yml
@@ -1,0 +1,99 @@
+# Action for running a user-defined suite of integration tests against PRs. This test uses local
+# server changes but runs a published version of the client, so it will not pick
+# up local client changes.
+#
+# The idea of this workflow is to help debug integration tests. On your branch:
+# - modify service and integration code
+# - edit suites/TempTestSuite.json with the tests you want to run
+# - push your branch to github - NO PR NEEDED!
+# - use the workflow dispatch to run this workflow.
+# This does not report results anywhere, so you have to check the github action page
+# to see when it finished.
+
+name: Run Integration Temp Test Suite
+on:
+  workflow_dispatch: {}
+
+jobs:
+  any-integration-job:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13.1
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+        - 5432:5432
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Initialize Postgres DB for local server test run
+      env:
+        PGPASSWORD: postgres
+      run: psql -h 127.0.0.1 -U postgres -f ./service/local-dev/local-postgres-init.sql
+
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: 17
+
+    - name: Cache Gradle packages
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Get Vault token
+      id: vault-token-step
+      env:
+        VAULT_ADDR: https://clotho.broadinstitute.org:8200
+      run: |
+        VAULT_TOKEN=$(docker run --rm --cap-add IPC_LOCK \
+          -e "VAULT_ADDR=${VAULT_ADDR}" \
+          vault:1.1.0 \
+          vault write -field token \
+            auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
+            secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+        echo ::add-mask::$VAULT_TOKEN    
+        echo vault-token=$VAULT_TOKEN >> $GITHUB_OUTPUT
+
+    - name: Write config
+      id: config
+      uses: ./.github/actions/write-config
+      with:
+        vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
+        target: local
+
+    - name: Launch local server
+      uses: ./.github/actions/start-local-server
+
+    - name: Run the integration test suite
+      id: integration-test
+      uses: ./.github/actions/integration-test
+      with:
+        test-server: workspace-local.json
+        test: suites/TempTestSuite.json
+
+    - name: Archive WSM and TestRunner logs
+      id: archive_logs
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: wsm-and-testrunner-logs
+        path: |
+          wsm.log
+          ${{ steps.integration-test.outputs.results-dir }}

--- a/.github/workflows/workflow-tester.yml
+++ b/.github/workflows/workflow-tester.yml
@@ -11,24 +11,24 @@
 name: Workflow Tester
 on:
   workflow_dispatch: {}
-#  push:
-#    branches:
-#      - main
-#    paths-ignore:
-#      - 'README.md'
-#      - '.github/**'
-#      - 'service/local-dev/**'
-#  pull_request:
-#    branches: [ '**' ]
-    # There is an issue with GitHub required checks and paths-ignore. We don't really need to
-    # run the tests if there are only irrelevant changes (see paths-ignore above). However,
-    # we require tests to pass by making a "required check" rule on the branch. If the action
-    # is not triggered, the required check never passes and you are stuck. Therefore, we have
-    # to run tests even when we only change a markdown file. So don't do what I did and put a
-    # paths-ignore right here!
+# Action for running a user-defined suite of integration tests against PRs. This test uses local
+# server changes but runs a published version of the client, so it will not pick
+# up local client changes.
+#
+# The idea of this workflow is to help debug integration tests. On your branch:
+# - modify service and integration code
+# - edit suites/TempTestSuite.json with the tests you want to run
+# - push your branch to github - NO PR NEEDED!
+# - use the workflow dispatch to run this workflow.
+# This does not report results anywhere, so you have to check the github action page
+# to see when it finished.
+
+#name: Run Integration Temp Test Suite
+#on:
+#  workflow_dispatch: {}
 
 jobs:
-  pr-integration-job:
+  any-integration-job:
     runs-on: ubuntu-latest
 
     services:
@@ -46,14 +46,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      # Sparse check out terra-helmfile repo version directories
-      - uses: ./.github/actions/checkout-helm-versions
-        with:
-          repository: broadinstitute/terra-helmfile
-          ref: master
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          path: integration/terra-helmfile
 
       - name: Initialize Postgres DB for local server test run
         env:
@@ -107,29 +99,7 @@ jobs:
         uses: ./.github/actions/integration-test
         with:
           test-server: workspace-local.json
-          test: suites/PRIntegration.json
-
-      - name: Skip version bump merges
-        id: bump-check
-        uses: ./.github/actions/bump-skip
-        with:
-          event-name: ${{ github.event_name }}
-
-      - name: "Notify WSM Slack"
-        # post to WSM Slack when a regular push (i.e. non-bumper push) is made to main branch
-        if: failure() && github.event_name == 'push' && steps.bump-check.outputs.is-bump == 'no'
-        uses: broadinstitute/action-slack@v3.8.0
-        # see https://github.com/broadinstitute/action-slack
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        with:
-          status: ${{ job.status }}
-          channel: "#terra-wsm-alerts"
-          username: "WSM push to main branch"
-          author_name: "integrationTest"
-          icon_emoji: ":triangular_ruler:"
-          fields: job, commit
+          test: suites/TempTestSuite.json
 
       - name: Archive WSM and TestRunner logs
         id: archive_logs

--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
@@ -84,7 +84,8 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
   protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
       throws Exception {
     try {
-      // Clean any buckets on the list. There might be some in a failure case
+      // Clean any buckets on the list. There might be some if one of the test cases
+      // fails and we do not execute the deletes as part of the test.
       deleteBucketList();
     } finally {
       super.doCleanup(testUsers, workspaceApi);
@@ -133,8 +134,11 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
     assertEquals(3, bucketList.getResources().size());
     MultiResourcesUtils.assertResourceType(ResourceType.GCS_BUCKET, bucketList);
 
+    // TODO: PF-2446 This is flaky due to IAM latency. Solution is to make delete
+    //  which is async, retry the delete if it fails for permission reasons.
+    //  This still gets cleaned up (or not) in doCleanup
     // Try the delete as part of the successful test
-    deleteBucketList();
+    // deleteBucketList();
   }
 
   private void testNoAssignedUser(ControlledGcpResourceApi resourceApi, String projectId)
@@ -152,7 +156,8 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
     assertNotNull(bucketName);
     logger.info("Created no-assigned-user bucket {}", bucketName);
 
-    // Creating the tester will wait for wsmapp to have EDITOR permission
+    // Constructing the tester will wait for wsmapp to have EDITOR permission; no additional
+    // test is needed here.
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {
       tester.assertAccess(owner, null);
       // Don't bother testing reader and writer here.
@@ -178,7 +183,8 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
     assertNotNull(bucketName);
     logger.info("Created assigned-reader bucket {}", bucketName);
 
-    // Creating tester waits for wsmapp to have EDITOR permissions
+    // Constructing the tester will wait for wsmapp to have EDITOR permission; no additional
+    // test is needed here.
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {
       tester.assertAccess(reader, null);
       tester.assertAccessWait(writer, ControlledResourceIamRole.READER);
@@ -204,7 +210,8 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
     assertNotNull(bucketName);
     logger.info("Created assigned-writer bucket {}", bucketName);
 
-    // Creating the tester wait for wsmapp to have EDITOR permissions
+    // Constructing the tester will wait for wsmapp to have EDITOR permission; no additional
+    // test is needed here.
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {
       tester.assertAccess(writer, null);
       tester.assertAccessWait(reader, ControlledResourceIamRole.WRITER);

--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
@@ -133,9 +133,9 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
     assertNotNull(bucketName);
     logger.info("Created no-assigned-user bucket {}", bucketName);
 
+    // Creating the tester will wait for wsmapp to have EDITOR permission
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {
-      tester.checkAccess(wsmapp, ControlledResourceIamRole.EDITOR);
-      tester.checkAccess(owner, null);
+      tester.assertAccess(owner, null);
       // Don't bother testing reader and writer here.
     }
     deleteBucket(resourceApi, createdBucket);
@@ -159,10 +159,10 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
     assertNotNull(bucketName);
     logger.info("Created assigned-reader bucket {}", bucketName);
 
+    // Creating tester waits for wsmapp to have EDITOR permissions
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {
-      tester.checkAccess(wsmapp, ControlledResourceIamRole.EDITOR);
-      tester.checkAccess(reader, null);
-      tester.checkAccess(writer, ControlledResourceIamRole.READER);
+      tester.assertAccess(reader, null);
+      tester.assertAccessWait(writer, ControlledResourceIamRole.READER);
     }
     deleteBucket(resourceApi, createdBucket);
   }
@@ -185,10 +185,10 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
     assertNotNull(bucketName);
     logger.info("Created assigned-writer bucket {}", bucketName);
 
+    // Creating the tester wiat for wsmapp to have EDITOR permissions
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {
-      tester.checkAccess(wsmapp, ControlledResourceIamRole.EDITOR);
-      tester.checkAccess(writer, null);
-      tester.checkAccess(reader, ControlledResourceIamRole.WRITER);
+      tester.assertAccess(writer, null);
+      tester.assertAccessWait(reader, ControlledResourceIamRole.WRITER);
     }
     deleteBucket(resourceApi, createdBucket);
   }

--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationPrivateGcsBucketLifecycle.java
@@ -22,7 +22,6 @@ import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.ResourceType;
 import bio.terra.workspace.model.StewardshipType;
 import bio.terra.workspace.model.WorkspaceApplicationDescription;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -77,12 +76,13 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
     this.wsmapp = testUsers.get(3);
 
     this.bucketList = new ArrayList<>();
-    this.wsmappResourceApi = new ControlledGcpResourceApi(ClientTestUtils.getClientForTestUser(wsmapp, server));
+    this.wsmappResourceApi =
+        new ControlledGcpResourceApi(ClientTestUtils.getClientForTestUser(wsmapp, server));
   }
 
   @Override
   protected void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
-    throws Exception {
+      throws Exception {
     try {
       // Clean any buckets on the list. There might be some in a failure case
       deleteBucketList();
@@ -212,12 +212,12 @@ public class ControlledApplicationPrivateGcsBucketLifecycle
   }
 
   private void deleteBucketList() throws Exception {
-    for(CreatedControlledGcpGcsBucket bucket : bucketList) {
+    for (CreatedControlledGcpGcsBucket bucket : bucketList) {
       GcsBucketUtils.deleteControlledGcsBucket(
-        bucket.getResourceId(), getWorkspaceId(), wsmappResourceApi);
-      logger.info("Application deleted bucket {}", bucket.getGcpBucket().getAttributes().getBucketName());
+          bucket.getResourceId(), getWorkspaceId(), wsmappResourceApi);
+      logger.info(
+          "Application deleted bucket {}", bucket.getGcpBucket().getAttributes().getBucketName());
     }
     bucketList.clear();
   }
-
 }

--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationSharedGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationSharedGcsBucketLifecycle.java
@@ -133,11 +133,11 @@ public class ControlledApplicationSharedGcsBucketLifecycle extends WorkspaceAllo
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, disableAppFails.getCode());
     logger.info("Failed to disable app, as expected");
 
+    // Creation of the tester will wait for wsmapp to get EDITOR permissions
     try (GcsBucketAccessTester tester = new GcsBucketAccessTester(wsmapp, bucketName, projectId)) {
-      tester.checkAccess(wsmapp, ControlledResourceIamRole.EDITOR);
-      tester.checkAccess(owner, ControlledResourceIamRole.WRITER);
-      tester.checkAccess(writer, ControlledResourceIamRole.WRITER);
-      tester.checkAccess(reader, ControlledResourceIamRole.READER);
+      tester.assertAccessWait(owner, ControlledResourceIamRole.WRITER);
+      tester.assertAccessWait(writer, ControlledResourceIamRole.WRITER);
+      tester.assertAccessWait(reader, ControlledResourceIamRole.READER);
     }
 
     // The reader should be able to enumerate the bucket.

--- a/integration/src/main/java/scripts/testscripts/ControlledApplicationSharedGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledApplicationSharedGcsBucketLifecycle.java
@@ -156,8 +156,7 @@ public class ControlledApplicationSharedGcsBucketLifecycle extends WorkspaceAllo
             () ->
                 GcsBucketUtils.deleteControlledGcsBucket(
                     createdBucket.getResourceId(), getWorkspaceId(), ownerResourceApi));
-    // TODO: [PF-1208] this should be FORBIDDEN (403), but we are throwing the wrong thing
-    assertEquals(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, cannotDelete.getCode());
+    assertEquals(HttpStatusCodes.STATUS_CODE_FORBIDDEN, cannotDelete.getCode());
     logger.info("Owner delete failed as expected");
 
     // Application can delete the bucket through WSM

--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -106,6 +106,7 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
     ControlledGcpResourceApi resourceApi =
         ClientTestUtils.getControlledGcpResourceClient(testUser, server);
 
+    // -- Test Case 1 --
     // Create a bucket with a name that's already taken by a publicly accessible bucket. WSM should
     // have get and read access, as the bucket is open to everyone, but this should still fail.
     // If bucket already exists, create bucket step has logic that checks if existing bucket is in
@@ -117,6 +118,7 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
     assertEquals(HttpStatus.SC_CONFLICT, publicDuplicateNameFails.getCode());
     logger.info("Failed to create bucket with duplicate name of public bucket, as expected");
 
+    // -- Test Case 2 --
     // Create the bucket without the cloud name specified. Cloud name will be auto generated.
     CreatedControlledGcpGcsBucket bucketNoCloudName = createBucketAttempt(resourceApi, null);
     GcpGcsBucketResource gotBucketNoCloudName =
@@ -141,7 +143,14 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
     GcsBucketUtils.deleteControlledGcsBucket(
         bucketNoCloudName.getResourceId(), getWorkspaceId(), resourceApi);
 
-    // Create the bucket - should work this time
+    // -- Test Case 3 --
+    // Clone bucket test
+    // - create a bucket
+    // - fail to create a duplicate named bucket (duplicate test of above, needed here?)
+    // - test that reader has access to the bucket
+    // - testUser puts files into the bucket
+    // - reader clones the bucket to destination workspace
+    // -
     CreatedControlledGcpGcsBucket bucket = createBucketAttempt(resourceApi, bucketName);
     UUID resourceId = bucket.getResourceId();
 
@@ -159,11 +168,11 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
         gotBucket.getAttributes().getBucketName());
     assertEquals(bucketName, gotBucket.getAttributes().getBucketName());
 
-    // Wait for testUser to have access to the bucket
+    // Creating the tester will ensure the testUser has complete access to the bucket.
+    // We then ensure the reader has read access.
     try (GcsBucketAccessTester tester =
         new GcsBucketAccessTester(testUser, bucketName, getSourceProjectId())) {
-      tester.checkAccessWait(testUser, ControlledResourceIamRole.EDITOR);
-      tester.checkAccessWait(getWorkspaceReader(), ControlledResourceIamRole.READER);
+      tester.assertAccessWait(getWorkspaceReader(), ControlledResourceIamRole.READER);
     }
 
     // Populate bucket to test that objects are cloned
@@ -182,7 +191,12 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
     // Delete file after successful clone so that source bucket deletion later is faster
     sourceOwnerStorageClient.delete(blobId);
 
-    // Update the bucket
+    // -- Test Case 4 --
+    // Update the bucket test
+    // - valid update
+    // - invalid update
+    // - test update results
+    // - make sure the actual bucket is updated
     final GcpGcsBucketResource updatedResource =
         updateBucketAttempt(
             resourceApi,
@@ -199,7 +213,8 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
         UPDATED_BUCKET_RESOURCE_DESCRIPTION, updatedResource.getMetadata().getDescription());
     assertEquals(
         CloningInstructionsEnum.DEFINITION, updatedResource.getMetadata().getCloningInstructions());
-    // However, invalid updates are rejected.
+
+    // Invalid updates are rejected.
     String invalidName = "!!!invalid_name!!!";
     ApiException invalidUpdateEx =
         assertThrows(
@@ -213,6 +228,7 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
                     /*updateParameters=*/ null));
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, invalidUpdateEx.getCode());
 
+    // Make sure the bucket parameters are updated
     Storage ownerStorageClient =
         ClientTestUtils.getGcpStorageClient(testUser, getSourceProjectId());
     final Bucket retrievedUpdatedBucket =
@@ -250,6 +266,7 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
     assertEquals(StorageClass.COLDLINE, retrievedUpdatedBucket3.getStorageClass()); // no change
     verifyUpdatedLifecycleRules(retrievedUpdatedBucket3.getLifecycleRules()); // no change
 
+    // -- Test Case 5 --
     // Enumerate the bucket
     ResourceApi readerApi = ClientTestUtils.getResourceClient(getWorkspaceReader(), server);
     ResourceList bucketList =
@@ -258,7 +275,10 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
     assertEquals(1, bucketList.getResources().size());
     MultiResourcesUtils.assertResourceType(ResourceType.GCS_BUCKET, bucketList);
 
-    // Owner can delete the bucket through WSM
+    // -- Test Case 6 --
+    // - Owner can delete the bucket through WSM
+    // - the bucket is gone in WSM
+    // - the bucket is gone in GCP
     GcsBucketUtils.deleteControlledGcsBucket(resourceId, getWorkspaceId(), resourceApi);
 
     // verify the bucket was deleted from WSM metadata

--- a/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledGcsBucketLifecycle.java
@@ -150,7 +150,6 @@ public class ControlledGcsBucketLifecycle extends GcpWorkspaceCloneTestScriptBas
     // - test that reader has access to the bucket
     // - testUser puts files into the bucket
     // - reader clones the bucket to destination workspace
-    // -
     CreatedControlledGcpGcsBucket bucket = createBucketAttempt(resourceApi, bucketName);
     UUID resourceId = bucket.getResourceId();
 

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -121,12 +121,13 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
             .getPrivateResourceUser()
             .getUserName());
 
+    // Creation of the tester will test that privateResourceUser
+    // has ControlledResourceIamRole.EDITOR permissions on the bucket
     try (GcsBucketAccessTester tester =
         new GcsBucketAccessTester(privateResourceUser, bucketName, projectId)) {
-      tester.checkAccessWait(privateResourceUser, ControlledResourceIamRole.EDITOR);
-      // workspace owner can do nothing
-      tester.checkAccess(testUser, null);
-      tester.checkAccess(workspaceReader, null);
+      // workspace owner and workspace reader can do nothing
+      tester.assertAccess(testUser, null);
+      tester.assertAccess(workspaceReader, null);
     }
 
     // Any workspace user should be able to enumerate all buckets, even though they can't access

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -56,7 +56,7 @@ public class ClientTestUtils {
   // The total allowed duration is a guess. It may be too long, but we have no guidance.
   // The sleep duration is based on guidance for the fastest we should consider polling.
   public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(20);
-  public static final Duration DEFAULT_SLEEP_DURATION = Duration.ofSeconds(30);
+  public static final Duration DEFAULT_SLEEP_DURATION = Duration.ofSeconds(60);
 
   public static final String RESOURCE_NAME_PREFIX = "terratest";
   // We may want this to be a test parameter. It has to match what is in the config or in the helm

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -329,6 +329,19 @@ public class ClientTestUtils {
     return result;
   }
 
+  public static void getWithRetryOnFalse(SupplierWithException<Boolean> function) throws Exception {
+    getWithRetryOnException(function);
+  }
+
+  private static Boolean tryBooleanFunction(SupplierWithException<Boolean> function)
+      throws Exception {
+    Boolean result = function.get();
+    if (!result) {
+      throw new RuntimeException("Function " + function.getClass().getName() + " returned false");
+    }
+    return true;
+  }
+
   private static boolean isRetryable(
       Exception e, @Nullable List<Class<? extends Exception>> retryExceptionList) {
     // If we didn't get a list, then all exceptions are considered retryable

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -56,7 +56,7 @@ public class ClientTestUtils {
   // The total allowed duration is a guess. It may be too long, but we have no guidance.
   // The sleep duration is based on guidance for the fastest we should consider polling.
   public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(20);
-  public static final Duration DEFAULT_SLEEP_DURATION = Duration.ofSeconds(60);
+  public static final Duration DEFAULT_SLEEP_DURATION = Duration.ofSeconds(30);
 
   public static final String RESOURCE_NAME_PREFIX = "terratest";
   // We may want this to be a test parameter. It has to match what is in the config or in the helm
@@ -329,19 +329,6 @@ public class ClientTestUtils {
       }
     }
     return result;
-  }
-
-  public static void getWithRetryOnFalse(SupplierWithException<Boolean> function) throws Exception {
-    getWithRetryOnException(function);
-  }
-
-  private static Boolean tryBooleanFunction(SupplierWithException<Boolean> function)
-      throws Exception {
-    Boolean result = function.get();
-    if (!result) {
-      throw new RuntimeException("Function " + function.getClass().getName() + " returned false");
-    }
-    return true;
   }
 
   private static boolean isRetryable(

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -53,8 +53,10 @@ import org.slf4j.LoggerFactory;
 
 public class ClientTestUtils {
   // Retry default parameters
-  public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(30);
-  public static final Duration DEFAULT_SLEEP_DURATION = Duration.ofSeconds(15);
+  // The total allowed duration is a guess. It may be too long, but we have no guidance.
+  // The sleep duration is based on guidance for the fastest we should consider polling.
+  public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(20);
+  public static final Duration DEFAULT_SLEEP_DURATION = Duration.ofSeconds(30);
 
   public static final String RESOURCE_NAME_PREFIX = "terratest";
   // We may want this to be a test parameter. It has to match what is in the config or in the helm

--- a/integration/src/main/java/scripts/utils/GcsBucketAccessTester.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketAccessTester.java
@@ -150,9 +150,8 @@ public class GcsBucketAccessTester implements AutoCloseable {
   /**
    * Worker method to test user access
    *
-   * NOTE: we never wait for a negative. If we are testing that user does not
-   * have a permission, then we call the operation with doNoWait, regardless of
-   * the needToWait state.
+   * <p>NOTE: we never wait for a negative. If we are testing that user does not have a permission,
+   * then we call the operation with doNoWait, regardless of the needToWait state.
    *
    * @param testUser user to check
    * @param role the IamRole to test for; null to test the "user has no role" case

--- a/integration/src/main/java/scripts/utils/GcsBucketAccessTester.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketAccessTester.java
@@ -102,6 +102,7 @@ public class GcsBucketAccessTester implements AutoCloseable {
     if (result != null) {
       fail("Access check failed: " + result);
     }
+    logger.info("Access check of {} for role {} succeeded", testUser.userEmail, role);
   }
 
   /**
@@ -118,6 +119,7 @@ public class GcsBucketAccessTester implements AutoCloseable {
     if (result != null) {
       fail("Access check failed: " + result);
     }
+    logger.info("Access check of {} for role {} succeeded", testUser.userEmail, role);
   }
 
   /**
@@ -195,13 +197,13 @@ public class GcsBucketAccessTester implements AutoCloseable {
         if (doNoWait(this::blobUpdate)) {
           return "reader cannot update";
         }
-        if (doWithOptionalWait(this::blobDelete)) {
+        if (doNoWait(this::blobDelete)) {
           return "reader cannot delete";
         }
-        if (doWithOptionalWait(this::bucketGet)) {
+        if (doNoWait(this::bucketGet)) {
           return "reader cannot bucket get";
         }
-        if (doWithOptionalWait(this::bucketDelete)) {
+        if (doNoWait(this::bucketDelete)) {
           return "reader cannot bucket delete";
         }
         return null; // Success

--- a/integration/src/main/java/scripts/utils/GcsBucketAccessTester.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketAccessTester.java
@@ -75,6 +75,10 @@ public class GcsBucketAccessTester implements AutoCloseable {
     // for testing another user's access. Ensure that the creator has valid access
     // before continuing.
     checkAccessWorker(creatorTestUser, ControlledResourceIamRole.EDITOR, true);
+    logger.info(
+        "User {} has permissions for role {}",
+        creatorTestUser.userEmail,
+        ControlledResourceIamRole.EDITOR);
   }
 
   @Override
@@ -145,6 +149,10 @@ public class GcsBucketAccessTester implements AutoCloseable {
 
   /**
    * Worker method to test user access
+   *
+   * NOTE: we never wait for a negative. If we are testing that user does not
+   * have a permission, then we call the operation with doNoWait, regardless of
+   * the needToWait state.
    *
    * @param testUser user to check
    * @param role the IamRole to test for; null to test the "user has no role" case
@@ -222,7 +230,6 @@ public class GcsBucketAccessTester implements AutoCloseable {
         if (!doWithOptionalWait(this::blobDelete)) {
           return "writer can delete";
         }
-
         if (doNoWait(this::bucketGet)) {
           return "writer cannot bucket get";
         }

--- a/integration/src/main/resources/suites/TempTestSuite.json
+++ b/integration/src/main/resources/suites/TempTestSuite.json
@@ -1,0 +1,11 @@
+{
+  "name": "Temp Test Suite",
+  "description": "Manual test suite - see workflow/run-integration-suite.yml",
+  "serverSpecificationFile": "workspace-local.json",
+  "testConfigurationFiles": [
+    "integration/ControlledApplicationPrivateGcsBucketLifecycle.json",
+    "integration/ControlledApplicationSharedGcsBucketLifecycle.json",
+    "integration/ControlledGcsBucketLifecycle.json",
+    "integration/PrivateControlledGcsBucketLifecycle.json"
+  ]
+}


### PR DESCRIPTION
This PR takes a stab at fixing up the access tester.

I changed the check code so that it would just check and not assert. Split out the wait and nowait cases, so instead of setting the boolean, we just call `doNoWait` for the "cannot XXX" cases. (h/t Yu).

I renamed the check methods to assertXXX and put the assert at the top level. A little hacky using the String to determine error or not, but it works.

I added a method that I plan to use in remove-user testing. Kicking off the PR now so you can review it and find out if it breaks any existing PR tests. In the meantime, I am locally running broken tests that use the tester to see if they behave better.