### PR TITLE
Revert "Fix bug with missing blob name in URL (WOR-830)."

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -212,17 +212,11 @@ public class AzureStorageAccessService {
     }
 
     String token;
-    String resourceName;
     if (sasTokenOptions.blobName() != null) {
       var blobClient = blobContainerClient.getBlobClient(sasTokenOptions.blobName());
       token = blobClient.generateSas(sasValues);
-      resourceName =
-          storageData.storageContainerResource().getStorageContainerName()
-              + "/"
-              + sasTokenOptions.blobName();
     } else {
       token = blobContainerClient.generateSas(sasValues);
-      resourceName = storageData.storageContainerResource().getStorageContainerName();
     }
 
     logger.info(
@@ -238,7 +232,7 @@ public class AzureStorageAccessService {
             Locale.ROOT,
             "https://%s.blob.core.windows.net/%s?%s",
             storageData.storageAccountName(),
-            resourceName,
+            storageData.storageContainerResource().getStorageContainerName(),
             token));
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -1,7 +1,8 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -392,7 +393,6 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
 
   @Test
   void createAzureStorageContainerSasToken_blobName() throws InterruptedException {
-    var blobName = "foo/the/bar.baz";
     var storageAccountResource = buildStorageAccount();
     var storageContainerResource =
         buildStorageContainerResource(
@@ -416,13 +416,9 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             storageContainerResource.getWorkspaceId(),
             storageContainerResource.getResourceId(),
             userRequest,
-            new SasTokenOptions(null, startTime, expiryTime, blobName, null));
+            new SasTokenOptions(null, startTime, expiryTime, "foo/the/bar.baz", null));
 
     assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), true);
-    assertTrue(
-        result
-            .sasUrl()
-            .contains(storageContainerResource.getStorageContainerName() + "/" + blobName + "?"));
   }
 
   @Test


### PR DESCRIPTION
Reverts DataBiosphere/terra-workspace-manager#1165

It turns out that TES is using the URL and injecting the blobName into it. Therefore I am going to revert this change until next week to give them more time to respond to the change (which will also require running Cromwells to be updated).

Slack thread: https://broadinstitute.slack.com/archives/C02GJ782BAA/p1679513399512369