### PR TITLE
[PF-2566] Handle null case in BigQuery lifetime backfill.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/backfill/UpdateControlledBigQueryDatasetsLifetimeStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/backfill/UpdateControlledBigQueryDatasetsLifetimeStep.java
@@ -59,10 +59,19 @@ public class UpdateControlledBigQueryDatasetsLifetimeStep implements Step {
     for (var resource : controlledBigQueryDatasets) {
       var id = resource.getResourceId();
       if (resourceIdsToWorkspaceIdMap.containsKey(id)) {
+        String tableLifetimeValue = resourceIdToDefaultTableLifetimeMap.get(id);
+        String partitionLifetimeValue = resourceIdToDefaultPartitionLifetimeMap.get(id);
+        // BigQuery dataset may have unspecified lifetime on the cloud.
+        // In this case, update with null.
+        Long tableLifetimeUpdate =
+            tableLifetimeValue == null ? null : Long.valueOf(tableLifetimeValue);
+        Long partitionLifetimeUpdate =
+            partitionLifetimeValue == null ? null : Long.valueOf(partitionLifetimeValue);
+
         resourceDao.updateBigQueryDatasetDefaultTableAndPartitionLifetime(
             resource.castByEnum(CONTROLLED_GCP_BIG_QUERY_DATASET),
-            Long.valueOf(resourceIdToDefaultTableLifetimeMap.get(id)),
-            Long.valueOf(resourceIdToDefaultPartitionLifetimeMap.get(id)));
+            tableLifetimeUpdate,
+            partitionLifetimeUpdate);
       }
     }
 


### PR DESCRIPTION
Previously, if the BigQuery datasets had one or two null lifetimes on the cloud, this would cause the flight to crash.

In retrieval:
- Now the `Pair<Long,Long>` can contain nulls in the coordinates,

In update:
- If the coordinate is null, then update with null (instead of throwing a null error upon conversion).

Tests:
- Added two tests to ensure the flight won't crash in both cases.

Re: #1041 (PF-2269).