### PR TITLE
[PF-2621] Handle null update parameter case for flex resources.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -388,7 +388,7 @@ public class ControlledResourceService {
             resource.getName());
 
     CloningInstructions resolvedCloningInstructions =
-        updateParameters.getCloningInstructions() == null
+        (updateParameters == null || updateParameters.getCloningInstructions() == null)
             ? resource.getCloningInstructions()
             : CloningInstructions.fromApiModel(updateParameters.getCloningInstructions());
 


### PR DESCRIPTION
Before, if `updateParameters` was `null`, then `updateParameters.getCloningInstructions()` would throw an error.

- Add a short-circuit OR checking first if the `updateParameters` are null.

