### PR TITLE
[PF-2725] Backfill GCP cloud context so we can remove V1

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
+++ b/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
@@ -8,9 +8,8 @@ import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfigura
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.workspace.WsmApplicationService;
-import javax.sql.DataSource;
-
 import bio.terra.workspace.service.workspace.gcpcontextbackfill.GcpCloudContextBackfill;
+import javax.sql.DataSource;
 import org.springframework.context.ApplicationContext;
 
 public final class StartupInitializer {
@@ -59,7 +58,7 @@ public final class StartupInitializer {
 
     // TODO (PF-2496): Clean this up once cloud context backfill is in all environments.
     GcpCloudContextBackfill gcpCloudContextBackfill =
-      applicationContext.getBean(GcpCloudContextBackfill.class);
+        applicationContext.getBean(GcpCloudContextBackfill.class);
     gcpCloudContextBackfill.gcpCloudContextBackfillAsync();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
+++ b/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
@@ -9,6 +9,8 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.workspace.WsmApplicationService;
 import javax.sql.DataSource;
+
+import bio.terra.workspace.service.workspace.gcpcontextbackfill.GcpCloudContextBackfill;
 import org.springframework.context.ApplicationContext;
 
 public final class StartupInitializer {
@@ -49,9 +51,15 @@ public final class StartupInitializer {
     // Fill in this method with any other initialization that needs to happen
     // between the point of having the entire application initialized and
     // the point of opening the port to start accepting REST requests.
+
     // TODO (PF-2269): Clean this up once the back-fill is done in all Terra environments.
     ControlledResourceService controlledResourceService =
         applicationContext.getBean(ControlledResourceService.class);
     controlledResourceService.updateControlledBigQueryDatasetsLifetimeAsync();
+
+    // TODO (PF-2496): Clean this up once cloud context backfill is in all environments.
+    GcpCloudContextBackfill gcpCloudContextBackfill =
+      applicationContext.getBean(GcpCloudContextBackfill.class);
+    gcpCloudContextBackfill.gcpCloudContextBackfillAsync();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHook.java
+++ b/service/src/main/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHook.java
@@ -383,26 +383,23 @@ public class WorkspaceActivityLogHook implements StairwayHook {
   }
 
   private void maybeLogGcpContextBackfillFlight(
-    FlightContext context, OperationType operationType, String userEmail, String subjectId) {
+      FlightContext context, OperationType operationType, String userEmail, String subjectId) {
     if (!context.getFlightStatus().equals(FlightStatus.SUCCESS)) {
       return;
     }
     List<String> backfillWorkspaceIdStrings =
-      Preconditions.checkNotNull(
-        context
-          .getInputParameters()
-          .get(UPDATED_WORKSPACES, new TypeReference<>() {}));
+        Preconditions.checkNotNull(
+            context.getInputParameters().get(UPDATED_WORKSPACES, new TypeReference<>() {}));
 
     for (String workspaceIdString : backfillWorkspaceIdStrings) {
       activityLogDao.writeActivity(
-        UUID.fromString(workspaceIdString),
-        new DbWorkspaceActivityLog(
-          userEmail,
-          subjectId,
-          operationType,
-          workspaceIdString,
-          ActivityLogChangedTarget.GCP_CLOUD_CONTEXT));
+          UUID.fromString(workspaceIdString),
+          new DbWorkspaceActivityLog(
+              userEmail,
+              subjectId,
+              operationType,
+              workspaceIdString,
+              ActivityLogChangedTarget.GCP_CLOUD_CONTEXT));
     }
   }
-
 }

--- a/service/src/main/java/bio/terra/workspace/common/logging/model/ActivityFlight.java
+++ b/service/src/main/java/bio/terra/workspace/common/logging/model/ActivityFlight.java
@@ -25,6 +25,8 @@ import bio.terra.workspace.service.workspace.flight.cloud.gcp.DeleteGcpContextFl
 import bio.terra.workspace.service.workspace.flight.cloud.gcp.RemoveUserFromWorkspaceFlight;
 import bio.terra.workspace.service.workspace.flight.create.workspace.WorkspaceCreateFlight;
 import bio.terra.workspace.service.workspace.flight.delete.workspace.WorkspaceDeleteFlight;
+import bio.terra.workspace.service.workspace.gcpcontextbackfill.GcpContextBackfillFlight;
+
 import java.util.Arrays;
 
 /**
@@ -92,9 +94,13 @@ public enum ActivityFlight {
 
   // AWS
   AWS_CLOUD_CONTEXT_CREATE_FLIGHT(
-      CreateAwsContextFlight.class.getName(), ActivityLogChangedTarget.AWS_CLOUD_CONTEXT),
+    CreateAwsContextFlight.class.getName(), ActivityLogChangedTarget.AWS_CLOUD_CONTEXT),
   AWS_CLOUD_CONTEXT_DELETE_FLIGHT(
-      DeleteAwsContextFlight.class.getName(), ActivityLogChangedTarget.AWS_CLOUD_CONTEXT);
+      DeleteAwsContextFlight.class.getName(), ActivityLogChangedTarget.AWS_CLOUD_CONTEXT),
+
+  // TODO: PF-2694 TEMPORARY BACKFILL
+  GCP_CONTEXT_BACKFILL_FLIGHT(
+    GcpContextBackfillFlight.class.getName(), ActivityLogChangedTarget.GCP_CLOUD_CONTEXT);
 
   private final String flightClassName;
   private final ActivityLogChangedTarget changedTarget;

--- a/service/src/main/java/bio/terra/workspace/common/logging/model/ActivityFlight.java
+++ b/service/src/main/java/bio/terra/workspace/common/logging/model/ActivityFlight.java
@@ -26,7 +26,6 @@ import bio.terra.workspace.service.workspace.flight.cloud.gcp.RemoveUserFromWork
 import bio.terra.workspace.service.workspace.flight.create.workspace.WorkspaceCreateFlight;
 import bio.terra.workspace.service.workspace.flight.delete.workspace.WorkspaceDeleteFlight;
 import bio.terra.workspace.service.workspace.gcpcontextbackfill.GcpContextBackfillFlight;
-
 import java.util.Arrays;
 
 /**
@@ -94,13 +93,13 @@ public enum ActivityFlight {
 
   // AWS
   AWS_CLOUD_CONTEXT_CREATE_FLIGHT(
-    CreateAwsContextFlight.class.getName(), ActivityLogChangedTarget.AWS_CLOUD_CONTEXT),
+      CreateAwsContextFlight.class.getName(), ActivityLogChangedTarget.AWS_CLOUD_CONTEXT),
   AWS_CLOUD_CONTEXT_DELETE_FLIGHT(
       DeleteAwsContextFlight.class.getName(), ActivityLogChangedTarget.AWS_CLOUD_CONTEXT),
 
   // TODO: PF-2694 TEMPORARY BACKFILL
   GCP_CONTEXT_BACKFILL_FLIGHT(
-    GcpContextBackfillFlight.class.getName(), ActivityLogChangedTarget.GCP_CLOUD_CONTEXT);
+      GcpContextBackfillFlight.class.getName(), ActivityLogChangedTarget.GCP_CLOUD_CONTEXT);
 
   private final String flightClassName;
   private final ActivityLogChangedTarget changedTarget;

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -664,4 +664,25 @@ public class WorkspaceDao {
 
     return jdbcTemplate.query(sql, params, WORKSPACE_USER_PAIR_ROW_MAPPER);
   }
+
+
+  // TODO: PF-2694 - remove backfill once propagated to all environments
+  /**
+   * Retrieve the list of workspace ids where GCP cloud context needs to be back-filled.
+   * @return list of workspace ids
+   */
+  @ReadTransaction
+  public List<String> getGcpContextBackfillWorkspaceList() {
+    String sql =
+      """
+      SELECT workspace_id FROM cloud_context
+      WHERE cloud_platform = :cloud_platform AND context->'samPolicyOwner' IS NULL
+      """;
+
+    MapSqlParameterSource params =
+      new MapSqlParameterSource().addValue("cloud_platform", CloudPlatform.GCP.toSql());
+
+    // Return the list of workspaces that need to be backfilled
+    return jdbcTemplate.query(sql, params, (rs, rowNum) -> rs.getString("workspace_id"));
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -665,22 +665,22 @@ public class WorkspaceDao {
     return jdbcTemplate.query(sql, params, WORKSPACE_USER_PAIR_ROW_MAPPER);
   }
 
-
   // TODO: PF-2694 - remove backfill once propagated to all environments
   /**
    * Retrieve the list of workspace ids where GCP cloud context needs to be back-filled.
+   *
    * @return list of workspace ids
    */
   @ReadTransaction
   public List<String> getGcpContextBackfillWorkspaceList() {
     String sql =
-      """
+        """
       SELECT workspace_id FROM cloud_context
       WHERE cloud_platform = :cloud_platform AND context->'samPolicyOwner' IS NULL
       """;
 
     MapSqlParameterSource params =
-      new MapSqlParameterSource().addValue("cloud_platform", CloudPlatform.GCP.toSql());
+        new MapSqlParameterSource().addValue("cloud_platform", CloudPlatform.GCP.toSql());
 
     // Return the list of workspaces that need to be backfilled
     return jdbcTemplate.query(sql, params, (rs, rowNum) -> rs.getString("workspace_id"));

--- a/service/src/main/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpCloudContextBackfill.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpCloudContextBackfill.java
@@ -1,0 +1,71 @@
+package bio.terra.workspace.service.workspace.gcpcontextbackfill;
+
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.controlled.flight.backfill.UpdateControlledBigQueryDatasetsLifetimeFlight;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.model.OperationType;
+import io.opencensus.contrib.spring.aop.Traced;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+// TODO: PF-2694 - remove backfill once propagated to all environments
+@Component
+public class GcpCloudContextBackfill {
+  private static final Logger logger = LoggerFactory.getLogger(GcpCloudContextBackfill.class);
+  private final SamService samService;
+  private final JobService jobService;
+  private final WorkspaceDao workspaceDao;
+
+  @Autowired
+  public GcpCloudContextBackfill(
+    SamService samService,
+    JobService jobService,
+    WorkspaceDao workspaceDao) {
+    this.samService = samService;
+    this.jobService = jobService;
+    this.workspaceDao = workspaceDao;
+  }
+
+  /**
+   * Starts a flight to update missing lifetime for controlled BigQuery datasets.
+   *
+   * @return the job ID string (to await job completion in the connected tests.)
+   */
+  @Traced
+  public @Nullable String gcpCloudContextBackfillAsync() {
+    String wsmSaToken = samService.getWsmServiceAccountToken();
+    // wsmSaToken is null for unit test when samService is mocked out.
+    if (wsmSaToken == null) {
+      logger.warn("Not running GCP context backfill because workspace manager service account token is null");
+      return null;
+    }
+
+    List<String> backfillIds = workspaceDao.getGcpContextBackfillWorkspaceList();
+    if (backfillIds.isEmpty()) {
+      logger.info("No GCP cloud contexts to backfill");
+      return null;
+    }
+
+    AuthenticatedUserRequest wsmSaRequest =
+      new AuthenticatedUserRequest().token(Optional.of(wsmSaToken));
+    return jobService
+      .newJob()
+      .description("Backfill Sam sync'd group names in GCP cloud context")
+      .flightClass(GcpContextBackfillFlight.class)
+      .userRequest(wsmSaRequest)
+      .operationType(OperationType.UPDATE)
+      // Overloading the key, but only for temporary back-fill
+      .addParameter(WorkspaceFlightMapKeys.UPDATED_WORKSPACES, backfillIds)
+      .submit();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpCloudContextBackfill.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpCloudContextBackfill.java
@@ -4,19 +4,16 @@ import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.resource.controlled.flight.backfill.UpdateControlledBigQueryDatasetsLifetimeFlight;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import io.opencensus.contrib.spring.aop.Traced;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 // TODO: PF-2694 - remove backfill once propagated to all environments
 @Component
@@ -28,16 +25,14 @@ public class GcpCloudContextBackfill {
 
   @Autowired
   public GcpCloudContextBackfill(
-    SamService samService,
-    JobService jobService,
-    WorkspaceDao workspaceDao) {
+      SamService samService, JobService jobService, WorkspaceDao workspaceDao) {
     this.samService = samService;
     this.jobService = jobService;
     this.workspaceDao = workspaceDao;
   }
 
   /**
-   * Starts a flight to update missing lifetime for controlled BigQuery datasets.
+   * Starts a flight to update GCP cloud context in V1 format missing their Sam groups
    *
    * @return the job ID string (to await job completion in the connected tests.)
    */
@@ -46,7 +41,8 @@ public class GcpCloudContextBackfill {
     String wsmSaToken = samService.getWsmServiceAccountToken();
     // wsmSaToken is null for unit test when samService is mocked out.
     if (wsmSaToken == null) {
-      logger.warn("Not running GCP context backfill because workspace manager service account token is null");
+      logger.warn(
+          "Not running GCP context backfill because workspace manager service account token is null");
       return null;
     }
 
@@ -57,15 +53,15 @@ public class GcpCloudContextBackfill {
     }
 
     AuthenticatedUserRequest wsmSaRequest =
-      new AuthenticatedUserRequest().token(Optional.of(wsmSaToken));
+        new AuthenticatedUserRequest().token(Optional.of(wsmSaToken));
     return jobService
-      .newJob()
-      .description("Backfill Sam sync'd group names in GCP cloud context")
-      .flightClass(GcpContextBackfillFlight.class)
-      .userRequest(wsmSaRequest)
-      .operationType(OperationType.UPDATE)
-      // Overloading the key, but only for temporary back-fill
-      .addParameter(WorkspaceFlightMapKeys.UPDATED_WORKSPACES, backfillIds)
-      .submit();
+        .newJob()
+        .description("Backfill Sam sync'd group names in GCP cloud context")
+        .flightClass(GcpContextBackfillFlight.class)
+        .userRequest(wsmSaRequest)
+        .operationType(OperationType.UPDATE)
+        // Overloading the key, but only for temporary back-fill
+        .addParameter(WorkspaceFlightMapKeys.UPDATED_WORKSPACES, backfillIds)
+        .submit();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpContextBackfillFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpContextBackfillFlight.java
@@ -1,0 +1,105 @@
+package bio.terra.workspace.service.workspace.gcpcontextbackfill;
+
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.utils.FlightBeanBag;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.WsmIamRole;
+import bio.terra.workspace.service.job.JobMapKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GcpContextBackfillFlight extends Flight {
+  private static final Logger logger = LoggerFactory.getLogger(GcpContextBackfillFlight.class);
+
+  public GcpContextBackfillFlight(FlightMap inputParameters, Object beanBag) {
+    super(inputParameters, beanBag);
+    FlightBeanBag flightBeanBag = FlightBeanBag.getFromObject(beanBag);
+    WorkspaceDao workspaceDao = flightBeanBag.getWorkspaceDao();
+    SamService samService = flightBeanBag.getSamService();
+
+    AuthenticatedUserRequest userRequest =
+        FlightUtils.getRequired(
+            inputParameters,
+            JobMapKeys.AUTH_USER_INFO.getKeyName(),
+            AuthenticatedUserRequest.class);
+
+    List<String> backfillIds =
+        inputParameters.get(WorkspaceFlightMapKeys.UPDATED_WORKSPACES, new TypeReference<>() {});
+    if (backfillIds == null || backfillIds.isEmpty()) {
+      throw new RuntimeException("No back-fill workspace ids provided to the flight");
+    }
+
+    for (String workspaceId : backfillIds) {
+      addStep(new GcpContextBackfillStep(workspaceId, workspaceDao, samService, userRequest));
+    }
+  }
+
+  public static class GcpContextBackfillStep implements Step {
+    private static final Logger logger = LoggerFactory.getLogger(GcpContextBackfillStep.class);
+    private final UUID workspaceId;
+    private final WorkspaceDao workspaceDao;
+    private final AuthenticatedUserRequest userRequest;
+    private final SamService samService;
+
+    public GcpContextBackfillStep(
+        String workspaceId,
+        WorkspaceDao workspaceDao,
+        SamService samService,
+        AuthenticatedUserRequest userRequest) {
+      this.workspaceId = UUID.fromString(workspaceId);
+      this.workspaceDao = workspaceDao;
+      this.samService = samService;
+      this.userRequest = userRequest;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext flightContext)
+        throws InterruptedException, RetryException {
+      GcpCloudContext context =
+          workspaceDao
+              .getCloudContext(workspaceId, CloudPlatform.GCP)
+              .map(GcpCloudContext::deserialize)
+              .orElse(null);
+
+      // The context may have been deleted between when the flight started and when we got here.
+      if (context == null) {
+        logger.info("Found no GCP cloud context when back-filling workspace {}", workspaceId);
+        return StepResult.getStepResultSuccess();
+      }
+
+      // The context may have been back-filled before we got here
+      if (context.getSamPolicyOwner().isEmpty()) {
+        logger.info("Found GCP cloud context already back-filled for workspace {}", workspaceId);
+        context.setSamPolicyOwner(
+            samService.getWorkspacePolicy(workspaceId, WsmIamRole.OWNER, userRequest));
+        context.setSamPolicyWriter(
+            samService.getWorkspacePolicy(workspaceId, WsmIamRole.WRITER, userRequest));
+        context.setSamPolicyReader(
+            samService.getWorkspacePolicy(workspaceId, WsmIamRole.READER, userRequest));
+        context.setSamPolicyApplication(
+            samService.getWorkspacePolicy(workspaceId, WsmIamRole.APPLICATION, userRequest));
+        workspaceDao.updateCloudContext(workspaceId, CloudPlatform.GCP, context.serialize());
+      }
+      return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) throws InterruptedException {
+      return StepResult.getStepResultSuccess();
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpContextBackfillFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpContextBackfillFlight.java
@@ -48,7 +48,7 @@ public class GcpContextBackfillFlight extends Flight {
     }
   }
 
-  public static class GcpContextBackfillStep implements Step {
+  private static class GcpContextBackfillStep implements Step {
     private static final Logger logger = LoggerFactory.getLogger(GcpContextBackfillStep.class);
     private final UUID workspaceId;
     private final WorkspaceDao workspaceDao;
@@ -83,7 +83,7 @@ public class GcpContextBackfillFlight extends Flight {
 
       // The context may have been back-filled before we got here
       if (context.getSamPolicyOwner().isEmpty()) {
-        logger.info("Found GCP cloud context already back-filled for workspace {}", workspaceId);
+        logger.info("Back-filling GCP cloud context for workspace {}", workspaceId);
         context.setSamPolicyOwner(
             samService.getWorkspacePolicy(workspaceId, WsmIamRole.OWNER, userRequest));
         context.setSamPolicyWriter(
@@ -93,6 +93,8 @@ public class GcpContextBackfillFlight extends Flight {
         context.setSamPolicyApplication(
             samService.getWorkspacePolicy(workspaceId, WsmIamRole.APPLICATION, userRequest));
         workspaceDao.updateCloudContext(workspaceId, CloudPlatform.GCP, context.serialize());
+      } else {
+        logger.info("Found GCP cloud context already back-filled for workspace {}", workspaceId);
       }
       return StepResult.getStepResultSuccess();
     }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpContextBackFillTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpContextBackFillTest.java
@@ -1,0 +1,114 @@
+package bio.terra.workspace.service.workspace.gcpcontextbackfill;
+
+import bio.terra.workspace.common.BaseConnectedTest;
+import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.UUID;
+
+import static bio.terra.workspace.common.BaseConnectedTest.BUFFER_SERVICE_DISABLED_ENVS_REG_EX;
+
+// TODO: PF-2694 - remove this backfill when propagated to all environments
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("connected")
+public class GcpContextBackFillTest extends BaseConnectedTest {
+  @Autowired WorkspaceDao workspaceDao;
+  @Autowired GcpCloudContextBackfill gcpCloudContextBackfill;
+  @Autowired UserAccessUtils userAccessUtils;
+  @Autowired WorkspaceConnectedTestUtils workspaceUtils;
+  @Autowired JobService jobService;
+
+  private UUID workspaceId1;
+  private UUID workspaceId2;
+  private String workspaceString1;
+  private String workspaceString2;
+
+  @BeforeAll
+  public void setup() {
+    workspaceId1 =
+      workspaceUtils
+        .createWorkspaceWithGcpContext(userAccessUtils.defaultUser().getAuthenticatedRequest())
+        .getWorkspaceId();
+    workspaceString1 = workspaceId1.toString();
+    workspaceId2 =
+      workspaceUtils
+        .createWorkspaceWithGcpContext(userAccessUtils.defaultUser().getAuthenticatedRequest())
+        .getWorkspaceId();
+    workspaceString2 = workspaceId2.toString();
+  }
+
+  @AfterAll
+  public void teardown() {
+    if (workspaceId1 != null) {
+      workspaceUtils.deleteWorkspaceAndCloudContext(userAccessUtils.defaultUser().getAuthenticatedRequest(), workspaceId1);
+    }
+    if (workspaceId2 != null) {
+      workspaceUtils.deleteWorkspaceAndCloudContext(userAccessUtils.defaultUser().getAuthenticatedRequest(), workspaceId2);
+    }
+  }
+
+  @Test
+  @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
+  public void backfillTest() {
+    // Test query - neither workspace should need updating
+    List<String> backfillList = workspaceDao.getGcpContextBackfillWorkspaceList();
+    assertFalse(backfillList.contains(workspaceString1));
+    assertFalse(backfillList.contains(workspaceString2));
+
+    // Rewrite one context to empty it
+    clearContext(workspaceId1);
+
+    // Test query - one workspace should need updating
+    backfillList = workspaceDao.getGcpContextBackfillWorkspaceList();
+    assertTrue(backfillList.contains(workspaceString1));
+    assertFalse(backfillList.contains(workspaceString2));
+
+    // Rewrite the other context to empty it
+    clearContext(workspaceId2);
+
+    // Test query - both workspace should need updating
+    backfillList = workspaceDao.getGcpContextBackfillWorkspaceList();
+    assertTrue(backfillList.contains(workspaceString1));
+    assertTrue(backfillList.contains(workspaceString2));
+
+    // Run the backfill flight
+    String jobId = gcpCloudContextBackfill.gcpCloudContextBackfillAsync();
+    jobService.waitForJob(jobId);
+
+    // Run the backfill flight again - should return null - nothing to do
+    jobId = gcpCloudContextBackfill.gcpCloudContextBackfillAsync();
+    assertNull(jobId);
+
+    // Test query - neither workspace should need updating
+    backfillList = workspaceDao.getGcpContextBackfillWorkspaceList();
+    assertTrue(backfillList.isEmpty());
+  }
+
+  private void clearContext(UUID workspaceId) {
+    GcpCloudContext context = workspaceDao.getCloudContext(workspaceId, CloudPlatform.GCP)
+      .map(GcpCloudContext::deserialize)
+      .orElseThrow();
+    context.setSamPolicyApplication(null);
+    context.setSamPolicyOwner(null);
+    context.setSamPolicyReader(null);
+    context.setSamPolicyWriter(null);
+    workspaceDao.updateCloudContext(workspaceId, CloudPlatform.GCP, context.serialize());
+  }
+
+}

--- a/service/src/test/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpContextBackFillTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/gcpcontextbackfill/GcpContextBackFillTest.java
@@ -1,5 +1,10 @@
 package bio.terra.workspace.service.workspace.gcpcontextbackfill;
 
+import static bio.terra.workspace.common.BaseConnectedTest.BUFFER_SERVICE_DISABLED_ENVS_REG_EX;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
@@ -7,6 +12,8 @@ import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -14,15 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
-import java.util.List;
-import java.util.UUID;
-
-import static bio.terra.workspace.common.BaseConnectedTest.BUFFER_SERVICE_DISABLED_ENVS_REG_EX;
 
 // TODO: PF-2694 - remove this backfill when propagated to all environments
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -42,24 +40,26 @@ public class GcpContextBackFillTest extends BaseConnectedTest {
   @BeforeAll
   public void setup() {
     workspaceId1 =
-      workspaceUtils
-        .createWorkspaceWithGcpContext(userAccessUtils.defaultUser().getAuthenticatedRequest())
-        .getWorkspaceId();
+        workspaceUtils
+            .createWorkspaceWithGcpContext(userAccessUtils.defaultUser().getAuthenticatedRequest())
+            .getWorkspaceId();
     workspaceString1 = workspaceId1.toString();
     workspaceId2 =
-      workspaceUtils
-        .createWorkspaceWithGcpContext(userAccessUtils.defaultUser().getAuthenticatedRequest())
-        .getWorkspaceId();
+        workspaceUtils
+            .createWorkspaceWithGcpContext(userAccessUtils.defaultUser().getAuthenticatedRequest())
+            .getWorkspaceId();
     workspaceString2 = workspaceId2.toString();
   }
 
   @AfterAll
   public void teardown() {
     if (workspaceId1 != null) {
-      workspaceUtils.deleteWorkspaceAndCloudContext(userAccessUtils.defaultUser().getAuthenticatedRequest(), workspaceId1);
+      workspaceUtils.deleteWorkspaceAndCloudContext(
+          userAccessUtils.defaultUser().getAuthenticatedRequest(), workspaceId1);
     }
     if (workspaceId2 != null) {
-      workspaceUtils.deleteWorkspaceAndCloudContext(userAccessUtils.defaultUser().getAuthenticatedRequest(), workspaceId2);
+      workspaceUtils.deleteWorkspaceAndCloudContext(
+          userAccessUtils.defaultUser().getAuthenticatedRequest(), workspaceId2);
     }
   }
 
@@ -101,14 +101,15 @@ public class GcpContextBackFillTest extends BaseConnectedTest {
   }
 
   private void clearContext(UUID workspaceId) {
-    GcpCloudContext context = workspaceDao.getCloudContext(workspaceId, CloudPlatform.GCP)
-      .map(GcpCloudContext::deserialize)
-      .orElseThrow();
+    GcpCloudContext context =
+        workspaceDao
+            .getCloudContext(workspaceId, CloudPlatform.GCP)
+            .map(GcpCloudContext::deserialize)
+            .orElseThrow();
     context.setSamPolicyApplication(null);
     context.setSamPolicyOwner(null);
     context.setSamPolicyReader(null);
     context.setSamPolicyWriter(null);
     workspaceDao.updateCloudContext(workspaceId, CloudPlatform.GCP, context.serialize());
   }
-
 }


### PR DESCRIPTION
When I put in GCP cloud context V2, I made an in-line fixer instead of a backfill. That meant I could never remove the V1.
This adds a backfill for GCP cloud context so I can then remove the V1 cloud context code and the in-line fixer.