### PR TITLE
Always run with BPM enabled for Azure (WOR-743).

### DIFF
--- a/integration/src/main/java/scripts/utils/CloudContextMaker.java
+++ b/integration/src/main/java/scripts/utils/CloudContextMaker.java
@@ -1,7 +1,6 @@
 package scripts.utils;
 
 import bio.terra.workspace.api.WorkspaceApi;
-import bio.terra.workspace.model.AzureContext;
 import bio.terra.workspace.model.CloudPlatform;
 import bio.terra.workspace.model.CreateCloudContextRequest;
 import bio.terra.workspace.model.CreateCloudContextResult;
@@ -34,26 +33,6 @@ public class CloudContextMaker {
     CreateCloudContextResult contextResult =
         waitForCloudContext(createContext, workspaceUuid, workspaceApi, contextJobId);
     return contextResult.getGcpContext().getProjectId();
-  }
-
-  /**
-   * Creates an Azure cloud context for a given workspace. Returns the Azure resource group ID as a
-   * string
-   */
-  public static String createAzureCloudContext(
-      UUID workspaceUuid, WorkspaceApi workspaceApi, AzureContext context) throws Exception {
-    String contextJobId = UUID.randomUUID().toString();
-
-    var createContext =
-        new CreateCloudContextRequest()
-            .cloudPlatform(CloudPlatform.AZURE)
-            .jobControl(new JobControl().id(contextJobId))
-            .azureContext(context);
-
-    logger.info("Creating Azure cloud context");
-    CreateCloudContextResult contextResult =
-        waitForCloudContext(createContext, workspaceUuid, workspaceApi, contextJobId);
-    return contextResult.getAzureContext().getResourceGroupId();
   }
 
   private static CreateCloudContextResult waitForCloudContext(

--- a/openapi/src/parts/workspace_cloudcontext.yaml
+++ b/openapi/src/parts/workspace_cloudcontext.yaml
@@ -101,15 +101,12 @@ components:
         Contains the CloudPlatform for the context and the JobControl object.
         For GCP, a project is created to contain the cloud resources of the context.
         For Azure, a managed resource group (MRG) is created outside of WSM within a tenant
-        and a subscription obtained from the spend profile linked to the parent workspace, unless
-        the spend profile service is not enabled; in that case, azureContext must be provided.
+        and a subscription obtained from the spend profile linked to the parent workspace.
       properties:
         cloudPlatform:
           $ref: '#/components/schemas/CloudPlatform'
         jobControl:
           $ref: '#/components/schemas/JobControl'
-        azureContext:
-          $ref: '#/components/schemas/AzureContext'
 
     CreateCloudContextResult:
       type: object

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/FeatureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/FeatureConfiguration.java
@@ -19,7 +19,6 @@ public class FeatureConfiguration {
   private boolean alpha1Enabled;
   private boolean tpsEnabled;
   private boolean bpmGcpEnabled;
-  private boolean bpmAzureEnabled;
   private boolean temporaryGrantEnabled;
   private boolean dataprocEnabled;
   private WsmResourceStateRule stateRule;
@@ -62,14 +61,6 @@ public class FeatureConfiguration {
 
   public void setBpmGcpEnabled(boolean bpmGcpEnabled) {
     this.bpmGcpEnabled = bpmGcpEnabled;
-  }
-
-  public boolean isBpmAzureEnabled() {
-    return bpmAzureEnabled;
-  }
-
-  public void setBpmAzureEnabled(boolean bpmAzureEnabled) {
-    this.bpmAzureEnabled = bpmAzureEnabled;
   }
 
   public boolean isTemporaryGrantEnabled() {
@@ -131,7 +122,6 @@ public class FeatureConfiguration {
     logger.info("Feature: aws-enabled: {}", isAwsEnabled());
     logger.info("Feature: alpha1-enabled: {}", isAlpha1Enabled());
     logger.info("Feature: tps-enabled: {}", isTpsEnabled());
-    logger.info("Feature: bpm-azure-enabled: {}", isBpmAzureEnabled());
     logger.info("Feature: bpm-gcp-enabled: {}", isBpmGcpEnabled());
     logger.info("Feature: temporary-grant-enabled: {}", isTemporaryGrantEnabled());
     logger.info("Feature: dataproc-enabled: {}", isDataprocEnabled());

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -540,11 +540,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
         workspaceService.validateMcWorkspaceAndAction(userRequest, uuid, SamWorkspaceAction.WRITE);
 
     if (body.getCloudPlatform() == ApiCloudPlatform.AZURE) {
-      AzureCloudContext azureCloudContext =
-          ControllerValidationUtils.validateAzureContextRequestBody(
-              body.getAzureContext(), featureConfiguration.isBpmAzureEnabled());
-      workspaceService.createAzureCloudContext(
-          workspace, jobId, userRequest, resultPath, azureCloudContext);
+      workspaceService.createAzureCloudContext(workspace, jobId, userRequest, resultPath);
     } else {
       workspaceService.createGcpCloudContext(workspace, jobId, userRequest, resultPath);
     }

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -1,19 +1,15 @@
 package bio.terra.workspace.common.utils;
 
 import bio.terra.common.exception.ValidationException;
-import bio.terra.workspace.generated.model.ApiAzureContext;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiProperty;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceCategory;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
-import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.exceptions.CloudPlatformNotImplementedException;
-import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.commons.validator.routines.InetAddressValidator;
@@ -191,33 +187,6 @@ public final class ControllerValidationUtils {
     }
     if (blobName.length() > 1024) {
       throw new ValidationException("Blob name must be <= 1024 chars");
-    }
-  }
-
-  /**
-   * Validate that a user has provided an Azure cloud context if one cannot be fetched from BPM
-   *
-   * @param apiAzureContext Azure cloud context included as request body parameter
-   * @param isBpmEnabled whether BPM (SpendProfileService) is enabled, in which case
-   *     AzureCloudContext should not be present
-   * @return AzureCloudContext to use for request
-   */
-  public static AzureCloudContext validateAzureContextRequestBody(
-      @Nullable ApiAzureContext apiAzureContext, boolean isBpmEnabled) {
-    Optional<AzureCloudContext> optionalAzureCloudContext =
-        Optional.ofNullable(apiAzureContext).map(AzureCloudContext::fromApi);
-    // if BPM is enabled for Azure, then the coordinates should be obtained from BPM.
-    if (isBpmEnabled) {
-      if (optionalAzureCloudContext.isPresent()) {
-        throw new CloudContextRequiredException(
-            "AzureContext should not be supplied when creating an Azure cloud context for a workspace if BPM is enabled");
-      }
-      return null;
-    } else {
-      return optionalAzureCloudContext.orElseThrow(
-          () ->
-              new CloudContextRequiredException(
-                  "AzureContext is required when creating an Azure cloud context for a workspace if BPM is disabled"));
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateCloudContextFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/LaunchCreateCloudContextFlightStep.java
@@ -13,7 +13,6 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
-import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
 
@@ -61,13 +60,7 @@ public class LaunchCreateCloudContextFlightStep implements Step {
     if (!flightAlreadyExists) {
       if (CloudPlatform.AZURE == cloudPlatform) {
         workspaceService.createAzureCloudContext(
-            destinationWorkspace,
-            cloudContextJobId,
-            userRequest,
-            null,
-            context
-                .getInputParameters()
-                .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class));
+            destinationWorkspace, cloudContextJobId, userRequest, null);
       } else {
         workspaceService.createGcpCloudContext(
             destinationWorkspace, cloudContextJobId, userRequest);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -33,7 +33,6 @@ import bio.terra.workspace.service.workspace.flight.azure.DeleteAzureContextFlig
 import bio.terra.workspace.service.workspace.flight.gcp.CreateGcpContextFlightV2;
 import bio.terra.workspace.service.workspace.flight.gcp.DeleteGcpContextFlight;
 import bio.terra.workspace.service.workspace.flight.gcp.RemoveUserFromWorkspaceFlight;
-import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceDescription;
@@ -499,15 +498,13 @@ public class WorkspaceService {
    * @param jobId caller-supplied job id of the async job
    * @param userRequest user authentication info
    * @param resultPath optional endpoint where the result of the completed job can be retrieved
-   * @param azureContext deprecated azure context information, only used if BPM is not enabled
    */
   @Traced
   public void createAzureCloudContext(
       Workspace workspace,
       String jobId,
       AuthenticatedUserRequest userRequest,
-      @Nullable String resultPath,
-      @Nullable AzureCloudContext azureContext) {
+      @Nullable String resultPath) {
     features.azureEnabledCheck();
 
     jobService
@@ -517,7 +514,6 @@ public class WorkspaceService {
         .workspaceId(workspace.getWorkspaceId().toString())
         .operationType(OperationType.CREATE)
         .flightClass(CreateAzureContextFlight.class)
-        .request(azureContext)
         .userRequest(userRequest)
         .addParameter(WorkspaceFlightMapKeys.WORKSPACE_ID, workspace.getWorkspaceId().toString())
         .addParameter(JobMapKeys.RESULT_PATH.getKeyName(), resultPath)

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/azure/CreateAzureContextFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/azure/CreateAzureContextFlight.java
@@ -42,16 +42,14 @@ public class CreateAzureContextFlight extends Flight {
     }
 
     // check that we are allowed to link to this spend profile
-    if (featureConfiguration.isBpmAzureEnabled()) {
-      addStep(
-          new CheckSpendProfileStep(
-              appContext.getWorkspaceDao(),
-              appContext.getSpendProfileService(),
-              workspaceUuid,
-              userRequest,
-              CloudPlatform.AZURE,
-              featureConfiguration.isBpmAzureEnabled()));
-    }
+    addStep(
+        new CheckSpendProfileStep(
+            appContext.getWorkspaceDao(),
+            appContext.getSpendProfileService(),
+            workspaceUuid,
+            userRequest,
+            CloudPlatform.AZURE,
+            true));
 
     // write the incomplete DB row to prevent concurrent creates
     addStep(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/azure/CreateDbAzureCloudContextFinishStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/azure/CreateDbAzureCloudContextFinishStep.java
@@ -7,7 +7,6 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.utils.FlightUtils;
-import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.spendprofile.SpendProfile;
 import bio.terra.workspace.service.workspace.AzureCloudContextService;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
@@ -33,19 +32,13 @@ public class CreateDbAzureCloudContextFinishStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     AzureCloudContext azureCloudContext;
-    if (featureConfiguration.isBpmAzureEnabled()) {
-      var spendProfile = flightContext.getWorkingMap().get(SPEND_PROFILE, SpendProfile.class);
-      azureCloudContext =
-          new AzureCloudContext(
-              spendProfile.tenantId().toString(),
-              spendProfile.subscriptionId().toString(),
-              spendProfile.managedResourceGroupId());
-    } else {
-      azureCloudContext =
-          flightContext
-              .getInputParameters()
-              .get(JobMapKeys.REQUEST.getKeyName(), AzureCloudContext.class);
-    }
+    var spendProfile = flightContext.getWorkingMap().get(SPEND_PROFILE, SpendProfile.class);
+    azureCloudContext =
+        new AzureCloudContext(
+            spendProfile.tenantId().toString(),
+            spendProfile.subscriptionId().toString(),
+            spendProfile.managedResourceGroupId());
+
     // Create the cloud context; throws if the context already exists.
     azureCloudContextService.createAzureCloudContextFinish(
         workspaceUuid, azureCloudContext, flightContext.getFlightId());

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/azure/ValidateMRGStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/azure/ValidateMRGStep.java
@@ -4,9 +4,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.spendprofile.SpendProfile;
 import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
@@ -24,26 +22,14 @@ public class ValidateMRGStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext flightContext) throws InterruptedException {
-    FlightBeanBag appContext = FlightBeanBag.getFromObject(flightContext.getApplicationContext());
+    var spendProfile =
+        flightContext.getWorkingMap().get(WorkspaceFlightMapKeys.SPEND_PROFILE, SpendProfile.class);
 
-    AzureCloudContext azureCloudContext;
-    if (appContext.getFeatureConfiguration().isBpmAzureEnabled()) {
-      var spendProfile =
-          flightContext
-              .getWorkingMap()
-              .get(WorkspaceFlightMapKeys.SPEND_PROFILE, SpendProfile.class);
-
-      azureCloudContext =
-          new AzureCloudContext(
-              spendProfile.tenantId().toString(),
-              spendProfile.subscriptionId().toString(),
-              spendProfile.managedResourceGroupId());
-    } else {
-      azureCloudContext =
-          flightContext
-              .getInputParameters()
-              .get(JobMapKeys.REQUEST.getKeyName(), AzureCloudContext.class);
-    }
+    AzureCloudContext azureCloudContext =
+        new AzureCloudContext(
+            spendProfile.tenantId().toString(),
+            spendProfile.subscriptionId().toString(),
+            spendProfile.managedResourceGroupId());
 
     try {
       ResourceManager resourceManager =

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -213,8 +213,6 @@ feature:
   tps-enabled: false
   # bpm-enabled-gcp - Controls whether spend profile checks are made for GCP workspaces
   bpm-gcp-enabled: false
-  # bpm-enabled-azure - Controls whether spend profile checks are made for Azure workspaces
-  bpm-azure-enabled: false
   # temporary-grant-enabled - Controls whether temporary direct ACL grants are made on creates
   temporary-grant-enabled: false
   # dataproc-enabled - Controls whether project level Dataproc permissions are enabled for owners

--- a/service/src/test/java/bio/terra/workspace/common/utils/ControllerValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/ControllerValidationUtilsTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.exception.ValidationException;
 import bio.terra.workspace.common.BaseUnitTest;
-import bio.terra.workspace.generated.model.ApiAzureContext;
-import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import org.junit.jupiter.api.Test;
 
 public class ControllerValidationUtilsTest extends BaseUnitTest {
@@ -96,18 +94,5 @@ public class ControllerValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         ValidationException.class,
         () -> ControllerValidationUtils.validateSasBlobName(largeString));
-  }
-
-  @Test
-  void validateAzureContextRequestBody() {
-    ApiAzureContext apiAzureContext = new ApiAzureContext();
-    ControllerValidationUtils.validateAzureContextRequestBody(apiAzureContext, false);
-    ControllerValidationUtils.validateAzureContextRequestBody(null, true);
-    assertThrows(
-        CloudContextRequiredException.class,
-        () -> ControllerValidationUtils.validateAzureContextRequestBody(apiAzureContext, true));
-    assertThrows(
-        CloudContextRequiredException.class,
-        () -> ControllerValidationUtils.validateAzureContextRequestBody(null, false));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/azure/CreateAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/azure/CreateAzureContextFlightTest.java
@@ -71,8 +71,7 @@ class CreateAzureContextFlightTest extends BaseAzureConnectedTest {
     assertTrue(azureCloudContextService.getAzureCloudContext(workspace.getWorkspaceId()).isEmpty());
 
     String jobId = UUID.randomUUID().toString();
-    workspaceService.createAzureCloudContext(
-        workspace, jobId, userRequest, /* resultPath */ null, null);
+    workspaceService.createAzureCloudContext(workspace, jobId, userRequest, /* resultPath */ null);
 
     // Wait for the job to complete
     FlightState flightState =
@@ -133,8 +132,7 @@ class CreateAzureContextFlightTest extends BaseAzureConnectedTest {
 
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     String jobId = UUID.randomUUID().toString();
-    workspaceService.createAzureCloudContext(
-        workspace, jobId, userRequest, /* resultPath */ null, null);
+    workspaceService.createAzureCloudContext(workspace, jobId, userRequest, /* resultPath */ null);
 
     // Wait for the job to complete
     FlightState flightState =

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -54,7 +54,6 @@ reference:
     - github.com
 feature:
   tps-enabled: true
-  bpm-azure-enabled: true
   temporary-grant-enabled: true
 
 #Terra Landing Zone Service configuration


### PR DESCRIPTION
Ticket:  https://broadworkbench.atlassian.net/browse/WOR-743

We previously minimized the usage of Azure workspaces with BPM disabled in https://github.com/DataBiosphere/terra-workspace-manager/pull/1010. The original hope was to remove the feature flag with that PR, but Azure VM integration tests that relied on creating a CloudContext without BPM prevented complete removal of the feature flag.

However, https://github.com/DataBiosphere/terra-workspace-manager/pull/1166 deleted the problematic integration test code, so we can now change Azure CloudContext creation to unconditionally pull MRG coordinates from the BPM spend profile.