### PR TITLE
[WOR-804] Handle VM extension provisioning errors

### DIFF
--- a/service/src/main/java/bio/terra/workspace/common/utils/ManagementExceptionUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ManagementExceptionUtils.java
@@ -20,6 +20,7 @@ public class ManagementExceptionUtils {
   public static final String CONFLICT = "Conflict";
   public static final String SUBNETS_NOT_IN_SAME_VNET = "SubnetsNotInSameVnet";
   public static final String NIC_RESERVED_FOR_ANOTHER_VM = "NicReservedForAnotherVm";
+  public static final String VM_EXTENSION_PROVISIONING_ERROR = "VMExtensionProvisioningError";
 
   /** Returns true iff the exception's code matches the supplied value. */
   public static boolean isExceptionCode(ManagementException ex, String exceptionCode) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
@@ -177,7 +177,7 @@ public class CreateAzureVmStep implements Step {
         }
 
         case ManagementExceptionUtils.RESOURCE_NOT_FOUND -> {
-          logger.info(
+          logger.error(
               "Either the disk, ip, or network passed into this createVm does not exist "
                   + String.format(
                       "%nResource Group: %s%n\tIp Name: %s%n\tNetwork Name: %s%n\tDisk Name: %s",
@@ -187,6 +187,12 @@ public class CreateAzureVmStep implements Step {
                       diskResource
                           .map(ControlledAzureDiskResource::getDiskName)
                           .orElse("<no disk>")));
+          yield new StepResult(
+              StepStatus.STEP_RESULT_FAILURE_FATAL, new AzureManagementException(e));
+        }
+
+        case ManagementExceptionUtils.VM_EXTENSION_PROVISIONING_ERROR -> {
+          logger.error("Error provisioning VM extension");
           yield new StepResult(
               StepStatus.STEP_RESULT_FAILURE_FATAL, new AzureManagementException(e));
         }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -367,7 +367,7 @@ public class CreateAzureVmStepTest extends BaseAzureUnitTest {
   }
 
   @Test
-  public void createVm_alreadyExists() throws InterruptedException {
+  void createVm_alreadyExists() throws InterruptedException {
     final ApiAzureVmCreationParameters creationParameters =
         ControlledResourceFixtures.getAzureVmCreationParameters();
 
@@ -393,7 +393,7 @@ public class CreateAzureVmStepTest extends BaseAzureUnitTest {
   }
 
   @Test
-  public void createVm_VmExtensionProvisioningError() throws InterruptedException {
+  void createVm_VmExtensionProvisioningError() throws InterruptedException {
     final ApiAzureVmCreationParameters creationParameters =
         ControlledResourceFixtures.getAzureVmCreationParameters();
 
@@ -428,7 +428,7 @@ public class CreateAzureVmStepTest extends BaseAzureUnitTest {
   }
 
   @Test
-  public void createVm_ResourceNotFound() throws InterruptedException {
+  void createVm_ResourceNotFound() throws InterruptedException {
     final ApiAzureVmCreationParameters creationParameters =
         ControlledResourceFixtures.getAzureVmCreationParameters();
 
@@ -460,7 +460,7 @@ public class CreateAzureVmStepTest extends BaseAzureUnitTest {
   }
 
   @Test
-  public void createVm_generic4xxException() throws InterruptedException {
+  void createVm_generic4xxException() throws InterruptedException {
     final ApiAzureVmCreationParameters creationParameters =
         ControlledResourceFixtures.getAzureVmCreationParameters();
 
@@ -490,7 +490,7 @@ public class CreateAzureVmStepTest extends BaseAzureUnitTest {
   }
 
   @Test
-  public void deleteVm() throws InterruptedException {
+  void deleteVm() throws InterruptedException {
     final ApiAzureVmCreationParameters creationParameters =
         ControlledResourceFixtures.getAzureVmCreationParameters();
 


### PR DESCRIPTION
## Context
[Related ticket](https://broadworkbench.atlassian.net/browse/WOR-804)
When a bad file URI is passed as an argument to the azure create VM step, azure will fail out with a `VMExtensionProvisioningError`. 
This error comes back with an HTTP status code of 200. The generic `ManagementException` error [handling logic](https://github.com/DataBiosphere/terra-workspace-manager/blob/main/service/src/main/java/bio/terra/workspace/common/utils/ManagementExceptionUtils.java#L39) only treats `4xx` errors as FATAL. 

So, WSM goes to retry the VM creation and then gets a 409 conflict as the moribund VM is still being destroyed. This has the undesirable effect of masking the root cause.

## This PR
* Adds explicit handling for the `VMExtensionProvisioningError` and immediately fails out the flight, which should make these issues a bit easier to diagnose in the future.
* Re-enables the `CreateAzureVmStepTest`. We disabled this test in January for reasons that are murky at the moment (I _think_ it may because we shifted to an explicit VM image name and the mocking was failing out). I've re-enabled the test and fixed up the mocking, as well as increased the coverage for the new error and another codepath that wasn't being exercised. 