### PR TITLE
Minor fixes to Sagemaker creation

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -403,7 +403,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
     if (StringUtils.isEmpty(instanceName)) {
       instanceName =
           ControlledAwsSageMakerNotebookHandler.getHandler()
-              .generateCloudName(workspaceUuid, body.getCommon().getName());
+              .generateCloudName(workspace.getUserFacingId(), body.getCommon().getName());
     }
     AwsResourceValidationUtils.validateAwsSageMakerNotebookName(instanceName);
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
@@ -3,7 +3,6 @@ package bio.terra.workspace.service.resource.controlled.cloud.aws.s3StorageFolde
 import bio.terra.common.exception.ApiException;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
-import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.RetryRule;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
@@ -15,6 +14,8 @@ import bio.terra.workspace.generated.model.ApiAwsS3StorageFolderAttributes;
 import bio.terra.workspace.generated.model.ApiAwsS3StorageFolderResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.resource.AwsResourceValidationUtils;
+import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
 import bio.terra.workspace.service.resource.controlled.model.*;
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 
 public class ControlledAwsS3StorageFolderResource extends ControlledResource {
+  private static final String RESOURCE_DESCRIPTOR = "ControlledAwsS3StorageFolder";
   private final String bucketName;
   private final String prefix;
 
@@ -185,10 +187,10 @@ public class ControlledAwsS3StorageFolderResource extends ControlledResource {
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected CONTROLLED_AWS_S3_STORAGE_FOLDER");
     }
-    if ((bucketName == null) || (prefix == null) || (getRegion() == null)) {
-      throw new MissingRequiredFieldException(
-          "Missing required field for ControlledAwsS3StorageFolderResource.");
-    }
+    ResourceValidationUtils.checkFieldNonNull(bucketName, "bucketName", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkFieldNonNull(prefix, "prefix", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkFieldNonNull(getRegion(), "region", RESOURCE_DESCRIPTOR);
+    AwsResourceValidationUtils.validateAwsS3StorageFolderName(prefix);
   }
 
   public static class Builder {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -56,7 +56,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
    */
   protected static final String NOTEBOOK_DISABLE_ROOT_METADATA_KEY = "notebook-disable-root";
 
-  protected static final String RESOURCE_DESCRIPTOR = "ControlledAiNotebookInstance";
+  private static final String RESOURCE_DESCRIPTOR = "ControlledAiNotebookInstance";
 
   /** Metadata keys that are reserved by terra. User cannot modify those. */
   public static final Set<String> RESERVED_METADATA_KEYS =

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceHandler.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceHandler.java
@@ -40,7 +40,7 @@ public interface WsmResourceHandler {
    * @param resourceName resource name
    * @return cloud-native name
    */
-  default String generateCloudName(String workspaceUserFacingId, String resourceName) {
+  default String generateCloudName(@Nullable String workspaceUserFacingId, String resourceName) {
     throw new BadRequestException(
         "generateCloudName with workspaceUserFacingId and resourceName not supported");
   }


### PR DESCRIPTION
- AWS sagemaker should use the Workspace.userfacingid and not workspace.uuid
- Add Nullable annotation to generateCloudName(String,String) function, similar to generateCloudName(Uuid,String)
- update resource.validate() method to only allow private notebooks
- leverage validationUtils for resource.validate steps
