### PR TITLE
[PF-2768] Handle deserializing placeholder gcp contexts

### DIFF
--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -720,21 +720,22 @@ public class WorkspaceDao {
   }
 
   /**
-   * Retrieve all non-BROKEN, non-DELETING, GCP cloud contexts. This is only used for back-filling
-   * custom roles on GCP projects of existing workspaces. See AdminService.
+   * Retrieve all non-BROKEN, non-DELETING, non-CREATING GCP cloud contexts. This is only used for
+   * back-filling custom roles on GCP projects of existing workspaces. See AdminService.
    *
    * @return a map of workspace id to GCP serialized cloud context
    */
   public ImmutableMap<UUID, DbCloudContext> getWorkspaceIdToGcpCloudContextMap() {
     String sql =
         BASE_CLOUD_CONTEXT_SELECT_SQL
-            + "WHERE cloud_platform = :cloud_platform AND state != :broken AND state != :deleting";
+            + "WHERE cloud_platform = :cloud_platform AND state != :broken AND state != :deleting AND state != :creating";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("cloud_platform", CloudPlatform.GCP.toSql())
             .addValue("broken", WsmResourceState.BROKEN.toDb())
-            .addValue("deleting", WsmResourceState.DELETING.toDb());
+            .addValue("deleting", WsmResourceState.DELETING.toDb())
+            .addValue("creating", WsmResourceState.CREATING.toDb());
 
     List<DbCloudContext> dbCloudContexts =
         jdbcTemplate.query(sql, params, CLOUD_CONTEXT_ROW_MAPPER);

--- a/service/src/main/java/bio/terra/workspace/service/admin/AdminService.java
+++ b/service/src/main/java/bio/terra/workspace/service/admin/AdminService.java
@@ -14,7 +14,6 @@ import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -38,10 +37,11 @@ public class AdminService {
     Map<UUID, String> workspaceIdToGcpProjectIdMap = new HashMap<>();
     for (Map.Entry<UUID, DbCloudContext> cloudContext :
         workspaceDao.getWorkspaceIdToGcpCloudContextMap().entrySet()) {
+      // GcpCloudContext.deserialize will only return empty for contexts in the CREATING state,
+      // which are filtered out above in getWorkspaceIdToGcpCloudContextMap.
       workspaceIdToGcpProjectIdMap.put(
           cloudContext.getKey(),
-          Objects.requireNonNull(GcpCloudContext.deserialize(cloudContext.getValue()))
-              .getGcpProjectId());
+          GcpCloudContext.deserialize(cloudContext.getValue()).orElseThrow().getGcpProjectId());
     }
 
     if (workspaceIdToGcpProjectIdMap.isEmpty()) {

--- a/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudContextService.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
 import bio.terra.stairway.RetryRule;
+import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.db.WorkspaceDao;
@@ -142,7 +143,11 @@ public class GcpCloudContextService implements CloudContextService {
 
   @Override
   public CloudContext makeCloudContextFromDb(DbCloudContext dbCloudContext) {
-    return GcpCloudContext.deserialize(dbCloudContext);
+    return GcpCloudContext.deserialize(dbCloudContext)
+        .orElseThrow(
+            () ->
+                new InternalLogicException(
+                    "Cannot call makeCloudContextFromDb on an unfinished GCP context"));
   }
 
   /**
@@ -155,7 +160,7 @@ public class GcpCloudContextService implements CloudContextService {
   public Optional<GcpCloudContext> getGcpCloudContext(UUID workspaceUuid) {
     return workspaceDao
         .getCloudContext(workspaceUuid, CloudPlatform.GCP)
-        .map(GcpCloudContext::deserialize);
+        .flatMap(GcpCloudContext::deserialize);
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -162,11 +162,11 @@ class WorkspaceDaoTest extends BaseUnitTest {
         new HashMap<>(workspaceDao.getWorkspaceIdToGcpCloudContextMap());
 
     GcpCloudContext context1 =
-        GcpCloudContext.deserialize(workspaceIdToGcpContextMap.get(workspace1));
+        GcpCloudContext.deserialize(workspaceIdToGcpContextMap.get(workspace1)).get();
     GcpCloudContext context2 =
-        GcpCloudContext.deserialize(workspaceIdToGcpContextMap.get(workspace2));
+        GcpCloudContext.deserialize(workspaceIdToGcpContextMap.get(workspace2)).get();
     GcpCloudContext context3 =
-        GcpCloudContext.deserialize(workspaceIdToGcpContextMap.get(workspace3));
+        GcpCloudContext.deserialize(workspaceIdToGcpContextMap.get(workspace3)).get();
 
     assertContext(project1, context1);
     assertContext(project2, context2);

--- a/service/src/test/java/bio/terra/workspace/service/admin/AdminServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/admin/AdminServiceTest.java
@@ -80,7 +80,7 @@ public class AdminServiceTest extends BaseConnectedTest {
             .getWorkspaceId());
     projectIds =
         workspaceDao.getWorkspaceIdToGcpCloudContextMap().values().stream()
-            .map(cloudContext -> GcpCloudContext.deserialize(cloudContext).getGcpProjectId())
+            .map(cloudContext -> GcpCloudContext.deserialize(cloudContext).get().getGcpProjectId())
             .toList();
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextUnitTest.java
@@ -108,6 +108,7 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
             DEFAULT_USER_EMAIL,
             null);
     workspaceDao.createWorkspace(workspace, /* applicationIds= */ null);
+
     workspaceDao.createCloudContextStart(
         workspaceUuid,
         CloudPlatform.GCP,
@@ -115,6 +116,7 @@ public class GcpCloudContextUnitTest extends BaseUnitTest {
         /*flightId=*/ UUID.randomUUID().toString());
     Optional<DbCloudContext> creatingContext =
         workspaceDao.getCloudContext(workspaceUuid, CloudPlatform.GCP);
+
     // After createCloudContextStart, a placeholder should exist in the DB.
     assertTrue(creatingContext.isPresent());
     Optional<GcpCloudContext> deserializedContext =


### PR DESCRIPTION
Currently, calling `createCloudContextStart` puts a placeholder value in the cloud_context DB. This is important for state management, but it does not have any GCP context information (policy groups, project ID) and so deserialization on this placeholder object will fail. IMO we should hide this placeholder as it will not have the fields most callers expect.

This is currently calling `getWorkspace` calls immediately after `createGcpCloudContext` calls to fail with a 400. After the context creation finishes, the `getWorkspace` calls start working again.