### PR TITLE
Move storage.bucket.get permission from bucket editor to workspace reader

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
@@ -32,7 +32,6 @@ public class CustomGcpIamRoleMapping {
   static final ImmutableList<String> GCS_BUCKET_EDITOR_PERMISSIONS =
       new ImmutableList.Builder<String>()
           .addAll(GCS_BUCKET_WRITER_PERMISSIONS)
-          .add("storage.buckets.get")
           .build();
   static final ImmutableList<String> BIG_QUERY_DATASET_READER_PERMISSIONS =
       ImmutableList.of(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
@@ -30,9 +30,7 @@ public class CustomGcpIamRoleMapping {
           .add("storage.objects.create", "storage.objects.delete", "storage.objects.update")
           .build();
   static final ImmutableList<String> GCS_BUCKET_EDITOR_PERMISSIONS =
-      new ImmutableList.Builder<String>()
-          .addAll(GCS_BUCKET_WRITER_PERMISSIONS)
-          .build();
+      new ImmutableList.Builder<String>().addAll(GCS_BUCKET_WRITER_PERMISSIONS).build();
   static final ImmutableList<String> BIG_QUERY_DATASET_READER_PERMISSIONS =
       ImmutableList.of(
           "bigquery.datasets.get",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/CustomGcpIamRoleMapping.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Table;
  */
 public class CustomGcpIamRoleMapping {
   static final ImmutableList<String> GCS_BUCKET_READER_PERMISSIONS =
-      ImmutableList.of("storage.objects.list", "storage.objects.get");
+      ImmutableList.of("storage.buckets.get", "storage.objects.list", "storage.objects.get");
   static final ImmutableList<String> GCS_BUCKET_WRITER_PERMISSIONS =
       new ImmutableList.Builder<String>()
           .addAll(GCS_BUCKET_READER_PERMISSIONS)

--- a/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudSyncRoleMapping.java
@@ -71,6 +71,7 @@ public class GcpCloudSyncRoleMapping {
           "serviceusage.quotas.get",
           "serviceusage.services.get",
           "serviceusage.services.list",
+          "storage.buckets.get",
           "storage.buckets.list");
   private final List<String> projectWriterPermissions =
       new ImmutableList.Builder<String>()

--- a/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudSyncRoleMapping.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudSyncRoleMapping.java
@@ -71,7 +71,6 @@ public class GcpCloudSyncRoleMapping {
           "serviceusage.quotas.get",
           "serviceusage.services.get",
           "serviceusage.services.list",
-          "storage.buckets.get",
           "storage.buckets.list");
   private final List<String> projectWriterPermissions =
       new ImmutableList.Builder<String>()


### PR DESCRIPTION
To enable the CLI to properly display bucket resource metadata when listed or described, and allow mounting referenced buckets where the user only has read access.