### PR TITLE
Fix notebook integration test error and connected test flakiness.

### DIFF
--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -170,12 +170,7 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
         "Other workspace user does not have access to a private notebook");
 
     // The user should be able to stop their notebook.
-    userNotebooks
-        .projects()
-        .locations()
-        .instances()
-        .stop(instanceName, new StopInstanceRequest())
-        .execute();
+    userNotebooks.projects().locations().instances().stop(instanceName, new StopInstanceRequest());
 
     // The user should not be able to directly delete their notebook.
     GoogleJsonResponseException directDeleteForbidden =
@@ -191,23 +186,17 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
     var newName = "new-instance-notebook-name";
     var newDescription = "new description for the new instance notebook name";
     var newMetadata = ImmutableMap.of("foo", "bar", "count", "3");
-    var newMachineType = "n1-standard-4";
     GcpAiNotebookInstanceResource updatedResource =
         resourceUserApi.updateAiNotebookInstance(
             new UpdateControlledGcpAiNotebookInstanceRequestBody()
                 .description(newDescription)
                 .name(newName)
-                .updateParameters(
-                    new GcpAiNotebookUpdateParameters()
-                        .metadata(newMetadata)
-                        .machineType(newMachineType)),
+                .updateParameters(new GcpAiNotebookUpdateParameters().metadata(newMetadata)),
             getWorkspaceId(),
             resourceId);
 
     assertEquals(newName, updatedResource.getMetadata().getName());
     assertEquals(newDescription, updatedResource.getMetadata().getDescription());
-    assertEquals(newMachineType, updatedResource.getAttributes().getMachineType());
-
     var metadata =
         userNotebooks.projects().locations().instances().get(instanceName).execute().getMetadata();
     for (var entrySet : newMetadata.entrySet()) {

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -186,17 +186,23 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
     var newName = "new-instance-notebook-name";
     var newDescription = "new description for the new instance notebook name";
     var newMetadata = ImmutableMap.of("foo", "bar", "count", "3");
+    var newMachineType = "n1-standard-4";
     GcpAiNotebookInstanceResource updatedResource =
         resourceUserApi.updateAiNotebookInstance(
             new UpdateControlledGcpAiNotebookInstanceRequestBody()
                 .description(newDescription)
                 .name(newName)
-                .updateParameters(new GcpAiNotebookUpdateParameters().metadata(newMetadata)),
+                .updateParameters(
+                    new GcpAiNotebookUpdateParameters()
+                        .metadata(newMetadata)
+                        .machineType(newMachineType)),
             getWorkspaceId(),
             resourceId);
 
     assertEquals(newName, updatedResource.getMetadata().getName());
     assertEquals(newDescription, updatedResource.getMetadata().getDescription());
+    assertEquals(newMachineType, updatedResource.getAttributes().getMachineType());
+
     var metadata =
         userNotebooks.projects().locations().instances().get(instanceName).execute().getMetadata();
     for (var entrySet : newMetadata.entrySet()) {

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -170,7 +170,24 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
         "Other workspace user does not have access to a private notebook");
 
     // The user should be able to stop their notebook.
-    userNotebooks.projects().locations().instances().stop(instanceName, new StopInstanceRequest());
+    userNotebooks
+        .projects()
+        .locations()
+        .instances()
+        .stop(instanceName, new StopInstanceRequest())
+        .execute();
+
+    // Wait until the notebook is stopped (or stopping).
+    ClientTestUtils.getWithRetry(
+        state -> state.equals("STOPPING") || state.equals("STOPPED"),
+        () ->
+            userNotebooks
+                .projects()
+                .locations()
+                .instances()
+                .get(instanceName)
+                .execute()
+                .getState());
 
     // The user should not be able to directly delete their notebook.
     GoogleJsonResponseException directDeleteForbidden =

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstanceLifecycle.java
@@ -170,7 +170,12 @@ public class PrivateControlledAiNotebookInstanceLifecycle extends WorkspaceAlloc
         "Other workspace user does not have access to a private notebook");
 
     // The user should be able to stop their notebook.
