### PR TITLE
[TERRA-504], [TERRA-525] Use default region in S3 creation, add generateCloudName

### DIFF
--- a/openapi/src/common/schemas_aws.yaml
+++ b/openapi/src/common/schemas_aws.yaml
@@ -3,6 +3,14 @@
 #  $ref: '#/components/schemas/<item-you-want>
 components:
   schemas:
+    AwsS3StorageFolderCloudName:
+      description: A valid object name per https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html.
+      type: object
+      required: [ generatedAwsS3StorageFolderCloudName ]
+      properties:
+        generatedAwsS3StorageFolderCloudName:
+          type: string
+
     AwsCredentialDurationSeconds:
       type: integer
       minimum: 900

--- a/openapi/src/parts/controlled_aws_s3_storage_folder.yaml
+++ b/openapi/src/parts/controlled_aws_s3_storage_folder.yaml
@@ -1,4 +1,25 @@
 paths:
+  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/storageFolder/generateName:
+    parameters:
+    - $ref: '#/components/parameters/WorkspaceId'
+    post:
+      summary: Generate a cloud native controlled AWS S3 Storage Folder name
+      operationId: generateAwsS3StorageFolderCloudName
+      tags: [ ControlledAwsResource ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateAwsS3StorageFolderCloudNameRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenerateAwsS3StorageFolderCloudNameResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/workspaces/v1/{workspaceId}/resources/controlled/aws/storageFolder:
     parameters:
     - $ref: '#/components/parameters/WorkspaceId'
@@ -14,7 +35,7 @@ paths:
               $ref: '#/components/schemas/CreateControlledAwsS3StorageFolderRequestBody'
       responses:
         '200':
-          $ref: '#/components/responses/CreatedControlledAwsS3StorageFolderResponse'
+          $ref: '#/components/responses/CreateControlledAwsS3StorageFolderResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '500':
@@ -103,6 +124,33 @@ paths:
 
 components:
   schemas:
+    AwsS3StorageFolderCreationParameters:
+      description: >-
+        S3 Storage Folder specific properties to be set on creation. These are a subset of the
+        values accepted by the AWS Storage API.
+      type: object
+      properties:
+        region:
+          description: A valid S3 Storage Folder region per https://docs.aws.amazon.com/general/latest/gr/s3.html.
+          type: string
+
+    GenerateAwsS3StorageFolderCloudNameRequestBody:
+      type: object
+      required: [ awsS3StorageFolderName ]
+      properties:
+        awsS3StorageFolderName:
+          type: string
+
+    CreateControlledAwsS3StorageFolderRequestBody:
+      description: Payload for requesting a new controlled AWS S3 Storage Folder resource.
+      type: object
+      required: [common, AwsS3StorageFolder]
+      properties:
+        common:
+          $ref: '#/components/schemas/ControlledResourceCommonFields'
+        AwsS3StorageFolder:
+          $ref: '#/components/schemas/AwsS3StorageFolderCreationParameters'
+
     CreatedControlledAwsS3StorageFolder:
       description: Response Payload for requesting a new controlled AWS S3 Storage Folder.
       type: object
@@ -115,43 +163,30 @@ components:
         AwsS3StorageFolder:
           $ref: '#/components/schemas/AwsS3StorageFolderResource'
 
-    CreateControlledAwsS3StorageFolderRequestBody:
-      description: Payload for requesting a new controlled AWS S3 Storage Folder resource.
-      type: object
-      required: [common, AwsS3StorageFolder]
-      properties:
-        common:
-          $ref: '#/components/schemas/ControlledResourceCommonFields'
-        AwsS3StorageFolder:
-          $ref: '#/components/schemas/AwsS3StorageFolderCreationParameters'
-
-    AwsS3StorageFolderCreationParameters:
-      description: >-
-        S3 Storage Folder specific properties to be set on creation. These are a subset of the
-        values accepted by the AWS Storage API.
-      type: object
-      properties:
-        region:
-          description: A valid S3 Storage Folder region per https://docs.aws.amazon.com/general/latest/gr/s3.html.
-          type: string
-
   responses:
-    CreatedControlledAwsS3StorageFolderResponse:
-      description: Response to Create controlled AWS S3 Storage Folder
+    GenerateAwsS3StorageFolderCloudNameResponse:
+      description: Response to generate a AWS S3 Storage Folder cloud name
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AwsS3StorageFolderCloudName'
+
+    CreateControlledAwsS3StorageFolderResponse:
+      description: Response to create controlled AWS S3 Storage Folder
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/CreatedControlledAwsS3StorageFolder'
 
     GetControlledAwsS3StorageFolderResponse:
-      description: Response to get S3 Storage Folder
+      description: Response to get AWS S3 Storage Folder
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/AwsS3StorageFolderResource'
 
     GetControlledAwsS3StorageFolderCredentialResponse:
-      description: Response to get S3 Storage Folder credential
+      description: Response to get AWS S3 Storage Folder credential
       content:
         application/json:
           schema:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -28,7 +28,7 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.AwsResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
-import bio.terra.workspace.service.resource.controlled.cloud.aws.AwsResourceConstant;
+import bio.terra.workspace.service.resource.controlled.cloud.aws.AwsResourceConstants;
 import bio.terra.workspace.service.resource.controlled.cloud.aws.s3storageFolder.ControlledAwsS3StorageFolderHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.aws.s3storageFolder.ControlledAwsS3StorageFolderResource;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -109,7 +109,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
             .getProperties()
             .getOrDefault(
                 WorkspaceConstants.Properties.DEFAULT_RESOURCE_LOCATION,
-                AwsResourceConstant.DEFAULT_REGION)
+                AwsResourceConstants.DEFAULT_REGION)
         : requestedRegion;
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -47,7 +47,7 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.WsmResourceService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstant;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstants;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetHandler;
@@ -160,7 +160,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
             .getProperties()
             .getOrDefault(
                 WorkspaceConstants.Properties.DEFAULT_RESOURCE_LOCATION,
-                GcpResourceConstant.DEFAULT_REGION)
+                GcpResourceConstants.DEFAULT_REGION)
         : requestedLocation;
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -13,7 +13,6 @@ import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketRequest
 import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketResult;
 import bio.terra.workspace.generated.model.ApiClonedControlledGcpBigQueryDataset;
 import bio.terra.workspace.generated.model.ApiClonedControlledGcpGcsBucket;
