### PR TITLE
PF-2498 - Integration tests for group policy merges

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
+++ b/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
@@ -480,23 +480,7 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
         new WsmPolicyUpdateRequest()
             .removeAttributes(getGroupPolicyInputs(groupNameA))
             .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT), groupTestWorkspace.getId());
-    workspaceApi.updatePolicies(
-        new WsmPolicyUpdateRequest()
-            .addAttributes(getRegionPolicyInputs(usaLocation))
-            .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT), groupTestWorkspace.getId());
 
-    var wsPre = workspaceApi.getWorkspace(groupTestWorkspace.getId(), null);
-    var dcPre = workspaceApi.getWorkspace(groupTestDataCollection.getId(), null);
-
-    referencedGcpResourceApi.cloneGcpGcsBucketReference(
-        new CloneReferencedResourceRequestBody().destinationWorkspaceId(groupTestWorkspace.getId()),
-        groupTestReferenceResource.getMetadata().getWorkspaceId(),
-        groupTestReferenceResource.getMetadata().getResourceId());
-
-    var wsPost = workspaceApi.getWorkspace(groupTestWorkspace.getId(), null);
-    var dcPost = workspaceApi.getWorkspace(groupTestDataCollection.getId(), null);
-
-    /*
     exception =
         assertThrows(
             ApiException.class,
@@ -508,8 +492,6 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
     assertEquals(exception.getCode(), HttpStatus.SC_CONFLICT);
     assertTrue(
         exception.getMessage().contains("Policy merge has conflicts"));
-
-     */
 
     WorkspaceDescription updatedWorkspace = workspaceApi.getWorkspace(groupTestWorkspace.getId(), null);
     List<WsmPolicyInput> updatedPolicies = updatedWorkspace.getPolicies();

--- a/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
+++ b/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
@@ -393,12 +393,15 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
 
     workspaceApi.deleteWorkspace(scenario8Workspace.getId());
 
-
     /*
      Scenario 9: Group policy merging. WS(groupA) can merge DC(nogroup).
     */
-    CreatedWorkspace groupTestWorkspace = createWorkspaceWithRegionPolicy(workspaceApi, usaLocation);
-    var request = new WsmPolicyUpdateRequest().addAttributes(getGroupPolicyInputs(groupNameA)).updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT);
+    CreatedWorkspace groupTestWorkspace =
+        createWorkspaceWithRegionPolicy(workspaceApi, usaLocation);
+    var request =
+        new WsmPolicyUpdateRequest()
+            .addAttributes(getGroupPolicyInputs(groupNameA))
+            .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT);
     workspaceApi.updatePolicies(request, groupTestWorkspace.getId());
 
     // data collection has no policies
@@ -413,30 +416,37 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
             "referenceBucket",
             CloningInstructionsEnum.REFERENCE);
 
-    CloneReferencedGcpGcsBucketResourceResult referenceResult = referencedGcpResourceApi.cloneGcpGcsBucketReference(
-        new CloneReferencedResourceRequestBody().destinationWorkspaceId(groupTestWorkspace.getId()),
-        groupTestReferenceResource.getMetadata().getWorkspaceId(),
-        groupTestReferenceResource.getMetadata().getResourceId());
+    CloneReferencedGcpGcsBucketResourceResult referenceResult =
+        referencedGcpResourceApi.cloneGcpGcsBucketReference(
+            new CloneReferencedResourceRequestBody()
+                .destinationWorkspaceId(groupTestWorkspace.getId()),
+            groupTestReferenceResource.getMetadata().getWorkspaceId(),
+            groupTestReferenceResource.getMetadata().getResourceId());
 
-    validateWorkspaceContainsGroupPolicy(
-        workspaceApi, groupTestWorkspace.getId(), groupNameA);
+    validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
 
     /*
      Scenario 10: Group policy merging. WS(groupA) can merge DC(groupA).
     */
     // update the data collection to have the same group policy as the workspace
     workspaceApi.updatePolicies(
-        new WsmPolicyUpdateRequest().addAttributes(getGroupPolicyInputs(groupNameA)).updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT), groupTestDataCollection.getId());
+        new WsmPolicyUpdateRequest()
+            .addAttributes(getGroupPolicyInputs(groupNameA))
+            .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT),
+        groupTestDataCollection.getId());
 
