### PR TITLE
[PF-2548] Disable group policy tests for milestone 1

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -616,6 +616,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
+  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
@@ -613,6 +613,7 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
+  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -365,6 +366,7 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
+  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -366,6 +367,7 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
+  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -357,6 +358,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
+  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -344,6 +345,7 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
+  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -357,6 +358,7 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
+  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
@@ -353,6 +353,7 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination
   // workspace policy
   @Test
+  @Disabled("Group policy milestone 1 restricts policy changes")
   void clone_policiesMerged() throws Exception {
     logger.info("features.isTpsEnabled(): %s".formatted(features.isTpsEnabled()));
     // Don't run the test if TPS is disabled


### PR DESCRIPTION
Adding group constraint breaks some tests. I also added a ticket for creating new/better tests for group constraint.
This is a quick fix to allow WSM to progress.