### PR TITLE
[TERRA-523] Add S3CreationParams.folderName

### DIFF
--- a/openapi/src/common/schemas_aws.yaml
+++ b/openapi/src/common/schemas_aws.yaml
@@ -4,7 +4,7 @@
 components:
   schemas:
     AwsS3StorageFolderCloudName:
-      description: A valid object name per https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html.
+      description: A valid folder name per https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html.
       type: object
       required: [ generatedAwsS3StorageFolderCloudName ]
       properties:

--- a/openapi/src/parts/controlled_aws_s3_storage_folder.yaml
+++ b/openapi/src/parts/controlled_aws_s3_storage_folder.yaml
@@ -130,6 +130,9 @@ components:
         values accepted by the AWS Storage API.
       type: object
       properties:
+        folderName:
+          description: A valid folder name per https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html.
+          type: string
         region:
           description: A valid S3 Storage Folder region per https://docs.aws.amazon.com/general/latest/gr/s3.html.
           type: string

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -147,9 +147,17 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
                 AccessScopeType.fromApi(body.getCommon().getAccessScope()),
                 ManagedByType.fromApi(body.getCommon().getManagedBy())));
 
-    AwsResourceValidationUtils.validateAwsS3StorageFolderName(body.getCommon().getName());
+    String folderName = body.getAwsS3StorageFolder().getFolderName();
+    if (StringUtils.isEmpty(folderName)) {
+      folderName =
+          ControlledAwsS3StorageFolderHandler.getHandler()
+              .generateCloudName(workspaceUuid, body.getCommon().getName());
+    }
+    AwsResourceValidationUtils.validateAwsS3StorageFolderName(folderName);
+
     String region =
         getResourceRegion(workspace, StringUtils.trim(body.getAwsS3StorageFolder().getRegion()));
+
     ControlledResourceFields commonFields =
         toCommonFields(
             workspaceUuid,
@@ -181,7 +189,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
         ControlledAwsS3StorageFolderResource.builder()
             .common(commonFields)
             .bucketName(landingZone.getStorageBucket().name())
-            .prefix(commonFields.getName())
+            .prefix(folderName)
             .build();
 
     ControlledAwsS3StorageFolderResource createdBucket =

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -134,7 +134,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
             .bucketName(
                 StringUtils.isEmpty(body.getGcsBucket().getName())
                     ? ControlledGcsBucketHandler.getHandler()
-                        .generateCloudName(commonFields.getWorkspaceId(), commonFields.getName())
+                        .generateCloudName(workspaceUuid, commonFields.getName())
                     : body.getGcsBucket().getName())
             .common(commonFields)
             .build();

--- a/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 public class AwsResourceValidationUtils {
   static final Pattern s3ObjectDisallowedChars = Pattern.compile("[{}^%`<>~#|@*+\\[\\]\"\'\\\\/]");
 
-  // TODO(TERRA-523) Is this validation needed for resource name?
   /**
    * Validate AWS storage folder name.
    *

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
 /** A collection of static validation functions */
 @Component
 public class ResourceValidationUtils {
-  // TODO(TERRA-503) Move Cloud specific functions to separate file
+  // TODO(TERRA-114) Move Cloud specific functions to separate file
   private static final Logger logger = LoggerFactory.getLogger(ResourceValidationUtils.class);
 
   /**


### PR DESCRIPTION
- Add S3CreationParams.folderName. If this is not provided in the input, generate a cloud-compatible name via handler.generateCloudName


Test: without folderName
```
{
  "common": {
    "name": "dex_s3_425_3-resourceName",
    "cloningInstructions": "COPY_NOTHING",
    "accessScope": "SHARED_ACCESS",
    "managedBy": "USER",
    "resourceId": "feae1f8e-3b00-4dd0-875a-341c9df90ce2"
  },
  "AwsS3StorageFolder": {}
}

// successfully created, resource have storageFolder.folderName populated as well 

{
  "resourceId": "feae1f8e-3b00-4dd0-875a-341c9df90ce2",
  "AwsS3StorageFolder": {
    "metadata": {
      "workspaceId": "feae1f8e-3b00-4dd0-875a-341c9df90ce4",
      "resourceId": "feae1f8e-3b00-4dd0-875a-341c9df90ce2",
      "name": "dex_s3_425_3-resourceName",
      "resourceType": "AWS_S3_STORAGE_FOLDER",
      "stewardshipType": "CONTROLLED",
...
        "region": "us-east-1"
      }, ...
    },
    "attributes": {
      "bucketName": "v0-saas-devel-us-east-1-terra",
      "prefix": "dex_s3_425_3-resourceName"
    }
  }
}
```

test: with folderName
```
{
  "common": {
    "name": "dex_s3_425_3-resourceName-again",
    "cloningInstructions": "COPY_NOTHING",
    "accessScope": "SHARED_ACCESS",
    "managedBy": "USER",
    "resourceId": "feae1f8e-3b00-4dd0-875a-341c9df90ce3"
  },
  "AwsS3StorageFolder": {
     "folderName": "dex_s3_425_3-folderName"
  }
}

// created successfully
{
  "resourceId": "feae1f8e-3b00-4dd0-875a-341c9df90ce3",
  "AwsS3StorageFolder": {
    "metadata": {
      "workspaceId": "feae1f8e-3b00-4dd0-875a-341c9df90ce4",
      "resourceId": "feae1f8e-3b00-4dd0-875a-341c9df90ce3",
      "name": "dex_s3_425_3-resourceName-again",
      "resourceType": "AWS_S3_STORAGE_FOLDER",
...
        "region": "us-east-1"
      },
...
    },
    "attributes": {
      "bucketName": "v0-saas-devel-us-east-1-terra",
      "prefix": "dex_s3_425_3-folderName"
    }
  }
}
```