### PR TITLE
[PF-2742] Stop generating names ending in dashes

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -76,7 +76,8 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
             .or(CharMatcher.is('-'))
             .retainFrom(aiNotebookName.toLowerCase());
     // The name must start with a letter.
-    generatedName = CharMatcher.inRange('0', '9').or(CharMatcher.is('-')).trimLeadingFrom(generatedName);
+    generatedName =
+        CharMatcher.inRange('0', '9').or(CharMatcher.is('-')).trimLeadingFrom(generatedName);
     // Truncate before trimming characters to ensure the name does not end with dash("-").
     generatedName = StringUtils.truncate(generatedName, MAX_INSTANCE_NAME_LENGTH);
     // The name cannot end with dash("-").

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -75,12 +75,12 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
             .or(CharMatcher.inRange('a', 'z'))
             .or(CharMatcher.is('-'))
             .retainFrom(aiNotebookName.toLowerCase());
-    // The name cannot start with number.
-    generatedName = CharMatcher.inRange('0', '9').trimLeadingFrom(generatedName);
+    // The name must start with a letter.
+    generatedName = CharMatcher.inRange('0', '9').or(CharMatcher.is('-')).trimLeadingFrom(generatedName);
     // Truncate before trimming characters to ensure the name does not end with dash("-").
     generatedName = StringUtils.truncate(generatedName, MAX_INSTANCE_NAME_LENGTH);
