### PR TITLE
[WOR-1031] Add AppTraces table for long term storage

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -193,6 +193,7 @@ landingzone:
       - AlertEvidence
       - AlertInfo
       - Anomalies
+      - AppTraces
       - CommonSecurityLog
       - ContainerLog
       - ContainerLogV2


### PR DESCRIPTION
We need the apptraces table present in long term storage for compliance. 