### PR TITLE
PF-2468: Remove redundant logging

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneReferencedResourceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneReferencedResourceStep.java
@@ -90,7 +90,7 @@ public class CloneReferencedResourceStep implements Step {
 
       try {
         referencedResourceService.createReferenceResourceForClone(
-            destinationResource.castToReferencedResource(), resource, userRequest);
+            destinationResource.castToReferencedResource());
         cloneDetails.setResult(WsmCloneResourceResult.SUCCEEDED);
       } catch (Exception e) {
         cloneDetails.setResult(WsmCloneResourceResult.FAILED).setErrorMessage(e.getMessage());

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceService.java
@@ -79,26 +79,8 @@ public class ReferencedResourceService {
   }
 
   @Traced
-  public ReferencedResource createReferenceResourceForClone(
-      ReferencedResource resourceToClone,
-      ReferencedResource sourceReferencedResource,
-      AuthenticatedUserRequest userRequest) {
+  public ReferencedResource createReferenceResourceForClone(ReferencedResource resourceToClone) {
     resourceDao.createReferencedResource(resourceToClone);
-
-    // Logs CLONE in the source workspace for the source resource that is cloned.
-    workspaceActivityLogService.writeActivity(
-        userRequest,
-        sourceReferencedResource.getWorkspaceId(),
-        OperationType.CLONE,
-        sourceReferencedResource.getResourceId().toString(),
-        ActivityLogChangedTarget.RESOURCE);
-    // Logs CREATE in the destination workspace for the new resource that is created.
-    workspaceActivityLogService.writeActivity(
-        userRequest,
-        resourceToClone.getWorkspaceId(),
-        OperationType.CREATE,
-        resourceToClone.getResourceId().toString(),
-        ActivityLogChangedTarget.RESOURCE);
     return getReferenceResource(resourceToClone.getWorkspaceId(), resourceToClone.getResourceId());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/clone/CloneReferenceResourceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/clone/CloneReferenceResourceStep.java
@@ -51,8 +51,7 @@ public class CloneReferenceResourceStep implements Step {
 
     try {
       var createdResource =
-          referencedResourceService.createReferenceResourceForClone(
-              destinationResource, sourceResource, userRequest);
+          referencedResourceService.createReferenceResourceForClone(destinationResource);
       FlightUtils.setResponse(context, createdResource, HttpStatus.OK);
       cloneDetails.setResult(WsmCloneResourceResult.SUCCEEDED);
     } catch (Exception e) {

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiBqDatasetEquals;
-import static bio.terra.workspace.common.utils.MockMvcUtils.assertClonedResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertControlledResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,6 +32,7 @@ import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobService;
@@ -334,7 +334,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         sourceDatasetName,
         LOCATION,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
+        userAccessUtils.secondUserAuthRequest());
 
     mockMvcUtils.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
@@ -424,7 +424,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         /*expectedDatasetName=*/ sourceDatasetName,
         LOCATION,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpBigQueryDatasetResource gotResource =
@@ -488,7 +488,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         /*expectedDatasetName=*/ destDatasetName,
         destLocation,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpBigQueryDatasetResource gotResource =
@@ -548,7 +548,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         /*expectedDatasetName=*/ destDatasetName,
         destLocation,
         userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpBigQueryDatasetResource gotResource =
@@ -602,7 +602,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         /*expectedProjectId=*/ projectId,
         /*expectedDatasetName=*/ sourceDatasetName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpBigQueryDatasetResource gotResource =
@@ -731,7 +731,8 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
       String expectedDatasetName,
       String expectedRegion,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
+      AuthenticatedUserRequest userRequest)
+      throws InterruptedException {
     assertClonedBqDataset(
         actualDataset,
         ApiStewardshipType.CONTROLLED,
@@ -742,7 +743,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         expectedProjectId,
         expectedDatasetName,
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        userRequest);
 
     assertControlledResourceMetadata(
         actualDataset.getMetadata().getControlledResourceMetadata(),
@@ -763,8 +764,9 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
       String expectedProjectId,
       String expectedDatasetName,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
-    assertClonedResourceMetadata(
+      AuthenticatedUserRequest userRequest)
+      throws InterruptedException {
+    mockMvcUtils.assertClonedResourceMetadata(
         actualDataset.getMetadata(),
         ApiCloudPlatform.GCP,
         ApiResourceType.BIG_QUERY_DATASET,
@@ -776,7 +778,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        userRequest);
 
     assertEquals(expectedProjectId, actualDataset.getAttributes().getProjectId());
     assertEquals(expectedDatasetName, actualDataset.getAttributes().getDatasetId());

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiGcsBucketEquals;
-import static bio.terra.workspace.common.utils.MockMvcUtils.assertClonedResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertControlledResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,6 +39,7 @@ import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobService;
@@ -348,7 +348,7 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
             .generateCloudName(workspaceId2, "cloned-" + destResourceName),
         LOCATION,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
+        userAccessUtils.secondUserAuthRequest());
 
     mockMvcUtils.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
@@ -432,7 +432,7 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
         sourceBucket.getMetadata().getDescription(),
         destBucketName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     ApiGcpGcsBucketResource gotResource =
@@ -487,7 +487,7 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
         destBucketName,
         destLocation,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     ApiGcpGcsBucketResource gotResource =
@@ -543,7 +543,7 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
         destBucketName,
         destLocation,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     ApiGcpGcsBucketResource gotResource =
@@ -599,7 +599,7 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
         sourceBucket.getMetadata().getDescription(),
         sourceBucketName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     ApiGcpGcsBucketResource gotResource =
@@ -726,7 +726,8 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
       String expectedBucketName,
       String expectedRegion,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
+      AuthenticatedUserRequest cloneUserRequest)
+      throws InterruptedException {
     assertClonedGcsBucket(
         actualBucket,
         ApiStewardshipType.CONTROLLED,
@@ -736,7 +737,7 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
         expectedResourceDescription,
         expectedBucketName,
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        cloneUserRequest);
     assertControlledResourceMetadata(
         actualBucket.getMetadata().getControlledResourceMetadata(),
         ApiAccessScope.SHARED_ACCESS,
@@ -755,8 +756,9 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
       String expectedResourceDescription,
       String expectedBucketName,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
-    assertClonedResourceMetadata(
+      AuthenticatedUserRequest cloneUserRequest)
+      throws InterruptedException {
+    mockMvcUtils.assertClonedResourceMetadata(
         actualBucket.getMetadata(),
         ApiCloudPlatform.GCP,
         ApiResourceType.GCS_BUCKET,
@@ -768,7 +770,7 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceBucket.getMetadata().getResourceId(),
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        cloneUserRequest);
 
     assertEquals(expectedBucketName, actualBucket.getAttributes().getBucketName());
   }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiBqDatasetEquals;
-import static bio.terra.workspace.common.utils.MockMvcUtils.assertClonedResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -22,6 +21,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.logging.WorkspaceActivityLogService;
@@ -253,7 +253,7 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
         projectId,
         sourceDatasetName,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
+        userAccessUtils.secondUserAuthRequest());
 
     mockMvcUtils.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
@@ -316,7 +316,7 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
         projectId,
         sourceDatasetName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpBigQueryDatasetResource gotResource =
@@ -351,7 +351,7 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
         projectId,
         sourceDatasetName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpBigQueryDatasetResource gotResource =
@@ -447,8 +447,9 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
       String expectedProjectId,
       String expectedDatasetName,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
-    assertClonedResourceMetadata(
+      AuthenticatedUserRequest cloneUserRequest)
+      throws InterruptedException {
+    mockMvcUtils.assertClonedResourceMetadata(
         actualResource.getMetadata(),
         ApiCloudPlatform.GCP,
         ApiResourceType.BIG_QUERY_DATASET,
@@ -460,7 +461,7 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        cloneUserRequest);
 
     assertEquals(expectedProjectId, actualResource.getAttributes().getProjectId());
     assertEquals(expectedDatasetName, actualResource.getAttributes().getDatasetId());

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiBqDataTableEquals;
-import static bio.terra.workspace.common.utils.MockMvcUtils.assertClonedResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -22,6 +21,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -258,7 +258,7 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
         sourceDatasetName,
         sourceTableId,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
+        userAccessUtils.secondUserAuthRequest());
     mockMvcUtils.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
@@ -318,7 +318,7 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
         sourceDatasetName,
         sourceTableId,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpBigQueryDataTableResource gotResource =
@@ -352,7 +352,7 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
         sourceDatasetName,
         sourceTableId,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpBigQueryDataTableResource gotResource =
@@ -449,8 +449,9 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
       String expectedDatasetName,
       String expectedTableId,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
-    assertClonedResourceMetadata(
+      AuthenticatedUserRequest cloneUserRequest)
+      throws InterruptedException {
+    mockMvcUtils.assertClonedResourceMetadata(
         actualResource.getMetadata(),
         ApiCloudPlatform.GCP,
         ApiResourceType.BIG_QUERY_DATA_TABLE,
@@ -462,7 +463,7 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        cloneUserRequest);
 
     assertEquals(expectedProjectId, actualResource.getAttributes().getProjectId());
     assertEquals(expectedDatasetName, actualResource.getAttributes().getDatasetId());

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiDataRepoEquals;
-import static bio.terra.workspace.common.utils.MockMvcUtils.assertClonedResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -21,6 +20,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -246,7 +246,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
         sourceInstanceName,
         sourceSnapshot,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
+        userAccessUtils.secondUserAuthRequest());
 
     mockMvcUtils.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
@@ -308,7 +308,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
         sourceInstanceName,
         sourceSnapshot,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiDataRepoSnapshotResource gotResource =
@@ -343,7 +343,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
         sourceInstanceName,
         sourceSnapshot,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiDataRepoSnapshotResource gotResource =
@@ -439,8 +439,9 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
       String expectedInstanceName,
       String expectedSnapshot,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
-    assertClonedResourceMetadata(
+      AuthenticatedUserRequest cloneUserRequest)
+      throws InterruptedException {
+    mockMvcUtils.assertClonedResourceMetadata(
         actualResource.getMetadata(),
         /*expectedCloudPlatform=*/ null,
         ApiResourceType.DATA_REPO_SNAPSHOT,
@@ -452,7 +453,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        cloneUserRequest);
 
     assertEquals(expectedInstanceName, actualResource.getAttributes().getInstanceName());
     assertEquals(expectedSnapshot, actualResource.getAttributes().getSnapshot());

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiGcsBucketEquals;
-import static bio.terra.workspace.common.utils.MockMvcUtils.assertClonedResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -22,6 +21,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -240,7 +240,7 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
         sourceResourceName,
         sourceBucketName,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
+        userAccessUtils.secondUserAuthRequest());
     mockMvcUtils.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
@@ -298,7 +298,7 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
         destResourceName,
         sourceBucketName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpGcsBucketResource gotResource =
@@ -330,7 +330,7 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
         destResourceName,
         sourceBucketName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpGcsBucketResource gotResource =
@@ -421,8 +421,9 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
       String expectedResourceName,
       String expectedBucketName,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
-    assertClonedResourceMetadata(
+      AuthenticatedUserRequest cloneUserRequest)
+      throws InterruptedException {
+    mockMvcUtils.assertClonedResourceMetadata(
         actualResource.getMetadata(),
         ApiCloudPlatform.GCP,
         ApiResourceType.GCS_BUCKET,
@@ -434,7 +435,7 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        cloneUserRequest);
 
     assertEquals(expectedBucketName, actualResource.getAttributes().getBucketName());
   }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
-import static bio.terra.workspace.common.utils.MockMvcUtils.assertClonedResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -21,6 +20,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -249,7 +249,7 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
         sourceBucketName,
         sourceFileName,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
+        userAccessUtils.secondUserAuthRequest());
     mockMvcUtils.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
@@ -309,7 +309,7 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
         sourceBucketName,
         sourceFileName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpGcsObjectResource gotResource =
@@ -343,7 +343,7 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
         sourceBucketName,
         sourceFileName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGcpGcsObjectResource gotResource =
@@ -438,8 +438,9 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
       String expectedBucketName,
       String expectedFileName,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
-    assertClonedResourceMetadata(
+      AuthenticatedUserRequest userRequest)
+      throws InterruptedException {
+    mockMvcUtils.assertClonedResourceMetadata(
         actualResource.getMetadata(),
         ApiCloudPlatform.GCP,
         ApiResourceType.GCS_OBJECT,
@@ -451,7 +452,7 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        userRequest);
 
     assertEquals(expectedBucketName, actualResource.getAttributes().getBucketName());
     assertEquals(expectedFileName, actualResource.getAttributes().getFileName());

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
-import static bio.terra.workspace.common.utils.MockMvcUtils.assertClonedResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -20,6 +19,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -246,7 +246,7 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
         sourceResourceName,
         sourceGitRepoUrl,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
+        userAccessUtils.secondUserAuthRequest());
 
     mockMvcUtils.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
@@ -306,7 +306,7 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
         destResourceName,
         sourceResource.getAttributes().getGitRepoUrl(),
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGitRepoResource gotResource =
@@ -339,7 +339,7 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
         destResourceName,
         sourceGitRepoUrl,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        /*expectedLastUpdatedBy=*/ userAccessUtils.getDefaultUserEmail());
+        userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
     final ApiGitRepoResource gotResource =
@@ -431,8 +431,9 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
       String expectedResourceName,
       String expectedGitRepoUrl,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
-    assertClonedResourceMetadata(
+      AuthenticatedUserRequest userRequest)
+      throws InterruptedException {
+    mockMvcUtils.assertClonedResourceMetadata(
         actualResource.getMetadata(),
         /*expectedCloudPlatform=*/ null,
         ApiResourceType.GIT_REPO,
@@ -444,7 +445,7 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
         expectedCreatedBy,
-        expectedLastUpdatedBy);
+        userRequest);
 
     assertEquals(expectedGitRepoUrl, actualResource.getAttributes().getGitRepoUrl());
   }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -2091,7 +2091,7 @@ public class MockMvcUtils {
         actualMetadata.getProperties());
   }
 
-  public static void assertClonedResourceMetadata(
+  public void assertClonedResourceMetadata(
       ApiResourceMetadata actualMetadata,
       ApiCloudPlatform expectedCloudPlatform,
       ApiResourceType expectedResourceType,
@@ -2103,13 +2103,17 @@ public class MockMvcUtils {
       UUID sourceWorkspaceId,
       UUID sourceResourceId,
       String expectedCreatedBy,
-      String expectedLastUpdatedBy) {
+      AuthenticatedUserRequest userRequest)
+      throws InterruptedException {
     ApiResourceLineage expectedResourceLineage = new ApiResourceLineage();
     expectedResourceLineage.add(
         new ApiResourceLineageEntry()
             .sourceWorkspaceId(sourceWorkspaceId)
             .sourceResourceId(sourceResourceId));
 
+    String expectedLastUpdatedBy = samService.getUserStatusInfo(userRequest).getUserEmail();
+    String expectedLastUpdatedBySubjectId =
+        samService.getUserStatusInfo(userRequest).getUserSubjectId();
     assertResourceMetadata(
         actualMetadata,
         expectedCloudPlatform,
@@ -2122,6 +2126,13 @@ public class MockMvcUtils {
         expectedResourceLineage,
         expectedCreatedBy,
         expectedLastUpdatedBy);
+    assertLatestActivityLogChangeDetails(
+        expectedWorkspaceId,
+        expectedLastUpdatedBy,
+        expectedLastUpdatedBySubjectId,
+        OperationType.CLONE,
+        sourceResourceId.toString(),
+        ActivityLogChangedTarget.RESOURCE);
   }
 
   public void assertLatestActivityLogChangeDetails(


### PR DESCRIPTION
Clone referenced resources is now a flight so log will be written in the WorkspaceActivityLogHook instead. `createReferenceResourceForClone` doesn't need to log the activity anymore.

All the clone test in the *controllerTest now also assert that a clone activity is logged in the destination workspace with the source resource id as the changeSubjectId.
i.e. foo is cloned from workspace 1 to workspace 2 by yu.
The log should be: in workspace 2, foo is cloned by yu at <timestamp>.