### PR TITLE
[WOR-757] Fail Azure workspace/cloud context deletion if there are controlled resources that user cannot delete

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/DeleteAzureContextFlight.java
@@ -25,6 +25,7 @@ public class DeleteAzureContextFlight extends Flight {
         new DeleteControlledAzureResourcesStep(
             appContext.getResourceDao(),
             appContext.getControlledResourceService(),
+            appContext.getSamService(),
             workspaceUuid,
             userRequest));
 

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceDeleteFlight.java
@@ -41,6 +41,7 @@ public class WorkspaceDeleteFlight extends Flight {
         new DeleteControlledAzureResourcesStep(
             appContext.getResourceDao(),
             appContext.getControlledResourceService(),
+            appContext.getSamService(),
             workspaceUuid,
             userRequest));
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteControlledAzureResourcesStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteControlledAzureResourcesStepTest.java
@@ -1,5 +1,12 @@
 package bio.terra.workspace.service.workspace.flight;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
@@ -17,19 +24,11 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 
 public class DeleteControlledAzureResourcesStepTest extends BaseAzureUnitTest {
   @Mock private ControlledResourceService mockControlledResourceService;
@@ -91,12 +90,12 @@ public class DeleteControlledAzureResourcesStepTest extends BaseAzureUnitTest {
             SamConstants.SamControlledResourceActions.DELETE_ACTION);
 
     DeleteControlledAzureResourcesStep deleteControlledAzureResourcesStep =
-            new DeleteControlledAzureResourcesStep(
-                    mockResourceDao,
-                    mockControlledResourceService,
-                    mockSamService,
-                    workspaceId,
-                    userRequest);
+        new DeleteControlledAzureResourcesStep(
+            mockResourceDao,
+            mockControlledResourceService,
+            mockSamService,
+            workspaceId,
+            userRequest);
 
     final StepResult result = deleteControlledAzureResourcesStep.doStep(mockFlightContext);
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteControlledAzureResourcesStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteControlledAzureResourcesStepTest.java
@@ -1,0 +1,110 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.BaseAzureUnitTest;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.SamConstants;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
+import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
+import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class DeleteControlledAzureResourcesStepTest extends BaseAzureUnitTest {
+  @Mock private ControlledResourceService mockControlledResourceService;
+  @Mock private ResourceDao mockResourceDao;
+  @Mock private SamService mockSamService;
+  @Mock private FlightContext mockFlightContext;
+
+  @Test
+  public void testRequiresDeleteAction() throws InterruptedException, RetryException {
+    UUID workspaceId = UUID.randomUUID();
+    AuthenticatedUserRequest userRequest =
+        new AuthenticatedUserRequest("user@example.com", "subjectId", Optional.empty());
+    ControlledResource deleteMe =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(UUID.randomUUID())
+                    .name("deleteMe")
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .createdByEmail(userRequest.getEmail())
+                    .managedBy(ManagedByType.MANAGED_BY_USER)
+                    .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
+                    .build())
+            .storageAccountId(UUID.randomUUID())
+            .storageContainerName("user-storage-container")
+            .build();
+    ControlledResource cannotDeleteMe =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(UUID.randomUUID())
+                    .name("cannotDeleteMe")
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .createdByEmail("application@example.com")
+                    .managedBy(ManagedByType.MANAGED_BY_APPLICATION)
+                    .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
+                    .build())
+            .storageAccountId(UUID.randomUUID())
+            .storageContainerName("application-storage-container")
+            .build();
+    doReturn(List.of(deleteMe, cannotDeleteMe))
+        .when(mockResourceDao)
+        .listControlledResources(workspaceId, CloudPlatform.AZURE);
+    doReturn(true)
+        .when(mockSamService)
+        .isAuthorized(
+            userRequest,
+            deleteMe.getCategory().getSamResourceName(),
+            deleteMe.getResourceId().toString(),
+            SamConstants.SamControlledResourceActions.DELETE_ACTION);
+    doReturn(false)
+        .when(mockSamService)
+        .isAuthorized(
+            userRequest,
+            cannotDeleteMe.getCategory().getSamResourceName(),
+            cannotDeleteMe.getResourceId().toString(),
+            SamConstants.SamControlledResourceActions.DELETE_ACTION);
+
+    DeleteControlledAzureResourcesStep deleteControlledAzureResourcesStep =
+            new DeleteControlledAzureResourcesStep(
+                    mockResourceDao,
+                    mockControlledResourceService,
+                    mockSamService,
+                    workspaceId,
+                    userRequest);
+
+    final StepResult result = deleteControlledAzureResourcesStep.doStep(mockFlightContext);
+
+    // Step is expected to fail and no resources should be deleted
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    verify(mockControlledResourceService, never())
+        .deleteControlledResourceSync(any(), any(), any());
+    verify(mockControlledResourceService, never())
+        .deleteControlledResourceAsync(any(), any(), any(), any(), any());
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteControlledAzureResourcesStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/DeleteControlledAzureResourcesStepTest.java
@@ -30,14 +30,14 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class DeleteControlledAzureResourcesStepTest extends BaseAzureUnitTest {
+class DeleteControlledAzureResourcesStepTest extends BaseAzureUnitTest {
   @Mock private ControlledResourceService mockControlledResourceService;
   @Mock private ResourceDao mockResourceDao;
   @Mock private SamService mockSamService;
   @Mock private FlightContext mockFlightContext;
 
   @Test
-  public void testRequiresDeleteAction() throws InterruptedException, RetryException {
+  void testRequiresDeleteAction() throws InterruptedException, RetryException {
     UUID workspaceId = UUID.randomUUID();
     AuthenticatedUserRequest userRequest =
         new AuthenticatedUserRequest("user@example.com", "subjectId", Optional.empty());
@@ -105,5 +105,75 @@ public class DeleteControlledAzureResourcesStepTest extends BaseAzureUnitTest {
         .deleteControlledResourceSync(any(), any(), any());
     verify(mockControlledResourceService, never())
         .deleteControlledResourceAsync(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void testDeletesAllResources() throws InterruptedException, RetryException {
+    UUID workspaceId = UUID.randomUUID();
+    AuthenticatedUserRequest userRequest =
+        new AuthenticatedUserRequest("user@example.com", "subjectId", Optional.empty());
+    ControlledResource deleteMe =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(UUID.randomUUID())
+                    .name("deleteMe")
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .createdByEmail(userRequest.getEmail())
+                    .managedBy(ManagedByType.MANAGED_BY_USER)
+                    .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
+                    .build())
+            .storageAccountId(UUID.randomUUID())
+            .storageContainerName("user-storage-container")
+            .build();
+    ControlledResource deleteMeToo =
+        ControlledAzureStorageContainerResource.builder()
+            .common(
+                ControlledResourceFields.builder()
+                    .workspaceUuid(workspaceId)
+                    .resourceId(UUID.randomUUID())
+                    .name("deleteMeToo")
+                    .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                    .createdByEmail("application@example.com")
+                    .managedBy(ManagedByType.MANAGED_BY_APPLICATION)
+                    .accessScope(AccessScopeType.ACCESS_SCOPE_SHARED)
+                    .build())
+            .storageAccountId(UUID.randomUUID())
+            .storageContainerName("application-storage-container")
+            .build();
+    doReturn(List.of(deleteMe, deleteMeToo))
+        .when(mockResourceDao)
+        .listControlledResources(workspaceId, CloudPlatform.AZURE);
+    doReturn(true)
+        .when(mockSamService)
+        .isAuthorized(
+            userRequest,
+            deleteMe.getCategory().getSamResourceName(),
+            deleteMe.getResourceId().toString(),
+            SamConstants.SamControlledResourceActions.DELETE_ACTION);
+    doReturn(true)
+        .when(mockSamService)
+        .isAuthorized(
+            userRequest,
+            deleteMeToo.getCategory().getSamResourceName(),
+            deleteMeToo.getResourceId().toString(),
+            SamConstants.SamControlledResourceActions.DELETE_ACTION);
+
+    DeleteControlledAzureResourcesStep deleteControlledAzureResourcesStep =
+        new DeleteControlledAzureResourcesStep(
+            mockResourceDao,
+            mockControlledResourceService,
+            mockSamService,
+            workspaceId,
+            userRequest);
+
+    final StepResult result = deleteControlledAzureResourcesStep.doStep(mockFlightContext);
+
+    assertThat(result, equalTo(StepResult.getStepResultSuccess()));
+    verify(mockControlledResourceService)
+        .deleteControlledResourceSync(workspaceId, deleteMe.getResourceId(), userRequest);
+    verify(mockControlledResourceService)
+        .deleteControlledResourceSync(workspaceId, deleteMeToo.getResourceId(), userRequest);
   }
 }


### PR DESCRIPTION
Ticket: [WOR-757](https://broadworkbench.atlassian.net/browse/WOR-757)
- Users cannot delete controlled application resources in their workspace. We need to check that a user can actually delete all controlled resources in their workspace _before_ we start deleting the cloud objects, not after.

[WOR-757]: https://broadworkbench.atlassian.net/browse/WOR-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