### PR TITLE
PF-2468: Correct clone log

### DIFF
--- a/service/src/main/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHook.java
+++ b/service/src/main/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHook.java
@@ -106,17 +106,8 @@ public class WorkspaceActivityLogHook implements StairwayHook {
 
     ActivityFlight af = ActivityFlight.fromFlightClassName(flightClassName);
     if (workspaceId == null) {
-      if (SyncGcpIamRolesFlight.class.getName().equals(flightClassName)) {
-        maybeLogForSyncGcpIamRolesFlight(context, operationType, userEmail, subjectId);
-      } else if (UpdateGcpControlledResourceRegionFlight.class.getName().equals(flightClassName)) {
-        maybeLogUpdateControlledResourceRegionFlight(context, operationType, userEmail, subjectId);
-      } else {
-        throw new UnhandledActivityLogException(
-            String.format(
-                "workspace id is missing from the flight %s, add special log handling",
-                flightClassName));
-      }
-      return HookAction.CONTINUE;
+      return maybeLogFlightWithoutWorkspaceId(
+          context, flightClassName, operationType, userEmail, subjectId);
     }
     UUID workspaceUuid = UUID.fromString(workspaceId);
     // If DELETE flight failed, cloud resource may or may not have been deleted. Check if cloud
@@ -140,50 +131,24 @@ public class WorkspaceActivityLogHook implements StairwayHook {
     // Always log when the flight succeeded.
     if (context.getFlightStatus() == FlightStatus.SUCCESS) {
       switch (af.getActivityLogChangedTarget()) {
-        case WORKSPACE, AZURE_CLOUD_CONTEXT, GCP_CLOUD_CONTEXT -> {
-          UUID subjectWorkspaceId = workspaceUuid;
-          if (OperationType.CLONE == operationType) {
-            // When the action is clone, the action clone is acted upon
-            // the source workspace.
-            subjectWorkspaceId =
-                getRequired(
-                    context.getInputParameters(),
-                    ControlledResourceKeys.SOURCE_WORKSPACE_ID,
-                    UUID.class);
-          }
-          activityLogDao.writeActivity(
-              workspaceUuid,
-              new DbWorkspaceActivityLog(
-                  userEmail,
-                  subjectId,
-                  operationType,
-                  subjectWorkspaceId.toString(),
-                  af.getActivityLogChangedTarget()));
-        }
-        case RESOURCE -> {
-          // The workspace id that a db transaction has happened. In
-          // the case of cloning, the db create a cloned resource in
-          // the destination workspace.
-          var affectedWorkspaceId = workspaceUuid;
-          if (OperationType.CLONE == operationType) {
-            affectedWorkspaceId =
-                getRequired(
-                    context.getInputParameters(),
-                    ControlledResourceKeys.DESTINATION_WORKSPACE_ID,
-                    UUID.class);
-          }
-          activityLogDao.writeActivity(
-              affectedWorkspaceId,
-              new DbWorkspaceActivityLog(
-                  userEmail,
-                  subjectId,
-                  operationType,
-                  getRequired(
-                          context.getInputParameters(), ResourceKeys.RESOURCE, WsmResource.class)
-                      .getResourceId()
-                      .toString(),
-                  af.getActivityLogChangedTarget()));
-        }
+        case WORKSPACE, AZURE_CLOUD_CONTEXT, GCP_CLOUD_CONTEXT -> activityLogDao.writeActivity(
+            workspaceUuid,
+            new DbWorkspaceActivityLog(
+                userEmail,
+                subjectId,
+                operationType,
+                getClonedWorkspaceId(context, operationType, workspaceUuid).toString(),
+                af.getActivityLogChangedTarget()));
+        case RESOURCE -> activityLogDao.writeActivity(
+            getAffectedWorkspaceId(context, operationType, workspaceUuid),
+            new DbWorkspaceActivityLog(
+                userEmail,
+                subjectId,
+                operationType,
+                getRequired(context.getInputParameters(), ResourceKeys.RESOURCE, WsmResource.class)
+                    .getResourceId()
+                    .toString(),
+                af.getActivityLogChangedTarget()));
         case FOLDER -> activityLogDao.writeActivity(
             workspaceUuid,
             new DbWorkspaceActivityLog(
@@ -205,6 +170,66 @@ public class WorkspaceActivityLogHook implements StairwayHook {
       }
     }
     return HookAction.CONTINUE;
+  }
+
+  /**
+   * For rare cases when a flight is missing workspace id, we should handle the logging on a
+   * case-by-case basis.
+   */
+  private HookAction maybeLogFlightWithoutWorkspaceId(
+      FlightContext context,
+      String flightClassName,
+      OperationType operationType,
+      String userEmail,
+      String subjectId) {
+    if (SyncGcpIamRolesFlight.class.getName().equals(flightClassName)) {
+      maybeLogForSyncGcpIamRolesFlight(context, operationType, userEmail, subjectId);
+    } else if (UpdateGcpControlledResourceRegionFlight.class.getName().equals(flightClassName)) {
+      maybeLogUpdateControlledResourceRegionFlight(context, operationType, userEmail, subjectId);
+    } else {
+      throw new UnhandledActivityLogException(
+          String.format(
+              "workspace id is missing from the flight %s, add special log handling",
+              flightClassName));
+    }
+    return HookAction.CONTINUE;
+  }
+
+  /**
+   * Get the workspace where the activity operation is acted upon. For cloning a workspace, it
+   * should be the source workspace.
+   */
+  private UUID getClonedWorkspaceId(
+      FlightContext context, OperationType operationType, UUID workspaceUuid) {
+    UUID subjectWorkspaceId = workspaceUuid;
+    if (OperationType.CLONE == operationType) {
+      // When the action is clone, the action clone is acted upon
+      // the source workspace.
+      subjectWorkspaceId =
+          getRequired(
+              context.getInputParameters(), ControlledResourceKeys.SOURCE_WORKSPACE_ID, UUID.class);
+    }
+    return subjectWorkspaceId;
+  }
+
+  /**
+   * Get the workspace where the activity happened. For cloning, it should be the destination
+   * workspace.
+   */
+  private UUID getAffectedWorkspaceId(
+      FlightContext context, OperationType operationType, UUID workspaceUuid) {
+    // The workspace id that a db transaction has happened. In
+    // the case of cloning, the db create a cloned resource in
+    // the destination workspace.
+    var affectedWorkspaceId = workspaceUuid;
+    if (OperationType.CLONE == operationType) {
+      affectedWorkspaceId =
+          getRequired(
+              context.getInputParameters(),
+              ControlledResourceKeys.DESTINATION_WORKSPACE_ID,
+              UUID.class);
+    }
+    return affectedWorkspaceId;
   }
 
   private void logApplicationAbleFlight(

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -325,7 +325,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         USER_REQUEST.getEmail(),
         USER_REQUEST.getSubjectId(),
         OperationType.CLONE,
-        destinationWorkspaceId.toString(),
+        sourceWorkspace.getId().toString(),
         ActivityLogChangedTarget.WORKSPACE);
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -35,12 +35,17 @@ import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.folder.flights.DeleteFolderFlight;
 import bio.terra.workspace.service.folder.model.Folder;
 import bio.terra.workspace.service.job.JobMapKeys;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
+import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.CloneControlledGcsBucketResourceFlight;
+import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.CloneWorkspaceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.workspace.flight.DeleteGcpContextFlight;
 import bio.terra.workspace.service.workspace.flight.WorkspaceCreateFlight;
 import bio.terra.workspace.service.workspace.flight.WorkspaceDeleteFlight;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
@@ -92,6 +97,64 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
             OperationType.CREATE,
             workspaceUuid.toString(),
             ActivityLogChangedTarget.WORKSPACE));
+  }
+
+  @Test
+  void cloneWorkspaceFlightSucceeds_activityLogUpdated() throws InterruptedException {
+    var workspaceUuid = UUID.randomUUID();
+    var destinationWorkspaceId = UUID.randomUUID();
+    var emptyChangeDetails = activityLogDao.getLastUpdatedDetails(destinationWorkspaceId);
+    assertTrue(emptyChangeDetails.isEmpty());
+
+    FlightMap inputParams = buildInputParams(workspaceUuid, OperationType.CLONE);
+    inputParams.put(ControlledResourceKeys.DESTINATION_WORKSPACE_ID, destinationWorkspaceId);
+    ControlledGcsBucketResource gcsBucketToClone =
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceUuid).build();
+    inputParams.put(ResourceKeys.RESOURCE, gcsBucketToClone);
+    hook.endFlight(
+        new FakeFlightContext(
+            CloneControlledGcsBucketResourceFlight.class.getName(),
+            inputParams,
+            FlightStatus.SUCCESS));
+    ActivityLogChangeDetails changeDetails =
+        activityLogDao.getLastUpdatedDetails(destinationWorkspaceId).get();
+    assertEquals(
+        changeDetails,
+        new ActivityLogChangeDetails(
+            changeDetails.changeDate(),
+            USER_REQUEST.getEmail(),
+            USER_REQUEST.getSubjectId(),
+            OperationType.CLONE,
+            gcsBucketToClone.getResourceId().toString(),
+            ActivityLogChangedTarget.RESOURCE));
+    assertTrue(activityLogDao.getLastUpdatedDetails(workspaceUuid).isEmpty());
+  }
+
+  @Test
+  void cloneControlledResourceFlightSucceeds_activityLogUpdated() throws InterruptedException {
+    var workspaceUuid = UUID.randomUUID();
+    var destinationWorkspaceId = UUID.randomUUID();
+    var emptyChangeDetails = activityLogDao.getLastUpdatedDetails(destinationWorkspaceId);
+    assertTrue(emptyChangeDetails.isEmpty());
+
+    FlightMap inputParams = buildInputParams(workspaceUuid, OperationType.CLONE);
+    inputParams.put(WorkspaceFlightMapKeys.WORKSPACE_ID, destinationWorkspaceId.toString());
+    inputParams.put(ControlledResourceKeys.SOURCE_WORKSPACE_ID, workspaceUuid);
+    hook.endFlight(
+        new FakeFlightContext(
+            CloneWorkspaceFlight.class.getName(), inputParams, FlightStatus.SUCCESS));
+    ActivityLogChangeDetails changeDetails =
+        activityLogDao.getLastUpdatedDetails(destinationWorkspaceId).get();
+    assertEquals(
+        changeDetails,
+        new ActivityLogChangeDetails(
+            changeDetails.changeDate(),
+            USER_REQUEST.getEmail(),
+            USER_REQUEST.getSubjectId(),
+            OperationType.CLONE,
+            workspaceUuid.toString(),
+            ActivityLogChangedTarget.WORKSPACE));
+    assertTrue(activityLogDao.getLastUpdatedDetails(workspaceUuid).isEmpty());
   }
 
   @Test


### PR DESCRIPTION
So the log is written on the destination workspace id. But the change_subject_id should be the source because that is what is cloned.