-import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpAiNotebookInstanceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpBigQueryDatasetRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpGcsBucketRequestBody;
@@ -55,9 +54,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.Contr
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
-import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
-import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.CommonUpdateParameters;
 import bio.terra.workspace.service.resource.model.StewardshipType;
@@ -123,7 +120,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     Workspace workspace =
         workspaceService.validateMcWorkspaceAndAction(
-            userRequest, workspaceUuid, getSamAction(body.getCommon()));
+            userRequest, workspaceUuid, ControllerValidationUtils.getSamAction(body.getCommon()));
     String resourceLocation = getResourceLocation(workspace, body.getGcsBucket().getLocation());
     ControlledResourceFields commonFields =
         toCommonFields(
@@ -378,7 +375,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     Workspace workspace =
         workspaceService.validateWorkspaceAndAction(
-            userRequest, workspaceUuid, getSamAction(body.getCommon()));
+            userRequest, workspaceUuid, ControllerValidationUtils.getSamAction(body.getCommon()));
     String resourceLocation = getResourceLocation(workspace, body.getDataset().getLocation());
     ControlledResourceFields commonFields =
         toCommonFields(
@@ -418,12 +415,6 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
             .resourceId(resourceId)
             .bigQueryDataset(createdDataset.toApiResource());
     return new ResponseEntity<>(response, HttpStatus.OK);
-  }
-
-  private String getSamAction(ApiControlledResourceCommonFields common) {
-    return ControllerValidationUtils.samCreateAction(
-        AccessScopeType.fromApi(common.getAccessScope()),
-        ManagedByType.fromApi(common.getManagedBy()));
   }
 
   @Override
