### PR TITLE
[PF-2514] Handle deleted projects in revokeActAs

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/grant/flight/RevokeStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/grant/flight/RevokeStep.java
@@ -290,7 +290,12 @@ public class RevokeStep implements Step {
   }
 
   private void revokeActAs(GrantData grantData) throws IOException {
-    String projectId = gcpCloudContextService.getRequiredGcpProject(grantData.workspaceId());
+    Optional<String> maybeProjectId = gcpCloudContextService.getGcpProject(grantData.workspaceId());
+    if (maybeProjectId.isEmpty()) {
+      // This GCP context has been deleted already, so there's nothing left to revoke.
+      return;
+    }
+    String projectId = maybeProjectId.get();
     logger.info(
         "Revoking grant {} type {} workspace {} project {}",
         grantData.grantId(),


### PR DESCRIPTION
There are a bunch of revokeGrant flights churning in devel + autopush caused by test workspaces which have been deleted before the grants can be revoked, this should handle them. The `revokeProject` and `revokeResource` methods already check whether the GCP context has been deleted so they don't need any changes.