### PR TITLE
[PF-2765] Use UUID for snapshot id in test

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotTest.java
@@ -60,7 +60,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotTest extends BaseCon
 
   private final String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
   private final String sourceInstanceName = TestUtils.appendRandomNumber("source-instance-name");
-  private final String sourceSnapshot = TestUtils.appendRandomNumber("source-snapshot");
+  private final String sourceSnapshot = UUID.randomUUID().toString();
   private ApiDataRepoSnapshotResource sourceResource;
 
   // See here for how to skip workspace creation for local runs:


### PR DESCRIPTION
Snapshot ids are UUIDs and we are now using them for policy. (TPS requires UUID for an object id)
The `ReferencedGcpResourceControllerDataRepoSnapshotTest` was using a name for the snapshot and that failed.
This PR is a one line change to use a generated UUID instead of a string for the snapshot id.