### PR TITLE
PF-2479 Small logic fix in setting actas

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/petserviceaccount/PetSaUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/petserviceaccount/PetSaUtils.java
@@ -36,7 +36,6 @@ public class PetSaUtils {
     Binding binding = getOrCreateBinding(saPolicy);
     if (binding.getMembers() == null) {
       binding.setMembers(new ArrayList<>());
-      return false;
     }
 
     if (binding.getMembers().contains(member)) {


### PR DESCRIPTION
I added a short-cut exit from PetSaUtils.addSaMember that was wrong.
Removing one line fixes the problem.