### PR TITLE
PF-2563: Disallow updating of group policies

### DIFF
--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -1,15 +1,16 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Main" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="human-readable-logging" />
+    <module name="terra-workspace-manager.service.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="bio.terra.workspace.app.Main" />
     <option name="ENABLE_JMX_AGENT" value="false" />
+    <option name="ACTIVE_PROFILES" value="human-readable-logging" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/service" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="SHORTEN_COMMAND_LINE" value="NONE" />
     <envs>
       <env name="GOOGLE_APPLICATION_CREDENTIALS" value="../config/wsm-sa.json" />
       <env name="WORKSPACE_CLI_OLDESTSUPPORTEDVERSION" value="0.149.0" />
-      <env name="WORKSPACE_POLICY_BASEPATH" value="http://localhost:8090" />
     </envs>
-    <module name="terra-workspace-manager.service.main" />
-    <option name="SPRING_BOOT_MAIN_CLASS" value="bio.terra.workspace.app.Main" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/service" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -1,16 +1,15 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Main" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <module name="terra-workspace-manager.service.main" />
-    <option name="SPRING_BOOT_MAIN_CLASS" value="bio.terra.workspace.app.Main" />
-    <option name="ENABLE_JMX_AGENT" value="false" />
     <option name="ACTIVE_PROFILES" value="human-readable-logging" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/service" />
-    <option name="ALTERNATIVE_JRE_PATH" />
-    <option name="SHORTEN_COMMAND_LINE" value="NONE" />
+    <option name="ENABLE_JMX_AGENT" value="false" />
     <envs>
       <env name="GOOGLE_APPLICATION_CREDENTIALS" value="../config/wsm-sa.json" />
       <env name="WORKSPACE_CLI_OLDESTSUPPORTEDVERSION" value="0.149.0" />
+      <env name="WORKSPACE_POLICY_BASEPATH" value="http://localhost:8090" />
     </envs>
+    <module name="terra-workspace-manager.service.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="bio.terra.workspace.app.Main" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/service" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/integration/src/main/java/scripts/testscripts/MergeGroupPolicies.java
+++ b/integration/src/main/java/scripts/testscripts/MergeGroupPolicies.java
@@ -11,6 +11,8 @@ import bio.terra.workspace.model.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+
+import org.apache.commons.math3.analysis.function.Add;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,9 +37,7 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
     String groupNameA = "wsm-test-group";
     String groupNameB = "wsm-test-group-alt";
 
-    /*
-     Add a cloud context and bucket resource to the test workspace. We'll use this resource to clone references in the scenarios in this journey.
-    */
+    // Add a cloud context and bucket resource to the test workspace. We'll use this resource to clone references in the scenarios in this journey.
     String projectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
     logger.info("Created project {}", projectId);
 
@@ -67,9 +67,7 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
                     .namespace("terra")
                     .addAdditionalDataItem(new WsmPolicyPair().key("group").value(groupNameB)));
 
-    /*
-     Scenario 1: WS(groupA) can merge DC(nogroup).
-    */
+    // Scenario 1: WS(groupA) can merge DC(nogroup).
     CreatedWorkspace groupTestWorkspace =
         createWorkspaceWithPolicy(
             UUID.randomUUID(), getSpendProfileId(), workspaceApi, groupPolicyA);
@@ -96,9 +94,7 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
     validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
     workspaceApi.deleteWorkspace(noGroupDataCollection.getId());
 
-    /*
-     Scenario 2: WS(groupA) can merge DC(groupA).
-    */
+    // Scenario 2: WS(groupA) can merge DC(groupA).
     CreatedWorkspace groupADataCollection =
         createWorkspaceWithPolicy(
             UUID.randomUUID(), getSpendProfileId(), workspaceApi, groupPolicyA);
@@ -125,9 +121,7 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
     validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
     workspaceApi.deleteWorkspace(groupADataCollection.getId());
 
-    /*
-     Scenario 3: WS(groupA) cannot merge DC(groupB).
-    */
+    // Scenario 3: WS(groupA) cannot merge DC(groupB).
     CreatedWorkspace groupBDataCollection =
         createWorkspaceWithPolicy(
             UUID.randomUUID(), getSpendProfileId(), workspaceApi, groupPolicyB);
@@ -159,9 +153,7 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
     // group should still be A only
     validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
 
