### PR TITLE
TOAZ-314 Adjust uami payload for azure batch pool creation endpoint

### DIFF
--- a/openapi/src/parts/controlled_azure_batch_pool.yaml
+++ b/openapi/src/parts/controlled_azure_batch_pool.yaml
@@ -154,14 +154,21 @@ components:
 
     AzureBatchPoolUserAssignedIdentity:
       type: object
-      description: User assigned identity associated with a batch pool
-      required: [ name, resourceGroupName ]
+      description: User assigned identity associated with a batch pool.
       properties:
         name:
-          description: The name of user assigned identity.
+          description: |
+            The name of the user assigned identity. This parameter is mutually exclusive with clientId.
           type: string
+        clientId:
+          description: |
+            The client id of the UAMI. This parameter is mutually exclusive with name. If this parameter 
+            is set instead of the name WSM will try to locate specific UAMI based on it.
+          type: string
+          format: uuid
         resourceGroupName:
-          description: The resource group name where identity resides.
+          description: |
+            The resource group name where identity resides. Default value is MRG where Azure Batch account exists.
           type: string
 
     AzureBatchPoolScaleSettings:

--- a/service/src/main/java/bio/terra/workspace/common/utils/MapperUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/MapperUtils.java
@@ -122,7 +122,10 @@ public class MapperUtils {
       }
 
       return userAssignedManagedIdentities.stream()
-          .map(i -> new BatchPoolUserAssignedManagedIdentity(i.getResourceGroupName(), i.getName()))
+          .map(
+              i ->
+                  new BatchPoolUserAssignedManagedIdentity(
+                      i.getResourceGroupName(), i.getName(), i.getClientId()))
           .collect(Collectors.toList());
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
@@ -272,11 +272,13 @@ public class ControlledAzureBatchPoolResource extends ControlledResource {
       }
     }
     if (userAssignedIdentities != null) {
-      var inconsistentUamiCount = userAssignedIdentities.stream()
+      var inconsistentUamiCount =
+          userAssignedIdentities.stream()
               .filter(uami -> uami.name() != null && uami.clientId() != null)
               .count();
       if (inconsistentUamiCount > 0) {
-        throw new InconsistentFieldsException("User assigned managed identity name and clientId are mutually exclusive.");
+        throw new InconsistentFieldsException(
+            "User assigned managed identity name and clientId are mutually exclusive.");
       }
     }
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
@@ -271,6 +271,14 @@ public class ControlledAzureBatchPoolResource extends ControlledResource {
             "Fixed scale settings and auto scale settings are mutually exclusive.");
       }
     }
+    if (userAssignedIdentities != null) {
+      var inconsistentUamiCount = userAssignedIdentities.stream()
+              .filter(uami -> uami.name() != null && uami.clientId() != null)
+              .count();
+      if (inconsistentUamiCount > 0) {
+        throw new InconsistentFieldsException("User assigned managed identity name and clientId are mutually exclusive.");
+      }
+    }
   }
 
   public static ControlledAzureBatchPoolResource.Builder builder() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/model/BatchPoolUserAssignedManagedIdentity.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/model/BatchPoolUserAssignedManagedIdentity.java
@@ -2,16 +2,5 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool.mo
 
 import java.util.UUID;
 
-public record BatchPoolUserAssignedManagedIdentity(String resourceGroupName, String name, UUID clientId) {
-    public BatchPoolUserAssignedManagedIdentity(String resourceGroupName, String name, UUID clientId) {
-        this.resourceGroupName = resourceGroupName;
-        this.name = name;
-        this.clientId = clientId;
-    }
-    public BatchPoolUserAssignedManagedIdentity(String resourceGroupName, String name) {
-        this(resourceGroupName, name, null);
-    }
-    public BatchPoolUserAssignedManagedIdentity(String resourceGroupName, UUID clientId) {
-        this(resourceGroupName, null, clientId);
-    }
-}
+public record BatchPoolUserAssignedManagedIdentity(
+    String resourceGroupName, String name, UUID clientId) {}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/model/BatchPoolUserAssignedManagedIdentity.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/model/BatchPoolUserAssignedManagedIdentity.java
@@ -1,3 +1,17 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool.model;
 
