### PR TITLE
Fix an invalid region in WSM connected test

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
@@ -194,7 +194,7 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
         new ApiCloneWorkspaceRequest()
             .spendProfile(WorkspaceFixtures.DEFAULT_SPEND_PROFILE)
             .additionalPolicies(
-                new ApiWsmPolicyInputs().addInputsItem(makeRegionPolicyInput("asia")));
+                new ApiWsmPolicyInputs().addInputsItem(makeRegionPolicyInput("asiapacific")));
 
     mockMvcUtils.postExpect(
         userAccessUtils.defaultUserAuthRequest(),


### PR DESCRIPTION
This caused a failure in Verily devel. Oddly enough it's passing in Broad dev, I think it's due to slightly different versions of WSM + TPS