### PR TITLE
[PF-2333] Increase default idle pool timeout in client

### DIFF
--- a/client/src/main/resources/swaggercodegen/libraries/jersey2/ApiClient.mustache
+++ b/client/src/main/resources/swaggercodegen/libraries/jersey2/ApiClient.mustache
@@ -826,9 +826,9 @@ public class ApiClient {
     // For JDK17, we need to use this connection provider to work around the way Jersey
     // implements PATCH
     clientConfig.connectorProvider(new JdkConnectorProvider());
-    // Set idle timeout higher than the default of 30s, as clients may poll more
+    // Set idle timeout to 2m rather than the default of 30s, as clients may poll more
     // slowly for long-running operations.
-    clientConfig.property(JdkConnectorProperties.CONTAINER_IDLE_TIMEOUT, 120000);
+    clientConfig.property(JdkConnectorProperties.CONTAINER_IDLE_TIMEOUT, /*120s*/ 120_000);
     {{! End Terra change }}
   }
 

--- a/client/src/main/resources/swaggercodegen/libraries/jersey2/ApiClient.mustache
+++ b/client/src/main/resources/swaggercodegen/libraries/jersey2/ApiClient.mustache
@@ -33,6 +33,7 @@ import org.glassfish.jersey.jackson.JacksonFeature;
 {{! Begin Terra change }}
 // Import the connector we use to workaround the JDK17 issues in Jersey
 import org.glassfish.jersey.jdk.connector.JdkConnectorProvider;
+import org.glassfish.jersey.jdk.connector.JdkConnectorProperties;
 {{! End Terra change }}
 
 {{^supportJava6}}
@@ -805,7 +806,9 @@ public class ApiClient {
     clientConfig.register(MultiPartFeature.class);
     clientConfig.register(json);
     clientConfig.register(JacksonFeature.class);
-    clientConfig.property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
+    {{! Begin Terra change }}
+    // Remove configuration properties for a connector we aren't using.
+    {{! End Terra change }}
     {{^supportJava6}}
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
@@ -823,6 +826,9 @@ public class ApiClient {
     // For JDK17, we need to use this connection provider to work around the way Jersey
     // implements PATCH
     clientConfig.connectorProvider(new JdkConnectorProvider());
+    // Set idle timeout higher than the default of 30s, as clients may poll more
+    // slowly for long-running operations.
+    clientConfig.property(JdkConnectorProperties.CONTAINER_IDLE_TIMEOUT, 120000);
     {{! End Terra change }}
   }
 


### PR DESCRIPTION
This bumps the client's default idle pool timeout from 30s -> 2m, so idle thread pools are not cleaned up while we're still using them. The existing timeout can cause infrequent `Connection Reset` errors for clients who poll slower than once per 30s. See [documentation](https://eclipse-ee4j.github.io/jersey.github.io/apidocs/latest/jersey/org/glassfish/jersey/jdk/connector/JdkConnectorProperties.html#CONTAINER_IDLE_TIMEOUT) for additional param info.