### PR TITLE
PF-2563 update tests to not update group policies

### DIFF
--- a/integration/src/main/java/scripts/utils/WorkspaceAllocateTestScriptBase.java
+++ b/integration/src/main/java/scripts/utils/WorkspaceAllocateTestScriptBase.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.model.CreatedWorkspace;
 import bio.terra.workspace.model.Properties;
 import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.WorkspaceStageModel;
+import bio.terra.workspace.model.WsmPolicyInputs;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -74,6 +75,15 @@ public abstract class WorkspaceAllocateTestScriptBase extends WorkspaceApiTestSc
    */
   protected CreatedWorkspace createWorkspace(
       UUID workspaceUuid, String spendProfileId, WorkspaceApi workspaceApi) throws Exception {
+    return createWorkspaceWithPolicy(workspaceUuid, spendProfileId, workspaceApi, null);
+  }
+
+  protected CreatedWorkspace createWorkspaceWithPolicy(
+      UUID workspaceUuid,
+      String spendProfileId,
+      WorkspaceApi workspaceApi,
+      WsmPolicyInputs policyInputs)
+      throws Exception {
     Properties properties = new Properties();
     Property property1 = new Property().key("foo").value("bar");
     Property property2 = new Property().key("xyzzy").value("plohg");
@@ -83,6 +93,7 @@ public abstract class WorkspaceAllocateTestScriptBase extends WorkspaceApiTestSc
     final var requestBody =
         new CreateWorkspaceRequestBody()
             .id(workspaceUuid)
+            .policies(policyInputs)
             .spendProfile(spendProfileId)
             .stage(getStageModel())
             .properties(properties);

--- a/integration/src/main/java/scripts/utils/WorkspaceAllocateWithPolicyTestScriptBase.java
+++ b/integration/src/main/java/scripts/utils/WorkspaceAllocateWithPolicyTestScriptBase.java
@@ -1,13 +1,7 @@
 package scripts.utils;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
 import bio.terra.workspace.api.WorkspaceApi;
-import bio.terra.workspace.model.CreateWorkspaceRequestBody;
 import bio.terra.workspace.model.CreatedWorkspace;
-import bio.terra.workspace.model.Properties;
-import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.WsmPolicyInput;
 import bio.terra.workspace.model.WsmPolicyInputs;
 import bio.terra.workspace.model.WsmPolicyPair;
@@ -22,12 +16,6 @@ public abstract class WorkspaceAllocateWithPolicyTestScriptBase
   @Override
   protected CreatedWorkspace createWorkspace(
       UUID workspaceUuid, String spendProfileId, WorkspaceApi workspaceApi) throws Exception {
-    Properties properties = new Properties();
-    Property property1 = new Property().key("foo").value("bar");
-    Property property2 = new Property().key("xyzzy").value("plohg");
-    properties.add(property1);
-    properties.add(property2);
-
     WsmPolicyInputs policies =
         new WsmPolicyInputs()
             .addInputsItem(
@@ -37,15 +25,6 @@ public abstract class WorkspaceAllocateWithPolicyTestScriptBase
                     .addAdditionalDataItem(
                         new WsmPolicyPair().key("region-name").value("us-central1")));
 
-    final var requestBody =
-        new CreateWorkspaceRequestBody()
-            .id(workspaceUuid)
-            .spendProfile(spendProfileId)
-            .stage(getStageModel())
-            .properties(properties)
-            .policies(policies);
-    final CreatedWorkspace workspace = workspaceApi.createWorkspace(requestBody);
-    assertThat(workspace.getId(), equalTo(workspaceUuid));
-    return workspace;
+    return createWorkspaceWithPolicy(workspaceUuid, spendProfileId, workspaceApi, policies);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -657,7 +657,9 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
+    assertThat(
+        destWorkspace.getPolicies(),
+        containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -32,6 +32,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
@@ -113,7 +114,9 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     projectId = workspace.getGcpContext().getProjectId();
     workspaceId2 =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithPolicy(
+                userAccessUtils.defaultUserAuthRequest(),
+                new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
             .getId();
     ApiWorkspaceDescription workspace2 =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
@@ -654,7 +657,7 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -7,6 +7,7 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetada
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -627,16 +628,16 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add region policy to source workspace. Add group policy to dest workspace.
+    // Add broader region policy to destination, narrow policy on source.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
         /*policiesToRemove=*/ null);
 
     // Clone resource
@@ -650,12 +651,11 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         destResourceName,
         /*destDatasetName*/ null);
 
-    // Assert dest workspace has group and region policies
+    // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(
-        destWorkspace.getPolicies(),
-        containsInAnyOrder(PolicyFixtures.GROUP_POLICY, PolicyFixtures.REGION_POLICY));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
@@ -39,6 +39,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
@@ -132,7 +133,9 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
     projectId = workspace.getGcpContext().getProjectId();
     workspaceId2 =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithPolicy(
+                userAccessUtils.defaultUserAuthRequest(),
+                new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
             .getId();
     ApiWorkspaceDescription workspace2 =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
@@ -652,7 +655,7 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
@@ -7,6 +7,7 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetada
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -624,16 +625,16 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add region policy to source workspace. Add group policy to dest workspace.
+    // Add broader region policy to destination, narrow policy on source.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
         /*policiesToRemove=*/ null);
 
     // Clone resource
@@ -648,12 +649,11 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
         /*destBucketName*/ null,
         /*destLocation*/ null);
 
