### PR TITLE
[PF-2743] Fix resource name issue; add logging contain assert

### DIFF
--- a/integration/src/main/java/scripts/testscripts/EnumerateJobs.java
+++ b/integration/src/main/java/scripts/testscripts/EnumerateJobs.java
@@ -1,7 +1,6 @@
 package scripts.testscripts;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -26,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
 import scripts.utils.MultiResourcesUtils;
+import scripts.utils.TestUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class EnumerateJobs extends WorkspaceAllocateTestScriptBase {
@@ -166,14 +166,14 @@ public class EnumerateJobs extends WorkspaceAllocateTestScriptBase {
         assertThrows(
             ApiException.class,
             () -> alpha1Api.enumerateJobs(getWorkspaceId(), -5, null, null, null, null, null));
-    assertThat(invalidPaginationException.getMessage(), containsString("Invalid pagination"));
+    TestUtils.assertContains(invalidPaginationException.getMessage(), "Invalid pagination");
 
     invalidPaginationException =
         assertThrows(
             ApiException.class,
             () ->
                 alpha1Api.enumerateJobs(getWorkspaceId(), 22, "junktoken", null, null, null, null));
-    assertThat(invalidPaginationException.getMessage(), containsString("Invalid page token"));
+    TestUtils.assertContains(invalidPaginationException.getMessage(), "Invalid page token");
   }
 
   private void logResult(String tag, EnumerateJobsResult result) {

--- a/integration/src/main/java/scripts/testscripts/EnumerateResources.java
+++ b/integration/src/main/java/scripts/testscripts/EnumerateResources.java
@@ -1,7 +1,6 @@
 package scripts.testscripts;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
@@ -30,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
 import scripts.utils.MultiResourcesUtils;
+import scripts.utils.TestUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class EnumerateResources extends WorkspaceAllocateTestScriptBase {
@@ -192,7 +192,7 @@ public class EnumerateResources extends WorkspaceAllocateTestScriptBase {
             () ->
                 ownerResourceApi.enumerateResources(
                     getWorkspaceId(), -11, 2, ResourceType.GCS_BUCKET, StewardshipType.CONTROLLED));
-    assertThat(invalidPaginationException.getMessage(), containsString("Invalid pagination"));
+    TestUtils.assertContains(invalidPaginationException.getMessage(), "Invalid pagination");
 
     invalidPaginationException =
         assertThrows(
@@ -200,7 +200,7 @@ public class EnumerateResources extends WorkspaceAllocateTestScriptBase {
             () ->
                 ownerResourceApi.enumerateResources(
                     getWorkspaceId(), 0, 0, ResourceType.GCS_BUCKET, StewardshipType.CONTROLLED));
-    assertThat(invalidPaginationException.getMessage(), containsString("Invalid pagination"));
+    TestUtils.assertContains(invalidPaginationException.getMessage(), "Invalid pagination");
   }
 
   private void logResult(String tag, ResourceList resourceList) {

--- a/integration/src/main/java/scripts/testscripts/MergeGroupPolicies.java
+++ b/integration/src/main/java/scripts/testscripts/MergeGroupPolicies.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
 import scripts.utils.GcsBucketUtils;
+import scripts.utils.TestUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
@@ -147,7 +148,7 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
                     groupBTestReferenceResource.getMetadata().getWorkspaceId(),
                     groupBTestReferenceResource.getMetadata().getResourceId()));
     assertEquals(HttpStatus.SC_CONFLICT, exception.getCode());
-    assertTrue(exception.getMessage().contains("Cannot update group policies."));
+    TestUtils.assertContains(exception.getMessage(), "Cannot update group policies.");
 
     // group should still be A only
     validateWorkspaceContainsGroupPolicy(workspaceApi, groupTestWorkspace.getId(), groupNameA);
@@ -166,7 +167,7 @@ public class MergeGroupPolicies extends WorkspaceAllocateTestScriptBase {
                     groupBTestReferenceResource.getMetadata().getWorkspaceId(),
                     groupBTestReferenceResource.getMetadata().getResourceId()));
     assertEquals(HttpStatus.SC_CONFLICT, exception.getCode());
-    assertTrue(exception.getMessage().contains("Cannot update group policies."));
+    TestUtils.assertContains(exception.getMessage(), "Cannot update group policies.");
 
     WorkspaceDescription updatedWorkspace =
         workspaceApi.getWorkspace(noGroupPolicyWorkspace.getId(), null);

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -40,6 +40,7 @@ import scripts.utils.CommonResourceFieldsUtil;
 import scripts.utils.GcsBucketAccessTester;
 import scripts.utils.GcsBucketUtils;
 import scripts.utils.MultiResourcesUtils;
+import scripts.utils.TestUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestScriptBase {
@@ -203,7 +204,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
                     ManagedBy.USER,
                     CloningInstructionsEnum.NOTHING,
                     privateUserNoEmail));
-    assertThat(ex.getMessage(), containsString("MethodArgumentNotValidException"));
+    TestUtils.assertContains(ex.getMessage(), "MethodArgumentNotValidException");
     assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, ex.getCode());
 
     String uniqueBucketName = String.format("terra-%s-bucket", UUID.randomUUID());

--- a/integration/src/main/java/scripts/utils/TestUtils.java
+++ b/integration/src/main/java/scripts/utils/TestUtils.java
@@ -1,12 +1,26 @@
 package scripts.utils;
 
 import java.util.Random;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestUtils {
+  private static final Logger logger = LoggerFactory.getLogger(TestUtils.class);
+
   private static final Random RANDOM = new Random();
 
   public static String appendRandomNumber(String string) {
     // Can't be dash because BQ dataset names can't have dash
     return string + "_" + RANDOM.nextInt(10000);
+  }
+
+  public static void assertContains(String actual, String expectedContains) {
+    if (StringUtils.contains(actual, expectedContains)) {
+      return;
+    }
+    logger.error("Actual '{}' does not contain '{}'", actual, expectedContains);
+    Assertions.fail("Actual does not contain expected");
   }
 }


### PR DESCRIPTION
The `ImportDataCollection` test was re-using a resource name. The sequence of checks changes and the name conflict appeared instead of the policy merge conflict. I made two changes:

1. Generated unique resource names in the test
2. Wrote `TestUtils.assertContains` that does the contains test and logs the contents if there is a mismatch. I replaced current usage with calls to that method in several tests.