### PR TITLE
[PF-2787] Fix connectedPlus tests to be happy with workspace state

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/WorkspaceDeleteFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/WorkspaceDeleteFlight.java
@@ -50,7 +50,8 @@ public class WorkspaceDeleteFlight extends Flight {
     for (CloudPlatform cloudPlatform : workspaceDao.listCloudPlatforms(workspaceUuid)) {
       String flightId = UUID.randomUUID().toString();
       addStep(
-          new RunDeleteCloudContextFlightStep(workspaceUuid, cloudPlatform, userRequest, flightId));
+          new RunDeleteCloudContextFlightStep(workspaceUuid, cloudPlatform, userRequest, flightId),
+          dbRetryRule);
     }
 
     // Delete all ANY controlled resources (right now, that means FlexResource). The only case

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
@@ -266,6 +267,9 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
   }
 
   @Test
+  @Disabled("PF-2259 - this test needs rewriting")
+  // TODO(PF-2259): This test is not testing the undo of CloneGcpWorkspaceFlight. It is
+  //  testing the undo of WorkspaceCreateFlight. It needs to be re
   public void cloneGcpWorkspaceUndoSteps() {
     Workspace sourceWorkspace = workspaceService.getWorkspace(workspaceId);
     // Enable an application
@@ -332,10 +336,11 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
         LaunchCloneAllResourcesFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(
         AwaitCloneAllResourcesFlightStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+    // TODO(PF-2259): Since the test is actually setting debug for the create workspace flight
+    //  lastStepFailure(true) will always cause a dismal failure.
     FlightDebugInfo debugInfo =
         FlightDebugInfo.newBuilder().undoStepFailures(retrySteps).lastStepFailure(true).build();
-    // TODO(PF-2259): This test is not actually testing the undo of CloneGcpWorkspaceFlight. It is
-    // testing the undo of WorkspaceCreateFlight.
+
     jobService.setFlightDebugInfoForTest(debugInfo);
 
     assertThrows(

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -543,9 +543,18 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     retrySteps.put(CreateWorkspaceStartStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(
         CreateWorkspacePoliciesStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    retrySteps.put(CreateWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_FATAL);
+    retrySteps.put(CreateWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
+
+    Map<String, StepStatus> triggerFailureStep = new HashMap<>();
+    triggerFailureStep.put(
+        CreateWorkspaceAuthzStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_FATAL);
+
     // The finish step is not undoable, so we make the failure at the penultimate step.
-    FlightDebugInfo debugInfo = FlightDebugInfo.newBuilder().undoStepFailures(retrySteps).build();
+    FlightDebugInfo debugInfo =
+        FlightDebugInfo.newBuilder()
+            .doStepFailures(triggerFailureStep)
+            .undoStepFailures(retrySteps)
+            .build();
     jobService.setFlightDebugInfoForTest(debugInfo);
 
     // Service methods which wait for a flight to complete will throw an


### PR DESCRIPTION
Fixes fir three connectedPlus tests:

1. Disabled `cloneGcpWorkspaceUndoSteps`. It is not testing what it should and we have a test case for create workspace undo, so it is of no use right now.
2. `createMcWorkspaceUndoSteps` is properly triggering the undo now
3. Retry of a step without a retry rule doesn't retry 