-    /*
-     Scenario 4: WS(nopolicy) cannot merge DC(groupB).
-    */
+    // Scenario 4: WS(nopolicy) cannot merge DC(groupB).
     CreatedWorkspace noGroupPolicyWorkspace =
         createWorkspace(UUID.randomUUID(), getSpendProfileId(), workspaceApi);
 
@@ -184,9 +176,7 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
     assertEquals(0, updatedPolicies.size());
     workspaceApi.deleteWorkspace(noGroupPolicyWorkspace.getId());
 
-    /*
-    Scenario 5: Clone a workspace and add additional groups. WS(groupA), Clone(+groupB) = WS(groupA, groupB)
-     */
+    // Scenario 5: Clone a workspace and add additional groups. WS(groupA), Clone(+groupB) = WS(groupA, groupB)
     CreatedWorkspace workspaceToClone =
         createWorkspaceWithPolicy(
             UUID.randomUUID(), getSpendProfileId(), workspaceApi, groupPolicyA);

--- a/integration/src/main/java/scripts/testscripts/MergeGroupPolicies.java
+++ b/integration/src/main/java/scripts/testscripts/MergeGroupPolicies.java
@@ -11,8 +11,6 @@ import bio.terra.workspace.model.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-
-import org.apache.commons.math3.analysis.function.Add;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +35,8 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
     String groupNameA = "wsm-test-group";
     String groupNameB = "wsm-test-group-alt";
 
-    // Add a cloud context and bucket resource to the test workspace. We'll use this resource to clone references in the scenarios in this journey.
+    // Add a cloud context and bucket resource to the test workspace. We'll use this resource to
+    // clone references in the scenarios in this journey.
     String projectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
     logger.info("Created project {}", projectId);
 
@@ -176,7 +175,8 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
     assertEquals(0, updatedPolicies.size());
     workspaceApi.deleteWorkspace(noGroupPolicyWorkspace.getId());
 
-    // Scenario 5: Clone a workspace and add additional groups. WS(groupA), Clone(+groupB) = WS(groupA, groupB)
+    // Scenario 5: Clone a workspace and add additional groups. WS(groupA), Clone(+groupB) =
+    // WS(groupA, groupB)
     CreatedWorkspace workspaceToClone =
         createWorkspaceWithPolicy(
             UUID.randomUUID(), getSpendProfileId(), workspaceApi, groupPolicyA);

