### PR TITLE
[WOR-993] Get user email from sam rather than relying on email from token for Azure SAS's

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -178,9 +178,12 @@ public class AzureStorageAccessService {
       SasTokenOptions sasTokenOptions) {
     features.azureEnabledCheck();
 
+    var userEmail =
+        SamRethrow.onInterrupted(
+            () -> samService.getUserEmailFromSam(userRequest), "getUserEmailFromSam");
     logger.info(
-        "user {} requesting SAS token for Azure storage container {} in workspace {}",
-        userRequest.getEmail(),
+        "User {} requesting SAS token for Azure storage container {} in workspace {}",
+        userEmail,
         storageContainerUuid.toString(),
         workspaceUuid.toString());
 
@@ -236,7 +239,7 @@ public class AzureStorageAccessService {
     logger.info(
         "SAS token with expiry time of {} generated for user {} on container {} in workspace {} [sha256 = {}]",
         sasTokenOptions.expiryTime(),
-        userRequest.getEmail(),
+        userEmail,
         storageContainerUuid,
         workspaceUuid,
         sha256hex);


### PR DESCRIPTION
## Why
We are relying on the email from the AuthenticatedUserRequest when logging the user email as we go through the process of minting a SAS token. This leads to inconsistent results as not all request tokens possess an email. We should use sam as the source of truth for the user's email.

## This PR
* Adds a call to Sam to fetch the user's email and threads it through into the relevant logging statements