### PR TITLE
[PF-2572] Use internal class for flex resource creation parameters.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource.ControlledFlexibleResource;
+import bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource.FlexResourceCreationParameters;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.WorkspaceService;
@@ -72,17 +73,27 @@ public class ControlledFlexibleResourceApiController extends ControlledResourceC
     byte[] encodedJSON = body.getFlexibleResource().getData();
     String decodedJSON = ControlledFlexibleResource.getDecodedJSONFromByteArray(encodedJSON);
 
+    String typeNamespace = body.getFlexibleResource().getTypeNamespace();
+    String type = body.getFlexibleResource().getType();
+
     ControlledFlexibleResource resource =
         ControlledFlexibleResource.builder()
             .common(commonFields)
-            .typeNamespace(body.getFlexibleResource().getTypeNamespace())
-            .type(body.getFlexibleResource().getType())
+            .typeNamespace(typeNamespace)
+            .type(type)
             .data(decodedJSON)
             .build();
 
+    FlexResourceCreationParameters creationParameters =
+        new FlexResourceCreationParameters()
+            .type(type)
+            .typeNamespace(typeNamespace)
+            .data(encodedJSON);
+
     ControlledFlexibleResource createdFlexibleResource =
         getControlledResourceService()
-            .createControlledResourceSync(resource, commonFields.getIamRole(), userRequest, body)
+            .createControlledResourceSync(
+                resource, commonFields.getIamRole(), userRequest, creationParameters)
             .castByEnum(WsmResourceType.CONTROLLED_FLEXIBLE_RESOURCE);
 
     var response =

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
@@ -73,22 +73,16 @@ public class ControlledFlexibleResourceApiController extends ControlledResourceC
     byte[] encodedJSON = body.getFlexibleResource().getData();
     String decodedJSON = ControlledFlexibleResource.getDecodedJSONFromByteArray(encodedJSON);
 
-    String typeNamespace = body.getFlexibleResource().getTypeNamespace();
-    String type = body.getFlexibleResource().getType();
-
     ControlledFlexibleResource resource =
         ControlledFlexibleResource.builder()
             .common(commonFields)
-            .typeNamespace(typeNamespace)
-            .type(type)
+            .typeNamespace(body.getFlexibleResource().getTypeNamespace())
+            .type(body.getFlexibleResource().getType())
             .data(decodedJSON)
             .build();
 
     FlexResourceCreationParameters creationParameters =
-        new FlexResourceCreationParameters()
-            .type(type)
-            .typeNamespace(typeNamespace)
-            .data(encodedJSON);
+        FlexResourceCreationParameters.fromApiCreationParameters(body.getFlexibleResource());
 
     ControlledFlexibleResource createdFlexibleResource =
         getControlledResourceService()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
@@ -3,8 +3,6 @@ package bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresour
 import bio.terra.workspace.generated.model.ApiControlledFlexibleResourceCreationParameters;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jetbrains.annotations.NotNull;
