### PR TITLE
[PF-2524] Fix ResourceRolePair deser and claims undo compare

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/ResourceRolePair.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/ResourceRolePair.java
@@ -2,6 +2,8 @@ package bio.terra.workspace.service.workspace.flight;
 
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A pair of ControlledResource and ControlledResourceIamRole objects. This represents a single role
@@ -12,7 +14,10 @@ public class ResourceRolePair {
   private final ControlledResource resource;
   private final ControlledResourceIamRole role;
 
-  public ResourceRolePair(ControlledResource resource, ControlledResourceIamRole role) {
+  @JsonCreator
+  public ResourceRolePair(
+      @JsonProperty("resource") ControlledResource resource,
+      @JsonProperty("role") ControlledResourceIamRole role) {
     this.resource = resource;
     this.role = role;
   }


### PR DESCRIPTION
there were two problems.

First, for mysterious reasons of its own, Jackson Json stopped being able to deserialize the `ResourceRolePair`. I added an explicit `@JsonCreator` and properties and it works fine now.

Second, the claim flight undo was failing because a full resource compare was coming up not equal. Apparently the `privateResourceState` was not included in the `equals` method. When I factored that into `WsmControlledResourceFields` I generated a new (comprehensive) equals.

I fixed the code to do the check on resource ID and not the resource contents.