### PR TITLE
[PF-2668] test fixes

### DIFF
--- a/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
+++ b/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
@@ -197,8 +197,7 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
                     dataCollectionReferenceResource.getMetadata().getWorkspaceId(),
                     dataCollectionReferenceResource.getMetadata().getResourceId()));
     assertEquals(exception.getCode(), HttpStatus.SC_CONFLICT);
-    assertTrue(
-        exception.getMessage().contains("Workspace contains resources in violation of policy."));
+    assertTrue(exception.getMessage().contains("violation of policy"));
 
     workspaceApi.deleteWorkspace(scenario5Workspace.getId());
 

--- a/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
+++ b/integration/src/main/java/scripts/testscripts/ImportDataCollection.java
@@ -196,6 +196,9 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
                         .destinationWorkspaceId(scenario5Workspace.getId()),
                     dataCollectionReferenceResource.getMetadata().getWorkspaceId(),
                     dataCollectionReferenceResource.getMetadata().getResourceId()));
+    logger.info(
+        "Captured exception - code: {} message: '%{}'",
+        exception.getCode(), exception.getMessage());
     assertEquals(exception.getCode(), HttpStatus.SC_CONFLICT);
     assertTrue(exception.getMessage().contains("violation of policy"));
 
@@ -308,7 +311,7 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
         cloneToAltLocationResult
             .getErrorReport()
             .getMessage()
-            .contains("The specified destination location violates region policies"));
+            .contains("violates region policies"));
 
     workspaceApi.deleteWorkspace(scenario7Workspace.getId());
 
@@ -384,11 +387,7 @@ public class ImportDataCollection extends WorkspaceAllocateTestScriptBase {
 
     assertEquals(JobReport.StatusEnum.FAILED, cloneBqResult.getJobReport().getStatus());
     assertEquals(HttpStatus.SC_CONFLICT, cloneBqResult.getJobReport().getStatusCode());
-    assertTrue(
-        cloneBqResult
-            .getErrorReport()
-            .getMessage()
-            .contains("The specified destination location violates region policies"));
+    assertTrue(cloneBqResult.getErrorReport().getMessage().contains("violates region policies"));
 
     workspaceApi.deleteWorkspace(scenario8Workspace.getId());
 

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateWorkspaceAgainstPolicyStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateWorkspaceAgainstPolicyStep.java
@@ -69,6 +69,8 @@ public class ValidateWorkspaceAgainstPolicyStep implements Step {
         // Some resources don't have regions. IE: Git repos.
         continue;
       }
+      // NOTE: part of this message text is validated in the integration tests.
+      // If you change the text, check its usage in integration.
       if (!validRegions.contains(existingResource.getRegion().toLowerCase())) {
         throw new PolicyConflictException(
             String.format(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -448,10 +448,8 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         projectId2,
         gotResource.getAttributes().getDatasetId(),
         EUROPE_LOCATION,
-        // TODO(PF-2269): Change to DEFAULT_TABLE_LIFETIME after PF-2269 is fixed
-        /*defaultTableLifetime*/ null,
-        // TODO(PF-2269): Change to DEFAULT_PARTITION_LIFETIME after PF-2269 is fixed
-        /*defaultPartitionLifetime*/ null);
+        DEFAULT_TABLE_LIFETIME,
+        DEFAULT_PARTITION_LIFETIME);
     mockMvcUtils.deleteBqDataset(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
@@ -514,10 +512,8 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         projectId,
         gotResource.getAttributes().getDatasetId(),
         EUROPE_LOCATION,
-        // TODO(PF-2269): Change to DEFAULT_TABLE_LIFETIME after PF-2269 is fixed
-        /*defaultTableLifetime*/ null,
-        // TODO(PF-2269): Change to DEFAULT_PARTITION_LIFETIME after PF-2269 is fixed
-        /*defaultPartitionLifetime*/ null);
+        DEFAULT_TABLE_LIFETIME,
+        DEFAULT_PARTITION_LIFETIME);
   }
 
   @Disabled("PF-2639 Need BigQuery Data Transfer service API enabled")
@@ -576,10 +572,8 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         projectId2,
         gotResource.getAttributes().getDatasetId(),
         EUROPE_LOCATION,
-        // TODO(PF-2269): Change to DEFAULT_TABLE_LIFETIME after PF-2269 is fixed
-        /*defaultTableLifetime*/ null,
-        // TODO(PF-2269): Change to DEFAULT_PARTITION_LIFETIME after PF-2269 is fixed
-        /*defaultPartitionLifetime*/ null);
+        DEFAULT_TABLE_LIFETIME,
+        DEFAULT_PARTITION_LIFETIME);
   }
 
   @Test


### PR DESCRIPTION
PR fixing the two tests I broke.

Integration test: ImportDataCollection depended on a specific error message. I changed the error. This is a compensating change to the test.

ConnectedPlus test: ControlledGcpResourceApiControllerBqDatasetTest needed to use the proper default lifetimes, since that TODO got implemented.
