### PR TITLE
Fix for ImportDataCollection test

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
+++ b/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
@@ -397,7 +397,7 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
      Scenario 9: Group policy merging. WS(groupA) can merge DC(nogroup).
     */
     CreatedWorkspace groupTestWorkspace =
-        createWorkspaceWithRegionPolicy(workspaceApi, usaLocation);
+        createWorkspace(UUID.randomUUID(), getSpendProfileId(), workspaceApi);
     var request =
         new WsmPolicyUpdateRequest()
             .addAttributes(getGroupPolicyInputs(groupNameA))
@@ -587,8 +587,8 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
     List<WsmPolicyInput> groupPolicies =
         updatedPolicies.stream().filter(p -> p.getName().equals("group-constraint")).toList();
     assertEquals(1, groupPolicies.size());
+    WsmPolicyPair groupPolicy = groupPolicies.get(0).getAdditionalData().get(0);
     assertEquals(1, groupPolicies.get(0).getAdditionalData().size());
-    WsmPolicyPair groupPolicy = updatedPolicies.get(0).getAdditionalData().get(0);
     assertEquals("group", groupPolicy.getKey());
     assertEquals(groupName, groupPolicy.getValue());
   }


### PR DESCRIPTION
Problem was that the test was creating a workspace with a region policy and then updating the policy to have a group policy. Our update method used to do a replace so the group policy was taken out, but that was a bug that was fixed so now that update leaves the group policy in place and adds a region policy. The rest of the verification was only expecting the group policy to exist.