### PR TITLE
Install plotnine library in post-startup script

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -228,6 +228,7 @@ ${RUN_AS_JUPYTER_USER} "pip install --user \
   nbdime \
   nbstripout \
   pandas_gbq \
+  plotnine \
   pre-commit \
   pylint \
   pytest"


### PR DESCRIPTION
[`plotnine`](https://pypi.org/project/plotnine/) is installed by default in CWB. Its absence in VWB makes it difficult to port workspaces from CWB.

Confirmed this works in VWB Primary Clarifier workspace environments.

Fixes [PF-2798](https://broadworkbench.atlassian.net/browse/PF-2798)

[PF-2798]: https://broadworkbench.atlassian.net/browse/PF-2798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