### PR TITLE
[PF-2581] Make RemoveUserFromSamStep idempotent

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromSamStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/RemoveUserFromSamStep.java
@@ -4,11 +4,9 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
-import bio.terra.workspace.common.exception.InvalidRemoveUserRequestException;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
-import java.util.List;
 import java.util.UUID;
 
 public class RemoveUserFromSamStep implements Step {
@@ -34,29 +32,6 @@ public class RemoveUserFromSamStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    // Validate that the user being removed is a direct member of the specified role. Users may also
-    // be added to a workspace via managed groups, but WSM does not control membership of those
-    // groups, and so cannot remove them here.
-    List<String> roleMembers =
-        samService.listUsersWithWorkspaceRole(workspaceUuid, roleToRemove, userRequest).stream()
-            // SAM does not always use lowercase emails, so lowercase everything here before the
-            // contains check below
-            .map(String::toLowerCase)
-            .toList();
-    if (!roleMembers.contains(userToRemoveEmail)) {
-      // If the above Sam call succeeds, the caller has permission to view workspace members, so
-      // we do not need to hide workspace member information by always returning 204.
-      throw new InvalidRemoveUserRequestException(
-          String.format(
-              "The specified user does not directly have the %s role in workspace %s. They may need to be removed from a group instead.",
-              roleToRemove.toSamRole(), workspaceUuid));
-    }
-    // Additionally, validate that the user is not removing themselves as the sole owner. WSM does
-    // not allow users to abandon resources this way.
-    if (roleToRemove.equals(WsmIamRole.OWNER) && roleMembers.size() == 1) {
-      throw new InvalidRemoveUserRequestException(
-          "You may not remove yourself as the sole workspace owner. Grant another user the workspace owner role before removing yourself.");
-    }
     // Sam returns a 204 regardless of whether the user was actually removed or not, so this step is
     // always idempotent.
     samService.removeWorkspaceRole(workspaceUuid, userRequest, roleToRemove, userToRemoveEmail);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/ValidateUserRoleStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/ValidateUserRoleStep.java
@@ -1,0 +1,68 @@
+package bio.terra.workspace.service.workspace.flight;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.exception.InvalidRemoveUserRequestException;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.WsmIamRole;
+import java.util.List;
+import java.util.UUID;
+
+public class ValidateUserRoleStep implements Step {
+
+  private final SamService samService;
+  private final UUID workspaceUuid;
+  private final WsmIamRole roleToRemove;
+  private final String userToRemoveEmail;
+  private final AuthenticatedUserRequest userRequest;
+
+  public ValidateUserRoleStep(
+      UUID workspaceUuid,
+      WsmIamRole roleToRemove,
+      String userToRemoveEmail,
+      SamService samService,
+      AuthenticatedUserRequest userRequest) {
+    this.samService = samService;
+    this.workspaceUuid = workspaceUuid;
+    this.roleToRemove = roleToRemove;
+    this.userToRemoveEmail = userToRemoveEmail;
+    this.userRequest = userRequest;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    // Validate that the user being removed is a direct member of the specified role. Users may also
+    // be added to a workspace via managed groups, but WSM does not control membership of those
+    // groups, and so cannot remove them here.
+    List<String> roleMembers =
+        samService.listUsersWithWorkspaceRole(workspaceUuid, roleToRemove, userRequest).stream()
+            // SAM does not always use lowercase emails, so lowercase everything here before the
+            // contains check below
+            .map(String::toLowerCase)
+            .toList();
+    if (!roleMembers.contains(userToRemoveEmail)) {
+      // If the above Sam call succeeds, the caller has permission to view workspace members, so
+      // we do not need to hide workspace member information by always returning 204.
+      throw new InvalidRemoveUserRequestException(
+          String.format(
+              "The specified user does not directly have the %s role in workspace %s. They may need to be removed from a group instead.",
+              roleToRemove.toSamRole(), workspaceUuid));
+    }
+    // Additionally, validate that the user is not removing themselves as the sole owner. WSM does
+    // not allow users to abandon resources this way.
+    if (roleToRemove.equals(WsmIamRole.OWNER) && roleMembers.size() == 1) {
+      throw new InvalidRemoveUserRequestException(
+          "You may not remove yourself as the sole workspace owner. Grant another user the workspace owner role before removing yourself.");
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // This step is validation only, nothing to undo.
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/RemoveUserFromWorkspaceFlightTest.java
@@ -42,6 +42,7 @@ import bio.terra.workspace.service.workspace.flight.MarkPrivateResourcesAbandone
 import bio.terra.workspace.service.workspace.flight.ReleasePrivateResourceCleanupClaimsStep;
 import bio.terra.workspace.service.workspace.flight.RemovePrivateResourceAccessStep;
 import bio.terra.workspace.service.workspace.flight.RemoveUserFromSamStep;
+import bio.terra.workspace.service.workspace.flight.ValidateUserRoleStep;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.model.CloudContextHolder;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
@@ -144,6 +145,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
 
     // Run the "removeUser" flight to the very end, then undo it, retrying steps along the way.
     Map<String, StepStatus> retrySteps = new HashMap<>();
+    retrySteps.put(ValidateUserRoleStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(RemoveUserFromSamStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(
         CheckUserStillInWorkspaceStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);


### PR DESCRIPTION
In #1196 I moved some validation inside `RemoveUserFromSamStep`. However, removing the user's role in the later part of the step means that validation no longer succeeds on rerun, and the step is no longer idempotent. This pulls the validation into a different step first.
This does introduce slightly more time between the validation and role removal, but I think that's worthwhile given the alternative of failing on step retry.