### PR TITLE
Set permissions of instance-boot script so the user can edit the file without sudo

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -324,11 +324,13 @@ readonly TERRA_BOOT_SERVICE="/etc/systemd/system/terra-instance-boot.service"
 
 cat <<EOF >"${TERRA_BOOT_SCRIPT}"
 #!/bin/bash
+# This script is run on instance boot to configure the instance for terra.
 
 # Mount terra workspace resources
 /usr/bin/terra resource mount
 EOF
 chmod +x "${TERRA_BOOT_SCRIPT}"
+chown ${JUPYTER_USER}:${JUPYTER_USER} "${TERRA_BOOT_SCRIPT}"
 
 # Create a systemd service to run the boot script on system boot
 cat <<EOF >"${TERRA_BOOT_SERVICE}"


### PR DESCRIPTION
We want to allow users to modify the instance boot script to turn off behaviors they don't want.