### PR TITLE
[no ticket] Only run full suites overnight

### DIFF
--- a/.github/workflows/full-integration-tests.yml
+++ b/.github/workflows/full-integration-tests.yml
@@ -6,8 +6,7 @@ name: Full Integration Tests
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 8/4 * * 1-5' # Run every 4 hours on weekdays starting at 3AM ET (8 UTC) M-F
-    - cron: '0 8 * * 0,6' # Run nightly on weekends at 3AM ET
+    - cron: '0 8 * * *' # Run nightly at 3AM ET
 
 jobs:
   full-integration-job:

--- a/.github/workflows/full-service-tests.yml
+++ b/.github/workflows/full-service-tests.yml
@@ -5,8 +5,7 @@ name: Full Connected Service Tests
 
 on:
   schedule:
-    - cron: '0 8/4 * * 1-5' # Run every 4 hours on weekdays starting at 3AM ET (8 UTC) M-F
-    - cron: '0 8 * * 0,6' # Run nightly on weekends at 3AM ET
+    - cron: '0 8 * * *' # Run nightly at 3AM ET
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
After watching this for a week or so, I'm thinking we are not getting a lot of value running the full suites during the day.
Further, they take github action slots for a long time, causing queue delays. This PR runs them nightly.