-    // Assert dest workspace has group and region policies
+    // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(
-        destWorkspace.getPolicies(),
-        containsInAnyOrder(PolicyFixtures.GROUP_POLICY, PolicyFixtures.REGION_POLICY));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
@@ -655,7 +655,9 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
+    assertThat(
+        destWorkspace.getPolicies(),
+        containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -5,6 +5,7 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiBqDatasetEq
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -376,16 +377,16 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add region policy to source workspace. Add group policy to dest workspace.
+    // Add broader region policy to destination, narrow policy on source.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
         /*policiesToRemove=*/ null);
 
     // Clone resource
@@ -398,12 +399,11 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
         ApiCloningInstructionsEnum.REFERENCE,
         destResourceName);
 
-    // Assert dest workspace has group and region policies
+    // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(
-        destWorkspace.getPolicies(),
-        containsInAnyOrder(PolicyFixtures.GROUP_POLICY, PolicyFixtures.REGION_POLICY));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -405,7 +405,9 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
+    assertThat(
+        destWorkspace.getPolicies(),
+        containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetTest.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
@@ -80,7 +81,9 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
     projectId = workspace.getGcpContext().getProjectId();
     workspaceId2 =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithPolicy(
+                userAccessUtils.defaultUserAuthRequest(),
+                new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
             .getId();
     sourceResource =
         mockMvcUtils.createReferencedBqDataset(
@@ -402,7 +405,7 @@ public class ReferencedGcpResourceControllerBqDatasetTest extends BaseConnectedT
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
@@ -406,7 +406,9 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
+    assertThat(
+        destWorkspace.getPolicies(),
+        containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
@@ -78,7 +79,9 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
     projectId = workspace.getGcpContext().getProjectId();
     workspaceId2 =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithPolicy(
+                userAccessUtils.defaultUserAuthRequest(),
+                new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
             .getId();
 
     sourceResource =
@@ -403,7 +406,7 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableTest.java
@@ -5,6 +5,7 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiBqDataTable
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -377,16 +378,16 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add region policy to source workspace. Add group policy to dest workspace.
+    // Add broader region policy to destination, narrow policy on source.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
         /*policiesToRemove=*/ null);
 
     // Clone resource
@@ -399,12 +400,11 @@ public class ReferencedGcpResourceControllerBqTableTest extends BaseConnectedTes
         ApiCloningInstructionsEnum.REFERENCE,
         destResourceName);
 
-    // Assert dest workspace has group and region policies
+    // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(
-        destWorkspace.getPolicies(),
-        containsInAnyOrder(PolicyFixtures.GROUP_POLICY, PolicyFixtures.REGION_POLICY));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
@@ -5,6 +5,7 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiDataRepoEqu
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -368,16 +369,16 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add region policy to source workspace. Add group policy to dest workspace.
+    // Add broader region policy to destination, narrow policy on source.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
         /*policiesToRemove=*/ null);
 
     // Clone resource
@@ -390,12 +391,11 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
         ApiCloningInstructionsEnum.REFERENCE,
         destResourceName);
 
