### PR TITLE
PF-2172: Integrate regional policy check to controlled resource create (re-add)

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -467,10 +467,11 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
         toCommonFields(
             workspaceUuid,
             body.getCommon(),
-            // AI notebook is a zonal resource. The resource location might be a zone instead of
-            // a region so we do not set this field in the wsm db yet. The region will be computed
-            // as part of the AI notebook creation flight.
-            /*region=*/ null,
+            // AI notebook is a zonal resource. It's set here so that we can validate it against
+            // policy. However, the notebook creation flight will compute a final location, which
+            // could be a zone if a region is passed here. The assumption for policy is that a zone
+            // is included inside of a region. The db entry is updated as part of the flight.
+            resourceLocation,
             userRequest,
             WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE);
     String projectId = gcpCloudContextService.getRequiredGcpProject(workspaceUuid);

--- a/service/src/main/java/bio/terra/workspace/common/utils/GcpUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/GcpUtils.java
@@ -148,4 +148,13 @@ public class GcpUtils {
     AccessToken accessToken = new AccessToken(userRequest.getRequiredToken(), null);
     return GoogleCredentials.create(accessToken);
   }
+
+  /**
+   * Extract the region part from the given location string. If the string is a region, return that.
+   * If the string looks like a zone, return just the region part. Basically, remove any trailing
+   * "-[a-z]".
+   */
+  public static String parseRegion(String location) {
+    return location.replaceAll("(?!^)-[a-z]$", "");
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -200,7 +200,11 @@ public class ResourceValidationUtils {
   public static void validateControlledResourceRegionAgainstPolicy(
       TpsApiDispatch tpsApiDispatch, UUID workspaceUuid, String location, CloudPlatform platform) {
     switch (platform) {
-      case AZURE -> validateAzureRegion(location);
+      case AZURE -> {
+        // TODO: enable policy check in Azure when we support Azure regions in the TPS ontology.
+        // validateAzureRegion(location);
+        return;
+      }
       case GCP -> validateGcpRegion(tpsApiDispatch, workspaceUuid, location);
       default -> throw new InvalidControlledResourceException("Unrecognized platform");
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -484,6 +484,9 @@ public class ResourceValidationUtils {
         throw new InvalidControlledResourceException(
             String.format("Specified location %s is not allowed by effective policy.", region));
       }
+    } else {
+      logger.warn(
+          "Workspace {} has no policy attached, cannot validate region constraints.", workspaceId);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -6,13 +6,17 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.app.configuration.external.GitRepoReferencedResourceConfiguration;
+import bio.terra.workspace.common.utils.GcpUtils;
 import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
+import bio.terra.workspace.service.policy.TpsApiDispatch;
+import bio.terra.workspace.service.resource.controlled.exception.InvalidControlledResourceException;
 import bio.terra.workspace.service.resource.exception.InvalidNameException;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import com.azure.core.management.Region;
 import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.google.common.annotations.VisibleForTesting;
@@ -20,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -157,7 +162,7 @@ public class ResourceValidationUtils {
    * Validates gcs-bucket name following Google documentation
    * https://cloud.google.com/storage/docs/naming-buckets#requirements on a best-effort base.
    *
-   * <p>This method DOES NOT guarentee that the bucket name is valid.
+   * <p>This method DOES NOT guarantee that the bucket name is valid.
    *
    * @param name gcs-bucket name
    * @param validationFailureError
@@ -189,6 +194,15 @@ public class ResourceValidationUtils {
         throw new InvalidNameException(
             "Invalid GCS bucket name specified. Bucket names cannot contains google or mis-spelled google. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
       }
+    }
+  }
+
+  public static void validateControlledResourceRegionAgainstPolicy(
+      TpsApiDispatch tpsApiDispatch, UUID workspaceUuid, String location, CloudPlatform platform) {
+    switch (platform) {
+      case AZURE -> validateAzureRegion(location);
+      case GCP -> validateGcpRegion(tpsApiDispatch, workspaceUuid, location);
+      default -> throw new InvalidControlledResourceException("Unrecognized platform");
     }
   }
 
@@ -441,14 +455,27 @@ public class ResourceValidationUtils {
     }
   }
 
-  public static void validateRegion(String region) {
+  public static void validateAzureRegion(String region) {
     if (!Region.values().stream()
         .map(Region::toString)
         .collect(Collectors.toList())
         .contains(region)) {
       logger.warn("Invalid Azure region {}", region);
-      throw new InvalidReferenceException(
-          "Invalid Azure Region specified. See the class `com.azure.core.management.Region`");
+      throw new InvalidControlledResourceException("Invalid Azure Region specified.");
+    }
+  }
+
+  public static void validateGcpRegion(
+      TpsApiDispatch tpsApiDispatch, UUID workspaceId, String region) {
+    region = GcpUtils.parseRegion(region);
+
+    // Get the list of valid locations for this workspace from TPS. If there are no regional
+    // constraints applied to the workspace, TPS should return all available regions.
+    List<String> validLocations = tpsApiDispatch.listValidRegions(workspaceId, CloudPlatform.GCP);
+
+    if (validLocations.stream().noneMatch(region::equalsIgnoreCase)) {
+      throw new InvalidControlledResourceException(
+          String.format("Specified location %s is not allowed by effective policy.", region));
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -204,7 +204,7 @@ public class ControlledAzureDiskResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureDisk.");
     }
-    ResourceValidationUtils.validateRegion(getRegion());
+    ResourceValidationUtils.validateAzureRegion(getRegion());
     ResourceValidationUtils.validateAzureDiskName(getDiskName());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/ip/ControlledAzureIpResource.java
@@ -191,7 +191,7 @@ public class ControlledAzureIpResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureIP.");
     }
-    ResourceValidationUtils.validateRegion(getRegion());
+    ResourceValidationUtils.validateAzureRegion(getRegion());
     ResourceValidationUtils.validateAzureIPorSubnetName(getIpName());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/network/ControlledAzureNetworkResource.java
@@ -248,7 +248,7 @@ public class ControlledAzureNetworkResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureNetwork.");
     }
-    ResourceValidationUtils.validateRegion(getRegion());
+    ResourceValidationUtils.validateAzureRegion(getRegion());
     ResourceValidationUtils.validateAzureNetworkName(getNetworkName());
     ResourceValidationUtils.validateAzureIPorSubnetName(getSubnetName());
     ResourceValidationUtils.validateAzureCidrBlock(getAddressSpaceCidr());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/ControlledAzureRelayNamespaceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/relayNamespace/ControlledAzureRelayNamespaceResource.java
@@ -197,7 +197,7 @@ public class ControlledAzureRelayNamespaceResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureRelayNamespace.");
     }
-    ResourceValidationUtils.validateRegion(getRegion());
+    ResourceValidationUtils.validateAzureRegion(getRegion());
     ResourceValidationUtils.validateAzureNamespace(getNamespaceName());
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
@@ -21,6 +21,7 @@ import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
+import com.azure.core.management.Region;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
@@ -77,7 +78,7 @@ public class ControlledAzureResourceApiControllerAzureVmTest extends BaseAzureUn
             controller.toCommonFields(
                 workspaceId,
                 commonFields,
-                /*region=*/ null,
+                Region.US_SOUTH_CENTRAL.name(),
                 USER_REQUEST,
                 WsmResourceType.CONTROLLED_AZURE_VM));
 

--- a/service/src/test/java/bio/terra/workspace/common/utils/GcpUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/GcpUtilsTest.java
@@ -1,0 +1,30 @@
+package bio.terra.workspace.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.workspace.common.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+
+public class GcpUtilsTest extends BaseUnitTest {
+
+  @Test
+  public void parseRegionWithRegions() {
+    assertEquals("us-east1", GcpUtils.parseRegion("us-east1"));
+    assertEquals("asia-northeast3", GcpUtils.parseRegion("asia-northeast3"));
+    assertEquals("australia-southeast2", GcpUtils.parseRegion("australia-southeast2"));
+  }
+
+  @Test
+  public void parseRegionEdgeCases() {
+    assertEquals("", GcpUtils.parseRegion(""));
+    assertEquals(" ", GcpUtils.parseRegion(" "));
+    assertEquals("-a", GcpUtils.parseRegion("-a"));
+  }
+
+  @Test
+  public void parseRegionWithZones() {
+    assertEquals("us-east1", GcpUtils.parseRegion("us-east1-a"));
+    assertEquals("asia-northeast3", GcpUtils.parseRegion("asia-northeast3-c"));
+    assertEquals("australia-southeast2", GcpUtils.parseRegion("australia-southeast2-b"));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -518,7 +518,6 @@ public class ValidationUtilsTest extends BaseUnitTest {
       validationUtils.validateControlledResourceRegionAgainstPolicy(
           mockTpsApiDispatch(), workspaceId, region.name(), CloudPlatform.AZURE);
     }
-
   }
 
   @Test
@@ -534,7 +533,6 @@ public class ValidationUtilsTest extends BaseUnitTest {
 
     assertThrows(
         InvalidControlledResourceException.class,
-        () ->
-            validationUtils.validateAzureRegion("badlocation"));
+        () -> validationUtils.validateAzureRegion("badlocation"));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultNotebookCreationParameters;
 import static bio.terra.workspace.service.workspace.model.WorkspaceConstants.ResourceProperties.FOLDER_ID_KEY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
@@ -13,11 +14,15 @@ import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureVmImage;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceContainerImage;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
+import bio.terra.workspace.service.resource.controlled.exception.InvalidControlledResourceException;
 import bio.terra.workspace.service.resource.exception.InvalidNameException;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import com.azure.core.management.Region;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -451,5 +456,63 @@ public class ValidationUtilsTest extends BaseUnitTest {
   @Test
   public void validateProperties_folderIdIsUuid_validates() {
     ResourceValidationUtils.validateProperties(Map.of(FOLDER_ID_KEY, UUID.randomUUID().toString()));
+  }
+
+  @Test
+  public void validateControlledResourceRegion() {
+    var testRegions = List.of("us", "us-central1", "us-east1");
+    UUID workspaceId = UUID.randomUUID();
+    String platform = "gcp";
+
+    when(mockTpsApiDispatch().listValidRegions(workspaceId, CloudPlatform.GCP))
+        .thenReturn(List.of("US", "us-central1", "us-east1"));
+
+    for (var region : testRegions) {
+      // these validations should not throw an exception
+      validationUtils.validateControlledResourceRegionAgainstPolicy(
+          mockTpsApiDispatch(), workspaceId, region, CloudPlatform.GCP);
+      validationUtils.validateControlledResourceRegionAgainstPolicy(
+          mockTpsApiDispatch(), workspaceId, region.toUpperCase(Locale.ROOT), CloudPlatform.GCP);
+    }
+  }
+
+  @Test
+  public void validateControlledResourceRegion_invalid_throws() {
+    UUID workspaceId = UUID.randomUUID();
+    String platform = "gcp";
+    when(mockTpsApiDispatch().listValidRegions(workspaceId, CloudPlatform.GCP))
+        .thenReturn(List.of("us-central1", "us-east1"));
+
+    assertThrows(
+        InvalidControlledResourceException.class,
+        () ->
+            validationUtils.validateControlledResourceRegionAgainstPolicy(
+                mockTpsApiDispatch(), workspaceId, "badregion", CloudPlatform.GCP));
+
+    assertThrows(
+        InvalidControlledResourceException.class,
+        () ->
+            validationUtils.validateControlledResourceRegionAgainstPolicy(
+                mockTpsApiDispatch(), workspaceId, "badregion", CloudPlatform.AZURE));
+  }
+
+  @Test
+  public void validateAzureRegion() {
+    UUID workspaceId = UUID.randomUUID();
+
+    for (var region : Region.values()) {
+      var regionName = region.name();
+      validationUtils.validateControlledResourceRegionAgainstPolicy(
+          mockTpsApiDispatch(), workspaceId, region.name(), CloudPlatform.AZURE);
+    }
+  }
+
+  @Test
+  public void validateAzureRegion_invalid_throws() {
+    assertThrows(
+        InvalidControlledResourceException.class,
+        () ->
+            validationUtils.validateControlledResourceRegionAgainstPolicy(
+                mockTpsApiDispatch(), UUID.randomUUID(), "badlocation", CloudPlatform.AZURE));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ValidationUtilsTest.java
@@ -492,11 +492,9 @@ public class ValidationUtilsTest extends BaseUnitTest {
             validationUtils.validateControlledResourceRegionAgainstPolicy(
                 mockTpsApiDispatch(), workspaceId, "badregion", CloudPlatform.GCP));
 
-    assertThrows(
-        InvalidControlledResourceException.class,
-        () ->
-            validationUtils.validateControlledResourceRegionAgainstPolicy(
-                mockTpsApiDispatch(), workspaceId, "badregion", CloudPlatform.AZURE));
+    // shouldn't throw until we start validating Azure regions against TPS
+    validationUtils.validateControlledResourceRegionAgainstPolicy(
+        mockTpsApiDispatch(), workspaceId, "badregion", CloudPlatform.AZURE);
   }
 
   @Test
@@ -515,25 +513,28 @@ public class ValidationUtilsTest extends BaseUnitTest {
 
     for (var region : Region.values()) {
       var regionName = region.name();
+      validationUtils.validateAzureRegion(regionName);
+
       validationUtils.validateControlledResourceRegionAgainstPolicy(
           mockTpsApiDispatch(), workspaceId, region.name(), CloudPlatform.AZURE);
     }
+
   }
 
   @Test
   public void validateAzureRegion_nullRegion() {
     UUID workspaceId = UUID.randomUUID();
 
-    validationUtils.validateControlledResourceRegionAgainstPolicy(
-        mockTpsApiDispatch(), workspaceId, null, CloudPlatform.AZURE);
+    // null region shouldn't throw.
+    validationUtils.validateAzureRegion(null);
   }
 
   @Test
   public void validateAzureRegion_invalid_throws() {
+
     assertThrows(
         InvalidControlledResourceException.class,
         () ->
-            validationUtils.validateControlledResourceRegionAgainstPolicy(
-                mockTpsApiDispatch(), UUID.randomUUID(), "badlocation", CloudPlatform.AZURE));
+            validationUtils.validateAzureRegion("badlocation"));
   }
 }


### PR DESCRIPTION
The previous commit broke 2 things and was reverted.
1) Creating Azure workspaces - since they don't pass a region to validate
2) Working with GCP workspaces created without policies - caused policy not found exceptions.

This PR re-introduces the changes to support regional policy checks, but also fixes those two pieces.

This is like the previous PR with a couple small changes I'll call out.