### PR TITLE
Use an empty list of auth domains instead of null when tps is disabled

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
 import bio.terra.workspace.service.policy.TpsUtilities;
 import bio.terra.workspace.service.workspace.model.Workspace;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -52,7 +53,7 @@ public class CreateWorkspaceAuthzStep implements Step {
     // possible this step already created the resource. If WSM can either read the existing Sam
     // resource or create a new one, this is considered successful.
     if (!canReadExistingWorkspace(workspace.getWorkspaceId())) {
-      List<String> authDomains = null;
+      List<String> authDomains = new ArrayList<>();
       if (features.isTpsEnabled()) {
         // Don't depend on the PAO being configured.
         TpsPaoGetResult pao = tpsApiDispatch.getPao(workspace.workspaceId());

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/CreateWorkspaceAuthzStep.java
@@ -12,7 +12,6 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
 import bio.terra.workspace.service.policy.TpsUtilities;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -53,7 +52,7 @@ public class CreateWorkspaceAuthzStep implements Step {
     // possible this step already created the resource. If WSM can either read the existing Sam
     // resource or create a new one, this is considered successful.
     if (!canReadExistingWorkspace(workspace.getWorkspaceId())) {
-      List<String> authDomains = new ArrayList<>();
+      List<String> authDomains = List.of();
       if (features.isTpsEnabled()) {
         // Don't depend on the PAO being configured.
         TpsPaoGetResult pao = tpsApiDispatch.getPao(workspace.workspaceId());


### PR DESCRIPTION
When the TPS feature is disabled, WSM's `createWorkspace` requests to Sam have `null` as the auth domain list. This leads to the required field not being serialized, making the request invalid. Instead, WSM should pass an empty list.