-    // The name cannot start or end with dash("-").
-    generatedName = CharMatcher.is('-').trimFrom(generatedName);
+    // The name cannot end with dash("-").
+    generatedName = CharMatcher.is('-').trimTrailingFrom(generatedName);
 
     if (generatedName.length() == 0) {
       throw new BadRequestException(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandler.java
@@ -6,6 +6,7 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceHandler;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Optional;
@@ -23,7 +24,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ControlledAiNotebookHandler implements WsmResourceHandler {
 
-  private static final int MAX_INSTANCE_NAME_LENGTH = 63;
+  @VisibleForTesting public static final int MAX_INSTANCE_NAME_LENGTH = 63;
   private static ControlledAiNotebookHandler theHandler;
   private final GcpCloudContextService gcpCloudContextService;
 
@@ -74,10 +75,12 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
             .or(CharMatcher.inRange('a', 'z'))
             .or(CharMatcher.is('-'))
             .retainFrom(aiNotebookName.toLowerCase());
-    // The name cannot start or end with dash("-")
-    generatedName = CharMatcher.is('-').trimFrom(generatedName);
     // The name cannot start with number.
     generatedName = CharMatcher.inRange('0', '9').trimLeadingFrom(generatedName);
+    // Truncate before trimming characters to ensure the name does not end with dash("-").
+    generatedName = StringUtils.truncate(generatedName, MAX_INSTANCE_NAME_LENGTH);
+    // The name cannot start or end with dash("-").
+    generatedName = CharMatcher.is('-').trimFrom(generatedName);
 
     if (generatedName.length() == 0) {
       throw new BadRequestException(
@@ -86,6 +89,6 @@ public class ControlledAiNotebookHandler implements WsmResourceHandler {
                   + " alphanumerical characters.",
               aiNotebookName));
     }
-    return StringUtils.truncate(generatedName, MAX_INSTANCE_NAME_LENGTH);
+    return generatedName;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -61,7 +61,6 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
   public static final Set<String> RESERVED_METADATA_KEYS =
       Set.of(PROXY_MODE_METADATA_KEY, WORKSPACE_ID_METADATA_KEY, SERVER_ID_METADATA_KEY);
 
-  protected static final int MAX_INSTANCE_NAME_LENGTH = 63;
   private final String instanceId;
   private final String location;
   private final String projectId;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandler.java
@@ -76,7 +76,9 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
             .or(CharMatcher.inRange('a', 'z'))
             .or(CharMatcher.is('-'))
             .retainFrom(generatedName);
-    // The name cannot start or end with dash("-")
+    // Truncate before trimming characters to ensure the name does not end with dash("-").
+    generatedName = StringUtils.truncate(generatedName, MAX_BUCKET_NAME_LENGTH);
+    // The name cannot start or end with dash("-").
     generatedName = CharMatcher.is('-').trimFrom(generatedName);
 
     if (generatedName.length() == 0) {
@@ -86,6 +88,6 @@ public class ControlledGcsBucketHandler implements WsmResourceHandler {
                   + " alphanumerical characters.",
               bucketName));
     }
-    return StringUtils.truncate(generatedName, MAX_BUCKET_NAME_LENGTH);
+    return generatedName;
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandlerTest.java
@@ -88,6 +88,6 @@ public class ControlledAiNotebookHandlerTest extends BaseUnitTest {
         ControlledAiNotebookHandler.getHandler().generateCloudName((UUID) null, instanceName);
 
     assertEquals(ControlledAiNotebookHandler.MAX_INSTANCE_NAME_LENGTH - 1, instanceId.length());
-    assertNotEquals(instanceId.charAt(instanceId.length() - 1), '-');
+    assertNotEquals('-', instanceId.charAt(instanceId.length() - 1));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookHandlerTest.java
@@ -1,10 +1,11 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook;
 
-import static bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookInstanceResource.MAX_INSTANCE_NAME_LENGTH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import bio.terra.workspace.common.BaseUnitTest;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 public class ControlledAiNotebookHandlerTest extends BaseUnitTest {
@@ -70,9 +71,23 @@ public class ControlledAiNotebookHandlerTest extends BaseUnitTest {
     String instanceId =
         ControlledAiNotebookHandler.getHandler().generateCloudName((UUID) null, instanceName);
 
-    int maxNameLength = MAX_INSTANCE_NAME_LENGTH;
+    assertEquals(ControlledAiNotebookHandler.MAX_INSTANCE_NAME_LENGTH, instanceId.length());
+    assertEquals(
+        instanceId.substring(0, ControlledAiNotebookHandler.MAX_INSTANCE_NAME_LENGTH), instanceId);
+  }
 
-    assertEquals(maxNameLength, instanceId.length());
-    assertEquals(instanceId.substring(0, maxNameLength), instanceId);
+  @Test
+  public void generateInstanceId_instanceNameTooLong_trimDashes() {
+    // Generate a name like "aaa-excessText" and ensure it is trimmed to "aaa", not "aaa-", as names
+    // may not end in dashes.
+    String instanceName =
+        StringUtils.repeat("a", ControlledAiNotebookHandler.MAX_INSTANCE_NAME_LENGTH - 1)
+            + "-"
+            + "andSomeMoreText";
+    String instanceId =
+        ControlledAiNotebookHandler.getHandler().generateCloudName((UUID) null, instanceName);
+
+    assertEquals(ControlledAiNotebookHandler.MAX_INSTANCE_NAME_LENGTH - 1, instanceId.length());
+    assertNotEquals(instanceId.charAt(instanceId.length() - 1), '-');
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -107,7 +107,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTestMockGcpCloudCont
         ControlledAiNotebookHandler.getHandler().generateCloudName((UUID) null, instanceName);
 
     assertEquals(MAX_BUCKET_NAME_LENGTH - 1, bucketName.length());
-    assertNotEquals(bucketName.charAt(bucketName.length() - 1), '-');
+    assertNotEquals('-', bucketName.charAt(bucketName.length() - 1));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -2,13 +2,16 @@ package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 
 import static bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketHandler.MAX_BUCKET_NAME_LENGTH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 
 import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookHandler;
 import java.io.IOException;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.annotation.DirtiesContext;
@@ -92,6 +95,19 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTestMockGcpCloudCont
 
     assertEquals(maxNameLength, generateCloudName.length());
     assertEquals(generateCloudName, generateCloudName.substring(0, maxNameLength));
+  }
+
+  @Test
+  public void generateBucketName_bucketNameTooLong_trimDashes() {
+    // Generate a name like "aaa-excessText" and ensure it is trimmed to "aaa", not "aaa-", as names
+    // may not end in dashes.
+    String instanceName =
+        StringUtils.repeat("a", MAX_BUCKET_NAME_LENGTH - 1) + "-" + "andSomeMoreText";
+    String bucketName =
+        ControlledAiNotebookHandler.getHandler().generateCloudName((UUID) null, instanceName);
+
+    assertEquals(MAX_BUCKET_NAME_LENGTH - 1, bucketName.length());
+    assertNotEquals(bucketName.charAt(bucketName.length() - 1), '-');
   }
 
   @Test


### PR DESCRIPTION
CLI tests relying on name generation are occasionally failing due to invalid names being returned, e.g. `gcsbucketwithoutspecifyingbucketname-terra-wsm-d-genial-orange-` which does not end in an alphanumeric character.