-public record BatchPoolUserAssignedManagedIdentity(String resourceGroupName, String name) {}
+import java.util.UUID;
+
+public record BatchPoolUserAssignedManagedIdentity(String resourceGroupName, String name, UUID clientId) {
+    public BatchPoolUserAssignedManagedIdentity(String resourceGroupName, String name, UUID clientId) {
+        this.resourceGroupName = resourceGroupName;
+        this.name = name;
+        this.clientId = clientId;
+    }
+    public BatchPoolUserAssignedManagedIdentity(String resourceGroupName, String name) {
+        this(resourceGroupName, name, null);
+    }
+    public BatchPoolUserAssignedManagedIdentity(String resourceGroupName, UUID clientId) {
+        this(resourceGroupName, null, clientId);
+    }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/exception/UserAssignedManagedIdentityNotFoundException.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/exception/UserAssignedManagedIdentityNotFoundException.java
@@ -1,0 +1,7 @@
+package bio.terra.workspace.service.resource.controlled.exception;
+
+public class UserAssignedManagedIdentityNotFoundException extends Exception {
+  public UserAssignedManagedIdentityNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/BaseBatchPoolTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/BaseBatchPoolTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseAzureConnectedTest;
+import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -20,10 +20,11 @@ import com.azure.resourcemanager.batch.models.DeploymentConfiguration;
 import com.azure.resourcemanager.batch.models.ImageReference;
 import com.azure.resourcemanager.batch.models.Pools;
 import com.azure.resourcemanager.batch.models.VirtualMachineConfiguration;
+import com.azure.resourcemanager.msi.MsiManager;
 import java.util.UUID;
 import org.mockito.Mock;
 
-public class BaseBatchPoolTest extends BaseAzureConnectedTest {
+public class BaseBatchPoolTest extends BaseAzureUnitTest {
   public static final UUID BATCH_POOL_ID = UUID.randomUUID();
   public static final String BATCH_POOL_VM_SIZE = "Standard_D2s_v3";
   public static final String BATCH_POOL_DISPLAY_NAME = "batchPoolDisplayName";
@@ -50,6 +51,7 @@ public class BaseBatchPoolTest extends BaseAzureConnectedTest {
   @Mock public FlightMap mockFlightMap;
   @Mock public FlightMap mockWorkingMap;
   @Mock public BatchManager mockBatchManager;
+  @Mock public MsiManager mockMsiManager;
   @Mock public BatchAccounts mockBatchAccounts;
   @Mock public BatchAccount mockBatchAccount;
   @Mock public Pools mockPools;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/BatchPoolFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/BatchPoolFixtures.java
@@ -22,6 +22,7 @@ import com.azure.resourcemanager.batch.models.TaskContainerSettings;
 import com.azure.resourcemanager.batch.models.UserIdentity;
 import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 
 public class BatchPoolFixtures {
   public static String START_TASK_COMMAND_LINE = "/bin/sh";
@@ -29,6 +30,7 @@ public class BatchPoolFixtures {
   public static Boolean WAIT_FOR_SUCCESS = Boolean.TRUE;
   public static String RESOURCE_GROUP = "resourceGroup";
   public static String IDENTITY_NAME = "identity1";
+  public static UUID IDENTITY_CLIENT_ID = UUID.randomUUID();
   public static String RESOURCE_FILE_PATH = "/opt";
   public static String RESOURCE_FILE_MODE = "wxr";
   public static String ENVIRONMENT_SETTINGS_NAME = "varName";
@@ -64,8 +66,12 @@ public class BatchPoolFixtures {
 
   private BatchPoolFixtures() {}
 
-  public static BatchPoolUserAssignedManagedIdentity createUami() {
-    return new BatchPoolUserAssignedManagedIdentity(RESOURCE_GROUP, IDENTITY_NAME);
+  public static BatchPoolUserAssignedManagedIdentity createUamiWithName() {
+    return new BatchPoolUserAssignedManagedIdentity(RESOURCE_GROUP, IDENTITY_NAME, null);
+  }
+
+  public static BatchPoolUserAssignedManagedIdentity createUamiWithClientId() {
+    return new BatchPoolUserAssignedManagedIdentity(RESOURCE_GROUP, null, IDENTITY_CLIENT_ID);
   }
 
   public static StartTask createStartTask() {


### PR DESCRIPTION
Adjust payload for user assigned identities for batch pool:
-make resourceGroupName parameter optional
-add clientId parameter. Batch pool API required UAMI name, but when this parameter is set UAMI and it's name will be found using clientId.
-make name and clientId parameters mutually exclusive