### PR TITLE
Fix bug with missing blob name in URL (WOR-830).

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -216,7 +216,10 @@ public class AzureStorageAccessService {
     if (sasTokenOptions.blobName() != null) {
       var blobClient = blobContainerClient.getBlobClient(sasTokenOptions.blobName());
       token = blobClient.generateSas(sasValues);
-      resourceName = storageData.storageContainerResource().getStorageContainerName() + "/" + sasTokenOptions.blobName();
+      resourceName =
+          storageData.storageContainerResource().getStorageContainerName()
+              + "/"
+              + sasTokenOptions.blobName();
     } else {
       token = blobContainerClient.generateSas(sasValues);
       resourceName = storageData.storageContainerResource().getStorageContainerName();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -212,11 +212,14 @@ public class AzureStorageAccessService {
     }
 
     String token;
+    String resourceName;
     if (sasTokenOptions.blobName() != null) {
       var blobClient = blobContainerClient.getBlobClient(sasTokenOptions.blobName());
       token = blobClient.generateSas(sasValues);
+      resourceName = storageData.storageContainerResource().getStorageContainerName() + "/" + sasTokenOptions.blobName();
     } else {
       token = blobContainerClient.generateSas(sasValues);
+      resourceName = storageData.storageContainerResource().getStorageContainerName();
     }
 
     logger.info(
@@ -232,7 +235,7 @@ public class AzureStorageAccessService {
             Locale.ROOT,
             "https://%s.blob.core.windows.net/%s?%s",
             storageData.storageAccountName(),
-            storageData.storageContainerResource().getStorageContainerName(),
+            resourceName,
             token));
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -1,8 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -393,6 +392,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
 
   @Test
   void createAzureStorageContainerSasToken_blobName() throws InterruptedException {
+    var blobName = "foo/the/bar.baz";
     var storageAccountResource = buildStorageAccount();
     var storageContainerResource =
         buildStorageContainerResource(
@@ -416,9 +416,10 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             storageContainerResource.getWorkspaceId(),
             storageContainerResource.getResourceId(),
             userRequest,
-            new SasTokenOptions(null, startTime, expiryTime, "foo/the/bar.baz", null));
+            new SasTokenOptions(null, startTime, expiryTime, blobName, null));
 
     assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), true);
+    assertTrue(result.sasUrl().contains(storageContainerResource.getStorageContainerName() + "/" + blobName + "?"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -419,7 +419,10 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             new SasTokenOptions(null, startTime, expiryTime, blobName, null));
 
     assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), true);
-    assertTrue(result.sasUrl().contains(storageContainerResource.getStorageContainerName() + "/" + blobName + "?"));
+    assertTrue(
+        result
+            .sasUrl()
+            .contains(storageContainerResource.getStorageContainerName() + "/" + blobName + "?"));
   }
 
   @Test


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/WOR-830 for details.

As far as I can tell (searching in repos and posting on [Slack](https://broadinstitute.slack.com/archives/C02GJ782BAA/p1679513399512369)), nobody is currently using the current URL format and injecting the blob name into it. I thought terra-ui was because it generates URLs with blob names in them, but the SAS token it uses (and URL modifies) is actually returned by a call to get the SAS token for the entire container.