### PR TITLE
[TERRA-312] Add Sagemaker notebook resource, generateCloudName endpoint

### DIFF
--- a/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
+++ b/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
@@ -1,0 +1,23 @@
+paths:
+  /api/workspaces/v1/{workspaceId}/resources/controlled/aws/notebook/generateName:
+    parameters:
+    - $ref: '#/components/parameters/WorkspaceId'
+    post:
+      summary: Generate a cloud native controlled AWS Sagemaker Notebook instance name.
+      operationId: generateAwsSagemakerNotebookCloudName
+      tags: [ ControlledAwsResource ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateAwsResourceCloudNameRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenerateAwsResourceCloudNameResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'

--- a/openapi/src/resources/aws_sagemaker_notebook.yaml
+++ b/openapi/src/resources/aws_sagemaker_notebook.yaml
@@ -1,0 +1,23 @@
+components:
+  schemas:
+    AwsSagemakerNotebookAttributes:
+      description: AWS Sagemaker Notebook instance resource properties included in post-creation get.
+      type: object
+      properties:
+        instanceName:
+          description: The name of the Sagemaker Notebook instance
+          type: string
+        instanceType:
+          description: The type of the Sagemaker Notebook instance
+          type: string
+
+    AwsSagemakerNotebookResource:
+      type: object
+      description: Description of an AWS Sagemaker Notebook instance resource.
+      required: [ metadata, attributes ]
+      properties:
+        metadata:
+          description: the resource metadata common to all resources
+          $ref: '#/components/schemas/ResourceMetadata'
+        attributes:
+          $ref: '#/components/schemas/AwsSagemakerNotebookAttributes'

--- a/openapi/src/resources/resource_type.yaml
+++ b/openapi/src/resources/resource_type.yaml
@@ -16,6 +16,7 @@ components:
         - AZURE_STORAGE_CONTAINER
         - AZURE_BATCH_POOL
         - AWS_S3_STORAGE_FOLDER
+        - AWS_SAGEMAKER_NOTEBOOK
         - GIT_REPO
         - TERRA_WORKSPACE
         - FLEXIBLE_RESOURCE
@@ -49,6 +50,8 @@ components:
           $ref: '#/components/schemas/AzureBatchPoolAttributes'
         awsS3StorageFolder:
           $ref: '#/components/schemas/AwsS3StorageFolderAttributes'
+        awsSagemakerNotebook:
+          $ref: '#/components/schemas/AwsSagemakerNotebookAttributes'
         gitRepo:
           $ref: '#/components/schemas/GitRepoAttributes'
         terraWorkspace:
@@ -85,6 +88,8 @@ components:
           $ref: '#/components/schemas/AzureBatchPoolResource'
         awsS3StorageFolder:
           $ref: '#/components/schemas/AwsS3StorageFolderResource'
+        awsSagemakerNotebook:
+          $ref: '#/components/schemas/AwsSagemakerNotebookResource'
         gitRepo:
           $ref: '#/components/schemas/GitRepoResource'
         terraWorkspace:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -31,6 +31,7 @@ import bio.terra.workspace.service.resource.controlled.ControlledResourceService
 import bio.terra.workspace.service.resource.controlled.cloud.aws.AwsResourceConstants;
 import bio.terra.workspace.service.resource.controlled.cloud.aws.s3storageFolder.ControlledAwsS3StorageFolderHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.aws.s3storageFolder.ControlledAwsS3StorageFolderResource;
+import bio.terra.workspace.service.resource.controlled.cloud.aws.sagemakerNotebook.ControlledAwsSagemakerNotebookHandler;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
@@ -327,5 +328,21 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
             .getControlledResource(workspaceUuid, resourceUuid)
             .castByEnum(WsmResourceType.CONTROLLED_AWS_S3_STORAGE_FOLDER);
     return getAwsResourceCredential(workspaceUuid, accessScope, durationSeconds, resource);
+  }
+
+  @Traced
+  @Override
+  public ResponseEntity<ApiAwsResourceCloudName> generateAwsSagemakerNotebookCloudName(
+      UUID workspaceUuid, @Valid ApiGenerateAwsResourceCloudNameRequestBody body) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    Workspace workspace =
+        workspaceService.validateMcWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.READ);
+
+    String generatedCloudName =
+        ControlledAwsSagemakerNotebookHandler.getHandler()
+            .generateCloudName(workspace.getUserFacingId(), body.getAwsResourceName());
+    return new ResponseEntity<>(
+        new ApiAwsResourceCloudName().awsResourceCloudName(generatedCloudName), HttpStatus.OK);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstants.java
@@ -13,4 +13,7 @@ public class AwsResourceConstants {
 
   /** Maximum length of a S3 storage folder name */
   public static final int MAX_S3_STORAGE_FOLDER_NAME_LENGTH = 1024;
+
+  /** Maximum length of a Sagemaker notebook instance name */
+  public static final int MAX_SAGEMAKER_NOTEBOOK_INSTANCE_NAME_LENGTH = 63;
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookAttributes.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookAttributes.java
@@ -1,0 +1,25 @@
+package bio.terra.workspace.service.resource.controlled.cloud.aws.sagemakerNotebook;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ControlledAwsSagemakerNotebookAttributes {
+  private final String instanceName;
+  private final String instanceType;
+
+  @JsonCreator
+  public ControlledAwsSagemakerNotebookAttributes(
+      @JsonProperty("instanceName") String instanceName,
+      @JsonProperty("instanceType") String instanceType) {
+    this.instanceName = instanceName;
+    this.instanceType = instanceType;
+  }
+
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+  public String getInstanceType() {
+    return instanceType;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandler.java
@@ -5,7 +5,6 @@ import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.service.resource.controlled.cloud.aws.AwsResourceConstants;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import javax.ws.rs.BadRequestException;
 import org.apache.commons.lang3.StringUtils;
@@ -45,13 +44,10 @@ public class ControlledAwsSagemakerNotebookHandler implements WsmResourceHandler
     Preconditions.checkArgument(StringUtils.isNotEmpty(workspaceUserFacingId));
     String generatedName = notebookName + "-" + workspaceUserFacingId;
 
+    generatedName = generatedName.replaceAll("(\\_)", "-");
     generatedName = StringUtils.stripStart(generatedName, "-");
     generatedName = StringUtils.stripEnd(generatedName, "-");
-    generatedName =
-        CharMatcher.inRange('0', '9')
-            .or(CharMatcher.inRange('A', 'z'))
-            .or(CharMatcher.is('-'))
-            .retainFrom(generatedName);
+    generatedName = generatedName.replaceAll("[^\\-a-zA-Z0-9]+", "");
 
     if (generatedName.length() == 0) {
       throw new BadRequestException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandler.java
@@ -1,0 +1,66 @@
+package bio.terra.workspace.service.resource.controlled.cloud.aws.sagemakerNotebook;
+
+import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.service.resource.controlled.cloud.aws.AwsResourceConstants;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceHandler;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Preconditions;
+import javax.ws.rs.BadRequestException;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+public class ControlledAwsSagemakerNotebookHandler implements WsmResourceHandler {
+
+  private static ControlledAwsSagemakerNotebookHandler theHandler;
+
+  public static ControlledAwsSagemakerNotebookHandler getHandler() {
+    if (theHandler == null) {
+      theHandler = new ControlledAwsSagemakerNotebookHandler();
+    }
+    return theHandler;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public WsmResource makeResourceFromDb(DbResource dbResource) {
+    ControlledAwsSagemakerNotebookResource attributes =
+        DbSerDes.fromJson(dbResource.getAttributes(), ControlledAwsSagemakerNotebookResource.class);
+
+    return new ControlledAwsSagemakerNotebookResource(
+        dbResource, attributes.getInstanceName(), attributes.getInstanceType());
+  }
+
+  /**
+   * Generate controlled AWS Sagemaker Notebook cloud name that meets the requirements for a valid
+   * name.
+   *
+   * <p>Alphanumeric characters and dashes can be safely used in valid names. Dashes may not be
+   * first or last characters. For details, see
+   * https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateNotebookInstance.html#sagemaker-CreateNotebookInstance-request-NotebookInstanceName
+   */
+  @Override
+  public String generateCloudName(@Nullable String workspaceUserFacingId, String notebookName) {
+    Preconditions.checkArgument(StringUtils.isNotEmpty(workspaceUserFacingId));
+    String generatedName = notebookName + "-" + workspaceUserFacingId;
+
+    generatedName = StringUtils.stripStart(generatedName, "-");
+    generatedName = StringUtils.stripEnd(generatedName, "-");
+    generatedName =
+        CharMatcher.inRange('0', '9')
+            .or(CharMatcher.inRange('A', 'z'))
+            .or(CharMatcher.is('-'))
+            .retainFrom(generatedName);
+
+    if (generatedName.length() == 0) {
+      throw new BadRequestException(
+          String.format(
+              "Cannot generate a valid sagemaker notebook name from %s, it must contain"
+                  + " alphanumerical characters.",
+              notebookName));
+    }
+    return StringUtils.truncate(
+        generatedName, AwsResourceConstants.MAX_SAGEMAKER_NOTEBOOK_INSTANCE_NAME_LENGTH);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookResource.java
@@ -112,7 +112,10 @@ public class ControlledAwsSagemakerNotebookResource extends ControlledResource {
   @Override
   @JsonIgnore
   public Optional<UniquenessCheckAttributes> getUniquenessCheckAttributes() {
-    return Optional.of(new UniquenessCheckAttributes().uniquenessScope(UniquenessScope.GLOBAL));
+    return Optional.of(
+        new UniquenessCheckAttributes()
+            .uniquenessScope(UniquenessScope.GLOBAL)
+            .addParameter("instanceName", instanceName));
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookResource.java
@@ -1,0 +1,206 @@
+package bio.terra.workspace.service.resource.controlled.cloud.aws.sagemakerNotebook;
+
+import bio.terra.common.exception.ApiException;
+import bio.terra.common.exception.BadRequestException;
+import bio.terra.common.exception.InconsistentFieldsException;
+import bio.terra.common.exception.MissingRequiredFieldException;
+import bio.terra.workspace.common.utils.FlightBeanBag;
+import bio.terra.workspace.db.DbSerDes;
+import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes;
+import bio.terra.workspace.db.model.UniquenessCheckAttributes.UniquenessScope;
+import bio.terra.workspace.generated.model.ApiAwsSagemakerNotebookAttributes;
+import bio.terra.workspace.generated.model.ApiAwsSagemakerNotebookResource;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
+import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
+import bio.terra.workspace.service.resource.controlled.model.WsmControlledResourceFields;
+import bio.terra.workspace.service.resource.flight.UpdateResourceFlight;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmResourceFamily;
+import bio.terra.workspace.service.resource.model.WsmResourceFields;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+
+public class ControlledAwsSagemakerNotebookResource extends ControlledResource {
+  private final String instanceName;
+  private final String instanceType;
+
+  @JsonCreator
+  public ControlledAwsSagemakerNotebookResource(
+      @JsonProperty("wsmResourceFields") WsmResourceFields resourceFields,
+      @JsonProperty("wsmControlledResourceFields")
+          WsmControlledResourceFields controlledResourceFields,
+      @JsonProperty("instanceName") String instanceName,
+      @JsonProperty("instanceType") String instanceType) {
+    super(resourceFields, controlledResourceFields);
+    this.instanceName = instanceName;
+    this.instanceType = instanceType;
+    validate();
+  }
+
+  private ControlledAwsSagemakerNotebookResource(
+      ControlledResourceFields common, String instanceName, String instanceType) {
+    super(common);
+    this.instanceName = instanceName;
+    this.instanceType = instanceType;
+    validate();
+  }
+
+  public ControlledAwsSagemakerNotebookResource(
+      DbResource dbResource, String instanceName, String instanceType) {
+    super(dbResource);
+    this.instanceName = instanceName;
+    this.instanceType = instanceType;
+    validate();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T castByEnum(WsmResourceType expectedType) {
+    if (getResourceType() != expectedType) {
+      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
+    }
+    return (T) this;
+  }
+
+  // -- getters used in serialization --
+  @JsonProperty("wsmResourceFields")
+  public WsmResourceFields getWsmResourceFields() {
+    return super.getWsmResourceFields();
+  }
+
+  @JsonProperty("wsmControlledResourceFields")
+  public WsmControlledResourceFields getWsmControlledResourceFields() {
+    return super.getWsmControlledResourceFields();
+  }
+
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+  public String getInstanceType() {
+    return instanceType;
+  }
+
+  // -- getters not included in serialization --
+
+  @Override
+  @JsonIgnore
+  public WsmResourceType getResourceType() {
+    return WsmResourceType.CONTROLLED_AWS_SAGEMAKER_NOTEBOOK;
+  }
+
+  @Override
+  @JsonIgnore
+  public WsmResourceFamily getResourceFamily() {
+    return WsmResourceFamily.AWS_SAGEMAKER_NOTEBOOK;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @JsonIgnore
+  public Optional<UniquenessCheckAttributes> getUniquenessCheckAttributes() {
+    return Optional.of(new UniquenessCheckAttributes().uniquenessScope(UniquenessScope.GLOBAL));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addCreateSteps(
+      CreateControlledResourceFlight flight,
+      String petSaEmail,
+      AuthenticatedUserRequest userRequest,
+      FlightBeanBag flightBeanBag) {
+    // TODO(TERRA-312) add create steps
+    throw new ApiException("addCreateSteps NotImplemented");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addDeleteSteps(DeleteControlledResourcesFlight flight, FlightBeanBag flightBeanBag) {
+    // TODO(TERRA-312) add create steps
+    throw new ApiException("addDeleteSteps NotImplemented");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void addUpdateSteps(UpdateResourceFlight flight, FlightBeanBag flightBeanBag) {
+    // TODO(TERRA-223) Add support for UpdateAwsSagemakerNotebook
+    throw new ApiException("addUpdateSteps NotImplemented");
+  }
+
+  public ApiAwsSagemakerNotebookAttributes toApiAttributes() {
+    return new ApiAwsSagemakerNotebookAttributes()
+        .instanceName(instanceName)
+        .instanceType(instanceType);
+  }
+
+  public ApiAwsSagemakerNotebookResource toApiResource() {
+    return new ApiAwsSagemakerNotebookResource()
+        .metadata(super.toApiMetadata())
+        .attributes(toApiAttributes());
+  }
+
+  @Override
+  public String attributesToJson() {
+    return DbSerDes.toJson(
+        new ControlledAwsSagemakerNotebookAttributes(instanceName, instanceType));
+  }
+
+  @Override
+  public ApiResourceAttributesUnion toApiAttributesUnion() {
+    ApiResourceAttributesUnion union = new ApiResourceAttributesUnion();
+    union.awsSagemakerNotebook(toApiAttributes());
+    return union;
+  }
+
+  @Override
+  public void validate() {
+    super.validate();
+    if (getResourceType() != WsmResourceType.CONTROLLED_AWS_SAGEMAKER_NOTEBOOK
+        || getResourceFamily() != WsmResourceFamily.AWS_SAGEMAKER_NOTEBOOK
+        || getStewardshipType() != StewardshipType.CONTROLLED) {
+      throw new InconsistentFieldsException("Expected CONTROLLED_AWS_SAGEMAKER_NOTEBOOK");
+    }
+    if ((instanceName == null) || (instanceType == null) || (getRegion() == null)) {
+      throw new MissingRequiredFieldException(
+          "Missing required field for ControlledAwsSagemakerNotebookResource.");
+    }
+  }
+
+  public static class Builder {
+    private ControlledResourceFields common;
+    private String instanceName;
+    private String instanceType;
+
+    public Builder common(ControlledResourceFields common) {
+      this.common = common;
+      return this;
+    }
+
+    public Builder instanceName(String instanceName) {
+      this.instanceName = instanceName;
+      return this;
+    }
+
+    public Builder instanceType(String instanceType) {
+      this.instanceType = instanceType;
+      return this;
+    }
+
+    public ControlledAwsSagemakerNotebookResource build() {
+      return new ControlledAwsSagemakerNotebookResource(common, instanceName, instanceType);
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFamily.java
@@ -68,6 +68,11 @@ public enum WsmResourceFamily {
       ApiResourceType.AWS_S3_STORAGE_FOLDER,
       null, // TODO(TERRA-195) add support for referenced buckets
       WsmResourceType.CONTROLLED_AWS_S3_STORAGE_FOLDER),
+  AWS_SAGEMAKER_NOTEBOOK(
+      "AWS_SAGEMAKER_NOTEBOOK",
+      ApiResourceType.AWS_SAGEMAKER_NOTEBOOK,
+      null, // no reference type for notebooks,
+      WsmResourceType.CONTROLLED_AWS_SAGEMAKER_NOTEBOOK),
 
   // FLEXIBLE
   FLEXIBLE_RESOURCE(

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceHandler.java
@@ -4,7 +4,6 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.workspace.db.model.DbResource;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
 
 /**
  * Interface defining the common methods for processing per-resource handlers. Each resource type
@@ -41,7 +40,7 @@ public interface WsmResourceHandler {
    * @param resourceName resource name
    * @return cloud-native name
    */
-  default String generateCloudName(@NotNull String workspaceUserFacingId, String resourceName) {
+  default String generateCloudName(String workspaceUserFacingId, String resourceName) {
     throw new BadRequestException(
         "generateCloudName with workspaceUserFacingId and resourceName not supported");
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceType.java
@@ -5,6 +5,8 @@ import bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresourc
 import bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource.FlexibleResourceHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.aws.s3storageFolder.ControlledAwsS3StorageFolderHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.aws.s3storageFolder.ControlledAwsS3StorageFolderResource;
+import bio.terra.workspace.service.resource.controlled.cloud.aws.sagemakerNotebook.ControlledAwsSagemakerNotebookHandler;
+import bio.terra.workspace.service.resource.controlled.cloud.aws.sagemakerNotebook.ControlledAwsSagemakerNotebookResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool.ControlledAzureBatchPoolHandler;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool.ControlledAzureBatchPoolResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskHandler;
@@ -155,6 +157,13 @@ public enum WsmResourceType {
       ApiResourceType.AWS_S3_STORAGE_FOLDER,
       ControlledAwsS3StorageFolderResource.class,
       ControlledAwsS3StorageFolderHandler::getHandler),
+  CONTROLLED_AWS_SAGEMAKER_NOTEBOOK(
+      CloudPlatform.AWS,
+      StewardshipType.CONTROLLED,
+      "CONTROLLED_AWS_SAGEMAKER_NOTEBOOK",
+      ApiResourceType.AWS_SAGEMAKER_NOTEBOOK,
+      ControlledAwsSagemakerNotebookResource.class,
+      ControlledAwsSagemakerNotebookHandler::getHandler),
 
   // FLEXIBLE
   CONTROLLED_FLEXIBLE_RESOURCE(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandlerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 public class ControlledAwsSagemakerNotebookHandlerTest extends BaseAwsUnitTest {
 
   @Test
-  public void generateFolderName_allCases() {
+  public void generateCloudName() {
     String workspaceUserFacingId = "workspaceUserFacingId";
     String resourceName = "resource";
     String generatedName = resourceName + '-' + workspaceUserFacingId;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandlerTest.java
@@ -1,0 +1,46 @@
+package bio.terra.workspace.service.resource.controlled.cloud.aws.sagemakerNotebook;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.workspace.common.BaseAwsUnitTest;
+import bio.terra.workspace.service.resource.controlled.cloud.aws.AwsResourceConstants;
+import liquibase.util.StringUtil;
+import org.junit.jupiter.api.Test;
+
+public class ControlledAwsSagemakerNotebookHandlerTest extends BaseAwsUnitTest {
+
+  @Test
+  public void generateFolderName() {
+    String workspaceUserFacingId = "workspaceUserFacingId";
+    String resourceName = "resource";
+    String generatedName = "resource-workspaceUserFacingId";
+
+    assertEquals(
+        generatedName,
+        ControlledAwsSagemakerNotebookHandler.getHandler()
+            .generateCloudName(workspaceUserFacingId, resourceName),
+        "resource name expected without changes");
+
+    assertEquals(
+        generatedName,
+        ControlledAwsSagemakerNotebookHandler.getHandler()
+            .generateCloudName(workspaceUserFacingId + "--", "--" + resourceName),
+        "resource name expected with leading & trailing dashes removed");
+
+    assertEquals(
+        generatedName,
+        ControlledAwsSagemakerNotebookHandler.getHandler()
+            .generateCloudName(workspaceUserFacingId, resourceName + ".!_(){}^%`<>~#|@*+[]'\"\\"),
+        "resource name expected with all non-alphanumeric characters & non-dashes removed");
+
+    resourceName =
+        StringUtil.repeat(
+            "a", AwsResourceConstants.MAX_SAGEMAKER_NOTEBOOK_INSTANCE_NAME_LENGTH + 1);
+    assertEquals(
+        AwsResourceConstants.MAX_SAGEMAKER_NOTEBOOK_INSTANCE_NAME_LENGTH,
+        ControlledAwsSagemakerNotebookHandler.getHandler()
+            .generateCloudName(workspaceUserFacingId, resourceName)
+            .length(),
+        "resource name expected to be trimmed to max length");
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandlerTest.java
@@ -13,13 +13,19 @@ public class ControlledAwsSagemakerNotebookHandlerTest extends BaseAwsUnitTest {
   public void generateFolderName() {
     String workspaceUserFacingId = "workspaceUserFacingId";
     String resourceName = "resource";
-    String generatedName = "resource-workspaceUserFacingId";
+    String generatedName = resourceName + '-' + workspaceUserFacingId;
 
     assertEquals(
         generatedName,
         ControlledAwsSagemakerNotebookHandler.getHandler()
             .generateCloudName(workspaceUserFacingId, resourceName),
         "resource name expected without changes");
+
+    assertEquals(
+        resourceName + "-a-b-" + workspaceUserFacingId,
+        ControlledAwsSagemakerNotebookHandler.getHandler()
+            .generateCloudName("b_" + workspaceUserFacingId, resourceName + "_a"),
+        "resource name expected with underscores replaced by dashes");
 
     assertEquals(
         generatedName,
@@ -30,7 +36,7 @@ public class ControlledAwsSagemakerNotebookHandlerTest extends BaseAwsUnitTest {
     assertEquals(
         generatedName,
         ControlledAwsSagemakerNotebookHandler.getHandler()
-            .generateCloudName(workspaceUserFacingId, resourceName + ".!_(){}^%`<>~#|@*+[]'\"\\"),
+            .generateCloudName(workspaceUserFacingId, resourceName + ".!(){}^%`<>~#|@*+[]'\"\\"),
         "resource name expected with all non-alphanumeric characters & non-dashes removed");
 
     resourceName =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sagemakerNotebook/ControlledAwsSagemakerNotebookHandlerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 public class ControlledAwsSagemakerNotebookHandlerTest extends BaseAwsUnitTest {
 
   @Test
-  public void generateFolderName() {
+  public void generateFolderName_allCases() {
     String workspaceUserFacingId = "workspaceUserFacingId";
     String resourceName = "resource";
     String generatedName = resourceName + '-' + workspaceUserFacingId;


### PR DESCRIPTION
The original AWS sagemaker support PR got over 1.5K line, hence making smaller PRs. 

- Add AWS sagemaker notebook resource, attributes to WSM. 
- Also add the controller and basic plumbing to support the resource & resource.generateCloudName

UT - added
Manual testing - 

Workspace User facing Id | Resource name | Generated name
-- | -- | --
“ws-ufid” | “simple” | "simple-ws-ufid"
“ws-ufid” | "-simp_le&8%$#(){}[]+=_s" | "simp-le8-s-ws-ufid"
ws-ufid_underscore" | “simple” | "simple-ws-ufid-underscore"
