### PR TITLE
[PF-2616] Stop throwing dismal failure in ValidateGroupPolicyAttributesStep

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
@@ -52,6 +52,6 @@ public class ValidateGroupPolicyAttributesStep implements Step {
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
     // Validation step so there should be nothing to undo, only propagate the flight failure.
-    return context.getResult();
+    return StepResult.getStepResultSuccess();
   }
 }


### PR DESCRIPTION
This triggered the `dismal failure` alerts in Verily devel + autopush tests last night. This is a validation-only step, so it can always be "undone" successfully. 