### PR TITLE
[WOR-1013] Check for hardcoded spend profile first

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -98,6 +98,17 @@ public class SpendProfileService {
     } else if (bpmEnabled) {
       // profiles returned from BPM means we are auth'ed
       spend = getSpendProfileFromBpm(userRequest, spendProfileId);
+    } else {
+      if (!SamRethrow.onInterrupted(
+          () ->
+              samService.isAuthorized(
+                  userRequest,
+                  SamConstants.SamResource.SPEND_PROFILE,
+                  spendProfileId.getId(),
+                  SamConstants.SamSpendProfileAction.LINK),
+          "isAuthorized")) {
+        throw SpendUnauthorizedException.linkUnauthorized(spendProfileId);
+      }
     }
 
     if (spend == null) {

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -82,22 +82,22 @@ public class SpendProfileService {
   public SpendProfile authorizeLinking(
       SpendProfileId spendProfileId, boolean bpmEnabled, AuthenticatedUserRequest userRequest) {
 
-    SpendProfile spend;
-    if (bpmEnabled) {
-      // profiles returned from BPM means we are auth'ed
-      spend = getSpendProfileFromBpm(userRequest, spendProfileId);
-    } else {
+    SpendProfile spend = null;
+    if (spendProfiles.containsKey(spendProfileId)) {
       if (!SamRethrow.onInterrupted(
-          () ->
-              samService.isAuthorized(
-                  userRequest,
-                  SamConstants.SamResource.SPEND_PROFILE,
-                  spendProfileId.getId(),
-                  SamConstants.SamSpendProfileAction.LINK),
-          "isAuthorized")) {
+              () ->
+                      samService.isAuthorized(
+                              userRequest,
+                              SamConstants.SamResource.SPEND_PROFILE,
+                              spendProfileId.getId(),
+                              SamConstants.SamSpendProfileAction.LINK),
+              "isAuthorized")) {
         throw SpendUnauthorizedException.linkUnauthorized(spendProfileId);
       }
       spend = spendProfiles.get(spendProfileId);
+    } else if (bpmEnabled) {
+      // profiles returned from BPM means we are auth'ed
+      spend = getSpendProfileFromBpm(userRequest, spendProfileId);
     }
 
     if (spend == null) {

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -85,13 +85,13 @@ public class SpendProfileService {
     SpendProfile spend = null;
     if (spendProfiles.containsKey(spendProfileId)) {
       if (!SamRethrow.onInterrupted(
-              () ->
-                      samService.isAuthorized(
-                              userRequest,
-                              SamConstants.SamResource.SPEND_PROFILE,
-                              spendProfileId.getId(),
-                              SamConstants.SamSpendProfileAction.LINK),
-              "isAuthorized")) {
+          () ->
+              samService.isAuthorized(
+                  userRequest,
+                  SamConstants.SamResource.SPEND_PROFILE,
+                  spendProfileId.getId(),
+                  SamConstants.SamSpendProfileAction.LINK),
+          "isAuthorized")) {
         throw SpendUnauthorizedException.linkUnauthorized(spendProfileId);
       }
       spend = spendProfiles.get(spendProfileId);


### PR DESCRIPTION
Integration tests expect a spend profile named "wm-default-spend-profile" to be present. Now that we have the BPM flag enabled in all environments, this check fails as BPM does not know about that profile. This PR checks the configured map of hardcoded spend profiles prior to reaching out to BPM. 