### PR TITLE
Get the resource from the correct map (WOR-544).

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -240,7 +240,7 @@ public class ControlledResourceService {
                 Optional.ofNullable(cloningInstructionsOverride)
                     .map(CloningInstructions::fromApiModel)
                     .orElse(sourceContainer.getCloningInstructions()))
-            .addParameter(ResourceKeys.PREFIXES_TO_CLONE, prefixesToClone);
+            .addParameter(ControlledResourceKeys.PREFIXES_TO_CLONE, prefixesToClone);
     return jobBuilder.submit();
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStep.java
@@ -55,9 +55,9 @@ public class CopyAzureStorageContainerBlobsStep implements Step {
                 ControlledAzureStorageContainerResource.class);
 
     List<String> prefixesToClone =
-        flightContext
-            .getWorkingMap()
-            .get(WorkspaceFlightMapKeys.ResourceKeys.PREFIXES_TO_CLONE, new TypeReference<>() {});
+        inputParameters.get(
+            WorkspaceFlightMapKeys.ControlledResourceKeys.PREFIXES_TO_CLONE,
+            new TypeReference<>() {});
 
     var sourceStorageData =
         azureStorageAccessService.getStorageAccountData(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -71,6 +71,7 @@ public final class WorkspaceFlightMapKeys {
     public static final String LOCATION = "location";
     public static final String RESOURCE_ID_TO_CLONE_RESULT = "resourceIdToCloneResult";
     public static final String RESOURCES_TO_CLONE = "resourcesToClone";
+    public static final String PREFIXES_TO_CLONE = "prefixesToClone";
     public static final String CONTROLLED_RESOURCES_TO_DELETE = "controlledResourcesToDelete";
     public static final String SOURCE_CLONE_INPUTS = "sourceCloneInputs";
     public static final String SOURCE_WORKSPACE_ID = "sourceWorkspaceId";
@@ -115,7 +116,6 @@ public final class WorkspaceFlightMapKeys {
     public static final String RESOURCE = "resource";
     public static final String DESTINATION_RESOURCE = "destinationResource";
     public static final String CLONING_INSTRUCTIONS = "cloningInstructions";
-    public static final String PREFIXES_TO_CLONE = "prefixesToClone";
     public static final String RESOURCE_STATE_RULE = "resourceStateRule";
     public static final String RESOURCE_STATE_CHANGED = "resourceStateChanged";
     public static final String UPDATE_PARAMETERS = "updateParameters";

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStepUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerBlobsStepUnitTest.java
@@ -43,6 +43,8 @@ public class CopyAzureStorageContainerBlobsStepUnitTest extends BaseAzureUnitTes
     inputParameters.put(
         WorkspaceFlightMapKeys.ControlledResourceKeys.DESTINATION_WORKSPACE_ID,
         destinationWorkspaceId);
+    inputParameters.put(
+        WorkspaceFlightMapKeys.ControlledResourceKeys.PREFIXES_TO_CLONE, clonePrefixes);
 
     var destinationContainer =
         ControlledResourceFixtures.getAzureStorageContainer("sc-" + UUID.randomUUID());
@@ -51,8 +53,6 @@ public class CopyAzureStorageContainerBlobsStepUnitTest extends BaseAzureUnitTes
     workingMap.put(
         WorkspaceFlightMapKeys.ControlledResourceKeys.CLONED_RESOURCE_DEFINITION,
         destinationContainer);
-
-    workingMap.put(WorkspaceFlightMapKeys.ResourceKeys.PREFIXES_TO_CLONE, clonePrefixes);
 
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);


### PR DESCRIPTION
Follow-up PR from https://github.com/DataBiosphere/terra-workspace-manager/pull/1188.

I confess that my manual testing of this (since we have no full integration test) is pretty sketchy-- I ended up commenting out a ton of code along the path to where I made this fix so that I could verify that the expected value is in the inputParameters map (without properly setting up a billing profile attached to an actual landing zone and creating a storage container in it). I feel like the risk here is low though because in the absence of the prefixes cloning continues to copy everything over.