### PR TITLE
TERRA-575: Attach correct role to SageMaker notebook.

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -636,8 +636,8 @@ public class ControlledResourceService {
             resource, privateResourceIamRole, jobControl, resultPath, userRequest);
     jobBuilder.addParameter(ControlledResourceKeys.CREATE_NOTEBOOK_PARAMETERS, creationParameters);
     jobBuilder.addParameter(
-        ControlledResourceKeys.AWS_ENVIRONMENT_USER_ROLE_ARN,
-        environment.getUserRoleArn().toString());
+        ControlledResourceKeys.AWS_ENVIRONMENT_NOTEBOOK_ROLE_ARN,
+        environment.getNotebookRoleArn().toString());
     jobBuilder.addParameter(
         ControlledResourceKeys.AWS_LANDING_ZONE_KMS_KEY_ARN,
         landingZone.getKmsKey().arn().toString());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/CreateAwsSageMakerNotebookStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/CreateAwsSageMakerNotebookStep.java
@@ -60,7 +60,7 @@ public class CreateAwsSageMakerNotebookStep implements Step {
     FlightUtils.validateRequiredEntries(
         inputParameters,
         ControlledResourceKeys.CREATE_NOTEBOOK_PARAMETERS,
-        ControlledResourceKeys.AWS_ENVIRONMENT_USER_ROLE_ARN,
+        ControlledResourceKeys.AWS_ENVIRONMENT_NOTEBOOK_ROLE_ARN,
         ControlledResourceKeys.AWS_LANDING_ZONE_KMS_KEY_ARN,
         ControlledResourceKeys.AWS_LANDING_ZONE_NOTEBOOK_LIFECYCLE_CONFIG_ARN);
 
@@ -89,7 +89,7 @@ public class CreateAwsSageMakerNotebookStep implements Step {
         resource,
         Arn.fromString(
             inputParameters.get(
-                ControlledResourceKeys.AWS_ENVIRONMENT_USER_ROLE_ARN, String.class)),
+                ControlledResourceKeys.AWS_ENVIRONMENT_NOTEBOOK_ROLE_ARN, String.class)),
         Arn.fromString(
             inputParameters.get(ControlledResourceKeys.AWS_LANDING_ZONE_KMS_KEY_ARN, String.class)),
         Arn.fromString(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -84,7 +84,7 @@ public final class WorkspaceFlightMapKeys {
 
     // AWS
     public static final String AWS_CLOUD_CONTEXT = "awsCloudContext";
-    public static final String AWS_ENVIRONMENT_USER_ROLE_ARN = "awsEnvironmentUserRoleArn";
+    public static final String AWS_ENVIRONMENT_NOTEBOOK_ROLE_ARN = "awsEnvironmentUserRoleArn";
     public static final String AWS_LANDING_ZONE_KMS_KEY_ARN = "awsLandingZoneKmsKeyArn";
     public static final String AWS_LANDING_ZONE_NOTEBOOK_LIFECYCLE_CONFIG_ARN =
         "awsLandingZoneNotebookLifecycleConfigArn";

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -84,7 +84,8 @@ public final class WorkspaceFlightMapKeys {
 
     // AWS
     public static final String AWS_CLOUD_CONTEXT = "awsCloudContext";
-    public static final String AWS_ENVIRONMENT_NOTEBOOK_ROLE_ARN = "awsEnvironmentUserRoleArn";
+    public static final String AWS_ENVIRONMENT_USER_ROLE_ARN = "awsEnvironmentUserRoleArn";
+    public static final String AWS_ENVIRONMENT_NOTEBOOK_ROLE_ARN = "awsEnvironmentNotebookRoleArn";
     public static final String AWS_LANDING_ZONE_KMS_KEY_ARN = "awsLandingZoneKmsKeyArn";
     public static final String AWS_LANDING_ZONE_NOTEBOOK_LIFECYCLE_CONFIG_ARN =
         "awsLandingZoneNotebookLifecycleConfigArn";


### PR DESCRIPTION
The wrong role is attached to SageMaker notebook instances, so they do not have permission to log or access tags.