### PR TITLE
[PF-2639] Move to v10 RBS pool, re-enable tests using BQ transfer API

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -109,7 +109,7 @@ workspace:
     enabled: true
     client-credential-file-path: ../config/buffer-client-sa.json
     instanceUrl: https://buffer.tools.integ.envs.broadinstitute.org
-    poolId: workspace_manager_v9
+    poolId: workspace_manager_v10
 
   policy:
     client-credential-file-path: ../config/policy-client-sa.json

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -457,7 +457,6 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         /*isControlled=*/ StewardshipType.REFERENCED);
   }
 
-  @Disabled("PF-2639 Need BigQuery Data Transfer service API enabled")
   @Test
   void clone_copyResource_sameWorkspace() throws Exception {
     // Source resource is in us-west4
@@ -516,7 +515,6 @@ public class ControlledGcpResourceApiControllerBqDatasetTest extends BaseConnect
         DEFAULT_PARTITION_LIFETIME);
   }
 
-  @Disabled("PF-2639 Need BigQuery Data Transfer service API enabled")
   @Test
   void clone_copyResource_differentWorkspace() throws Exception {
     // Source resource is in us-west4

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetTest.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;


### PR DESCRIPTION
This points local and test runs to use the `workspace_manager_v10` RBS pool for GCP projects. This is the same as v9 with the additional BQ Data Transfer API enabled. Now that this API is enabled, I'm also re-enabling tests that require it.