-    userNotebooks.projects().locations().instances().stop(instanceName, new StopInstanceRequest());
+    userNotebooks
+        .projects()
+        .locations()
+        .instances()
+        .stop(instanceName, new StopInstanceRequest())
+        .execute();
 
     // The user should not be able to directly delete their notebook.
     GoogleJsonResponseException directDeleteForbidden =

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookTest.java
@@ -5,18 +5,12 @@ import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEF
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEFAULT_CREATED_AI_NOTEBOOK_MACHINE_TYPE;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertControlledResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
-import static bio.terra.workspace.common.utils.RetryUtils.DEFAULT_RETRY_FACTOR_INCREASE;
-import static bio.terra.workspace.common.utils.RetryUtils.DEFAULT_RETRY_SLEEP_DURATION;
-import static bio.terra.workspace.common.utils.RetryUtils.DEFAULT_RETRY_SLEEP_DURATION_MAX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
-import bio.terra.workspace.common.utils.GcpUtils;
-import bio.terra.workspace.common.utils.GcpUtilsTest;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.RetryUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -36,14 +30,9 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.AcceleratorConfig;
 import bio.terra.workspace.service.workspace.model.WorkspaceConstants;
-
-import java.time.Duration;
+import com.google.cloud.notebooks.v1.Instance;
 import java.util.List;
 import java.util.UUID;
-
-import com.google.api.services.notebooks.v1.model.StopInstanceRequest;
-import com.google.cloud.notebooks.v1.GetInstanceRequest;
-import com.google.cloud.notebooks.v1.Instance;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookTest.java
@@ -5,13 +5,20 @@ import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEF
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEFAULT_CREATED_AI_NOTEBOOK_MACHINE_TYPE;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertControlledResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
+import static bio.terra.workspace.common.utils.RetryUtils.DEFAULT_RETRY_FACTOR_INCREASE;
+import static bio.terra.workspace.common.utils.RetryUtils.DEFAULT_RETRY_SLEEP_DURATION;
+import static bio.terra.workspace.common.utils.RetryUtils.DEFAULT_RETRY_SLEEP_DURATION_MAX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.utils.GcpUtils;
+import bio.terra.workspace.common.utils.GcpUtilsTest;
 import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.common.utils.RetryUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAccessScope;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
@@ -29,8 +36,14 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.AcceleratorConfig;
 import bio.terra.workspace.service.workspace.model.WorkspaceConstants;
+
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
+
+import com.google.api.services.notebooks.v1.model.StopInstanceRequest;
+import com.google.cloud.notebooks.v1.GetInstanceRequest;
+import com.google.cloud.notebooks.v1.Instance;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -150,6 +163,13 @@ public class ControlledGcpResourceApiControllerAiNotebookTest extends BaseConnec
 
     // Stop the notebook so the CPU and GPU can be updated.
     crlService.getAIPlatformNotebooksCow().instances().stop(instanceName).execute();
+
+    // Wait until the notebook is stopped (or stopping).
+    RetryUtils.getWithRetry(
+        state ->
+            state.getState().equals(com.google.cloud.notebooks.v1.Instance.State.STOPPED.toString())
+                || state.getState().equals(Instance.State.STOPPING.toString()),
+        () -> crlService.getAIPlatformNotebooksCow().instances().get(instanceName).execute());
 
     var updatedNotebook =
         mockMvcUtils.updateAiNotebookInstance(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookTest.java
@@ -155,9 +155,11 @@ public class ControlledGcpResourceApiControllerAiNotebookTest extends BaseConnec
 
     // Wait until the notebook is stopped (or stopping).
     RetryUtils.getWithRetry(
-        state ->
-            state.getState().equals(com.google.cloud.notebooks.v1.Instance.State.STOPPED.toString())
-                || state.getState().equals(Instance.State.STOPPING.toString()),
+        instance ->
+            instance
+                    .getState()
+                    .equals(com.google.cloud.notebooks.v1.Instance.State.STOPPED.toString())
+                || instance.getState().equals(Instance.State.STOPPING.toString()),
         () -> crlService.getAIPlatformNotebooksCow().instances().get(instanceName).execute());
 
     var updatedNotebook =


### PR DESCRIPTION
Overall, the biggest test change is waiting for the stop request to be properly executed (and not just queued), before continuing.

#### Integration
In the integration test, we never queued the stop request before. Pretty sure we needed to call `.execute()` on that request.

Changes pass manually triggered full integration tests run: https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/4622277782

#### Connected

To resolve flakiness in the connected test, wait until the notebook is stopping/stopped before continuing with the update.

- Before, the stop operation was still queued when we tried to update, as the notebook was still provisioning.
