### PR TITLE
PF-2533: Case insensitive check for existing resources when performing the merge check

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -758,7 +758,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
               targetWorkspaceId, CloudPlatform.fromApiCloudPlatform(platform));
 
       for (var existingResource : existingResources) {
-        if (!validRegions.contains(existingResource.getRegion())) {
+        if (!validRegions.stream().anyMatch(existingResource.getRegion()::equalsIgnoreCase)) {
           resourceWithConflicts.add(existingResource.getResourceId());
         }
       }


### PR DESCRIPTION
Issue came up where we were marking a conflict if a workspace had an existing resource with a region that didn't match exactly one of the regions from TPS. Checking existing resources should be a case-insensitive comparison.