### PR TITLE
[PF-2571] Use partialEquals instead of equals; cannot repro the  failure

### DIFF
--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -2042,7 +2042,7 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
                 resource, null, user.getAuthenticatedRequest(), creationParameters)
             .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
 
-    assertEquals(resource, createdDataset);
+    assertTrue(resource.partialEqual(createdDataset));
     return createdDataset;
   }
 


### PR DESCRIPTION
Very small fix