### PR TITLE
TOAZ-313 Delete Batch Pools through WSM

### DIFF
--- a/openapi/src/parts/controlled_azure_batch_pool.yaml
+++ b/openapi/src/parts/controlled_azure_batch_pool.yaml
@@ -24,6 +24,26 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/batchpool/{resourceId}:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/ResourceId'
+    delete:
+      summary: Delete an Azure Batch Pool
+      operationId: deleteAzureBatchPool
+      tags: [ ControlledAzureResource ]
+      responses:
+        '204':
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
 components:
   schemas:
     AzureBatchPoolCreationParameters:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -79,6 +79,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Controller
 public class ControlledAzureResourceApiController extends ControlledResourceControllerBase
@@ -512,6 +513,26 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             .resourceId(createdBatchPool.getResourceId())
             .azureBatchPool(createdBatchPool.toApiResource());
     return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @Traced
+  @Override
+  public ResponseEntity<Void> deleteAzureBatchPool(
+      @PathVariable("workspaceId") UUID workspaceId, @PathVariable("resourceId") UUID resourceId) {
+    features.azureEnabledCheck();
+
+    final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    controlledResourceMetadataManager.validateControlledResourceAndAction(
+        userRequest, workspaceId, resourceId, SamControlledResourceActions.DELETE_ACTION);
+
+    logger.info(
+        "delete {}({}) from workspace {}",
+        "Azure Batch Pool",
+        resourceId.toString(),
+        workspaceId.toString());
+
+    controlledResourceService.deleteControlledResourceSync(workspaceId, resourceId, userRequest);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
   @Override


### PR DESCRIPTION
Synchronous endpoint for Azure Batch Pool deletion. The related deletion step was implemented earlier.