### PR TITLE
[DDO-2694] Automatically update TPS in wsmtest-eng BEE

### DIFF
--- a/.github/workflows/test-env-refresh.yml
+++ b/.github/workflows/test-env-refresh.yml
@@ -1,0 +1,29 @@
+# This workflow is broken out because multiple other scheduled crons may all
+# expect the test environment to be updated. Rather than them all potentially
+# running the refresh at the same time, we do it once, earlier in the night, here.
+
+name: WSM Test Env Refresh
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 6 * * *' # Run nightly at 1AM ET
+jobs:
+  refresh-environment:
+    uses: broadinstitute/sherlock/.github/workflows/client-refresh-environment.yaml@main
+    with:
+      environment-name: wsmtest-eng
+    permissions:
+      id-token: 'write'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+
+  curl-version-endpoint:
+    runs-on: ubuntu-latest
+    needs: [refresh-environment]
+    steps:
+      - name: "Get wsmtest-eng TPS version"
+        run: |
+          echo "## Resulting TPS version: "
+          curl -X 'GET' \
+            'https://tps.wsmtest-eng.bee.envs-terra.bio/version' \
+            -H 'accept: */*' | jq >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-env-refresh.yml
+++ b/.github/workflows/test-env-refresh.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: "Get wsmtest-eng TPS version"
         run: |
-          echo "## Resulting TPS version: "
+          echo "## Resulting TPS version: " >> $GITHUB_STEP_SUMMARY
           curl -X 'GET' \
             'https://tps.wsmtest-eng.bee.envs-terra.bio/version' \
             -H 'accept: */*' | jq >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR works in two parts:

- This actual workflow here will "refresh" the wsmtest-eng BEE and sync the entire environment in ArgoCD
- That "refresh" will actually do something because over in Beehive, tps-wsmtest-eng is configured to get it's app version from tps-dev. The refresh will get the latest tps-dev version and the sync will deploy it.

This action also tries to curl TPS's version endpoint and print it to the GitHub Actions summary so it should be visible without going through logs.