@@ -501,7 +492,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     Workspace workspace =
         workspaceService.validateWorkspaceAndAction(
-            userRequest, workspaceUuid, getSamAction(body.getCommon()));
+            userRequest, workspaceUuid, ControllerValidationUtils.getSamAction(body.getCommon()));
     String resourceLocation =
         getResourceLocation(workspace, body.getAiNotebookInstance().getLocation());
     ControlledResourceFields commonFields =

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledResourceControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledResourceControllerBase.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Super class for controllers containing common code. The code in here requires the @Autowired
@@ -80,7 +81,7 @@ public class ControlledResourceControllerBase extends ControllerBase {
 
     if (!WSM_RESOURCE_WITHOUT_REGION_IN_CREATION_PARAMS.contains(wsmResourceType)) {
       checkArgument(
-          region != null,
+          StringUtils.isNotEmpty(region),
           "Controlled resource must have an associated region specified"
               + "on creation except for Azure storage containers, Azure VMs, Azure batch pools, "
               + "Vertex AI notebooks, and Flexible resources");

--- a/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/ControllerValidationUtils.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.common.utils;
 
 import bio.terra.common.exception.ValidationException;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
+import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiProperty;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceCategory;
@@ -116,6 +117,12 @@ public final class ControllerValidationUtils {
   }
 
   /** Return the appropriate IAM action for creating the specified controlled resource in Sam. */
+  public static String getSamAction(ApiControlledResourceCommonFields common) {
+    return samCreateAction(
+        AccessScopeType.fromApi(common.getAccessScope()),
+        ManagedByType.fromApi(common.getManagedBy()));
+  }
+
   public static String samCreateAction(ControlledResourceFields commonFields) {
     return samCreateAction(commonFields.getAccessScope(), commonFields.getManagedBy());
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
@@ -26,7 +26,6 @@ public class AwsResourceValidationUtils {
     }
   }
 
-
   /**
    * Validate AWS credential duration.
    *
@@ -34,11 +33,8 @@ public class AwsResourceValidationUtils {
    * @throws InvalidNameException invalid duration
    */
   public static void validateAwsCredentialDurationSecond(int duration) {
-    if (duration < 900 || duration > 3600 ) {
-      throw new InvalidNameException(
-              "credential duration must be between 900 & 3600 seconds");
+    if (duration < 900 || duration > 3600) {
+      throw new InvalidNameException("credential duration must be between 900 & 3600 seconds");
     }
   }
-
-
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.resource;
 
+import bio.terra.workspace.service.resource.controlled.cloud.aws.AwsResourceConstants;
 import bio.terra.workspace.service.resource.exception.InvalidNameException;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
@@ -19,7 +20,9 @@ public class AwsResourceValidationUtils {
    */
   public static void validateAwsS3StorageFolderName(String prefixName) {
     int nameLength = prefixName.getBytes(StandardCharsets.UTF_8).length;
-    if (nameLength < 1 || nameLength > 1024 || s3ObjectDisallowedChars.matcher(prefixName).find()) {
+    if (nameLength < 1
+        || nameLength > AwsResourceConstants.MAX_S3_STORAGE_FOLDER_NAME_LENGTH
+        || s3ObjectDisallowedChars.matcher(prefixName).find()) {
       throw new InvalidNameException(
           String.format(
               "storage folder names must contain any sequence of valid Unicode characters (excluding %s), of length 1-1024 bytes when UTF-8 encoded",
@@ -34,7 +37,8 @@ public class AwsResourceValidationUtils {
    * @throws InvalidNameException invalid duration
    */
   public static void validateAwsCredentialDurationSecond(int duration) {
-    if (duration < 900 || duration > 3600) {
+    if (duration < AwsResourceConstants.MIN_CREDENTIAL_DURATION_SECONDS
+        || duration > AwsResourceConstants.MAX_CREDENTIAL_DURATION_SECONDS) {
       throw new InvalidNameException("credential duration must be between 900 & 3600 seconds");
     }
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
@@ -25,4 +25,20 @@ public class AwsResourceValidationUtils {
               s3ObjectDisallowedChars.pattern()));
     }
   }
+
+
+  /**
+   * Validate AWS credential duration.
+   *
+   * @param duration duration in seconds
+   * @throws InvalidNameException invalid duration
+   */
+  public static void validateAwsCredentialDurationSecond(int duration) {
+    if (duration < 900 || duration > 3600 ) {
+      throw new InvalidNameException(
+              "credential duration must be between 900 & 3600 seconds");
+    }
+  }
+
+
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 public class AwsResourceValidationUtils {
   static final Pattern s3ObjectDisallowedChars = Pattern.compile("[{}^%`<>~#|@*+\\[\\]\"\'\\\\/]");
 
+  // TODO(TERRA-523) Is this validation needed for resource name?
   /**
    * Validate AWS storage folder name.
    *

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
 /** A collection of static validation functions */
 @Component
 public class ResourceValidationUtils {
-
+  // TODO(TERRA-503) Move Cloud specific functions to separate file
   private static final Logger logger = LoggerFactory.getLogger(ResourceValidationUtils.class);
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstant.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstant.java
@@ -1,8 +1,0 @@
-package bio.terra.workspace.service.resource.controlled.cloud.aws;
-
-/** Constants shared among resource types. */
-public class AwsResourceConstant {
-
-  /** Default region of a resource. */
-  public static final String DEFAULT_REGION = "us-east-1";
-}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstant.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstant.java
@@ -1,0 +1,8 @@
+package bio.terra.workspace.service.resource.controlled.cloud.aws;
+
+/** Constants shared among resource types. */
+public class AwsResourceConstant {
+
+  /** Default region of a resource. */
+  public static final String DEFAULT_REGION = "us-east-1";
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstants.java
@@ -1,0 +1,16 @@
+package bio.terra.workspace.service.resource.controlled.cloud.aws;
+
+/** Constants shared among resource types. */
+public class AwsResourceConstants {
+
+  /** Default region of a resource. */
+  public static final String DEFAULT_REGION = "us-east-1";
+
+  /** Minimum and maximum duration in seconds for AWS credentials */
+  public static final int MIN_CREDENTIAL_DURATION_SECONDS = 900;
+
+  public static final int MAX_CREDENTIAL_DURATION_SECONDS = 3600;
+
+  /** Maximum length of a S3 storage folder name */
+  public static final int MAX_S3_STORAGE_FOLDER_NAME_LENGTH = 1024;
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3storageFolder/ControlledAwsS3StorageFolderHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3storageFolder/ControlledAwsS3StorageFolderHandler.java
@@ -1,15 +1,17 @@
 package bio.terra.workspace.service.resource.controlled.cloud.aws.s3storageFolder;
 
-import bio.terra.workspace.common.exception.FeatureNotSupportedException;
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import com.google.common.base.CharMatcher;
 import java.util.UUID;
+import javax.ws.rs.BadRequestException;
 import org.jetbrains.annotations.Nullable;
 
 public class ControlledAwsS3StorageFolderHandler implements WsmResourceHandler {
 
+  private static final int MAX_FOLDER_NAME_LENGTH = 1024;
   private static ControlledAwsS3StorageFolderHandler theHandler;
 
   public static ControlledAwsS3StorageFolderHandler getHandler() {
@@ -37,8 +39,27 @@ public class ControlledAwsS3StorageFolderHandler implements WsmResourceHandler {
    * details, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
    */
   @Override
-  public String generateCloudName(@Nullable UUID workspaceUuid, String resourceName) {
-    // TODO(TERRA-504): Implement generateCloudName
-    throw new FeatureNotSupportedException("Generate cloud name feature is not implemented yet");
+  public String generateCloudName(@Nullable UUID workspaceUuid, String storageFolderName) {
+    String generatedName =
+        storageFolderName.length() > MAX_FOLDER_NAME_LENGTH
+            ? storageFolderName.substring(0, MAX_FOLDER_NAME_LENGTH)
+            : storageFolderName;
+
+    // The regular expression only allow legal character combinations containing
+    // alphanumeric characters and one or more of "!-_.*'()". It trims any other combinations.
+    generatedName =
+        CharMatcher.inRange('0', '9')
+            .or(CharMatcher.inRange('A', 'z'))
+            .or(CharMatcher.anyOf("!-_.*'()"))
+            .retainFrom(generatedName);
+
+    if (generatedName.length() == 0) {
+      throw new BadRequestException(
+          String.format(
+              "Cannot generate a valid s3 storage folder name from %s, it must contain"
+                  + " alphanumerical characters.",
+              storageFolderName));
+    }
+    return generatedName;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3storageFolder/ControlledAwsS3StorageFolderHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3storageFolder/ControlledAwsS3StorageFolderHandler.java
@@ -29,6 +29,13 @@ public class ControlledAwsS3StorageFolderHandler implements WsmResourceHandler {
         dbResource, attributes.getBucketName(), attributes.getPrefix());
   }
 
+  /**
+   * Generate controlled AWS S3 Storage folder cloud name that meets the requirements for a valid
+   * name.
+   *
+   * <p>Alphanumeric characters and certain special characters can be safely used in valid names For
+   * details, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+   */
   @Override
   public String generateCloudName(@Nullable UUID workspaceUuid, String resourceName) {
     // TODO(TERRA-504): Implement generateCloudName

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3storageFolder/ControlledAwsS3StorageFolderHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3storageFolder/ControlledAwsS3StorageFolderHandler.java
@@ -47,6 +47,7 @@ public class ControlledAwsS3StorageFolderHandler implements WsmResourceHandler {
 
     // The regular expression only allow legal character combinations containing
     // alphanumeric characters and one or more of "!-_.*'()". It trims any other combinations.
+    generatedName = generatedName.replaceAll("\\[", "").replaceAll("\\]", "");
     generatedName =
         CharMatcher.inRange('0', '9')
             .or(CharMatcher.inRange('A', 'z'))

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3storageFolder/ControlledAwsS3StorageFolderHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3storageFolder/ControlledAwsS3StorageFolderHandler.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.aws.s3storageFolde
 
 import bio.terra.workspace.db.DbSerDes;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.cloud.aws.AwsResourceConstants;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import com.google.common.base.CharMatcher;
@@ -11,7 +12,6 @@ import org.jetbrains.annotations.Nullable;
 
 public class ControlledAwsS3StorageFolderHandler implements WsmResourceHandler {
 
-  private static final int MAX_FOLDER_NAME_LENGTH = 1024;
   private static ControlledAwsS3StorageFolderHandler theHandler;
 
   public static ControlledAwsS3StorageFolderHandler getHandler() {
@@ -41,8 +41,8 @@ public class ControlledAwsS3StorageFolderHandler implements WsmResourceHandler {
   @Override
   public String generateCloudName(@Nullable UUID workspaceUuid, String storageFolderName) {
     String generatedName =
-        storageFolderName.length() > MAX_FOLDER_NAME_LENGTH
-            ? storageFolderName.substring(0, MAX_FOLDER_NAME_LENGTH)
+        storageFolderName.length() > AwsResourceConstants.MAX_S3_STORAGE_FOLDER_NAME_LENGTH
+            ? storageFolderName.substring(0, AwsResourceConstants.MAX_S3_STORAGE_FOLDER_NAME_LENGTH)
             : storageFolderName;
 
     // The regular expression only allow legal character combinations containing

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/GcpResourceConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/GcpResourceConstants.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp;
 
 /** Constants shared among resource types. */
-public class GcpResourceConstant {
+public class GcpResourceConstants {
 
   /** Default region of a resource. */
   public static final String DEFAULT_REGION = "us-central1";

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -85,7 +85,7 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
     if (generatedName.length() == 0) {
       throw new BadRequestException(
           String.format(
-              "Cannot generate a valid AI notebook name from %s, it must contains"
+              "Cannot generate a valid AI notebook name from %s, it must contain"
                   + " alphanumerical characters.",
               aiNotebookName));
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook;
 
-import static bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstant.DEFAULT_ZONE;
+import static bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstants.DEFAULT_ZONE;
 
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import bio.terra.common.exception.BadRequestException;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetHandler.java
@@ -88,7 +88,7 @@ public class ControlledBigQueryDatasetHandler implements WsmResourceHandler {
     if (generatedName.length() == 0) {
       throw new BadRequestException(
           String.format(
-              "Cannot generate a valid big query dataset name from %s, it must contains"
+              "Cannot generate a valid big query dataset name from %s, it must contain"
                   + " alphanumerical characters.",
               bqDatasetName));
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -82,7 +82,7 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
     if (generatedName.length() == 0) {
       throw new BadRequestException(
           String.format(
-              "Cannot generate a gcs bucket name from %s, it must contains"
+              "Cannot generate a gcs bucket name from %s, it must contain"
                   + " alphanumerical characters.",
               bucketName));
     }

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool.Con
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.vm.ControlledAzureVmResource;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstant;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstants;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource.Builder;
@@ -86,7 +86,7 @@ public class ControlledResourceFixtures {
   public static final ApiGcpGcsBucketCreationParameters GOOGLE_BUCKET_CREATION_PARAMETERS_MINIMAL =
       new ApiGcpGcsBucketCreationParameters()
           .name(TestUtils.appendRandomNumber(BUCKET_NAME_PREFIX))
-          .location(GcpResourceConstant.DEFAULT_REGION);
+          .location(GcpResourceConstants.DEFAULT_REGION);
   public static final String DEFAULT_AZURE_RESOURCE_REGION = Region.US_EAST2.name();
   public static final String TEST_AZURE_STORAGE_ACCOUNT_NAME = "teststgacctdonotdelete";
 
@@ -95,7 +95,7 @@ public class ControlledResourceFixtures {
     return new ApiGcpGcsBucketCreationParameters()
         .name(uniqueBucketName())
         .defaultStorageClass(ApiGcpGcsBucketDefaultStorageClass.STANDARD)
-        .location(GcpResourceConstant.DEFAULT_REGION)
+        .location(GcpResourceConstants.DEFAULT_REGION)
         .lifecycle(new ApiGcpGcsBucketLifecycle().rules(LIFECYCLE_RULES));
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResourceTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook;
 
-import static bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstant.DEFAULT_ZONE;
+import static bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstants.DEFAULT_ZONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/CreateGcsBucketStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/CreateGcsBucketStepTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.getGoogleBucketCreationParameters;
-import static bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstant.DEFAULT_REGION;
+import static bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstants.DEFAULT_REGION;
 import static bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.GcsApiConversions.toGoogleDateTime;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;


### PR DESCRIPTION
#### [TERRA_525](https://verily.atlassian.net/browse/TERRA-525)
Use the workspace default region (from properties) if the region is not provided in create s3 folder request

```
// create workdpace
{
  "id": "feae1f8e-3b00-4dd0-875a-341c9df90ce4",
  "stage": "MC_WORKSPACE",
  "properties": [
    {
      "key": "terra-default-location",
      "value": "us-east-1"
    }
  ]
}

// create storage
{
  "common": { ... },
  "AwsS3StorageFolder": {
    "region": ""
  }
}

// successfully created
{
  "resourceId": "feae1f8e-3b00-4dd0-875a-341c9df90ce5",
  "AwsS3StorageFolder": {
    "metadata": { ...
      "controlledResourceMetadata": { ...
        "region": "us-east-1"
      }, ...
    },
    "attributes": {
      "bucketName": "v0-saas-devel-us-east-1-terra",
      "prefix": "dex-s3-425-1"
    }
  }
}

{
  "common": { ... },
  "AwsS3StorageFolder": {  }
}
// created successfully
```

#### [TERRA_504](https://verily.atlassian.net/browse/TERRA-504)
Add API for generateClouldName

```
http://localhost:8080/swagger-ui.html#/ControlledAwsResource/generateAwsS3StorageFolderCloudName

request :  { "awsS3StorageFolderName": "dex-s3-425-1" }
response:  { "generatedAwsS3StorageFolderCloudName": "dex-s3-425-1" }

request :  { "awsS3StorageFolderName": "awsS3StorageFolderName": "dex-/:s3*-[|]425 - 1" }
response:  { "generatedAwsS3StorageFolderCloudName": "dex-s3*-425-1" }
```