### PR TITLE
[PF-2436] fix ControlledGcpResourceApiControllerBqDatasetTest

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -53,7 +53,7 @@ import scripts.utils.MultiResourcesUtils;
 import scripts.utils.SamClientUtils;
 
 // TODO: This test no longer clones. Extend WorkspaceAllocateTestScriptBase instead of
-// GcpWorkspaceCloneTestScriptBase.
+//  GcpWorkspaceCloneTestScriptBase.
 public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScriptBase {
   private static final Logger logger =
       LoggerFactory.getLogger(ControlledBigQueryDatasetLifecycle.class);

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateWorkspaceAgainstPolicyStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateWorkspaceAgainstPolicyStep.java
@@ -5,6 +5,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
@@ -43,9 +44,10 @@ public class ValidateWorkspaceAgainstPolicyStep implements Step {
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
     final TpsPaoGetResult effectivePolicies =
-        flightContext
-            .getWorkingMap()
-            .get(WorkspaceFlightMapKeys.EFFECTIVE_POLICIES, TpsPaoGetResult.class);
+        FlightUtils.getRequired(
+            flightContext.getWorkingMap(),
+            WorkspaceFlightMapKeys.EFFECTIVE_POLICIES,
+            TpsPaoGetResult.class);
 
     if (cloudPlatform != CloudPlatform.GCP) {
       // We can only validate GCP right now. We'll need to add other platforms
@@ -68,13 +70,18 @@ public class ValidateWorkspaceAgainstPolicyStep implements Step {
         continue;
       }
       if (!validRegions.contains(existingResource.getRegion().toLowerCase())) {
-        throw new PolicyConflictException("Workspace contains resources in violation of policy.");
+        throw new PolicyConflictException(
+            String.format(
+                "Workspace contains resources in region '%s' in violation of policy.",
+                existingResource.getRegion()));
       }
     }
 
     if (destinationLocation != null && !validRegions.contains(destinationLocation.toLowerCase())) {
       throw new PolicyConflictException(
-          "The specified destination location violates region policies");
+          String.format(
+              "The specified destination location '%s' violates region policies",
+              destinationLocation));
     }
 
     return StepResult.getStepResultSuccess();

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import bio.terra.stairway.FlightDebugInfo;
@@ -33,8 +32,6 @@ import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
-import bio.terra.workspace.generated.model.ApiWsmPolicyInput;
-import bio.terra.workspace.generated.model.ApiWsmPolicyPair;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
@@ -654,9 +651,6 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
         /*policiesToRemove=*/ null);
 
-    dumpWorkspaceRegionPolicies(workspaceId);
-    dumpWorkspaceRegionPolicies(workspaceId2);
-
     // Clone resource
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
     mockMvcUtils.cloneControlledBqDataset(
@@ -677,21 +671,6 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
     // Clean up: Delete policies
     mockMvcUtils.deletePolicies(userRequest, workspaceId);
     mockMvcUtils.deletePolicies(userRequest, workspaceId2);
-  }
-
-  private void dumpWorkspaceRegionPolicies(UUID workspaceId) throws Exception {
-    ApiWorkspaceDescription workspace =
-        mockMvcUtils.getWorkspace(
-            userAccessUtils.defaultUser().getAuthenticatedRequest(), workspaceId);
-    for (ApiWsmPolicyInput policy : workspace.getPolicies()) {
-      if (policy.getName().equals(PolicyFixtures.REGION_CONSTRAINT)) {
-        logger.info(
-            ">> REGION POLICY DUMP - workspace {} id {}", workspace.getUserFacingId(), workspaceId);
-        for (ApiWsmPolicyPair pair : policy.getAdditionalData()) {
-          logger.info(">> {} | {}", pair.getKey(), pair.getValue());
-        }
-      }
-    }
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
@@ -183,10 +183,6 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
         userAccessUtils.defaultUser().getGoogleCredentials(), projectId);
     GcpCloudUtils.waitForProjectAccess(
         userAccessUtils.defaultUser().getGoogleCredentials(), projectId2);
-    GcpCloudUtils.waitForProjectAccess(
-        userAccessUtils.secondUser().getGoogleCredentials(), projectId);
-    GcpCloudUtils.waitForProjectAccess(
-        userAccessUtils.secondUser().getGoogleCredentials(), projectId2);
 
     // It is easier to make two buckets and do clone both directions than to
     // get different permissions on users.

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketTest.java
@@ -183,6 +183,10 @@ public class ControlledGcpResourceApiControllerGcsBucketTest extends BaseConnect
         userAccessUtils.defaultUser().getGoogleCredentials(), projectId);
     GcpCloudUtils.waitForProjectAccess(
         userAccessUtils.defaultUser().getGoogleCredentials(), projectId2);
+    GcpCloudUtils.waitForProjectAccess(
+        userAccessUtils.secondUser().getGoogleCredentials(), projectId);
+    GcpCloudUtils.waitForProjectAccess(
+        userAccessUtils.secondUser().getGoogleCredentials(), projectId2);
 
     // It is easier to make two buckets and do clone both directions than to
     // get different permissions on users.

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -166,6 +166,7 @@ import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.hamcrest.Matcher;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -2464,9 +2465,11 @@ public class MockMvcUtils {
             .sourceWorkspaceId(sourceWorkspaceId)
             .sourceResourceId(sourceResourceId));
 
-    String expectedLastUpdatedBy = samService.getUserStatusInfo(userRequest).getUserEmail();
-    String expectedLastUpdatedBySubjectId =
-        samService.getUserStatusInfo(userRequest).getUserSubjectId();
+    UserStatusInfo userStatusInfo = samService.getUserStatusInfo(userRequest);
+    String expectedLastUpdatedBy = userStatusInfo.getUserEmail();
+    String expectedLastUpdatedBySubjectId = userStatusInfo.getUserSubjectId();
+    logger.info(">>Expect last updated by {}", expectedLastUpdatedBy);
+
     assertResourceMetadata(
         actualMetadata,
         expectedCloudPlatform,
@@ -2479,6 +2482,7 @@ public class MockMvcUtils {
         expectedResourceLineage,
         expectedCreatedBy,
         expectedLastUpdatedBy);
+    // The CLONE activity log entry is keyed to the DESTINATION workspace for some reason!?
     assertLatestActivityLogChangeDetails(
         expectedWorkspaceId,
         expectedLastUpdatedBy,


### PR DESCRIPTION
This test was disabled due to permission propagation insanity. I rewrote it so there are no dynamic grant/revokes.
