### PR TITLE
Skip sonarqube for bump builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,7 @@ jobs:
       run: ./gradlew :service:${{ matrix.gradleTask }} --scan
 
     - name: SonarQube scan
+      if: steps.skiptest.outputs.is-bump == 'no'
       run: ./gradlew --build-cache :service:sonarqube
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
We didn't run tests or Codacy checks for bump builds. But we missed adding that condition when we switched to sonarqube.