-
 import javax.annotation.Nullable;
 
 public class FlexResourceCreationParameters {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource;
 
+import bio.terra.workspace.generated.model.ApiControlledFlexibleResourceCreationParameters;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.NotNull;
@@ -61,5 +62,13 @@ public class FlexResourceCreationParameters {
   public FlexResourceCreationParameters data(byte[] data) {
     this.data = data;
     return this;
+  }
+
+  public static FlexResourceCreationParameters fromApiCreationParameters(
+      ApiControlledFlexibleResourceCreationParameters apiCreationParamters) {
+    return new FlexResourceCreationParameters()
+        .typeNamespace(apiCreationParamters.getTypeNamespace())
+        .type(apiCreationParamters.getType())
+        .data(apiCreationParamters.getData());
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
@@ -5,12 +5,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nullable;
 
-public class FlexResourceCreationParameters {
-  private String typeNamespace;
-  private String type;
-  @Nullable private byte[] data;
-
-  public FlexResourceCreationParameters() {}
+public record FlexResourceCreationParameters(
+    String typeNamespace, String type, @Nullable byte[] data) {
 
   @JsonCreator
   public FlexResourceCreationParameters(
@@ -22,51 +18,11 @@ public class FlexResourceCreationParameters {
     this.data = data;
   }
 
-  public String getTypeNamespace() {
-    return typeNamespace;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  @Nullable
-  public byte[] getData() {
-    return data;
-  }
-
-  public void setTypeNamespace(String typeNamespace) {
-    this.typeNamespace = typeNamespace;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public void setData(@Nullable byte[] data) {
-    this.data = data;
-  }
-
-  public FlexResourceCreationParameters type(String type) {
-    this.type = type;
-    return this;
-  }
-
-  public FlexResourceCreationParameters typeNamespace(String typeNamespace) {
-    this.typeNamespace = typeNamespace;
-    return this;
-  }
-
-  public FlexResourceCreationParameters data(byte[] data) {
-    this.data = data;
-    return this;
-  }
-
   public static FlexResourceCreationParameters fromApiCreationParameters(
-      ApiControlledFlexibleResourceCreationParameters apiCreationParamters) {
-    return new FlexResourceCreationParameters()
-        .typeNamespace(apiCreationParamters.getTypeNamespace())
-        .type(apiCreationParamters.getType())
-        .data(apiCreationParamters.getData());
+      ApiControlledFlexibleResourceCreationParameters apiCreationParameters) {
+    return new FlexResourceCreationParameters(
+        apiCreationParameters.getTypeNamespace(),
+        apiCreationParameters.getType(),
+        apiCreationParameters.getData());
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
@@ -7,28 +7,26 @@ import org.jetbrains.annotations.NotNull;
 import javax.annotation.Nullable;
 
 public class FlexResourceCreationParameters {
-  @NotNull private String typeNamespace;
-  @NotNull private String type;
+  private String typeNamespace;
+  private String type;
   @Nullable private byte[] data;
 
   public FlexResourceCreationParameters() {}
 
   @JsonCreator
   public FlexResourceCreationParameters(
-      @NotNull @JsonProperty("typeNamespace") String typeNamespace,
-      @NotNull @JsonProperty("type") String type,
+      @JsonProperty("typeNamespace") String typeNamespace,
+      @JsonProperty("type") String type,
       @Nullable @JsonProperty("data") byte[] data) {
     this.typeNamespace = typeNamespace;
     this.type = type;
     this.data = data;
   }
 
-  @NotNull
   public String getTypeNamespace() {
     return typeNamespace;
   }
 
-  @NotNull
   public String getType() {
     return type;
   }
@@ -38,11 +36,11 @@ public class FlexResourceCreationParameters {
     return data;
   }
 
-  public void setTypeNamespace(@NotNull String typeNamespace) {
+  public void setTypeNamespace(String typeNamespace) {
     this.typeNamespace = typeNamespace;
   }
 
-  public void setType(@NotNull String type) {
+  public void setType(String type) {
     this.type = type;
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
@@ -1,23 +1,10 @@
 package bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource;
 
 import bio.terra.workspace.generated.model.ApiControlledFlexibleResourceCreationParameters;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nullable;
 
 public record FlexResourceCreationParameters(
     String typeNamespace, String type, @Nullable byte[] data) {
-
-  @JsonCreator
-  public FlexResourceCreationParameters(
-      @JsonProperty("typeNamespace") String typeNamespace,
-      @JsonProperty("type") String type,
-      @Nullable @JsonProperty("data") byte[] data) {
-    this.typeNamespace = typeNamespace;
-    this.type = type;
-    this.data = data;
-  }
-
   public static FlexResourceCreationParameters fromApiCreationParameters(
       ApiControlledFlexibleResourceCreationParameters apiCreationParameters) {
     return new FlexResourceCreationParameters(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/FlexResourceCreationParameters.java
@@ -1,0 +1,67 @@
+package bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+public class FlexResourceCreationParameters {
+  @NotNull private String typeNamespace;
+  @NotNull private String type;
+  @Nullable private byte[] data;
+
+  public FlexResourceCreationParameters() {}
+
+  @JsonCreator
+  public FlexResourceCreationParameters(
+      @NotNull @JsonProperty("typeNamespace") String typeNamespace,
+      @NotNull @JsonProperty("type") String type,
+      @Nullable @JsonProperty("data") byte[] data) {
+    this.typeNamespace = typeNamespace;
+    this.type = type;
+    this.data = data;
+  }
+
+  @NotNull
+  public String getTypeNamespace() {
+    return typeNamespace;
+  }
+
+  @NotNull
+  public String getType() {
+    return type;
+  }
+
+  @Nullable
+  public byte[] getData() {
+    return data;
+  }
+
+  public void setTypeNamespace(@NotNull String typeNamespace) {
+    this.typeNamespace = typeNamespace;
+  }
+
+  public void setType(@NotNull String type) {
+    this.type = type;
+  }
+
+  public void setData(@Nullable byte[] data) {
+    this.data = data;
+  }
+
+  public FlexResourceCreationParameters type(String type) {
+    this.type = type;
+    return this;
+  }
+
+  public FlexResourceCreationParameters typeNamespace(String typeNamespace) {
+    this.typeNamespace = typeNamespace;
+    return this;
+  }
+
+  public FlexResourceCreationParameters data(byte[] data) {
+    this.data = data;
+    return this;
+  }
+}


### PR DESCRIPTION
Adds internal class `FlexResourceCreationParameters` which will be used in creation / cloning flights.

#1133 will be merged on top of this change.