-    referencedGcpResourceApi.deleteBucketReference(referenceResult.getResource().getMetadata().getWorkspaceId(), referenceResult.getResource().getMetadata().getResourceId());
+    referencedGcpResourceApi.deleteBucketReference(
+        referenceResult.getResource().getMetadata().getWorkspaceId(),
+        referenceResult.getResource().getMetadata().getResourceId());
 
-    referenceResult = referencedGcpResourceApi.cloneGcpGcsBucketReference(
-        new CloneReferencedResourceRequestBody().destinationWorkspaceId(groupTestWorkspace.getId()),
-        groupTestReferenceResource.getMetadata().getWorkspaceId(),
-        groupTestReferenceResource.getMetadata().getResourceId());
+    referenceResult =
+        referencedGcpResourceApi.cloneGcpGcsBucketReference(
+            new CloneReferencedResourceRequestBody()
+                .destinationWorkspaceId(groupTestWorkspace.getId()),
+            groupTestReferenceResource.getMetadata().getWorkspaceId(),
+            groupTestReferenceResource.getMetadata().getResourceId());
 
-    validateWorkspaceContainsGroupPolicy(
-        workspaceApi, groupTestWorkspace.getId(), groupNameA);
+    validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
 
     /*
      Scenario 11: Group policy merging. WS(groupA) cannot merge DC(groupB).
@@ -445,32 +455,34 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
     workspaceApi.updatePolicies(
         new WsmPolicyUpdateRequest()
             .removeAttributes(getGroupPolicyInputs(groupNameA))
-            .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT), groupTestDataCollection.getId());
+            .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT),
+        groupTestDataCollection.getId());
     workspaceApi.updatePolicies(
         new WsmPolicyUpdateRequest()
             .addAttributes(getGroupPolicyInputs(groupNameB))
-            .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT), groupTestDataCollection.getId());
+            .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT),
+        groupTestDataCollection.getId());
 
-    validateWorkspaceContainsGroupPolicy(
-        workspaceApi, groupTestDataCollection.getId(), groupNameB);
+    validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestDataCollection.getId(), groupNameB);
 
-    referencedGcpResourceApi.deleteBucketReference(referenceResult.getResource().getMetadata().getWorkspaceId(), referenceResult.getResource().getMetadata().getResourceId());
+    referencedGcpResourceApi.deleteBucketReference(
+        referenceResult.getResource().getMetadata().getWorkspaceId(),
+        referenceResult.getResource().getMetadata().getResourceId());
 
     exception =
         assertThrows(
             ApiException.class,
             () ->
                 referencedGcpResourceApi.cloneGcpGcsBucketReference(
-                    new CloneReferencedResourceRequestBody().destinationWorkspaceId(groupTestWorkspace.getId()),
+                    new CloneReferencedResourceRequestBody()
+                        .destinationWorkspaceId(groupTestWorkspace.getId()),
                     groupTestReferenceResource.getMetadata().getWorkspaceId(),
                     groupTestReferenceResource.getMetadata().getResourceId()));
     assertEquals(exception.getCode(), HttpStatus.SC_CONFLICT);
-    assertTrue(
-        exception.getMessage().contains("Policy merge has conflicts"));
+    assertTrue(exception.getMessage().contains("Policy merge has conflicts"));
 
     // group should still be A only
-    validateWorkspaceContainsGroupPolicy(
-        workspaceApi, groupTestWorkspace.getId(), groupNameA);
+    validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
 
     /*
      Scenario 12: Group policy merging. WS(nopolicy) cannot merge DC(groupB).
@@ -479,21 +491,23 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
     workspaceApi.updatePolicies(
         new WsmPolicyUpdateRequest()
             .removeAttributes(getGroupPolicyInputs(groupNameA))
-            .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT), groupTestWorkspace.getId());
+            .updateMode(WsmPolicyUpdateMode.ENFORCE_CONFLICT),
+        groupTestWorkspace.getId());
 
     exception =
         assertThrows(
             ApiException.class,
             () ->
                 referencedGcpResourceApi.cloneGcpGcsBucketReference(
-                    new CloneReferencedResourceRequestBody().destinationWorkspaceId(groupTestWorkspace.getId()),
+                    new CloneReferencedResourceRequestBody()
+                        .destinationWorkspaceId(groupTestWorkspace.getId()),
                     groupTestReferenceResource.getMetadata().getWorkspaceId(),
                     groupTestReferenceResource.getMetadata().getResourceId()));
     assertEquals(exception.getCode(), HttpStatus.SC_CONFLICT);
-    assertTrue(
-        exception.getMessage().contains("Policy merge has conflicts"));
+    assertTrue(exception.getMessage().contains("Policy merge has conflicts"));
 
-    WorkspaceDescription updatedWorkspace = workspaceApi.getWorkspace(groupTestWorkspace.getId(), null);
+    WorkspaceDescription updatedWorkspace =
+        workspaceApi.getWorkspace(groupTestWorkspace.getId(), null);
     List<WsmPolicyInput> updatedPolicies = updatedWorkspace.getPolicies();
 
     assertEquals(0, updatedPolicies.size());
@@ -570,7 +584,8 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
     WorkspaceDescription updatedWorkspace = workspaceApi.getWorkspace(workspaceId, null);
     List<WsmPolicyInput> updatedPolicies = updatedWorkspace.getPolicies();
 
-    List<WsmPolicyInput> groupPolicies = updatedPolicies.stream().filter(p -> p.getName().equals("group-constraint")).toList();
+    List<WsmPolicyInput> groupPolicies =
+        updatedPolicies.stream().filter(p -> p.getName().equals("group-constraint")).toList();
     assertEquals(1, groupPolicies.size());
     assertEquals(1, groupPolicies.get(0).getAdditionalData().size());
     WsmPolicyPair groupPolicy = updatedPolicies.get(0).getAdditionalData().get(0);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -616,7 +616,6 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
-  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled
@@ -628,16 +627,16 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add group policy to source workspace. Add region policy to dest workspace.
+    // Add region policy to source workspace. Add group policy to dest workspace.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
         /*policiesToRemove=*/ null);
 
     // Clone resource

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
@@ -613,7 +613,6 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
-  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled
@@ -625,16 +624,16 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add group policy to source workspace. Add region policy to dest workspace.
+    // Add region policy to source workspace. Add group policy to dest workspace.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
         /*policiesToRemove=*/ null);
 
     // Clone resource

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -32,7 +32,6 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -378,16 +378,16 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add group policy to source workspace. Add region policy to dest workspace.
+    // Add region policy to source workspace. Add group policy to dest workspace.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
         /*policiesToRemove=*/ null);
 
     // Clone resource

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -366,7 +366,6 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
-  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
@@ -367,7 +367,6 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
-  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled
@@ -379,16 +378,16 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add group policy to source workspace. Add region policy to dest workspace.
+    // Add region policy to source workspace. Add group policy to dest workspace.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
         /*policiesToRemove=*/ null);
 
     // Clone resource

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
@@ -358,7 +358,6 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
-  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled
@@ -370,16 +369,16 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add group policy to source workspace. Add region policy to dest workspace.
+    // Add region policy to source workspace. Add group policy to dest workspace.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
         /*policiesToRemove=*/ null);
 
     // Clone resource

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
@@ -357,16 +357,16 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add group policy to source workspace. Add region policy to dest workspace.
+    // Add region policy to source workspace. Add group policy to dest workspace.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
         /*policiesToRemove=*/ null);
 
     // Clone resource

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
@@ -345,7 +345,6 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
-  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
@@ -358,7 +358,6 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
-  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled
@@ -370,16 +369,16 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add group policy to source workspace. Add region policy to dest workspace.
+    // Add region policy to source workspace. Add group policy to dest workspace.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
         /*policiesToRemove=*/ null);
 
     // Clone resource

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
@@ -353,7 +353,6 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
-  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
@@ -365,16 +365,16 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add group policy to source workspace. Add region policy to dest workspace.
+    // Add region policy to source workspace. Add group policy to dest workspace.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
         /*policiesToRemove=*/ null);
 
     // Clone resource


### PR DESCRIPTION
These tests account for the m1 limitations - in that group constraints can only merge if source and destination are equal, or source does not have a group constraint.
Some connected tests needed to be updated for the same logic.