### PR TITLE
add another null checker

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/RetrieveNetworkNameStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/RetrieveNetworkNameStep.java
@@ -94,7 +94,7 @@ public class RetrieveNetworkNameStep implements Step {
   }
 
   private void pickAndStoreNetwork(SubnetworkList subnetworks, FlightMap workingMap) {
-    if (subnetworks.getItems().isEmpty()) {
+    if (subnetworks.getItems() == null || subnetworks.getItems().isEmpty()) {
       throw new BadRequestException(
           String.format("No subnetworks available for location '%s'", resource.getLocation()));
     }


### PR DESCRIPTION
subnetwork item can be null if there's simply no subnet in that location


This is irrelevant to the recent failure in notebook creation as I suspect this issue is always there but we just didn't catch it as no one is creating notebook in tokyo.