### PR TITLE
[PF-2791] Change serdes for state exceptions; remove exception from DeleteFailure

### DIFF
--- a/service/src/main/java/bio/terra/workspace/common/utils/FlightUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/FlightUtils.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.workspace.exceptions.MissingRequiredFieldsException;
 import bio.terra.workspace.service.workspace.model.Workspace;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
@@ -101,15 +102,6 @@ public final class FlightUtils {
     }
   }
 
-  /**
-   * Validate that all common entries are present in the flight map
-   *
-   * @param flightMap input parameters
-   */
-  public static void validateCommonEntries(FlightMap flightMap) {
-    validateRequiredEntries(flightMap, COMMON_FLIGHT_INPUTS.keySet().toArray(new String[0]));
-  }
-
   public static FlightMap getResultMapRequired(FlightState flightState) {
     return flightState
         .getResultMap()
@@ -144,16 +136,6 @@ public final class FlightUtils {
   }
 
   /**
-   * Copy the parameters common to all WSM flights
-   *
-   * @param source source flight map
-   * @param dest destination flight map
-   */
-  public static void copyCommonParams(FlightMap source, FlightMap dest) {
-    COMMON_FLIGHT_INPUTS.forEach((key, clazz) -> dest.put(key, source.get(key, clazz)));
-  }
-
-  /**
    * Get a value from one of the flight maps and check that it is not null. If it is null, throw.
    *
    * @param flightMap input or working map
@@ -164,6 +146,23 @@ public final class FlightUtils {
    */
   public static <T> T getRequired(FlightMap flightMap, String key, Class<T> tClass) {
     var value = flightMap.get(key, tClass);
+    if (value == null) {
+      throw new MissingRequiredFieldsException("Missing required flight map key: " + key);
+    }
+    return value;
+  }
+
+  /**
+   * Get a value from one of the flight maps and check that it is not null. If it is null, throw.
+   *
+   * @param flightMap input or working map
+   * @param key string key to lookup in the map
+   * @param typeReference Jackson type reference
+   * @param <T> generic
+   * @return T
+   */
+  public static <T> T getRequired(FlightMap flightMap, String key, TypeReference<T> typeReference) {
+    var value = flightMap.get(key, typeReference);
     if (value == null) {
       throw new MissingRequiredFieldsException("Missing required flight map key: " + key);
     }

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -7,7 +7,6 @@ import static java.util.stream.Collectors.toList;
 
 import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
-import bio.terra.common.exception.ErrorReportException;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
 import bio.terra.workspace.db.model.DbResource;
@@ -116,14 +115,9 @@ public class ResourceDao {
                   OffsetDateTime.ofInstant(
                       rs.getTimestamp("created_date").toInstant(), ZoneId.of("UTC")))
               .createdByEmail(rs.getString("created_by_email"))
-              // TODO(PF-2290): throw if resource is controlled resource and the region is null once
-              // we backfill the existing resource rows with regions.
               .region(rs.getString("region"))
               .state(WsmResourceState.fromDb(rs.getString("state")))
-              .error(
-                  Optional.ofNullable(rs.getString("error"))
-                      .map(errorJson -> DbSerDes.fromJson(errorJson, ErrorReportException.class))
-                      .orElse(null))
+              .error(StateDao.deserializeException(rs.getString("error")))
               .flightId(rs.getString("flight_id"));
 
   private final NamedParameterJdbcTemplate jdbcTemplate;

--- a/service/src/main/java/bio/terra/workspace/db/StateDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/StateDao.java
@@ -114,7 +114,7 @@ public class StateDao {
   }
 
   @VisibleForTesting
-  public String normalizeException(Exception exception) {
+  public static String normalizeException(@Nullable Exception exception) {
     // Normalize any exception into a serialized error report
     if (exception == null) {
       return null;

--- a/service/src/main/java/bio/terra/workspace/db/exception/GeneralErrorReportException.java
+++ b/service/src/main/java/bio/terra/workspace/db/exception/GeneralErrorReportException.java
@@ -1,0 +1,26 @@
+package bio.terra.workspace.db.exception;
+
+import bio.terra.common.exception.ErrorReportException;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+
+/**
+ * This exception is not intended to be thrown. It is a constructable form of ErrorReportException
+ * that can be safely serialized and deserialized from the error columns in the database.
+ *
+ * <p>NOTE: this class is serialized to JSON, so take care modifying it.
+ */
+public class GeneralErrorReportException extends ErrorReportException {
+  public GeneralErrorReportException(String message) {
+    super(message);
+  }
+
+  public GeneralErrorReportException(
+      String message,
+      Throwable cause,
+      @Nullable List<String> causes,
+      @Nullable HttpStatus statusCode) {
+    super(message, cause, causes, statusCode);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/WorkspaceFlightMapKeys.java
@@ -22,6 +22,7 @@ public final class WorkspaceFlightMapKeys {
   public static final String PET_SA_CREDENTIALS = "petSaCredentials";
   public static final String CLOUD_PLATFORM = "cloudPlatform";
   public static final String CLOUD_CONTEXT = "cloudContext";
+  public static final String FLIGHT_IDS = "flightIds";
 
   private WorkspaceFlightMapKeys() {}
 

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/DeleteWorkspaceStartStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/DeleteWorkspaceStartStep.java
@@ -42,10 +42,7 @@ public class DeleteWorkspaceStartStep implements Step {
             .getWorkingMap()
             .get(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_STATE_CHANGED, Boolean.class);
     if (TRUE.equals(resourceStateChanged)) {
-      workspaceDao.deleteWorkspaceFailure(
-          workspaceUuid,
-          flightContext.getFlightId(),
-          flightContext.getResult().getException().orElse(null));
+      workspaceDao.deleteWorkspaceFailure(workspaceUuid, flightContext.getFlightId());
     }
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/MakeFlightIdsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/MakeFlightIdsStep.java
@@ -32,7 +32,6 @@ public class MakeFlightIdsStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     Map<CloudPlatform, String> flightIds = new HashMap<>();
 
-    // For each cloud context in the workspace, run the cloud context delete flight
     for (CloudPlatform cloudPlatform : workspaceDao.listCloudPlatforms(workspaceUuid)) {
       String flightId = UUID.randomUUID().toString();
       flightIds.put(cloudPlatform, flightId);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/MakeFlightIdsStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/MakeFlightIdsStep.java
@@ -1,0 +1,49 @@
+package bio.terra.workspace.service.workspace.flight.delete.workspace;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generate flight ids and store them in the working map. The ids need to be stable across runs of
+ * the RunDeleteCloudContextFlightStep.
+ */
+public class MakeFlightIdsStep implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(MakeFlightIdsStep.class);
+
+  private final UUID workspaceUuid;
+  private final WorkspaceDao workspaceDao;
+
+  public MakeFlightIdsStep(UUID workspaceUuid, WorkspaceDao workspaceDao) {
+    this.workspaceUuid = workspaceUuid;
+    this.workspaceDao = workspaceDao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Map<CloudPlatform, String> flightIds = new HashMap<>();
+
+    // For each cloud context in the workspace, run the cloud context delete flight
+    for (CloudPlatform cloudPlatform : workspaceDao.listCloudPlatforms(workspaceUuid)) {
+      String flightId = UUID.randomUUID().toString();
+      flightIds.put(cloudPlatform, flightId);
+      logger.info("Made flight id {} for deleting {} cloud context", flightId, cloudPlatform);
+    }
+    context.getWorkingMap().put(WorkspaceFlightMapKeys.FLIGHT_IDS, flightIds);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/RunDeleteCloudContextFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/RunDeleteCloudContextFlightStep.java
@@ -11,10 +11,10 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.DuplicateFlightIdException;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.exception.InternalLogicException;
+import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.common.utils.RetryUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
-import bio.terra.workspace.service.workspace.exceptions.MissingRequiredFieldsException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.delete.cloudcontext.DeleteCloudContextFlight;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
@@ -106,13 +106,9 @@ public class RunDeleteCloudContextFlightStep implements Step {
   }
 
   private String getFlightId(FlightContext context, CloudPlatform cloudPlatform) {
-    // Retrieve our flight id
     Map<CloudPlatform, String> flightIds =
-        context.getWorkingMap().get(WorkspaceFlightMapKeys.FLIGHT_IDS, new TypeReference<>() {});
-    if (flightIds == null) {
-      throw new MissingRequiredFieldsException(
-          "Missing required flight map key: " + WorkspaceFlightMapKeys.FLIGHT_IDS);
-    }
+        FlightUtils.getRequired(
+            context.getWorkingMap(), WorkspaceFlightMapKeys.FLIGHT_IDS, new TypeReference<>() {});
 
     String flightId = flightIds.get(cloudPlatform);
     if (flightId == null) {

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/RunDeleteCloudContextFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/RunDeleteCloudContextFlightStep.java
@@ -10,13 +10,17 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.DuplicateFlightIdException;
 import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.RetryUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
+import bio.terra.workspace.service.workspace.exceptions.MissingRequiredFieldsException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.delete.cloudcontext.DeleteCloudContextFlight;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.Duration;
+import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,17 +36,12 @@ public class RunDeleteCloudContextFlightStep implements Step {
   private final UUID workspaceUuid;
   private final CloudPlatform cloudPlatform;
   private final AuthenticatedUserRequest userRequest;
-  private final String flightId;
 
   public RunDeleteCloudContextFlightStep(
-      UUID workspaceUuid,
-      CloudPlatform cloudPlatform,
-      AuthenticatedUserRequest userRequest,
-      String flightId) {
+      UUID workspaceUuid, CloudPlatform cloudPlatform, AuthenticatedUserRequest userRequest) {
     this.workspaceUuid = workspaceUuid;
     this.cloudPlatform = cloudPlatform;
     this.userRequest = userRequest;
-    this.flightId = flightId;
   }
 
   @Override
@@ -52,6 +51,8 @@ public class RunDeleteCloudContextFlightStep implements Step {
     inputs.put(WorkspaceFlightMapKeys.CLOUD_PLATFORM, cloudPlatform);
     inputs.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), userRequest);
     Stairway stairway = context.getStairway();
+
+    String flightId = getFlightId(context, cloudPlatform);
 
     try {
       stairway.submit(flightId, DeleteCloudContextFlight.class, inputs);
@@ -98,12 +99,26 @@ public class RunDeleteCloudContextFlightStep implements Step {
 
   private boolean flightComplete(FlightState flightState) {
     logger.info(
-        "Delete {} cloud context flight {} state is {}",
-        cloudPlatform,
-        flightId,
-        flightState.getFlightStatus());
+        "Delete {} cloud context state is {}", cloudPlatform, flightState.getFlightStatus());
     return (flightState.getFlightStatus() == FlightStatus.ERROR
         || flightState.getFlightStatus() == FlightStatus.FATAL
         || flightState.getFlightStatus() == FlightStatus.SUCCESS);
+  }
+
+  private String getFlightId(FlightContext context, CloudPlatform cloudPlatform) {
+    // Retrieve our flight id
+    Map<CloudPlatform, String> flightIds =
+        context.getWorkingMap().get(WorkspaceFlightMapKeys.FLIGHT_IDS, new TypeReference<>() {});
+    if (flightIds == null) {
+      throw new MissingRequiredFieldsException(
+          "Missing required flight map key: " + WorkspaceFlightMapKeys.FLIGHT_IDS);
+    }
+
+    String flightId = flightIds.get(cloudPlatform);
+    if (flightId == null) {
+      throw new InternalLogicException(
+          "No flightId generated for cloud platform: " + cloudPlatform);
+    }
+    return flightId;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/WorkspaceDeleteFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/WorkspaceDeleteFlight.java
@@ -46,11 +46,12 @@ public class WorkspaceDeleteFlight extends Flight {
 
     addStep(new DeleteWorkspaceStartStep(workspaceUuid, workspaceDao), dbRetryRule);
 
+    addStep(new MakeFlightIdsStep(workspaceUuid, workspaceDao));
+
     // For each cloud context in the workspace, run the cloud context delete flight
     for (CloudPlatform cloudPlatform : workspaceDao.listCloudPlatforms(workspaceUuid)) {
-      String flightId = UUID.randomUUID().toString();
       addStep(
-          new RunDeleteCloudContextFlightStep(workspaceUuid, cloudPlatform, userRequest, flightId),
+          new RunDeleteCloudContextFlightStep(workspaceUuid, cloudPlatform, userRequest),
           dbRetryRule);
     }
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceUnitTest.java
@@ -48,21 +48,23 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   @MockBean private PolicyValidator mockPolicyValidator;
   @MockBean private WorkspaceActivityLogService mockWorkspaceActivityLogService;
 
-  @Autowired private StateDao stateDao;
   @Autowired private WorkspaceService workspaceService;
 
   @Test
-  void testErrorSerdes() throws Exception {
+  void testErrorSerdes_errorReportExceptionWorks() {
     // Normal case exercising the exception serdes code
     var fex =
         new ForbiddenException(
             "User mnemosyne.ninetynine@gmail.com is not authorized to perform action delete on controlled-application-private-workspace-resource ef5ee667-48f1-4407-8ca1-0efe109591c7");
-    String errorJson = stateDao.normalizeException(fex);
+    String errorJson = StateDao.normalizeException(fex);
 
     var ex = StateDao.deserializeException(errorJson);
     assertEquals(fex.getStatusCode(), ex.getStatusCode());
     assertTrue(StringUtils.contains(ex.getMessage(), fex.getMessage()));
+  }
 
+  @Test
+  void testErrorSerdes_junkExceptionWorks() {
     // Case where junk is in the exception
     var exrex = StateDao.deserializeException("bad bad bad");
     assertTrue(exrex instanceof SerializationException);


### PR DESCRIPTION
My code to serialize and deserialize exceptions on state changes didn't work. This change adds a method of normalizing the exceptions stored. Added another method that tolerate column contents that cannot be deserialized, rather than breaking workspace retrieval altogether.

Also, this removes the ability to set any exception on a workspace delete failure. That shouldn't have been there in the first place.
