### PR TITLE
[IA-4065] Remove Azure VM size validation

### DIFF
--- a/openapi/src/parts/controlled_azure_vm.yaml
+++ b/openapi/src/parts/controlled_azure_vm.yaml
@@ -115,7 +115,7 @@ components:
           description: A valid vm name per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
           type: string
         vmSize:
-          description: A valid image size as per com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes
+          description: A valid image size as per https://learn.microsoft.com/en-us/azure/virtual-machines/sizes
           type: string
         diskId:
           description: A valid WSM identifier for an Azure Disk that corresponds to a valid azure resource

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -19,7 +19,6 @@ import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
-import com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.net.URI;
@@ -442,17 +441,6 @@ public class ResourceValidationUtils {
       throw new InvalidReferenceException(
           "Invalid Azure Storage Container name. The name must be 3 to 63 alphanumeric lower case characters "
               + "or dashes, must start and end with a letter or number, and cannot contain consecutive dashes.");
-    }
-  }
-
-  public static void validateAzureVmSize(String vmSize) {
-    if (!VirtualMachineSizeTypes.values().stream()
-        .map(VirtualMachineSizeTypes::toString)
-        .toList()
-        .contains(vmSize)) {
-      logger.warn("Invalid Azure vmSize {}", vmSize);
-      throw new InvalidReferenceException(
-          "Invalid Azure vm size specified. See the class `com.azure.resourcemanager.compute.models.VirtualMachineSizeTypes`");
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -238,7 +238,6 @@ public class ControlledAzureVmResource extends ControlledResource {
           "Missing required valid vmImage field for ControlledAzureVm.");
     }
     ResourceValidationUtils.validateAzureIPorSubnetName(getVmName());
-//    ResourceValidationUtils.validateAzureVmSize(getVmSize());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -238,7 +238,7 @@ public class ControlledAzureVmResource extends ControlledResource {
           "Missing required valid vmImage field for ControlledAzureVm.");
     }
     ResourceValidationUtils.validateAzureIPorSubnetName(getVmName());
-    ResourceValidationUtils.validateAzureVmSize(getVmSize());
+//    ResourceValidationUtils.validateAzureVmSize(getVmSize());
   }
 
   @Override


### PR DESCRIPTION
Before, we were validating the user-specified Azure machine type against this enum: https://learn.microsoft.com/en-us/java/api/com.azure.resourcemanager.compute.models.virtualmachinesizetypes?view=azure-java-stable

However, according to Azure the enum is deprecated and incomplete:
```
The enum data type is currently deprecated and will be removed by December 23rd 2023.
Recommended way to get the list of available sizes is using these APIs:
[List all available virtual machine sizes in an availability set]([https://docs.microsoft.com/rest/api/compute/availabilitysets/listavailablesizes](https://learn.microsoft.com/en-us/rest/api/compute/availabilitysets/listavailablesizes))
[List all available virtual machine sizes in a region]( [https://docs.microsoft.com/rest/api/compute/resourceskus/list](https://learn.microsoft.com/en-us/rest/api/compute/resourceskus/list))
[List all available virtual machine sizes for resizing]([https://docs.microsoft.com/rest/api/compute/virtualmachines/listavailablesizes](https://learn.microsoft.com/en-us/rest/api/compute/virtualmachines/listavailablesizes)). For more information about virtual machine sizes, see [Sizes for virtual machines]([https://docs.microsoft.com/azure/virtual-machines/sizes](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes)).
```

See also: https://github.com/Azure/azure-sdk-for-net/issues/17510#issuecomment-780988380

This came up because Hail team is trying to use a standard machine type (`Standard_E4ds_v4`) which is not present in this enum. I validated it works with this change. I was thinking it's okay to not have up-front validation of the machine type and just pass the string to the Azure API -- let me know if you disagree.