### PR TITLE
Support limiting which blobs to clone (WOR-544).

### DIFF
--- a/openapi/src/parts/controlled_azure_storage_container.yaml
+++ b/openapi/src/parts/controlled_azure_storage_container.yaml
@@ -154,6 +154,11 @@ components:
           format: uuid
         cloningInstructions:
           $ref: "#/components/schemas/CloningInstructionsEnum"
+        prefixesToClone:
+          description: if a non-empty value is specified, cloning will be limited to the blobs that start with a prefix in this array
+          type: array
+          items:
+            type: string
         name:
           $ref: "#/components/schemas/Name"
         description:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -500,7 +500,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             body.getDescription(),
             body.getName(),
             body.getCloningInstructions(),
-            body.getPrefixesToClone().toArray(new String[0]));
+            body.getPrefixesToClone());
 
     final ApiCloneControlledAzureStorageContainerResult result =
         fetchCloneAzureContainerResult(jobId);

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -499,7 +499,8 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             body.getName(),
             body.getDescription(),
             body.getName(),
-            body.getCloningInstructions());
+            body.getCloningInstructions(),
+            body.getPrefixesToClone().toArray(new String[0]));
 
     final ApiCloneControlledAzureStorageContainerResult result =
         fetchCloneAzureContainerResult(jobId);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -202,7 +202,8 @@ public class ControlledResourceService {
       @Nullable String destinationResourceName,
       @Nullable String destinationDescription,
       @Nullable String destinationContainerName,
-      @Nullable ApiCloningInstructionsEnum cloningInstructionsOverride) {
+      @Nullable ApiCloningInstructionsEnum cloningInstructionsOverride,
+      @Nullable String[] prefixesToClone) {
     final ControlledResource sourceContainer =
         getControlledResource(sourceWorkspaceId, sourceResourceId);
 
@@ -238,7 +239,8 @@ public class ControlledResourceService {
                 ResourceKeys.CLONING_INSTRUCTIONS,
                 Optional.ofNullable(cloningInstructionsOverride)
                     .map(CloningInstructions::fromApiModel)
-                    .orElse(sourceContainer.getCloningInstructions()));
+                    .orElse(sourceContainer.getCloningInstructions()))
+            .addParameter(ResourceKeys.PREFIXES_TO_CLONE, prefixesToClone);
     return jobBuilder.submit();
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -203,7 +203,7 @@ public class ControlledResourceService {
       @Nullable String destinationDescription,
       @Nullable String destinationContainerName,
       @Nullable ApiCloningInstructionsEnum cloningInstructionsOverride,
-      @Nullable String[] prefixesToClone) {
+      @Nullable List<String> prefixesToClone) {
     final ControlledResource sourceContainer =
         getControlledResource(sourceWorkspaceId, sourceResourceId);
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopier.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopier.java
@@ -11,6 +11,8 @@ import com.azure.storage.blob.models.BlobCopyInfo;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.options.BlobBeginCopyOptions;
 import java.time.Duration;
+import java.util.Arrays;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,19 +35,29 @@ public class BlobCopier {
    *
    * @param sourceStorageData Azure storage container containing the blobs to be copied
    * @param destStorageData Azure storage container that will receive the copied blobs
+   * @param prefixesToCopy optional array of prefixes that will filter which blobs to copy
    * @return BlobCopyResult containing the status of each copy operation
    */
-  public BlobCopierResult copyBlobs(StorageData sourceStorageData, StorageData destStorageData) {
+  public BlobCopierResult copyBlobs(
+      StorageData sourceStorageData,
+      StorageData destStorageData,
+      @Nullable String[] prefixesToCopy) {
     var sourceBlobContainerClient =
         storageAccessService.buildBlobContainerClient(sourceStorageData);
     var destinationBlobContainerClient =
         storageAccessService.buildBlobContainerClient(destStorageData);
 
-    // directories are presented as zero-length blobs, filter these out as they are
-    // not copy-able
+    // Directories are presented as zero-length blobs, filter these out as they are not
+    // copy-able. Also filter out blobs that should not be copied if `prefixToCopy` was specified.
+    var copyAllBlobs = prefixesToCopy == null || prefixesToCopy.length == 0;
     var blobItems =
         sourceBlobContainerClient.listBlobs().stream()
-            .filter(blobItem -> blobItem.getProperties().getContentLength() > 0);
+            .filter(
+                blobItem ->
+                    blobItem.getProperties().getContentLength() > 0
+                        && (copyAllBlobs
+                            || Arrays.asList(prefixesToCopy).stream()
+                                .anyMatch(prefix -> blobItem.getName().startsWith(prefix))));
 
     var blobPollers =
         blobItems.map(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopier.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopier.java
@@ -11,7 +11,7 @@ import com.azure.storage.blob.models.BlobCopyInfo;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.options.BlobBeginCopyOptions;
 import java.time.Duration;
-import java.util.Arrays;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +41,7 @@ public class BlobCopier {
   public BlobCopierResult copyBlobs(
       StorageData sourceStorageData,
       StorageData destStorageData,
-      @Nullable String[] prefixesToCopy) {
+      @Nullable List<String> prefixesToCopy) {
     var sourceBlobContainerClient =
         storageAccessService.buildBlobContainerClient(sourceStorageData);
     var destinationBlobContainerClient =
@@ -49,14 +49,14 @@ public class BlobCopier {
 
     // Directories are presented as zero-length blobs, filter these out as they are not
     // copy-able. Also filter out blobs that should not be copied if `prefixToCopy` was specified.
-    var copyAllBlobs = prefixesToCopy == null || prefixesToCopy.length == 0;
+    var copyAllBlobs = prefixesToCopy == null || prefixesToCopy.size() == 0;
     var blobItems =
         sourceBlobContainerClient.listBlobs().stream()
             .filter(
                 blobItem ->
                     blobItem.getProperties().getContentLength() > 0
                         && (copyAllBlobs
-                            || Arrays.asList(prefixesToCopy).stream()
+                            || prefixesToCopy.stream()
                                 .anyMatch(prefix -> blobItem.getName().startsWith(prefix))));
 
     var blobPollers =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStep.java
@@ -12,6 +12,8 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageA
 import bio.terra.workspace.service.resource.controlled.cloud.azure.BlobCopier;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 
 public class CopyAzureStorageContainerBlobsStep implements Step {
@@ -52,10 +54,10 @@ public class CopyAzureStorageContainerBlobsStep implements Step {
                 WorkspaceFlightMapKeys.ControlledResourceKeys.CLONED_RESOURCE_DEFINITION,
                 ControlledAzureStorageContainerResource.class);
 
-    String[] prefixesToClone =
+    List<String> prefixesToClone =
         flightContext
             .getWorkingMap()
-            .get(WorkspaceFlightMapKeys.ResourceKeys.PREFIXES_TO_CLONE, String[].class);
+            .get(WorkspaceFlightMapKeys.ResourceKeys.PREFIXES_TO_CLONE, new TypeReference<>() {});
 
     var sourceStorageData =
         azureStorageAccessService.getStorageAccountData(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStep.java
@@ -52,6 +52,11 @@ public class CopyAzureStorageContainerBlobsStep implements Step {
                 WorkspaceFlightMapKeys.ControlledResourceKeys.CLONED_RESOURCE_DEFINITION,
                 ControlledAzureStorageContainerResource.class);
 
+    String[] prefixesToClone =
+        flightContext
+            .getWorkingMap()
+            .get(WorkspaceFlightMapKeys.ResourceKeys.PREFIXES_TO_CLONE, String[].class);
+
     var sourceStorageData =
         azureStorageAccessService.getStorageAccountData(
             sourceContainer.getWorkspaceId(), sourceContainer.getResourceId(), userRequest);
@@ -61,7 +66,7 @@ public class CopyAzureStorageContainerBlobsStep implements Step {
             destinationContainer.getResourceId(),
             userRequest);
 
-    var results = blobCopier.copyBlobs(sourceStorageData, destStorageData);
+    var results = blobCopier.copyBlobs(sourceStorageData, destStorageData, prefixesToClone);
     if (results.anyFailures()) {
       FlightUtils.setErrorResponse(
           flightContext, "Blobs failed to copy", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -118,6 +118,7 @@ public final class WorkspaceFlightMapKeys {
     public static final String RESOURCE = "resource";
     public static final String DESTINATION_RESOURCE = "destinationResource";
     public static final String CLONING_INSTRUCTIONS = "cloningInstructions";
+    public static final String PREFIXES_TO_CLONE = "prefixesToClone";
     public static final String RESOURCE_STATE_RULE = "resourceStateRule";
     public static final String RESOURCE_STATE_CHANGED = "resourceStateChanged";
     public static final String UPDATE_PARAMETERS = "updateParameters";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopierConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopierConnectedTest.java
@@ -104,21 +104,21 @@ public class BlobCopierConnectedTest extends BaseAzureConnectedTest {
 
   @ParameterizedTest
   @MethodSource("getPrefixesToCopyAllFiles")
-  void copyAllBlobs(@Nullable String[] prefixesToCopy, String[] blobNames) {
+  void copyAllBlobs(@Nullable List<String> prefixesToCopy, String[] blobNames) {
     assertCopyBlobs(prefixesToCopy, blobNames, blobNames);
   }
 
   private static java.util.stream.Stream<Arguments> getPrefixesToCopyAllFiles() {
     return java.util.stream.Stream.of(
         Arguments.of(null, generateFilenames(6)),
-        Arguments.of(new String[] {}, generateFilenames(3)),
-        Arguments.of(new String[] {""}, generateFilenames(2)),
-        Arguments.of(new String[] {"0/", "1/", "2/", "3/", "4/"}, generateFilenames(5)));
+        Arguments.of(List.of(), generateFilenames(3)),
+        Arguments.of(List.of(""), generateFilenames(2)),
+        Arguments.of(List.of("0/", "1/", "2/", "3/", "4/"), generateFilenames(5)));
   }
 
   @ParameterizedTest
   @MethodSource("getPrefixesToCopySomeFiles")
-  void copyBlobsWithPrefix(String[] prefixesToCopy, String[] allNames, String[] copiedNames) {
+  void copyBlobsWithPrefix(List<String> prefixesToCopy, String[] allNames, String[] copiedNames) {
     assertCopyBlobs(prefixesToCopy, allNames, copiedNames);
   }
 
@@ -128,16 +128,17 @@ public class BlobCopierConnectedTest extends BaseAzureConnectedTest {
         new String[] {"folder/item1.txt", "folder/item2.txt", "folder/item3.txt"};
     return java.util.stream.Stream.of(
         Arguments.of(
-            new String[] {" ", "/", "it-blob", "/it-blob"}, generateFilenames(1), new String[] {}),
-        Arguments.of(new String[] {"2", "5"}, sixItems, new String[] {sixItems[2], sixItems[5]}),
-        Arguments.of(new String[] {"folder/"}, folderWithThreeItems, folderWithThreeItems),
+            List.of(" ", "/", "it-blob", "/it-blob"), generateFilenames(1), new String[] {}),
+        Arguments.of(List.of("2", "5"), sixItems, new String[] {sixItems[2], sixItems[5]}),
+        Arguments.of(List.of("folder/"), folderWithThreeItems, folderWithThreeItems),
         Arguments.of(
-            new String[] {"folder/item2", "folder/item1.txt"},
+            List.of("folder/item2", "folder/item1.txt"),
             folderWithThreeItems,
             new String[] {folderWithThreeItems[0], folderWithThreeItems[1]}));
   }
 
-  private void assertCopyBlobs(String[] prefixesToCopy, String[] allNames, String[] copiedNames) {
+  private void assertCopyBlobs(
+      List<String> prefixesToCopy, String[] allNames, String[] copiedNames) {
     // upload blob to source container
     var sourceContainerClient =
         azureStorageAccessService.buildBlobContainerClient(sourceContainer, storageAcct);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopierConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopierConnectedTest.java
@@ -127,7 +127,8 @@ public class BlobCopierConnectedTest extends BaseAzureConnectedTest {
     var folderWithThreeItems =
         new String[] {"folder/item1.txt", "folder/item2.txt", "folder/item3.txt"};
     return java.util.stream.Stream.of(
-        Arguments.of(new String[] {" "}, generateFilenames(1), new String[] {}),
+        Arguments.of(
+            new String[] {" ", "/", "it-blob", "/it-blob"}, generateFilenames(1), new String[] {}),
         Arguments.of(new String[] {"2", "5"}, sixItems, new String[] {sixItems[2], sixItems[5]}),
         Arguments.of(new String[] {"folder/"}, folderWithThreeItems, folderWithThreeItems),
         Arguments.of(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStepUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStepUnitTest.java
@@ -18,10 +18,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.BlobCopierRes
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import com.azure.core.util.polling.LongRunningOperationStatus;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -33,7 +30,7 @@ public class CopyAzureStorageContainerBlobsStepUnitTest extends BaseAzureUnitTes
   @Mock private ControlledAzureStorageContainerResource sourceContainer;
   @Mock private FlightContext flightContext;
 
-  private final String[] clonePrefixes = {"analyses/"};
+  private final List<String> clonePrefixes = new ArrayList<>(List.of("analyses/"));
 
   private final AuthenticatedUserRequest userRequest =
       new AuthenticatedUserRequest().email("example@example.com").token(Optional.of("fake-token"));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStepUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStepUnitTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.azure.container;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +33,8 @@ public class CopyAzureStorageContainerBlobsStepUnitTest extends BaseAzureUnitTes
   @Mock private ControlledAzureStorageContainerResource sourceContainer;
   @Mock private FlightContext flightContext;
 
+  private final String[] clonePrefixes = {"analyses/"};
+
   private final AuthenticatedUserRequest userRequest =
       new AuthenticatedUserRequest().email("example@example.com").token(Optional.of("fake-token"));
 
@@ -52,6 +54,9 @@ public class CopyAzureStorageContainerBlobsStepUnitTest extends BaseAzureUnitTes
     workingMap.put(
         WorkspaceFlightMapKeys.ControlledResourceKeys.CLONED_RESOURCE_DEFINITION,
         destinationContainer);
+
+    workingMap.put(WorkspaceFlightMapKeys.ResourceKeys.PREFIXES_TO_CLONE, clonePrefixes);
+
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
   }
@@ -64,7 +69,7 @@ public class CopyAzureStorageContainerBlobsStepUnitTest extends BaseAzureUnitTes
             azureStorageAccessService, sourceContainer, resourceDao, userRequest, copier);
     var copyResult =
         new BlobCopierResult(Map.of(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED, List.of()));
-    when(copier.copyBlobs(any(), any())).thenReturn(copyResult);
+    when(copier.copyBlobs(any(), any(), eq(clonePrefixes))).thenReturn(copyResult);
 
     var result = copyBlobsStep.doStep(flightContext);
 
@@ -84,7 +89,7 @@ public class CopyAzureStorageContainerBlobsStepUnitTest extends BaseAzureUnitTes
                 List.of(),
                 LongRunningOperationStatus.FAILED,
                 List.of()));
-    when(copier.copyBlobs(any(), any())).thenReturn(errorCopyResult);
+    when(copier.copyBlobs(any(), any(), eq(clonePrefixes))).thenReturn(errorCopyResult);
 
     var result = copyBlobsStep.doStep(flightContext);
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-544

Allows passing an array of prefixes that limit which blobs to clone. If the array is not present or is of zero length, all blobs will be cloned.