--- a/integration/src/main/java/scripts/testscripts/MergeGroupPolicies.java
+++ b/integration/src/main/java/scripts/testscripts/MergeGroupPolicies.java
@@ -1,0 +1,220 @@
+package scripts.testscripts;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import bio.terra.workspace.api.ControlledGcpResourceApi;
+import bio.terra.workspace.api.ReferencedGcpResourceApi;
+import bio.terra.workspace.api.WorkspaceApi;
+import bio.terra.workspace.client.ApiException;
+import bio.terra.workspace.model.*;
+import java.util.List;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scripts.utils.ClientTestUtils;
+import scripts.utils.CloudContextMaker;
+import scripts.utils.GcsBucketUtils;
+import scripts.utils.WorkspaceAllocateTestScriptBase;
+
+public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
+  private static final Logger logger = LoggerFactory.getLogger(MergeGroupPolicies.class);
+
+  private static final String DATASET_RESOURCE_NAME = "wsmtest_mergegroups";
+
+  @Override
+  protected void doUserJourney(TestUserSpecification testUser, WorkspaceApi workspaceApi)
+      throws Exception {
+    ControlledGcpResourceApi resourceApi =
+        ClientTestUtils.getControlledGcpResourceClient(testUser, server);
+    ReferencedGcpResourceApi referencedGcpResourceApi =
+        ClientTestUtils.getReferencedGcpResourceClient(testUser, server);
+
+    String groupNameA = "wsm-test-group";
+    String groupNameB = "wsm-test-group-alt";
+
+    /*
+     Add a cloud context and bucket resource to the test workspace. We'll use this resource to clone references in the scenarios in this journey.
+    */
+    String projectId = CloudContextMaker.createGcpCloudContext(getWorkspaceId(), workspaceApi);
+    logger.info("Created project {}", projectId);
+
+    // Create a shared Bucket
+    CreatedControlledGcpGcsBucket controlledBucket =
+        GcsBucketUtils.makeControlledGcsBucketUserShared(
+            resourceApi,
+            getWorkspaceId(),
+            DATASET_RESOURCE_NAME,
+            CloningInstructionsEnum.REFERENCE);
+    UUID resourceId = controlledBucket.getResourceId();
+    GcpGcsBucketResource controlledBucketResource = controlledBucket.getGcpBucket();
+    logger.info("Created controlled bucket {}", resourceId);
+
+    var groupPolicyA =
+        new WsmPolicyInputs()
+            .addInputsItem(
+                new WsmPolicyInput()
+                    .name("group-constraint")
+                    .namespace("terra")
+                    .addAdditionalDataItem(new WsmPolicyPair().key("group").value(groupNameA)));
+    var groupPolicyB =
+        new WsmPolicyInputs()
+            .addInputsItem(
+                new WsmPolicyInput()
+                    .name("group-constraint")
+                    .namespace("terra")
+                    .addAdditionalDataItem(new WsmPolicyPair().key("group").value(groupNameB)));
+
+    /*
+     Scenario 1: WS(groupA) can merge DC(nogroup).
+    */
+    CreatedWorkspace groupTestWorkspace =
+        createWorkspaceWithPolicy(
+            UUID.randomUUID(), getSpendProfileId(), workspaceApi, groupPolicyA);
+
+    // data collection has no policies
+    CreatedWorkspace noGroupDataCollection =
+        createWorkspace(UUID.randomUUID(), getSpendProfileId(), workspaceApi);
+
+    GcpGcsBucketResource groupTestReferenceResource =
+        GcsBucketUtils.makeGcsBucketReference(
+            controlledBucketResource.getAttributes(),
+            referencedGcpResourceApi,
+            noGroupDataCollection.getId(),
+            "referenceBucket",
+            CloningInstructionsEnum.REFERENCE);
+
+    CloneReferencedGcpGcsBucketResourceResult referenceResult =
+        referencedGcpResourceApi.cloneGcpGcsBucketReference(
+            new CloneReferencedResourceRequestBody()
+                .destinationWorkspaceId(groupTestWorkspace.getId()),
+            groupTestReferenceResource.getMetadata().getWorkspaceId(),
+            groupTestReferenceResource.getMetadata().getResourceId());
+
+    validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
+    workspaceApi.deleteWorkspace(noGroupDataCollection.getId());
+
+    /*
+     Scenario 2: WS(groupA) can merge DC(groupA).
+    */
+    CreatedWorkspace groupADataCollection =
+        createWorkspaceWithPolicy(
+            UUID.randomUUID(), getSpendProfileId(), workspaceApi, groupPolicyA);
+
+    GcpGcsBucketResource groupATestReferenceResource =
+        GcsBucketUtils.makeGcsBucketReference(
+            controlledBucketResource.getAttributes(),
+            referencedGcpResourceApi,
+            groupADataCollection.getId(),
+            "referenceBucket",
+            CloningInstructionsEnum.REFERENCE);
+
+    referencedGcpResourceApi.deleteBucketReference(
+        referenceResult.getResource().getMetadata().getWorkspaceId(),
+        referenceResult.getResource().getMetadata().getResourceId());
+
+    referenceResult =
+        referencedGcpResourceApi.cloneGcpGcsBucketReference(
+            new CloneReferencedResourceRequestBody()
+                .destinationWorkspaceId(groupTestWorkspace.getId()),
+            groupATestReferenceResource.getMetadata().getWorkspaceId(),
+            groupATestReferenceResource.getMetadata().getResourceId());
+
+    validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
+    workspaceApi.deleteWorkspace(groupADataCollection.getId());
+
+    /*
+     Scenario 3: WS(groupA) cannot merge DC(groupB).
+    */
+    CreatedWorkspace groupBDataCollection =
+        createWorkspaceWithPolicy(
+            UUID.randomUUID(), getSpendProfileId(), workspaceApi, groupPolicyB);
+    GcpGcsBucketResource groupBTestReferenceResource =
+        GcsBucketUtils.makeGcsBucketReference(
+            controlledBucketResource.getAttributes(),
+            referencedGcpResourceApi,
+            groupBDataCollection.getId(),
+            "referenceBucket",
+            CloningInstructionsEnum.REFERENCE);
+
+    // remove the old reference
+    referencedGcpResourceApi.deleteBucketReference(
+        referenceResult.getResource().getMetadata().getWorkspaceId(),
+        referenceResult.getResource().getMetadata().getResourceId());
+
+    ApiException exception =
+        assertThrows(
+            ApiException.class,
+            () ->
+                referencedGcpResourceApi.cloneGcpGcsBucketReference(
+                    new CloneReferencedResourceRequestBody()
+                        .destinationWorkspaceId(groupTestWorkspace.getId()),
+                    groupBTestReferenceResource.getMetadata().getWorkspaceId(),
+                    groupBTestReferenceResource.getMetadata().getResourceId()));
+    assertEquals(HttpStatus.SC_CONFLICT, exception.getCode());
+    assertTrue(exception.getMessage().contains("Policy merge has conflicts"));
+
+    // group should still be A only
+    validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
+
+    /*
+     Scenario 4: WS(nopolicy) cannot merge DC(groupB).
+    */
+    CreatedWorkspace noGroupPolicyWorkspace =
+        createWorkspace(UUID.randomUUID(), getSpendProfileId(), workspaceApi);
+
+    exception =
+        assertThrows(
+            ApiException.class,
+            () ->
+                referencedGcpResourceApi.cloneGcpGcsBucketReference(
+                    new CloneReferencedResourceRequestBody()
+                        .destinationWorkspaceId(noGroupPolicyWorkspace.getId()),
+                    groupBTestReferenceResource.getMetadata().getWorkspaceId(),
+                    groupBTestReferenceResource.getMetadata().getResourceId()));
+    assertEquals(HttpStatus.SC_CONFLICT, exception.getCode());
+    assertTrue(exception.getMessage().contains("Policy merge has conflicts"));
+
+    WorkspaceDescription updatedWorkspace =
+        workspaceApi.getWorkspace(noGroupPolicyWorkspace.getId(), null);
+    List<WsmPolicyInput> updatedPolicies = updatedWorkspace.getPolicies();
+
+    assertEquals(0, updatedPolicies.size());
+    workspaceApi.deleteWorkspace(noGroupPolicyWorkspace.getId());
+
+    /*
+    Scenario 5:
+     */
+
+    // Clean up the data collections used in most of the scenarios.
+    workspaceApi.deleteWorkspace(groupBDataCollection.getId());
+    workspaceApi.deleteWorkspace(groupTestWorkspace.getId());
+  }
+
+  private void validateWorkspaceContainsGroupPolicy(
+      WorkspaceApi workspaceApi, UUID workspaceId, String groupName) throws Exception {
+    WorkspaceDescription updatedWorkspace = workspaceApi.getWorkspace(workspaceId, null);
+    List<WsmPolicyInput> updatedPolicies = updatedWorkspace.getPolicies();
+
+    List<WsmPolicyInput> groupPolicies =
+        updatedPolicies.stream().filter(p -> p.getName().equals("group-constraint")).toList();
+    assertEquals(1, groupPolicies.size());
+    WsmPolicyPair groupPolicy = groupPolicies.get(0).getAdditionalData().get(0);
+    assertEquals(1, groupPolicies.get(0).getAdditionalData().size());
+    assertEquals("group", groupPolicy.getKey());
+    assertEquals(groupName, groupPolicy.getValue());
+  }
+
+  @Override
+  public void doCleanup(List<TestUserSpecification> testUsers, WorkspaceApi workspaceApi)
+      throws Exception {
+    try {
+      workspaceApi.deleteWorkspace(getWorkspaceId());
+    } catch (ApiException e) {
+      if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
+        throw e;
+      }
+    }
+  }
+}

