### PR TITLE
[PF-2544] Add custom ser / deser to CloudContextHolder

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolder.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolder.java
@@ -1,5 +1,10 @@
 package bio.terra.workspace.service.workspace.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize(using = CloudContextHolderSerializer.class)
+@JsonDeserialize(using = CloudContextHolderDeserializer.class)
 public class CloudContextHolder {
   private GcpCloudContext gcpCloudContext;
   private AzureCloudContext azureCloudContext;

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolderDeserializer.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolderDeserializer.java
@@ -1,0 +1,34 @@
+package bio.terra.workspace.service.workspace.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+
+public class CloudContextHolderDeserializer extends StdDeserializer<CloudContextHolder> {
+  public CloudContextHolderDeserializer() {
+    this(null);
+  }
+
+  public CloudContextHolderDeserializer(Class<CloudContextHolder> t) {
+    super(t);
+  }
+
+  @Override
+  public CloudContextHolder deserialize(JsonParser jsonParser, DeserializationContext ctx)
+      throws IOException {
+    CloudContextHolder cch = new CloudContextHolder();
+    JsonNode cchNode = jsonParser.readValueAsTree();
+
+    JsonNode contextNode;
+    if ((contextNode = cchNode.get("gcpCloudContext")) != null) {
+      cch.setGcpCloudContext(GcpCloudContext.deserialize(contextNode.asText()));
+    }
+    if ((contextNode = cchNode.get("azureCloudContext")) != null) {
+      cch.setAzureCloudContext(AzureCloudContext.deserialize(contextNode.asText()));
+    }
+
+    return cch;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolderDeserializer.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolderDeserializer.java
@@ -2,18 +2,12 @@ package bio.terra.workspace.service.workspace.model;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import java.io.IOException;
 
-public class CloudContextHolderDeserializer extends StdDeserializer<CloudContextHolder> {
-  public CloudContextHolderDeserializer() {
-    this(null);
-  }
-
-  public CloudContextHolderDeserializer(Class<CloudContextHolder> t) {
-    super(t);
-  }
+public class CloudContextHolderDeserializer extends JsonDeserializer<CloudContextHolder> {
+  public CloudContextHolderDeserializer() {}
 
   @Override
   public CloudContextHolder deserialize(JsonParser jsonParser, DeserializationContext ctx)

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolderSerializer.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolderSerializer.java
@@ -1,29 +1,44 @@
 package bio.terra.workspace.service.workspace.model;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import java.io.IOException;
 
-public class CloudContextHolderSerializer extends StdSerializer<CloudContextHolder> {
-  public CloudContextHolderSerializer() {
-    this(null);
-  }
+public class CloudContextHolderSerializer extends JsonSerializer<CloudContextHolder> {
+  public CloudContextHolderSerializer() {}
 
-  public CloudContextHolderSerializer(Class<CloudContextHolder> t) {
-    super(t);
+  @Override
+  public void serializeWithType(
+      CloudContextHolder cch,
+      JsonGenerator jsonGen,
+      SerializerProvider provider,
+      TypeSerializer typeSer)
+      throws IOException {
+    WritableTypeId typeId = typeSer.typeId(cch, JsonToken.START_OBJECT);
+    typeSer.writeTypePrefix(jsonGen, typeId);
+    writeFields(cch, jsonGen);
+    typeId.wrapperWritten = !jsonGen.canWriteTypeId();
+    typeSer.writeTypeSuffix(jsonGen, typeId);
   }
 
   @Override
   public void serialize(CloudContextHolder cch, JsonGenerator jsonGen, SerializerProvider provider)
       throws IOException {
     jsonGen.writeStartObject();
+    writeFields(cch, jsonGen);
+    jsonGen.writeEndObject();
+  }
+
+  private void writeFields(CloudContextHolder cch, JsonGenerator jsonGen) throws IOException {
     if (cch.getGcpCloudContext() != null) {
       jsonGen.writeStringField("gcpCloudContext", cch.getGcpCloudContext().serialize());
     }
     if (cch.getAzureCloudContext() != null) {
       jsonGen.writeStringField("azureCloudContext", cch.getAzureCloudContext().serialize());
     }
-    jsonGen.writeEndObject();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolderSerializer.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextHolderSerializer.java
@@ -1,0 +1,29 @@
+package bio.terra.workspace.service.workspace.model;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+public class CloudContextHolderSerializer extends StdSerializer<CloudContextHolder> {
+  public CloudContextHolderSerializer() {
+    this(null);
+  }
+
+  public CloudContextHolderSerializer(Class<CloudContextHolder> t) {
+    super(t);
+  }
+
+  @Override
+  public void serialize(CloudContextHolder cch, JsonGenerator jsonGen, SerializerProvider provider)
+      throws IOException {
+    jsonGen.writeStartObject();
+    if (cch.getGcpCloudContext() != null) {
+      jsonGen.writeStringField("gcpCloudContext", cch.getGcpCloudContext().serialize());
+    }
+    if (cch.getAzureCloudContext() != null) {
+      jsonGen.writeStringField("azureCloudContext", cch.getAzureCloudContext().serialize());
+    }
+    jsonGen.writeEndObject();
+  }
+}


### PR DESCRIPTION
Problem - basic object mapper used for ser / deser included via stairway does not support custom serialization / deserialization of included fields. 
Serialize() / Deserialize() methods of gcpCloudContext & azureCloudContext need to be explicitly called. 

Proposed solution - add custom serializer & deserializer for CloudContextHolder. 
This is preferred over alternates - add config to objectMapper / change gcpCloudContext & azureCloudContext to make them serializable directly and override  relevant functions.

--
encountered this error while adding additional platform cloud context in CCH