### PR TITLE
PF-2689: mergeCheck doesn't note conflicting group policies

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -5,6 +5,8 @@ import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertM
 import static bio.terra.workspace.common.utils.ControllerValidationUtils.validatePropertiesDeleteRequestBody;
 import static bio.terra.workspace.common.utils.ControllerValidationUtils.validatePropertiesUpdateRequestBody;
 
+import bio.terra.policy.model.TpsPaoConflict;
+import bio.terra.policy.model.TpsPaoDescription;
 import bio.terra.policy.model.TpsPaoGetResult;
 import bio.terra.policy.model.TpsPaoUpdateResult;
 import bio.terra.policy.model.TpsPolicyInputs;
@@ -60,6 +62,7 @@ import bio.terra.workspace.service.logging.WorkspaceActivityLogService;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
 import bio.terra.workspace.service.policy.TpsApiConversionUtils;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
+import bio.terra.workspace.service.policy.TpsUtilities;
 import bio.terra.workspace.service.policy.model.PolicyExplainResult;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
@@ -776,6 +779,8 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     TpsPaoUpdateResult dryRunResults =
         tpsApiDispatch.mergePao(targetWorkspaceId, sourceWorkspaceId, TpsUpdateMode.DRY_RUN);
 
+    validateMergeGroups(targetWorkspaceId, sourceWorkspaceId, dryRunResults);
+
     List<UUID> resourceWithConflicts = new ArrayList<>();
 
     for (var platform : ApiCloudPlatform.values()) {
@@ -824,5 +829,49 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
   private AuthenticatedUserRequest getCloningCredentials(UUID workspaceUuid) {
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     return petSaService.getWorkspacePetCredentials(workspaceUuid, userRequest).orElse(userRequest);
+  }
+
+  /**
+   * Check that group policies are not changed during a merge operation. TPS allows this, but WSM
+   * will need to enforce the Milestone 1 limitation of immutable groups. If groups change during a
+   * merge request, WSM will add a conflict in to the TpsPaoUpdateResult.
+   *
+   * @param targetWorkspaceId
+   * @param sourceWorkspaceId
+   * @param dryRunResults
+   */
+  private void validateMergeGroups(
+      UUID targetWorkspaceId, UUID sourceWorkspaceId, TpsPaoUpdateResult dryRunResults) {
+    TpsPaoGetResult targetPaoPreUpdate = tpsApiDispatch.getPao(targetWorkspaceId);
+
+    HashSet<String> priorGroups =
+        new HashSet<>(
+            TpsUtilities.getGroupConstraintsFromInputs(
+                targetPaoPreUpdate.getEffectiveAttributes()));
+    HashSet<String> mergedGroups =
+        new HashSet<>(
+            TpsUtilities.getGroupConstraintsFromInputs(
+                dryRunResults.getResultingPao().getEffectiveAttributes()));
+
+    if (!priorGroups.equals(mergedGroups)) {
+      var sourcePao = tpsApiDispatch.getPao(sourceWorkspaceId);
+      TpsPaoDescription targetDescription =
+          new TpsPaoDescription()
+              .objectId(targetWorkspaceId)
+              .component(targetPaoPreUpdate.getComponent())
+              .objectType(targetPaoPreUpdate.getObjectType());
+      TpsPaoDescription sourceDescription =
+          new TpsPaoDescription()
+              .objectId(sourceWorkspaceId)
+              .component(sourcePao.getComponent())
+              .objectType(sourcePao.getObjectType());
+
+      TpsPaoConflict conflict = new TpsPaoConflict();
+      conflict.setConflictPao(sourceDescription);
+      conflict.setTargetPao(targetDescription);
+      conflict.setNamespace(TpsUtilities.TERRA_NAMESPACE);
+      conflict.setName(TpsUtilities.GROUP_CONSTRAINT);
+      dryRunResults.addConflictsItem(conflict);
+    }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -779,7 +779,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     TpsPaoUpdateResult dryRunResults =
         tpsApiDispatch.mergePao(targetWorkspaceId, sourceWorkspaceId, TpsUpdateMode.DRY_RUN);
 
-    validateMergeGroups(targetWorkspaceId, sourceWorkspaceId, dryRunResults);
+    addAnyGroupMergeConflicts(targetWorkspaceId, sourceWorkspaceId, dryRunResults);
 
     List<UUID> resourceWithConflicts = new ArrayList<>();
 
@@ -840,7 +840,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
    * @param sourceWorkspaceId
    * @param dryRunResults
    */
-  private void validateMergeGroups(
+  private void addAnyGroupMergeConflicts(
       UUID targetWorkspaceId, UUID sourceWorkspaceId, TpsPaoUpdateResult dryRunResults) {
     TpsPaoGetResult targetPaoPreUpdate = tpsApiDispatch.getPao(targetWorkspaceId);
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -496,6 +496,32 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Test
   @EnabledIf(expression = "${feature.tps-enabled}", loadContext = true)
+  public void mergeCheck_nonMatchingGroups() throws Exception {
+    var userRequest = userAccessUtils.defaultUserAuthRequest();
+    UUID targetWorkspaceId = null;
+    UUID sourceWorkspaceId = null;
+    try {
+      targetWorkspaceId =
+          mockMvcUtils.createWorkspaceWithGroupConstraint(
+              userRequest, PolicyFixtures.DEFAULT_GROUP);
+      sourceWorkspaceId =
+          mockMvcUtils.createWorkspaceWithGroupConstraint(userRequest, PolicyFixtures.ALT_GROUP);
+
+      ApiWsmPolicyMergeCheckResult result =
+          mergeCheck(userRequest, targetWorkspaceId, sourceWorkspaceId);
+
+      assertEquals(1, result.getConflicts().size());
+      assertEquals(0, result.getResourcesWithConflict().size());
+      assertEquals(PolicyFixtures.NAMESPACE, result.getConflicts().get(0).getNamespace());
+      assertEquals(PolicyFixtures.GROUP_CONSTRAINT, result.getConflicts().get(0).getName());
+    } finally {
+      mockMvcUtils.deleteWorkspace(userRequest, targetWorkspaceId);
+      mockMvcUtils.deleteWorkspace(userRequest, sourceWorkspaceId);
+    }
+  }
+
+  @Test
+  @EnabledIf(expression = "${feature.tps-enabled}", loadContext = true)
   public void updatePolicies_tpsEnabledAndPolicyUpdated() throws Exception {
     ApiWorkspaceDescription workspaceWithoutPolicy =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -711,6 +711,20 @@ public class MockMvcUtils {
     return workspace.getId();
   }
 
+  public UUID createWorkspaceWithGroupConstraint(
+      AuthenticatedUserRequest userRequest, String groupName) throws Exception {
+    ApiWsmPolicyInputs groupPolicy =
+        new ApiWsmPolicyInputs()
+            .addInputsItem(
+                new ApiWsmPolicyInput()
+                    .namespace(PolicyFixtures.NAMESPACE)
+                    .name(PolicyFixtures.GROUP_CONSTRAINT)
+                    .addAdditionalDataItem(
+                        new ApiWsmPolicyPair().key(PolicyFixtures.GROUP).value(groupName)));
+    ApiCreatedWorkspace workspace = createWorkspaceWithPolicy(userRequest, groupPolicy);
+    return workspace.getId();
+  }
+
   public UUID createWorkspaceWithRegionConstraintAndCloudContext(
       AuthenticatedUserRequest userRequest, String regionName) throws Exception {
     UUID resultWorkspaceId = createWorkspaceWithRegionConstraint(userRequest, regionName);


### PR DESCRIPTION
The mergeCheck is called in the UI before the actual merge workspace call. That allows us to give users before-hand info about why a merge will not be allowed. However, the mergeCheck API isn't handling group merging.

The merge workspace api does error out in the backend with a policy conflict as expected, but the mergeCheck should also provide the same info in order to be more user friendly.

Added a connected test since the enforcement of group merges needs to happen on the WSM side, so we can't rely on TPS tests to provide coverage for this.