### PR TITLE
[PF-2079] Add retry to CloneWorkspace test getWorkspace()

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -39,6 +39,7 @@ import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.GcpGcsObjectAttributes;
 import bio.terra.workspace.model.GcpGcsObjectResource;
 import bio.terra.workspace.model.IamRole;
+import bio.terra.workspace.model.Properties;
 import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.ResourceCloneDetails;
 import bio.terra.workspace.model.ResourceMetadata;
@@ -370,11 +371,14 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
         getWorkspaceId(),
         cloneResult.getWorkspace().getSourceWorkspaceId(),
         "Source workspace ID reported accurately.");
+    Properties sourceProperties =
+    ClientTestUtils.getWithRetryOnException(
+        () -> sourceOwnerWorkspaceApi
+            .getWorkspace(getWorkspaceId(), /*minimumHighestRole=*/ null)
+            .getProperties());
     assertEquals(
         destinationWorkspaceDescription.getProperties(),
-        sourceOwnerWorkspaceApi
-            .getWorkspace(getWorkspaceId(), /*minimumHighestRole=*/ null)
-            .getProperties(),
+        sourceProperties,
         "Properties cloned successfully");
     assertEquals(cloningUser.userEmail, destinationWorkspaceDescription.getCreatedBy());
 

--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -372,10 +372,11 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
         cloneResult.getWorkspace().getSourceWorkspaceId(),
         "Source workspace ID reported accurately.");
     Properties sourceProperties =
