### PR TITLE
[TOAZ-319] Removes vm size validation for batch pool creation

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
@@ -266,7 +266,6 @@ public class ControlledAzureBatchPoolResource extends ControlledResource {
       throw new InconsistentFieldsException("Expected controlled AZURE_BATCH_POOL");
     }
     ResourceValidationUtils.validateAzureBatchPoolId(getId());
-    ResourceValidationUtils.validateAzureVmSize(getVmSize());
     ResourceValidationUtils.validateBatchPoolDisplayName(getDisplayName());
     if (deploymentConfiguration != null) {
       if (deploymentConfiguration.virtualMachineConfiguration() != null

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/CreateAzureBatchPoolStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/CreateAzureBatchPoolStepTest.java
@@ -363,6 +363,20 @@ public class CreateAzureBatchPoolStepTest extends BaseBatchPoolTest {
     assertThat(metadata.get(0).value(), equalTo(BatchPoolFixtures.METADATA_VALUE));
   }
 
+  @Test
+  public void createBatchPoolWithVmSizeNotInSDKListSucceeds() throws InterruptedException{
+    resource = buildDefaultResourceBuilder()
+            .vmSize("Standard_D4ads_v5")
+            .build();
+    initDeleteStep(resource);
+    setupMocks(true);
+
+    StepResult stepResult = createAzureBatchPoolStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(mockPoolDefinitionStateCreate, times(1)).create(any());
+  }
+
   private void initDeleteStep(ControlledAzureBatchPoolResource resource) {
     createAzureBatchPoolStep =
         new CreateAzureBatchPoolStep(mockAzureConfig, mockCrlService, resource);


### PR DESCRIPTION
- PR removes the VM size value validation that relies on the [deprecated](https://learn.microsoft.com/en-us/java/api/com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes?view=azure-java-stable) enum `VirtualMachineSizeTypes`.
  -  This validation was preventing TES from creating a batch pool using a valid VM size not included in the enum.

- This validation is redundant as TES performs pre-validation of the VMsize considering, pricing, quota and region availability.  