### PR TITLE
Add content disposition parameter to SAS

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -184,7 +184,7 @@ public class AzureStorageAccessService {
 
     var samUser = samService.getSamUser(userRequest);
     logger.info(
-        "User {} [sub={}] requesting SAS token for Azure storage container {} in workspace {}",
+        "User {} [SubjectId={}] requesting SAS token for Azure storage container {} in workspace {}",
         samUser.getEmail(),
         samUser.getSubjectId(),
         storageContainerUuid.toString(),
@@ -241,7 +241,7 @@ public class AzureStorageAccessService {
             .toUpperCase();
 
     logger.info(
-        "SAS token with expiry time of {} generated for user {} [sub={}] on container {} in workspace {} [sha256 = {}]",
+        "SAS token with expiry time of {} generated for user {} [SubjectId={}] on container {} in workspace {} [sha256 = {}]",
         sasTokenOptions.expiryTime(),
         samUser.getEmail(),
         samUser.getSubjectId(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -182,7 +182,7 @@ public class AzureStorageAccessService {
       SasTokenOptions sasTokenOptions) {
     features.azureEnabledCheck();
 
-    var samUser= samService.getSamUser(userRequest);
+    var samUser = samService.getSamUser(userRequest);
     logger.info(
         "User {} [sub={}] requesting SAS token for Azure storage container {} in workspace {}",
         samUser.getEmail(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -182,12 +182,11 @@ public class AzureStorageAccessService {
       SasTokenOptions sasTokenOptions) {
     features.azureEnabledCheck();
 
-    var userEmail =
-        SamRethrow.onInterrupted(
-            () -> samService.getUserEmailFromSam(userRequest), "getUserEmailFromSam");
+    var samUser= samService.getSamUser(userRequest);
     logger.info(
-        "User {} requesting SAS token for Azure storage container {} in workspace {}",
-        userEmail,
+        "User {} [sub={}] requesting SAS token for Azure storage container {} in workspace {}",
+        samUser.getEmail(),
+        samUser.getSubjectId(),
         storageContainerUuid.toString(),
         workspaceUuid.toString());
 
@@ -214,6 +213,7 @@ public class AzureStorageAccessService {
     BlobServiceSasSignatureValues sasValues =
         new BlobServiceSasSignatureValues(sasTokenOptions.expiryTime(), blobContainerSasPermission)
             .setStartTime(sasTokenOptions.startTime())
+            .setContentDisposition(samUser.getSubjectId())
             .setProtocol(SasProtocol.HTTPS_ONLY);
 
     if (sasTokenOptions.ipRange() != null) {
@@ -241,9 +241,10 @@ public class AzureStorageAccessService {
             .toUpperCase();
 
     logger.info(
-        "SAS token with expiry time of {} generated for user {} on container {} in workspace {} [sha256 = {}]",
+        "SAS token with expiry time of {} generated for user {} [sub={}] on container {} in workspace {} [sha256 = {}]",
         sasTokenOptions.expiryTime(),
-        userEmail,
+        samUser.getEmail(),
+        samUser.getSubjectId(),
         storageContainerUuid,
         workspaceUuid,
         sha256hex);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.exception.ForbiddenException;
+import bio.terra.common.iam.BearerToken;
+import bio.terra.common.iam.SamUser;
 import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureUnitTest;
@@ -65,8 +67,8 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
     var keyProvider = mock(StorageAccountKeyProvider.class);
     var cred = new StorageSharedKeyCredential("fake", "fake");
     when(keyProvider.getStorageAccountKey(any(), any())).thenReturn(cred);
-    when(mockSamService().getUserEmailFromSamAndRethrowOnInterrupt(eq(userRequest)))
-        .thenReturn(userRequest.getEmail());
+    when(mockSamService().getSamUser(eq(userRequest)))
+        .thenReturn(new SamUser("example@example.com", "123ABC", new BearerToken("token")));
     when(mockSamService().getWsmServiceAccountToken()).thenReturn("wsm-token");
     azureStorageAccessService =
         new AzureStorageAccessService(
@@ -482,7 +484,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
                 null));
 
     assertEquals(
-        "9FFE137AEB017B2BBF4E9DD724EEC987A4BE60321C0E54B279F8C558031DDE8B", result.sha256());
+        "AA2137EFE8AC6FE96478DDAA844D917A4472005E3DE3984BF0C6FF641D293AB3", result.sha256());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -129,7 +129,9 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
           "SAS is for a container resource", signedContainerResourceRegex.matcher(sas).find());
     }
     assertThat("SAS grants correct permissions", permissionsRegex.matcher(sas).find());
-    assertThat("SAS contains user subject ID in content dispostion query parameter", contentDispositionRegex.matcher(sas).find());
+    assertThat(
+        "SAS contains user subject ID in content dispostion query parameter",
+        contentDispositionRegex.matcher(sas).find());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -117,6 +117,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
     Pattern signedContainerResourceRegex = Pattern.compile("sr=c&");
     Pattern signedBlobResourceRegex = Pattern.compile("sr=b&");
     Pattern permissionsRegex = Pattern.compile("sp=" + expectedPermissions.toString() + "&");
+    Pattern contentDispositionRegex = Pattern.compile("rscd=" + "123ABC");
 
     assertThat("SAS is https", protocolRegex.matcher(sas).find());
     assertThat("SAS validity starts today", startTimeRegex.matcher(sas).find());
@@ -128,6 +129,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
           "SAS is for a container resource", signedContainerResourceRegex.matcher(sas).find());
     }
     assertThat("SAS grants correct permissions", permissionsRegex.matcher(sas).find());
+    assertThat("SAS contains user subject ID in content dispostion query parameter", contentDispositionRegex.matcher(sas).find());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -67,7 +67,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
     var keyProvider = mock(StorageAccountKeyProvider.class);
     var cred = new StorageSharedKeyCredential("fake", "fake");
     when(keyProvider.getStorageAccountKey(any(), any())).thenReturn(cred);
-    when(mockSamService().getSamUser(eq(userRequest)))
+    when(mockSamService().getSamUser(userRequest))
         .thenReturn(new SamUser("example@example.com", "123ABC", new BearerToken("token")));
     when(mockSamService().getWsmServiceAccountToken()).thenReturn("wsm-token");
     azureStorageAccessService =


### PR DESCRIPTION
[Relevant ticket ](https://broadworkbench.atlassian.net/browse/WOR-1006)

## Why
We would like to more easily tie the storage access logs in Azure together with the WSM logs as captured in GCP. Today that requires a SHA256 from the SAS request (or the corresponding blob log entry in Azure). This works, but is cumbersome. We are going to start including the Sam subject ID in the SAS so we can more easily search for logs related to a particular user in both systems.

## This PR
* Pulls the request user's subject ID from Sam and sets it as the [content disposition value](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.sas.sasqueryparameters.contentdisposition?view=azure-dotnet) when minting a SAS token. This is technically not what the header is for, but given that we do not serve files directly in the browser, instead giving them SAS's and an azcopy cmd, this seems like an acceptable tradeoff.