--- a/integration/src/main/resources/configs/integration/MergeGroupPolicies.json
+++ b/integration/src/main/resources/configs/integration/MergeGroupPolicies.json
@@ -1,0 +1,21 @@
+{
+  "name": "MergeGroupPolicies",
+  "description": "Import Data Collection into a workspace and merge its policies.",
+  "serverSpecificationFile": "workspace-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "MergeGroupPolicies",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 1,
+      "expectedTimeForEach": 75,
+      "expectedTimeForEachUnit": "MINUTES",
+      "parametersMap": {
+        "spend-profile-id": "wm-default-spend-profile"
+      }
+    }
+  ],
+  "testUserFiles": ["bella.json"],
+  "maxRetries" : 0
+}

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -13,6 +13,7 @@
     "integration/ImportDataCollection.json",
     "integration/Jobs.json",
     "integration/ListWorkspaces.json",
+    "integration/MergeGroupPolicies.json",
     "integration/PrivateControlledAiNotebookInstanceLifecycle.json",
     "integration/ReferencedBigQueryResourceLifecycle.json",
     "integration/ReferencedDataRepoSnapshotLifecycle.json",

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
@@ -7,6 +7,7 @@ import java.util.List;
 public class TpsUtilities {
   public static final String TERRA_NAMESPACE = "terra";
   public static final String GROUP_CONSTRAINT = "group-constraint";
+  public static final String GROUP_KEY = "group";
 
   public static List<String> getGroupConstraintsFromInputs(TpsPolicyInputs inputs) {
     List<String> result = new ArrayList<>();
@@ -19,7 +20,9 @@ public class TpsUtilities {
       if (input.getNamespace().equals(TERRA_NAMESPACE)
           && input.getName().equals(GROUP_CONSTRAINT)) {
         for (var data : input.getAdditionalData()) {
-          result.add(data.getValue());
+          if (data.getKey().equals(GROUP_KEY)) {
+            result.add(data.getValue());
+          }
         }
       }
     }

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
@@ -41,11 +41,11 @@ public class ValidateGroupPolicyAttributesStep implements Step {
         new HashSet<>(
             TpsUtilities.getGroupConstraintsFromInputs(mergedPao.getEffectiveAttributes()));
 
-    if (!(groups1.containsAll(groups2) && groups2.containsAll(groups1))) {
-      throw new PolicyConflictException("Cannot update group policies.");
+    if (groups1.containsAll(groups2) && groups2.containsAll(groups1)) {
+      return StepResult.getStepResultSuccess();
     }
 
-    return StepResult.getStepResultSuccess();
+    throw new PolicyConflictException("Cannot update group policies.");
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
@@ -34,10 +34,14 @@ public class ValidateGroupPolicyAttributesStep implements Step {
 
     final TpsPaoGetResult currentPao = tpsApiDispatch.getPao(workspaceId);
 
-    HashSet<String> groups1 = new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes()));
-    HashSet<String> groups2 = new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(mergedPao.getEffectiveAttributes()));
+    HashSet<String> groups1 =
+        new HashSet<>(
+            TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes()));
+    HashSet<String> groups2 =
+        new HashSet<>(
+            TpsUtilities.getGroupConstraintsFromInputs(mergedPao.getEffectiveAttributes()));
 
-    if (! (groups1.containsAll(groups2) && groups2.containsAll(groups1))) {
+    if (!(groups1.containsAll(groups2) && groups2.containsAll(groups1))) {
       throw new PolicyConflictException("Cannot update group policies.");
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import java.util.HashSet;
 import java.util.UUID;
 
+// TODO: Once we have support for group update, we can remove this class.
 public class ValidateGroupPolicyAttributesStep implements Step {
   private final UUID workspaceId;
   private final TpsApiDispatch tpsApiDispatch;
@@ -24,7 +25,7 @@ public class ValidateGroupPolicyAttributesStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    final TpsPaoGetResult mergedPao =
+    TpsPaoGetResult mergedPao =
         flightContext
             .getWorkingMap()
             .get(WorkspaceFlightMapKeys.EFFECTIVE_POLICIES, TpsPaoGetResult.class);
@@ -32,16 +33,16 @@ public class ValidateGroupPolicyAttributesStep implements Step {
     // For Milestone 1, we aren't able to change groups. So if the effectivePolices have different
     // groups than the existing workspace, we'll fail. Otherwise, the step will succeed.
 
-    final TpsPaoGetResult currentPao = tpsApiDispatch.getPao(workspaceId);
+    TpsPaoGetResult currentPao = tpsApiDispatch.getPao(workspaceId);
 
-    HashSet<String> groups1 =
+    HashSet<String> currentGroup =
         new HashSet<>(
             TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes()));
-    HashSet<String> groups2 =
+    HashSet<String> mergedGroup =
         new HashSet<>(
             TpsUtilities.getGroupConstraintsFromInputs(mergedPao.getEffectiveAttributes()));
 
-    if (groups1.containsAll(groups2) && groups2.containsAll(groups1)) {
+    if (currentGroup.equals(mergedGroup)) {
       return StepResult.getStepResultSuccess();
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
@@ -1,0 +1,52 @@
+package bio.terra.workspace.service.policy.flight;
+
+import bio.terra.policy.model.TpsPaoGetResult;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.service.policy.TpsApiDispatch;
+import bio.terra.workspace.service.policy.TpsUtilities;
+import bio.terra.workspace.service.resource.exception.PolicyConflictException;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import java.util.HashSet;
+import java.util.UUID;
+
+public class ValidateGroupPolicyAttributesStep implements Step {
+  private final UUID workspaceId;
+  private final TpsApiDispatch tpsApiDispatch;
+
+  public ValidateGroupPolicyAttributesStep(UUID workspaceId, TpsApiDispatch tpsApiDispatch) {
+    this.workspaceId = workspaceId;
+    this.tpsApiDispatch = tpsApiDispatch;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    final TpsPaoGetResult mergedPao =
+        flightContext
+            .getWorkingMap()
+            .get(WorkspaceFlightMapKeys.EFFECTIVE_POLICIES, TpsPaoGetResult.class);
+
+    // For Milestone 1, we aren't able to change groups. So if the effectivePolices have different
+    // groups than the existing workspace, we'll fail. Otherwise, the step will succeed.
+
+    final TpsPaoGetResult currentPao = tpsApiDispatch.getPao(workspaceId);
+
+    HashSet<String> groups1 = new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes()));
+    HashSet<String> groups2 = new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(mergedPao.getEffectiveAttributes()));
+
+    if (! (groups1.containsAll(groups2) && groups2.containsAll(groups1))) {
+      throw new PolicyConflictException("Cannot update group policies.");
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Validation step so there should be nothing to undo, only propagate the flight failure.
+    return context.getResult();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
@@ -10,6 +10,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.policy.flight.MergePolicyAttributesDryRunStep;
 import bio.terra.workspace.service.policy.flight.MergePolicyAttributesStep;
+import bio.terra.workspace.service.policy.flight.ValidateGroupPolicyAttributesStep;
 import bio.terra.workspace.service.policy.flight.ValidateWorkspaceAgainstPolicyStep;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.RetrieveGcsBucketCloudAttributesStep;
@@ -100,6 +101,10 @@ public class CloneControlledGcsBucketResourceFlight extends Flight {
               userRequest,
               flightBeanBag.getResourceDao(),
               flightBeanBag.getTpsApiDispatch()));
+
+      addStep(
+          new ValidateGroupPolicyAttributesStep(
+              destinationWorkspaceId, flightBeanBag.getTpsApiDispatch()));
 
       addStep(
           new MergePolicyAttributesStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.policy.flight.MergePolicyAttributesDryRunStep;
 import bio.terra.workspace.service.policy.flight.MergePolicyAttributesStep;
+import bio.terra.workspace.service.policy.flight.ValidateGroupPolicyAttributesStep;
 import bio.terra.workspace.service.policy.flight.ValidateWorkspaceAgainstPolicyStep;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.flight.clone.CheckControlledResourceAuthStep;
@@ -86,6 +87,10 @@ public class CloneControlledGcpBigQueryDatasetResourceFlight extends Flight {
               userRequest,
               flightBeanBag.getResourceDao(),
               flightBeanBag.getTpsApiDispatch()));
+
+      addStep(
+          new ValidateGroupPolicyAttributesStep(
+              destinationWorkspaceId, flightBeanBag.getTpsApiDispatch()));
 
       addStep(
           new MergePolicyAttributesStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/clone/CloneReferencedResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/clone/CloneReferencedResourceFlight.java
@@ -10,6 +10,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.policy.flight.MergePolicyAttributesDryRunStep;
 import bio.terra.workspace.service.policy.flight.MergePolicyAttributesStep;
+import bio.terra.workspace.service.policy.flight.ValidateGroupPolicyAttributesStep;
 import bio.terra.workspace.service.policy.flight.ValidateWorkspaceAgainstPolicyStep;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.referenced.model.ReferencedResource;
@@ -81,6 +82,10 @@ public class CloneReferencedResourceFlight extends Flight {
               userRequest,
               appContext.getResourceDao(),
               appContext.getTpsApiDispatch()));
+
+      addStep(
+          new ValidateGroupPolicyAttributesStep(
+              destinationWorkspaceId, appContext.getTpsApiDispatch()));
 
       addStep(
           new MergePolicyAttributesStep(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
+import static bio.terra.workspace.common.fixtures.PolicyFixtures.IOWA_REGION;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CLONE_WORKSPACE_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -171,23 +172,6 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
   }
 
   @Test
-  public void cloneWorkspaceMerge_additionalPolicy_conflictGroupPolicy() throws Exception {
-    workspaceSetup(ApiCloningInstructionsEnum.REFERENCE);
-    ApiCloneWorkspaceRequest request =
-        new ApiCloneWorkspaceRequest()
-            .spendProfile(WorkspaceFixtures.DEFAULT_SPEND_PROFILE)
-            .additionalPolicies(
-                new ApiWsmPolicyInputs()
-                    .addInputsItem(makeGroupPolicyInput(PolicyFixtures.ALT_GROUP)));
-
-    mockMvcUtils.postExpect(
-        userAccessUtils.defaultUserAuthRequest(),
-        objectMapper.writeValueAsString(request),
-        CLONE_WORKSPACE_PATH_FORMAT.formatted(sourceWorkspaceId.toString()),
-        HttpStatus.SC_CONFLICT);
-  }
-
-  @Test
   public void cloneWorkspaceMerge_additionalPolicy_conflictRegionPolicy() throws Exception {
     workspaceSetup(ApiCloningInstructionsEnum.REFERENCE);
     ApiCloneWorkspaceRequest request =
@@ -201,6 +185,19 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
         objectMapper.writeValueAsString(request),
         CLONE_WORKSPACE_PATH_FORMAT.formatted(sourceWorkspaceId.toString()),
         HttpStatus.SC_CONFLICT);
+  }
+
+  @Test
+  public void cloneWorkspaceMerge_addAdditionalGroupPolicy() throws Exception {
+    testWorkspaceCloneWithAdditionalPolicy(
+        ApiCloningInstructionsEnum.REFERENCE,
+        new ApiWsmPolicyInputs()
+            .addInputsItem(wsmTestGroup)
+            .addInputsItem(PolicyFixtures.REGION_POLICY_IOWA),
+        List.of(IOWA_REGION));
+
+    checkRegionPolicy(destinationWorkspaceId, List.of(IOWA_REGION));
+    checkGroupPolicy(destinationWorkspaceId, List.of(PolicyFixtures.DEFAULT_GROUP));
   }
 
   private void testResourceClone(ApiCloningInstructionsEnum cloningInstruction) throws Exception {
@@ -241,6 +238,28 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
     assertEquals(expectedRegions, actualRegions);
   }
 
+  private void checkGroupPolicy(UUID workspaceUuid, List<String> expectedGroups)
+      throws Exception {
+    ApiWorkspaceDescription workspaceDescription =
+        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceUuid);
+
+    List<ApiWsmPolicyInput> policies = workspaceDescription.getPolicies();
+    ApiWsmPolicyInput groupPolicy =
+        policies.stream()
+            .filter(p -> p.getNamespace().equals(PolicyFixtures.NAMESPACE) && p.getName().equals(PolicyFixtures.GROUP_CONSTRAINT))
+            .findAny()
+            .get();
+    assertEquals(PolicyFixtures.GROUP_CONSTRAINT, groupPolicy.getName());
+    assertEquals(expectedGroups.size(), groupPolicy.getAdditionalData().size());
+
+    List<String> actualGroups =
+        groupPolicy.getAdditionalData().stream()
+            .filter(data -> data.getKey().equals(PolicyFixtures.GROUP))
+            .map(group -> group.getValue())
+            .toList();
+    assertEquals(expectedGroups, actualGroups);
+  }
+
   private ApiWsmPolicyInput makeRegionPolicyInput(String region) {
     return new ApiWsmPolicyInput()
         .namespace(PolicyFixtures.NAMESPACE)
@@ -251,8 +270,8 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
   private ApiWsmPolicyInput makeGroupPolicyInput(String group) {
     return new ApiWsmPolicyInput()
         .namespace(PolicyFixtures.NAMESPACE)
-        .name(PolicyFixtures.GROUP)
-        .addAdditionalDataItem(new ApiWsmPolicyPair().key(PolicyFixtures.REGION).value(group));
+        .name(PolicyFixtures.GROUP_CONSTRAINT)
+        .addAdditionalDataItem(new ApiWsmPolicyPair().key(PolicyFixtures.GROUP).value(group));
   }
 
   private void resourceSetup() throws Exception {
@@ -266,8 +285,7 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
             .spendProfile("wm-default-spend-profile")
             .policies(
                 new ApiWsmPolicyInputs()
-                    .addInputsItem(PolicyFixtures.REGION_POLICY_USA)
-                    .addInputsItem(wsmTestGroup));
+                    .addInputsItem(PolicyFixtures.REGION_POLICY_USA));
 
     mockMvcUtils.createdWorkspaceWithoutCloudContext(
         userAccessUtils.defaultUserAuthRequest(), workspaceRequest);
@@ -336,8 +354,7 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
             .spendProfile("wm-default-spend-profile")
             .policies(
                 new ApiWsmPolicyInputs()
-                    .addInputsItem(PolicyFixtures.REGION_POLICY_USA)
-                    .addInputsItem(wsmTestGroup));
+                    .addInputsItem(PolicyFixtures.REGION_POLICY_USA));
 
     mockMvcUtils.createdWorkspaceWithoutCloudContext(
         userAccessUtils.defaultUserAuthRequest(), workspaceRequest);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
@@ -238,15 +238,17 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
     assertEquals(expectedRegions, actualRegions);
   }
 
-  private void checkGroupPolicy(UUID workspaceUuid, List<String> expectedGroups)
-      throws Exception {
+  private void checkGroupPolicy(UUID workspaceUuid, List<String> expectedGroups) throws Exception {
     ApiWorkspaceDescription workspaceDescription =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceUuid);
 
     List<ApiWsmPolicyInput> policies = workspaceDescription.getPolicies();
     ApiWsmPolicyInput groupPolicy =
         policies.stream()
-            .filter(p -> p.getNamespace().equals(PolicyFixtures.NAMESPACE) && p.getName().equals(PolicyFixtures.GROUP_CONSTRAINT))
+            .filter(
+                p ->
+                    p.getNamespace().equals(PolicyFixtures.NAMESPACE)
+                        && p.getName().equals(PolicyFixtures.GROUP_CONSTRAINT))
             .findAny()
             .get();
     assertEquals(PolicyFixtures.GROUP_CONSTRAINT, groupPolicy.getName());
@@ -283,9 +285,7 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
             .userFacingId(WorkspaceFixtures.getUserFacingId(sourceWorkspaceId))
             .stage(ApiWorkspaceStageModel.MC_WORKSPACE)
             .spendProfile("wm-default-spend-profile")
-            .policies(
-                new ApiWsmPolicyInputs()
-                    .addInputsItem(PolicyFixtures.REGION_POLICY_USA));
+            .policies(new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.REGION_POLICY_USA));
 
     mockMvcUtils.createdWorkspaceWithoutCloudContext(
         userAccessUtils.defaultUserAuthRequest(), workspaceRequest);
@@ -352,9 +352,7 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
             .userFacingId(WorkspaceFixtures.getUserFacingId(sourceWorkspaceId))
             .stage(ApiWorkspaceStageModel.MC_WORKSPACE)
             .spendProfile("wm-default-spend-profile")
-            .policies(
-                new ApiWsmPolicyInputs()
-                    .addInputsItem(PolicyFixtures.REGION_POLICY_USA));
+            .policies(new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.REGION_POLICY_USA));
 
     mockMvcUtils.createdWorkspaceWithoutCloudContext(
         userAccessUtils.defaultUserAuthRequest(), workspaceRequest);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
@@ -188,7 +188,7 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
   }
 
   @Test
-  public void cloneWorkspaceMerge_addAdditionalGroupPolicy() throws Exception {
+  public void cloneWorkspaceMerge_mergeCompatibleRegionPolicy() throws Exception {
     testWorkspaceCloneWithAdditionalPolicy(
         ApiCloningInstructionsEnum.REFERENCE,
         new ApiWsmPolicyInputs()


### PR DESCRIPTION
A lot of the logic has to happen inside of WSM because there are cases where we should allow groups to merge (like when we are cloning a workspace and adding additional group policies). Other cases - like cloning a reference from a data collection into a workspace should not allow group merge to change the group list. TPS won't know the difference so WSM needs to do that logic.
I also split the Group merging tests from the ImportDataCollection tests into its own set of integration tests.