### PR TITLE
Remove `terra cromwell generate-config` command from post-startup script

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -192,9 +192,6 @@ if [[ -n "$TERRA_SSH_KEY" ]]; then
   sudo -u "${JUPYTER_USER}" sh -c 'ssh-add .ssh/id_rsa; ssh-keyscan -H github.com >> ~/.ssh/known_hosts'
 fi
 
-# Generate cromwell.conf
-sudo -u "${JUPYTER_USER}" sh -c "terra cromwell generate-config"
-
 # Attempt to clone all the git repo references in the workspace. If the user's ssh key does not exist or doesn't have access
 # to the git references, the corresponding git repo cloning will be skipped.
 # Keep this as last thing in script. There will be integration test for git cloning (PF-1660). If this is last thing, then


### PR DESCRIPTION
I recently updated this command to require a bucket path parameter. The expectation is that this config file includes a workspace bucket. A user needs to specify the bucket when calling this command. 

I don't think the startup script should have called this command in the first place. Before my change, it produced a config file that wouldn't work because there is no workspace bucket. 