-    ClientTestUtils.getWithRetryOnException(
-        () -> sourceOwnerWorkspaceApi
-            .getWorkspace(getWorkspaceId(), /*minimumHighestRole=*/ null)
-            .getProperties());
+        ClientTestUtils.getWithRetryOnException(
+            () ->
+                sourceOwnerWorkspaceApi
+                    .getWorkspace(getWorkspaceId(), /*minimumHighestRole=*/ null)
+                    .getProperties());
     assertEquals(
         destinationWorkspaceDescription.getProperties(),
         sourceProperties,


### PR DESCRIPTION
CloneWorkspace flaked twice last night:

https://github.com/verily-src/terra-service-ws-manager/actions/runs/4061783399/jobs/6992138839

In both cases, this [call to getWorkspace()](https://github.com/DataBiosphere/terra-workspace-manager/blob/main/integration/src/main/java/scripts/testscripts/CloneWorkspace.java#L376) failed with `java.io.IOException: Connection timed out`. Test logs hang for ~15 mins:

```
2023-02-01T07:15:48.5275230Z 2023-02-01 07:15:48.413   INFO   --- [pool-3-thread-1] scripts.utils.ClientTestUtils            : Operation Clone Workspace succeeded
2023-02-01T07:31:44.6188029Z javax.ws.rs.ProcessingException: java.io.IOException: Connection timed out
2023-02-01T07:31:44.6189105Z 	at org.glassfish.jersey.jdk.connector.internal.JdkConnector.apply(JdkConnector.java:74)
2023-02-01T07:31:44.6190251Z 	at org.glassfish.jersey.client.ClientRuntime.invoke(ClientRuntime.java:297)
2023-02-01T07:31:44.6191569Z 	at org.glassfish.jersey.client.JerseyInvocation.lambda$invoke$0(JerseyInvocation.java:619)
2023-02-01T07:31:44.6192392Z 	at org.glassfish.jersey.client.JerseyInvocation.call(JerseyInvocation.java:654)
2023-02-01T07:31:44.6196204Z 	at org.glassfish.jersey.client.JerseyInvocation.lambda$runInScope$3(JerseyInvocation.java:648)
2023-02-01T07:31:44.6197277Z 2023-02-01 07:31:44.513   INFO   --- [           main] bio.terra.testrunner.runner.TestRunner   : Test Scripts: Compiling the results from all thread pools
2023-02-01T07:31:44.6198129Z 2023-02-01 07:31:44.514   INFO   --- [           main] bio.terra.testrunner.runner.TestRunner   : Test Scripts: Calling the cleanup methods
2023-02-01T07:31:44.6198949Z 	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
2023-02-01T07:31:44.6200065Z 	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
2023-02-01T07:31:44.6200671Z 	at org.glassfish.jersey.internal.Errors.process(Errors.java:205)
2023-02-01T07:31:44.6201340Z 	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:390)
2023-02-01T07:31:44.6202071Z 	at org.glassfish.jersey.client.JerseyInvocation.runInScope(JerseyInvocation.java:648)
2023-02-01T07:31:44.6202759Z 	at org.glassfish.jersey.client.JerseyInvocation.invoke(JerseyInvocation.java:618)
2023-02-01T07:31:44.6203436Z 	at org.glassfish.jersey.client.JerseyInvocation$Builder.method(JerseyInvocation.java:397)
2023-02-01T07:31:44.6204098Z 	at org.glassfish.jersey.client.JerseyInvocation$Builder.get(JerseyInvocation.java:297)
2023-02-01T07:31:44.6204714Z 	at bio.terra.workspace.client.ApiClient.invokeAPI(ApiClient.java:713)
2023-02-01T07:31:44.6205340Z 	at bio.terra.workspace.api.WorkspaceApi.getWorkspace(WorkspaceApi.java:561)
2023-02-01T07:31:44.6205975Z 	at scripts.testscripts.CloneWorkspace.doUserJourney(CloneWorkspace.java:376)
2023-02-01T07:31:44.6206743Z 	at scripts.utils.WorkspaceApiTestScriptBase.userJourney(WorkspaceApiTestScriptBase.java:40)
2023-02-01T07:31:44.6207433Z 	at bio.terra.testrunner.runner.TestRunner.tryDoUserJourney(TestRunner.java:442)
2023-02-01T07:31:44.6208118Z 	at bio.terra.testrunner.runner.TestRunner.access$000(TestRunner.java:27)
2023-02-01T07:31:44.6208736Z 	at bio.terra.testrunner.runner.TestRunner$UserJourneyThread.call(TestRunner.java:427)
2023-02-01T07:31:44.6209424Z 	at bio.terra.testrunner.runner.TestRunner$UserJourneyThread.call(TestRunner.java:401)
2023-02-01T07:31:44.6210013Z 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
2023-02-01T07:31:44.6210664Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
2023-02-01T07:31:44.6211344Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
2023-02-01T07:31:44.6211890Z 	at java.base/java.lang.Thread.run(Thread.java:833)
2023-02-01T07:31:44.6212363Z Caused by: java.io.IOException: Connection timed out
2023-02-01T07:31:44.6212854Z 	at java.base/sun.nio.ch.SocketDispatcher.read0(Native Method)
2023-02-01T07:31:44.6213409Z 	at java.base/sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:47)
2023-02-01T07:31:44.6213975Z 	at java.base/sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:330)
2023-02-01T07:31:44.6214488Z 	at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:296)
2023-02-01T07:31:44.6214944Z 	at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:266)
2023-02-01T07:31:44.6215910Z 	at java.base/sun.nio.ch.UnixAsynchronousSocketChannelImpl.finishRead(UnixAsynchronousSocketChannelImpl.java:400)
2023-02-01T07:31:44.6216704Z 	at java.base/sun.nio.ch.UnixAsynchronousSocketChannelImpl.finish(UnixAsynchronousSocketChannelImpl.java:195)
2023-02-01T07:31:44.6217495Z 	at java.base/sun.nio.ch.UnixAsynchronousSocketChannelImpl.onEvent(UnixAsynchronousSocketChannelImpl.java:217)
2023-02-01T07:31:44.6218161Z 	at java.base/sun.nio.ch.EPollPort$EventHandlerTask.run(EPollPort.java:306)
2023-02-01T07:31:44.6218802Z 	at java.base/sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:113)
2023-02-01T07:31:44.6219283Z 	... 3 more
```
Nothing jumps out in [WSM logs](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2023-01-31T19:14:23.382Z;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22terra-devel%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22terra%22%0Aresource.labels.namespace_name%3D%22ws-manager%22%0Alabels.k8s-pod%2Fapp%3D%22ws-manager%22%0Atimestamp%3D%222023-01-31T19:14:13.381Z%22%0AinsertId%3D%22zp03o90k0m1z57lq%22;timeRange=2023-01-31T19:15:48.430Z%2F2023-01-31T19:15:48.430Z--PT1H?project=terra-devel).

I have no idea why that specific call fails. But adding retry.

Will merge after Full Integration Tests pass.
