### PR TITLE
PF-2527: Fix connected test when regions are validated

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -570,7 +570,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         HttpStatus.SC_CONFLICT,
-        buildWsmRegionPolicyInput("asia"),
+        buildWsmRegionPolicyInput("asiapacific"),
         ApiWsmPolicyUpdateMode.ENFORCE_CONFLICT);
     updatedWorkspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());


### PR DESCRIPTION
We added input validation in TPS for regions. One of the connected tests used an invalid region and so the test started failing when the input was validated.