-    // Assert dest workspace has group and region policies
+    // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(
-        destWorkspace.getPolicies(),
-        containsInAnyOrder(PolicyFixtures.GROUP_POLICY, PolicyFixtures.REGION_POLICY));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
@@ -397,7 +397,9 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
+    assertThat(
+        destWorkspace.getPolicies(),
+        containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
@@ -21,6 +21,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -71,7 +72,9 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
             .getId();
     workspaceId2 =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithPolicy(
+                userAccessUtils.defaultUserAuthRequest(),
+                new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
             .getId();
 
     sourceResource =
@@ -394,7 +397,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -72,7 +73,9 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
             .getId();
     workspaceId2 =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithPolicy(
+                userAccessUtils.defaultUserAuthRequest(),
+                new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
             .getId();
 
     sourceResource =
@@ -377,7 +380,7 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketTest.java
@@ -380,7 +380,9 @@ public class ReferencedGcpResourceControllerGcsBucketTest extends BaseConnectedT
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
+    assertThat(
+        destWorkspace.getPolicies(),
+        containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
@@ -21,6 +21,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -71,7 +72,9 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
             .getId();
     workspaceId2 =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithPolicy(
+                userAccessUtils.defaultUserAuthRequest(),
+                new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
             .getId();
 
     sourceResource =
@@ -394,7 +397,7 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
@@ -4,6 +4,7 @@ import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RES
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -368,16 +369,16 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add region policy to source workspace. Add group policy to dest workspace.
+    // Add broader region policy to destination, narrow policy on source.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
         /*policiesToRemove=*/ null);
 
     // Clone resource
@@ -390,12 +391,11 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
         ApiCloningInstructionsEnum.REFERENCE,
         destResourceName);
 
-    // Assert dest workspace has group and region policies
+    // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(
-        destWorkspace.getPolicies(),
-        containsInAnyOrder(PolicyFixtures.GROUP_POLICY, PolicyFixtures.REGION_POLICY));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectTest.java
@@ -397,7 +397,9 @@ public class ReferencedGcpResourceControllerGcsObjectTest extends BaseConnectedT
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
+    assertThat(
+        destWorkspace.getPolicies(),
+        containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
@@ -20,6 +20,7 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
+import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -72,7 +73,9 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
             .getId();
     workspaceId2 =
         mockMvcUtils
-            .createWorkspaceWithoutCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithPolicy(
+                userAccessUtils.defaultUserAuthRequest(),
+                new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
             .getId();
 
     sourceResource =
@@ -390,7 +393,9 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertThat(
+        destWorkspace.getPolicies(),
+        containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoTest.java
@@ -4,6 +4,7 @@ import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RES
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -364,16 +365,16 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
-    // Add region policy to source workspace. Add group policy to dest workspace.
+    // Add broader region policy to destination, narrow policy on source.
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
-        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.GROUP_POLICY),
+        /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
         /*policiesToRemove=*/ null);
 
     // Clone resource
@@ -386,12 +387,11 @@ public class ReferencedGcpResourceControllerGitRepoTest extends BaseConnectedTes
         ApiCloningInstructionsEnum.REFERENCE,
         destResourceName);
 
-    // Assert dest workspace has group and region policies
+    // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
-    assertThat(
-        destWorkspace.getPolicies(),
-        containsInAnyOrder(PolicyFixtures.GROUP_POLICY, PolicyFixtures.REGION_POLICY));
+    assertThat(destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA));
+    assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
     mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/PolicyFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/PolicyFixtures.java
@@ -5,22 +5,20 @@ import bio.terra.workspace.generated.model.ApiWsmPolicyPair;
 
 public class PolicyFixtures {
   public static final String NAMESPACE = "terra";
-  public static final String GROUP_CONSTRAINT = "group-constraint";
   public static final String REGION_CONSTRAINT = "region-constraint";
-  public static final String GROUP = "group";
   public static final String REGION = "region-name";
-  public static final String DDGROUP = "ddgroup";
   public static final String US_REGION = "usa";
+  public static final String IOWA_REGION = "iowa";
 
-  public static ApiWsmPolicyInput GROUP_POLICY =
-      new ApiWsmPolicyInput()
-          .namespace(NAMESPACE)
-          .name(GROUP_CONSTRAINT)
-          .addAdditionalDataItem(new ApiWsmPolicyPair().key(GROUP).value(DDGROUP));
-
-  public static ApiWsmPolicyInput REGION_POLICY =
+  public static ApiWsmPolicyInput REGION_POLICY_USA =
       new ApiWsmPolicyInput()
           .namespace(NAMESPACE)
           .name(REGION_CONSTRAINT)
           .addAdditionalDataItem(new ApiWsmPolicyPair().key(REGION).value(US_REGION));
+
+  public static ApiWsmPolicyInput REGION_POLICY_IOWA =
+      new ApiWsmPolicyInput()
+          .namespace(NAMESPACE)
+          .name(REGION_CONSTRAINT)
+          .addAdditionalDataItem(new ApiWsmPolicyPair().key(REGION).value(IOWA_REGION));
 }

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/PolicyFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/PolicyFixtures.java
@@ -5,11 +5,25 @@ import bio.terra.workspace.generated.model.ApiWsmPolicyPair;
 
 public class PolicyFixtures {
   public static final String NAMESPACE = "terra";
+  public static final String GROUP_CONSTRAINT = "group-constraint";
   public static final String REGION_CONSTRAINT = "region-constraint";
+  public static final String GROUP = "group";
+  public static final String DEFAULT_GROUP = "wsm-test-group";
+  public static final String ALT_GROUP = "wsm-test-group-alt";
   public static final String REGION = "region-name";
   public static final String US_REGION = "usa";
   public static final String IOWA_REGION = "iowa";
 
+  public static ApiWsmPolicyInput GROUP_POLICY_DEFAULT =
+      new ApiWsmPolicyInput()
+          .namespace(NAMESPACE)
+          .name(GROUP_CONSTRAINT)
+          .addAdditionalDataItem(new ApiWsmPolicyPair().key(GROUP).value(DEFAULT_GROUP));
+  public static ApiWsmPolicyInput GROUP_POLICY_ALT =
+      new ApiWsmPolicyInput()
+          .namespace(NAMESPACE)
+          .name(GROUP_CONSTRAINT)
+          .addAdditionalDataItem(new ApiWsmPolicyPair().key(GROUP).value(ALT_GROUP));
   public static ApiWsmPolicyInput REGION_POLICY_USA =
       new ApiWsmPolicyInput()
           .namespace(NAMESPACE)

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -666,10 +666,10 @@ public class MockMvcUtils {
         new ApiWsmPolicyInputs()
             .addInputsItem(
                 new ApiWsmPolicyInput()
-                    .namespace("terra")
-                    .name("region-constraint")
+                    .namespace(PolicyFixtures.NAMESPACE)
+                    .name(PolicyFixtures.REGION_CONSTRAINT)
                     .addAdditionalDataItem(
-                        new ApiWsmPolicyPair().key("region-name").value(regionName)));
+                        new ApiWsmPolicyPair().key(PolicyFixtures.REGION).value(regionName)));
     ApiCreatedWorkspace workspace = createWorkspaceWithPolicy(userRequest, regionPolicy);
     return workspace.getId();
   }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -25,6 +25,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.controller.shared.PropertiesUtils;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
 import bio.terra.workspace.common.logging.model.ActivityLogChangedTarget;
