### PR TITLE
[PF-2478] Only run checks when PR targets 'main' branch

### DIFF
--- a/.github/workflows/linter-tests.yml
+++ b/.github/workflows/linter-tests.yml
@@ -6,7 +6,7 @@ on:
     - main
   pull_request:
     branches:
-    - '**'
+    - main
 
 jobs:
   lint-and-static-analysis:

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -12,7 +12,8 @@ on:
       - '.github/**'
       - 'service/local-dev/**'
   pull_request:
-    branches: [ '**' ]
+    branches:
+      - main
     # There is an issue with GitHub required checks and paths-ignore. We don't really need to
     # run the tests if there are only irrelevant changes (see paths-ignore above). However,
     # we require tests to pass by making a "required check" rule on the branch. If the action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ on:
       - '.github/**'
       - 'service/local-dev/**'
   pull_request:
-    branches: [ '**' ]
+    branches:
+      - main
     # There is an issue with GitHub required checks and paths-ignore. We don't really need to
     # run the tests if there are only irrelevant changes (see paths-ignore above). However,
     # we require tests to pass by making a "required check" rule on the branch. If the action


### PR DESCRIPTION
Only run PR checks when the PR targets main/master branch

currently, all PRs (irrespective of the branch they target) automatically trigger PR checks. This is unnecessary and may cause the checks to be queued up on GitHub runner.