### PR TITLE
[BENCH-612] Temporarily disable flagsmith usage to enable AWS 

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/FeatureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/FeatureConfiguration.java
@@ -15,6 +15,7 @@ public class FeatureConfiguration {
   private static final Logger logger = LoggerFactory.getLogger(FeatureConfiguration.class);
 
   private boolean azureEnabled;
+  private boolean awsEnabled;
   private boolean alpha1Enabled;
   private boolean tpsEnabled;
   private boolean bpmGcpEnabled;
@@ -28,6 +29,14 @@ public class FeatureConfiguration {
 
   public void setAzureEnabled(boolean azureEnabled) {
     this.azureEnabled = azureEnabled;
+  }
+
+  public boolean isAwsEnabled() {
+    return awsEnabled;
+  }
+
+  public void setAwsEnabled(boolean awsEnabled) {
+    this.awsEnabled = awsEnabled;
   }
 
   public boolean isAlpha1Enabled() {
@@ -85,6 +94,12 @@ public class FeatureConfiguration {
     }
   }
 
+  public void awsEnabledCheck() {
+    if (!isAwsEnabled()) {
+      throw new FeatureNotSupportedException("AWS features are not enabled");
+    }
+  }
+
   public void alpha1EnabledCheck() {
     if (!isAlpha1Enabled()) {
       throw new FeatureNotSupportedException("Alpha1 features are not supported");
@@ -104,6 +119,7 @@ public class FeatureConfiguration {
    */
   public void logFeatures() {
     logger.info("Feature: azure-enabled: {}", isAzureEnabled());
+    logger.info("Feature: aws-enabled: {}", isAwsEnabled());
     logger.info("Feature: alpha1-enabled: {}", isAlpha1Enabled());
     logger.info("Feature: tps-enabled: {}", isTpsEnabled());
     logger.info("Feature: bpm-gcp-enabled: {}", isBpmGcpEnabled());

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -227,7 +227,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
   @Override
   public ResponseEntity<ApiCreatedControlledAwsS3StorageFolder> createAwsS3StorageFolder(
       UUID workspaceUuid, @Valid ApiCreateControlledAwsS3StorageFolderRequestBody body) {
-    featureService.awsEnabledCheck();
+    features.awsEnabledCheck();
 
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     Workspace workspace =
@@ -382,7 +382,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
   @Override
   public ResponseEntity<ApiCreateControlledAwsSageMakerNotebookResult> createAwsSageMakerNotebook(
       UUID workspaceUuid, @Valid ApiCreateControlledAwsSageMakerNotebookRequestBody body) {
-    featureService.awsEnabledCheck();
+    features.awsEnabledCheck();
 
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     Workspace workspace =

--- a/service/src/main/java/bio/terra/workspace/service/workspace/AwsCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/AwsCloudContextService.java
@@ -6,6 +6,7 @@ import bio.terra.aws.resource.discovery.LandingZone;
 import bio.terra.aws.resource.discovery.Metadata;
 import bio.terra.workspace.app.configuration.external.AwsConfiguration;
 import bio.terra.workspace.app.configuration.external.AwsConfiguration.Authentication;
+import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.exception.StaleConfigurationException;
 import bio.terra.workspace.common.utils.AwsUtils;
@@ -47,6 +48,7 @@ import software.amazon.awssdk.regions.Region;
 public class AwsCloudContextService implements CloudContextService {
   private final AwsConfiguration awsConfiguration;
   private final WorkspaceDao workspaceDao;
+  private final FeatureConfiguration featureConfiguration;
   private final FeatureService featureService;
   private final ResourceDao resourceDao;
   private final ControlledResourceService controlledResourceService;
@@ -56,12 +58,14 @@ public class AwsCloudContextService implements CloudContextService {
   @Autowired
   public AwsCloudContextService(
       WorkspaceDao workspaceDao,
+      FeatureConfiguration featureConfiguration,
       FeatureService featureService,
       AwsConfiguration awsConfiguration,
       ResourceDao resourceDao,
       ControlledResourceService controlledResourceService) {
     this.awsConfiguration = awsConfiguration;
     this.workspaceDao = workspaceDao;
+    this.featureConfiguration = featureConfiguration;
     this.featureService = featureService;
     this.resourceDao = resourceDao;
     this.controlledResourceService = controlledResourceService;
@@ -170,7 +174,7 @@ public class AwsCloudContextService implements CloudContextService {
    */
   public Environment discoverEnvironment() throws IllegalArgumentException, InternalLogicException {
     try {
-      featureService.awsEnabledCheck();
+      featureConfiguration.awsEnabledCheck();
       initializeEnvironmentDiscovery();
 
       if (this.environmentDiscovery == null) {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -207,6 +207,8 @@ landingzone:
 feature:
   # azure-enabled - Controls inclusion of Azure support in WSM
   azure-enabled: true
+  # aws-enabled - Controls inclusion of AWS support in WSM
+  aws-enabled: false
   # alpha1-enabled - Controls support of the Alpha1 experimental API and service
   alpha1-enabled: false
   # tps-enabled - Controls whether Terra Policy Service is called. It is always built into WSM

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
@@ -4,6 +4,7 @@ import bio.terra.aws.resource.discovery.Environment;
 import bio.terra.aws.resource.discovery.LandingZone;
 import bio.terra.aws.resource.discovery.Metadata;
 import bio.terra.workspace.app.configuration.external.AwsConfiguration;
+import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseAwsConnectedTest;
 import bio.terra.workspace.service.features.FeatureService;
 import java.io.IOException;
@@ -23,6 +24,7 @@ import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 public class AwsUtilsTest extends BaseAwsConnectedTest {
   private static final Logger logger = LoggerFactory.getLogger(AwsUtilsTest.class);
   @Autowired private AwsConfiguration awsConfiguration;
+  @Autowired private FeatureConfiguration featureConfiguration;
   @Autowired private FeatureService featureService;
 
   private void logEnvironmentMetadata(Metadata metadata) {
@@ -36,7 +38,7 @@ public class AwsUtilsTest extends BaseAwsConnectedTest {
 
   @Test
   void hello_bucket() throws IOException {
-    Assertions.assertDoesNotThrow(() -> featureService.awsEnabledCheck());
+    Assertions.assertDoesNotThrow(() -> featureConfiguration.awsEnabledCheck());
 
     // Log the AWS config
     logger.info("AWS Configuration: {}", awsConfiguration.toString());


### PR DESCRIPTION
Temporarily disable flagsmith usage to enable AWS - to address failures on WSM till flagsmith deployment errors are looked into 
(refer to https://github.com/DataBiosphere/terra-workspace-manager/pull/1205 for initial change to use flagsmith)


Cloud context create failure without aws-enabled
```
{
  "jobReport": {
    "id": "aws-2",
    "description": "Create AWS Cloud Context for workspace 95a70d96-094a-4258-9251-a99ac0e8fa61",
    "status": "FAILED",
    "statusCode": 501,
    "submitted": "2023-05-22T18:03:21.947021Z",
    "completed": "2023-05-22T18:03:22.096078Z",
    "resultURL": "http://localhost:8080/api/workspaces/v1/95a70d96-094a-4258-9251-a99ac0e8fa61/cloudcontexts/result/aws-2"
  },
  "errorReport": {
    "message": "AWS feature are not enabled",
    "statusCode": 501,
    "causes": []
  }
}
```


Cloud context create success with aws-enabled
```
{
  "jobReport": {
    "id": "aws-4",
    "description": "Create AWS Cloud Context for workspace 95a70d96-094a-4258-9251-a99ac0e8fa61",
    "status": "SUCCEEDED",
    "statusCode": 200,
    "submitted": "2023-05-22T18:10:41.524128Z",
    "completed": "2023-05-22T18:10:44.132765Z",
    "resultURL": "http://localhost:8080/api/workspaces/v1/95a70d96-094a-4258-9251-a99ac0e8fa61/cloudcontexts/result/aws-4"
  },
  "awsContext": {
    "majorVersion": "v0",
    "organizationId": "..",
    "accountId": "..",
    "tenantAlias": "saas",
    "environmentAlias": "devel"
  }
}
```