@@ -153,6 +154,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
@@ -384,6 +386,26 @@ public class MockMvcUtils {
     ApiCreatedWorkspace createdWorkspace = createWorkspaceWithoutCloudContext(userRequest);
     createGcpCloudContextAndWait(userRequest, createdWorkspace.getId());
     return createdWorkspace;
+  }
+
+  public ApiCreatedWorkspace createWorkspaceWithPolicy(
+      AuthenticatedUserRequest userRequest, ApiWsmPolicyInputs policy) throws Exception {
+    ApiCreateWorkspaceRequestBody request =
+        WorkspaceFixtures.createWorkspaceRequestBody().policies(policy);
+
+    String serializedResponse =
+        mockMvc
+            .perform(
+                addJsonContentType(
+                    addAuth(
+                        post(WORKSPACES_V1_PATH).content(objectMapper.writeValueAsString(request)),
+                        userRequest)))
+            .andExpect(status().is(HttpStatus.SC_OK))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    return objectMapper.readValue(serializedResponse, ApiCreatedWorkspace.class);
   }
 
   public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
@@ -629,34 +651,27 @@ public class MockMvcUtils {
         userRequest,
         workspaceId,
         /*policiesToAdd=*/ null,
-        /*policiesToRemove=*/ workspace.getPolicies());
+        /*policiesToRemove=*/ workspace.getPolicies().stream()
+            .filter(
+                p ->
+                    // We cannot remove group policies but will remove all others.
+                    !(p.getNamespace().equals(PolicyFixtures.NAMESPACE)
+                        && p.getName().equals(PolicyFixtures.GROUP_CONSTRAINT)))
+            .collect(Collectors.toList()));
   }
 
   public UUID createWorkspaceWithRegionConstraint(
       AuthenticatedUserRequest userRequest, String regionName) throws Exception {
-    ApiCreateWorkspaceRequestBody request =
-        WorkspaceFixtures.createWorkspaceRequestBody()
-            .policies(
-                new ApiWsmPolicyInputs()
-                    .addInputsItem(
-                        new ApiWsmPolicyInput()
-                            .namespace("terra")
-                            .name("region-constraint")
-                            .addAdditionalDataItem(
-                                new ApiWsmPolicyPair().key("region-name").value(regionName))));
-    String serializedResponse =
-        mockMvc
-            .perform(
-                addJsonContentType(
-                    addAuth(
-                        post(WORKSPACES_V1_PATH).content(objectMapper.writeValueAsString(request)),
-                        userRequest)))
-            .andExpect(status().is(HttpStatus.SC_OK))
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-    return objectMapper.readValue(serializedResponse, ApiCreatedWorkspace.class).getId();
+    ApiWsmPolicyInputs regionPolicy =
+        new ApiWsmPolicyInputs()
+            .addInputsItem(
+                new ApiWsmPolicyInput()
+                    .namespace("terra")
+                    .name("region-constraint")
+                    .addAdditionalDataItem(
+                        new ApiWsmPolicyPair().key("region-name").value(regionName)));
+    ApiCreatedWorkspace workspace = createWorkspaceWithPolicy(userRequest, regionPolicy);
+    return workspace.getId();
   }
 
   public UUID createWorkspaceWithRegionConstraintAndCloudContext(


### PR DESCRIPTION
In milestone 1, we aren't able to modify auth domains, so TPS won't allow updating group policies. Group policies need to be set during workspace create and can't be changed afterward. The pattern in many of our tests was to create a workspace and then update the policies on the workspace. Those tests need to be updated.