### PR TITLE
[PF-2604] Update BigQuery lifetime attributes in database.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -172,6 +172,13 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
         getResourceFromFlightInputParameters(
             flight, WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
 
+    // Update the BigQuery attributes in the database (default table lifetime and default partition
+    // lifetime).
+    flight.addStep(
+        new UpdateControlledBigQueryDatasetLifetimeAttributesStep(
+            flightBeanBag.getResourceDao(), resource),
+        RetryRules.shortDatabase());
+
     // Retrieve existing attributes in case of undo later.
     flight.addStep(
         new RetrieveBigQueryDatasetCloudAttributesStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/UpdateControlledBigQueryDatasetLifetimeAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/UpdateControlledBigQueryDatasetLifetimeAttributesStep.java
@@ -1,0 +1,87 @@
+package bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset;
+
+import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys.UPDATE_PARAMETERS;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetUpdateParameters;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import java.util.Optional;
+
+public class UpdateControlledBigQueryDatasetLifetimeAttributesStep implements Step {
+  private final ResourceDao resourceDao;
+  private final ControlledBigQueryDatasetResource sourceDataset;
+
+  public UpdateControlledBigQueryDatasetLifetimeAttributesStep(
+      ResourceDao resourceDao, ControlledBigQueryDatasetResource sourceDataset) {
+    this.resourceDao = resourceDao;
+    this.sourceDataset = sourceDataset;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    String previousAttributes = sourceDataset.attributesToJson();
+    context
+        .getWorkingMap()
+        .put(WorkspaceFlightMapKeys.ResourceKeys.PREVIOUS_ATTRIBUTES, previousAttributes);
+
+    final ApiGcpBigQueryDatasetUpdateParameters updateParameters =
+        context
+            .getInputParameters()
+            .get(UPDATE_PARAMETERS, ApiGcpBigQueryDatasetUpdateParameters.class);
+    if (updateParameters == null) {
+      return StepResult.getStepResultSuccess();
+    }
+    Long newDefaultTableLifetime =
+        Optional.ofNullable(updateParameters.getDefaultTableLifetime())
+            .orElse(sourceDataset.getDefaultTableLifetime());
+    Long newDefaultPartitionLifetime =
+        Optional.ofNullable(updateParameters.getDefaultPartitionLifetime())
+            .orElse(sourceDataset.getDefaultPartitionLifetime());
+
+    String newAttributes =
+        DbSerDes.toJson(
+            new ControlledBigQueryDatasetAttributes(
+                sourceDataset.getDatasetName(),
+                sourceDataset.getProjectId(),
+                newDefaultTableLifetime,
+                newDefaultPartitionLifetime));
+
+    boolean updated =
+        resourceDao.updateResource(
+            sourceDataset.getWorkspaceId(),
+            sourceDataset.getResourceId(),
+            /*name=*/ null,
+            /*description=*/ null,
+            newAttributes,
+            /*cloningInstructions=*/ null);
+
+    if (!updated) {
+      throw new RetryException("Failed to update dataset with new data.");
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    String previousAttributes =
+        flightContext
+            .getWorkingMap()
+            .get(WorkspaceFlightMapKeys.ResourceKeys.PREVIOUS_ATTRIBUTES, String.class);
+    if (previousAttributes == null) {
+      return StepResult.getStepResultSuccess();
+    }
+    resourceDao.updateResource(
+        sourceDataset.getWorkspaceId(),
+        sourceDataset.getResourceId(),
+        null,
+        null,
+        previousAttributes,
+        null);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceTest.java
@@ -74,6 +74,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.Creat
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.DeleteBigQueryDatasetStep;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.RetrieveBigQueryDatasetCloudAttributesStep;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.UpdateBigQueryDatasetStep;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.UpdateControlledBigQueryDatasetLifetimeAttributesStep;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.CreateGcsBucketStep;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.DeleteGcsBucketStep;
@@ -1087,6 +1088,9 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
     // Test idempotency of dataset-specific steps by retrying them once.
     Map<String, StepStatus> retrySteps = new HashMap<>();
     retrySteps.put(
+        UpdateControlledBigQueryDatasetLifetimeAttributesStep.class.getName(),
+        StepStatus.STEP_RESULT_FAILURE_RETRY);
+    retrySteps.put(
         RetrieveBigQueryDatasetCloudAttributesStep.class.getName(),
         StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(UpdateBigQueryDatasetStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
@@ -1124,6 +1128,8 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
     assertEquals(newName, fetchedResource.getName());
     assertEquals(newDescription, fetchedResource.getDescription());
+    assertEquals(newDefaultTableLifetime, fetchedResource.getDefaultTableLifetime());
+    assertEquals(newDefaultPartitionLifetime, fetchedResource.getDefaultPartitionLifetime());
   }
 
   @Test
@@ -1153,6 +1159,9 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
 
     // Test idempotency of dataset-specific steps by retrying them once.
     Map<String, StepStatus> retrySteps = new HashMap<>();
+    retrySteps.put(
+        UpdateControlledBigQueryDatasetLifetimeAttributesStep.class.getName(),
+        StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(
         RetrieveBigQueryDatasetCloudAttributesStep.class.getName(),
         StepStatus.STEP_RESULT_FAILURE_RETRY);
@@ -1198,6 +1207,9 @@ public class ControlledResourceServiceTest extends BaseConnectedTest {
             .castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET);
     assertEquals(resource.getName(), fetchedResource.getName());
     assertEquals(resource.getDescription(), fetchedResource.getDescription());
+    assertEquals(resource.getDefaultTableLifetime(), fetchedResource.getDefaultTableLifetime());
+    assertEquals(
+        resource.getDefaultPartitionLifetime(), fetchedResource.getDefaultPartitionLifetime());
   }
 
   @Test


### PR DESCRIPTION
We added `defaultTableLifetime` and `defaultPartitionLifetime` to the controlled BigQuery attributes in #1034.

However, we only update the BQ-specific attributes on the cloud.

This PR adds a step to update the lifetime attributes in the database (before updating the cloud).

I used the API object for the update step, but I figured this would be replaced / fixed by Dan's update refactoring.