### PR TITLE
PF-2793 - updatePolicy should detect if groups change

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
@@ -106,7 +106,14 @@ public class PolicyValidator {
   public List<String> validateWorkspaceConformsToGroupPolicy(
       Workspace workspace, TpsPaoGetResult policies, AuthenticatedUserRequest userRequest) {
     var groups = TpsUtilities.getGroupConstraintsFromInputs(policies.getEffectiveAttributes());
+    var currentPao = tpsApiDispatch.getPao((workspace.getWorkspaceId()));
+    var existingGroups = TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes());
+
     if (!groups.isEmpty()) {
+      if (groups.containsAll(existingGroups) && existingGroups.containsAll(groups)) {
+        // groups have not changed.
+        return List.of();
+      }
       return List.of("policies with group constraints not yet supported for this api call");
     } else {
       return List.of();

--- a/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
@@ -107,7 +107,8 @@ public class PolicyValidator {
       Workspace workspace, TpsPaoGetResult policies, AuthenticatedUserRequest userRequest) {
     var groups = TpsUtilities.getGroupConstraintsFromInputs(policies.getEffectiveAttributes());
     var currentPao = tpsApiDispatch.getPao((workspace.getWorkspaceId()));
-    var existingGroups = TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes());
+    var existingGroups =
+        TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes());
 
     if (!groups.isEmpty()) {
       if (groups.containsAll(existingGroups) && existingGroups.containsAll(groups)) {

--- a/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
@@ -108,7 +108,9 @@ public class PolicyValidator {
     var groups = TpsUtilities.getGroupConstraintsFromInputs(policies.getEffectiveAttributes());
     var currentPao = tpsApiDispatch.getPao((workspace.getWorkspaceId()));
     var existingGroups =
-        TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes());
+        (currentPao == null)
+            ? new ArrayList<String>()
+            : TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes());
 
     if (!groups.isEmpty()) {
       if (groups.containsAll(existingGroups) && existingGroups.containsAll(groups)) {

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneTest.java
@@ -400,11 +400,12 @@ public class ReferencedResourceCloneTest extends BaseConnectedTest {
     try {
       // Update the source workspace policy
       ApiWsmPolicyUpdateResult result =
-          mockMvcUtils.updatePolicies(
+          mockMvcUtils.updatePoliciesExpectStatus(
               userAccessUtils.defaultUserAuthRequest(),
               sourceWorkspaceId,
               /*policiesToAdd*/ locationsToAdd,
-              /*policiesToRemove*/ locationsToRemove);
+              /*policiesToRemove*/ locationsToRemove,
+              HttpStatus.SC_CONFLICT);
       assertFalse(result.isUpdateApplied());
       assertFalse(
           result.getConflicts().stream()

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -657,6 +657,18 @@ public class MockMvcUtils {
       @Nullable List<ApiWsmPolicyInput> policiesToAdd,
       @Nullable List<ApiWsmPolicyInput> policiesToRemove)
       throws Exception {
+    return updatePoliciesExpectStatus(
+        userRequest, workspaceId, policiesToAdd, policiesToRemove, HttpStatus.SC_OK);
+  }
+
+  public ApiWsmPolicyUpdateResult updatePoliciesExpectStatus(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      @Nullable List<ApiWsmPolicyInput> policiesToAdd,
+      @Nullable List<ApiWsmPolicyInput> policiesToRemove,
+      int httpStatus)
+      throws Exception {
+
     ApiWsmPolicyUpdateRequest requestBody =
         new ApiWsmPolicyUpdateRequest().updateMode(ApiWsmPolicyUpdateMode.FAIL_ON_CONFLICT);
     if (policiesToAdd != null) {
@@ -675,7 +687,7 @@ public class MockMvcUtils {
                         .characterEncoding("UTF-8")
                         .content(objectMapper.writeValueAsString(requestBody)),
                     userRequest))
-            .andExpect(status().is(HttpStatus.SC_OK))
+            .andExpect(status().is(httpStatus))
             .andReturn()
             .getResponse()
             .getContentAsString();


### PR DESCRIPTION
The current validation fails if any groups are set - even if they already exist and aren't being added. This update checks for a change in group policies.