### PR TITLE
[PF-2788] enforce state

### DIFF
--- a/openapi/src/common/schemas.yaml
+++ b/openapi/src/common/schemas.yaml
@@ -174,6 +174,20 @@ components:
       type: string
       pattern: '^[a-zA-Z0-9][-_a-zA-Z0-9]{0,1023}$'
 
+    OperationState:
+      type: object
+      description: Common operation state properties for cloud context and workspaces
+      required: [ state ]
+      properties:
+        state:
+          $ref: '#/components/schemas/State'
+        errorReport:
+          # Null if the object is not in a broken state
+          $ref: '#/components/schemas/ErrorReport'
+        jobId:
+          # Null if the no WSM operation is running on the object (create, update, delete)
+          type: string
+
     PrivateResourceUser:
       description: >-
         This text describes the target state:

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -837,6 +837,8 @@ components:
           description: The auth domains that the user is missing for this workspace
           items:
             type: string
+        operationState:
+          $ref: '#/components/schemas/OperationState'
 
     WorkspaceDescriptionList:
       type: object

--- a/openapi/src/parts/workspace_cloudcontext.yaml
+++ b/openapi/src/parts/workspace_cloudcontext.yaml
@@ -133,6 +133,8 @@ components:
         projectId:
           description: The ID of the GCP project associated with the workspace.
           type: string
+        operationState:
+          $ref: '#/components/schemas/OperationState'
 
     AzureContext:
       type: object
@@ -147,6 +149,8 @@ components:
         resourceGroupId:
           description: The ID of the Azure resource group associated with the workspace.
           type: string
+        operationState:
+          $ref: '#/components/schemas/OperationState'
 
     AwsContext:
       type: object
@@ -167,6 +171,8 @@ components:
         environmentAlias:
           description: The name of the Terra environment associated with the workspace.
           type: string
+        operationState:
+          $ref: '#/components/schemas/OperationState'
 
     CreateCloudContextRequest:
       type: object

--- a/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/Alpha1ApiController.java
@@ -85,6 +85,7 @@ public class Alpha1ApiController implements Alpha1Api {
             .validateControlledResourceAndAction(
                 userRequest, workspaceId, resourceId, SamControlledResourceActions.WRITE_ACTION)
             .castByEnum(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
+    workspaceService.validateWorkspaceState(workspaceId);
     String jobId =
         controlledResourceService.transferUrlListToGcsBucket(
             userRequest, workspaceId, bucket, body.getManifestFileUrl());

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -47,6 +47,7 @@ import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.AwsCloudContext;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceConstants;
 import com.google.common.base.Strings;
@@ -138,6 +139,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
     ControlledResource awsResource =
         controlledResourceMetadataManager.validateControlledResourceAndAction(
             userRequest, workspaceUuid, resourceUuid, SamControlledResourceActions.DELETE_ACTION);
+    workspaceService.validateWorkspaceAndContextState(workspaceUuid, CloudPlatform.AWS);
 
     // sanity check that resource is of expected type
     if (awsResource.getResourceType() != wsmResourceType) {
@@ -237,6 +239,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
             ControllerValidationUtils.samCreateAction(
                 AccessScopeType.fromApi(body.getCommon().getAccessScope()),
                 ManagedByType.fromApi(body.getCommon().getManagedBy())));
+    workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AWS);
 
     String folderName = body.getAwsS3StorageFolder().getFolderName();
     if (StringUtils.isEmpty(folderName)) {
@@ -392,6 +395,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
             ControllerValidationUtils.samCreateAction(
                 AccessScopeType.fromApi(body.getCommon().getAccessScope()),
                 ManagedByType.fromApi(body.getCommon().getManagedBy())));
+    workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AWS);
 
     InstanceType instanceType =
         InstanceType.fromValue(body.getAwsSageMakerNotebook().getInstanceType());

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -308,8 +308,8 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
       UUID workspaceUuid, ApiCreateControlledAzureBatchPoolRequestBody body) {
     features.azureEnabledCheck();
 
-    final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    final ControlledResourceFields commonFields =
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    ControlledResourceFields commonFields =
         toCommonFields(
             workspaceUuid,
             body.getCommon(),

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -508,9 +508,9 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
       throw new ValidationException(
           "Copying azure storage containers by reference is not supported");
     }
-    workspaceService.validateWorkspaceAndContextState(workspaceUuid, CloudPlatform.GCP);
+    workspaceService.validateWorkspaceAndContextState(workspaceUuid, CloudPlatform.AZURE);
     workspaceService.validateWorkspaceAndContextState(
-        body.getDestinationWorkspaceId(), CloudPlatform.GCP);
+        body.getDestinationWorkspaceId(), CloudPlatform.AZURE);
 
     var jobId =
         controlledResourceService.cloneAzureContainer(

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -37,6 +37,7 @@ import bio.terra.workspace.service.features.FeatureService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceActions;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
@@ -54,6 +55,8 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.Workspace;
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.time.OffsetDateTime;
@@ -123,8 +126,10 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
                 userRequest, workspaceService.getWorkspace(workspaceUuid)),
             userRequest,
             WsmResourceType.CONTROLLED_AZURE_DISK);
-    workspaceService.validateMcWorkspaceAndAction(
-        userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
+    Workspace workspace =
+        workspaceService.validateMcWorkspaceAndAction(
+            userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
+    workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
     ControlledAzureDiskResource resource =
         ControlledAzureDiskResource.builder()
@@ -158,6 +163,13 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
           String sasPermissions,
           String sasBlobName) {
     features.azureEnabledCheck();
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    // You must have at least READ on the workspace to use this method. Actual permissions
+    // are determined below.
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.READ);
+    workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
     ControllerValidationUtils.validateIpAddressRange(sasIpRange);
     AzureUtils.validateSasExpirationDuration(
@@ -173,11 +185,13 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             : azureConfiguration.getSasTokenExpiryTimeMinutesOffset() * 60;
     OffsetDateTime expiryTime = OffsetDateTime.now().plusSeconds(secondDuration);
 
+    // TODO: the access control is buried inside of AzureStorageAccessService. It should be
+    //  here in the controller with the results passed into the method.
     var sasBundle =
         azureControlledStorageResourceService.createAzureStorageContainerSasToken(
             workspaceUuid,
             storageContainerUuid,
-            getAuthenticatedInfo(),
+            userRequest,
             new SasTokenOptions(sasIpRange, startTime, expiryTime, sasBlobName, sasPermissions));
 
     return new ResponseEntity<>(
@@ -202,8 +216,10 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
                 userRequest, workspaceService.getWorkspace(workspaceUuid)),
             userRequest,
             WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
-    workspaceService.validateMcWorkspaceAndAction(
-        userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
+    Workspace workspace =
+        workspaceService.validateMcWorkspaceAndAction(
+            userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
+    workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
     ControlledAzureStorageContainerResource resource =
         ControlledAzureStorageContainerResource.builder()
@@ -239,8 +255,10 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
                 userRequest, workspaceService.getWorkspace(workspaceUuid)),
             userRequest,
             WsmResourceType.CONTROLLED_AZURE_VM);
-    workspaceService.validateMcWorkspaceAndAction(
-        userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
+    Workspace workspace =
+        workspaceService.validateMcWorkspaceAndAction(
+            userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
+    workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
     ResourceValidationUtils.validateApiAzureVmCreationParameters(body.getAzureVm());
     ControlledAzureVmResource resource =
@@ -299,8 +317,10 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
                 userRequest, workspaceService.getWorkspace(workspaceUuid)),
             userRequest,
             WsmResourceType.CONTROLLED_AZURE_BATCH_POOL);
-    workspaceService.validateMcWorkspaceAndAction(
-        userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
+    Workspace workspace =
+        workspaceService.validateMcWorkspaceAndAction(
+            userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
+    workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
     ControlledAzureBatchPoolResource resource =
         ControlledAzureBatchPoolResource.builder()
@@ -344,6 +364,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     controlledResourceMetadataManager.validateControlledResourceAndAction(
         userRequest, workspaceUuid, resourceUuid, SamControlledResourceActions.DELETE_ACTION);
+    workspaceService.validateWorkspaceAndContextState(workspaceUuid, CloudPlatform.AZURE);
 
     logger.info(
         "delete {}({}) from workspace {}",
@@ -442,6 +463,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     controlledResourceMetadataManager.validateControlledResourceAndAction(
         userRequest, workspaceUuid, resourceUuid, SamControlledResourceActions.DELETE_ACTION);
+    workspaceService.validateWorkspaceAndContextState(workspaceUuid, CloudPlatform.AZURE);
     final ApiJobControl jobControl = body.getJobControl();
     logger.info(
         "delete {}({}) from workspace {}",
@@ -486,6 +508,9 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
       throw new ValidationException(
           "Copying azure storage containers by reference is not supported");
     }
+    workspaceService.validateWorkspaceAndContextState(workspaceUuid, CloudPlatform.GCP);
+    workspaceService.validateWorkspaceAndContextState(
+        body.getDestinationWorkspaceId(), CloudPlatform.GCP);
 
     var jobId =
         controlledResourceService.cloneAzureContainer(

--- a/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/FolderApiController.java
@@ -28,6 +28,7 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.logging.WorkspaceActivityLogService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.OperationType;
+import bio.terra.workspace.service.workspace.model.Workspace;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.util.List;
 import java.util.Optional;
@@ -74,8 +75,10 @@ public class FolderApiController extends ControllerBase implements FolderApi {
   public ResponseEntity<ApiFolder> createFolder(
       UUID workspaceUuid, ApiCreateFolderRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(workspace);
     var folderId = UUID.randomUUID();
     Folder folder =
         folderService.createFolder(
@@ -104,8 +107,11 @@ public class FolderApiController extends ControllerBase implements FolderApi {
   public ResponseEntity<ApiFolder> updateFolder(
       UUID workspaceUuid, UUID folderId, ApiUpdateFolderRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(workspace);
+
     Folder folder =
         folderService.updateFolder(
             workspaceUuid,
@@ -157,8 +163,10 @@ public class FolderApiController extends ControllerBase implements FolderApi {
     // If requester is writer and folder has private resources (not owned by requester), requester
     // won't have permission to delete private resources. That access control check is done in
     // folderService#deleteFolder.
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.WRITE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(workspace);
 
     String jobId = folderService.deleteFolder(workspaceUuid, folderId, userRequest);
     ApiJobResult response = jobApiUtils.fetchJobResult(jobId);
@@ -180,8 +188,10 @@ public class FolderApiController extends ControllerBase implements FolderApi {
   public ResponseEntity<Void> updateFolderProperties(
       UUID workspaceUuid, UUID folderUuid, List<ApiProperty> properties) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(workspace);
 
     validatePropertiesUpdateRequestBody(properties);
 
@@ -202,8 +212,11 @@ public class FolderApiController extends ControllerBase implements FolderApi {
       UUID workspaceUuid, UUID folderUuid, List<String> propertyKeys) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     validatePropertiesDeleteRequestBody(propertyKeys);
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(workspace);
+
     folderService.deleteFolderProperties(workspaceUuid, folderUuid, propertyKeys);
     workspaceActivityLogService.writeActivity(
         userRequest,

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -67,6 +67,7 @@ import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject.Refer
 import bio.terra.workspace.service.resource.referenced.model.ReferencedResource;
 import bio.terra.workspace.service.resource.referenced.terra.workspace.ReferencedTerraWorkspaceResource;
 import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.model.Workspace;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.util.Optional;
 import java.util.UUID;
@@ -122,8 +123,11 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<ApiGcpGcsObjectResource> createGcsObjectReference(
       UUID workspaceUuid, @Valid ApiCreateGcpGcsObjectReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
+
     // Construct a ReferenceGcsBucketResource object from the API input
     var resource =
         ReferencedGcsObjectResource.builder()
@@ -177,6 +181,8 @@ public class ReferencedGcpResourceController extends ControllerBase
     ReferencedResource resource =
         referencedResourceService.validateReferencedResourceAndAction(
             userRequest, workspaceUuid, resourceUuid, SamWorkspaceAction.UPDATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspaceUuid);
+
     wsmResourceService.updateResource(
         userRequest,
         resource,
@@ -196,8 +202,11 @@ public class ReferencedGcpResourceController extends ControllerBase
   @Override
   public ResponseEntity<Void> deleteGcsObjectReference(UUID workspaceUuid, UUID resourceUuid) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
+
     referencedResourceService.deleteReferenceResourceForResourceType(
         workspaceUuid, resourceUuid, WsmResourceType.REFERENCED_GCP_GCS_OBJECT, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -209,8 +218,11 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<ApiGcpGcsBucketResource> createBucketReference(
       UUID workspaceUuid, @Valid ApiCreateGcpGcsBucketReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
+
     // Construct a ReferenceGcsBucketResource object from the API input
     var resource =
         ReferencedGcsBucketResource.builder()
@@ -233,7 +245,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   @Override
   public ResponseEntity<ApiGcpGcsBucketResource> getBucketReference(UUID uuid, UUID referenceId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(userRequest, uuid, SamWorkspaceAction.READ);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(userRequest, uuid, SamWorkspaceAction.READ);
+    workspaceService.validateWorkspaceState(workspace);
+
     ReferencedGcsBucketResource referenceResource =
         referencedResourceService
             .getReferenceResource(uuid, referenceId)
@@ -258,8 +273,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<ApiGcpGcsBucketResource> updateBucketReferenceResource(
       UUID workspaceUuid, UUID resourceUuid, ApiUpdateGcsBucketReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.UPDATE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.UPDATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
     ReferencedResource resource =
         referencedResourceService.validateReferencedResourceAndAction(
             userRequest, workspaceUuid, resourceUuid, SamWorkspaceAction.UPDATE_REFERENCE);
@@ -282,8 +299,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   @Override
   public ResponseEntity<Void> deleteBucketReference(UUID workspaceUuid, UUID resourceUuid) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
     referencedResourceService.deleteReferenceResourceForResourceType(
         workspaceUuid, resourceUuid, WsmResourceType.REFERENCED_GCP_GCS_BUCKET, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -295,8 +314,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<ApiGcpBigQueryDataTableResource> createBigQueryDataTableReference(
       UUID workspaceUuid, @Valid ApiCreateGcpBigQueryDataTableReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
     var resource =
         ReferencedBigQueryDataTableResource.builder()
             .wsmResourceFields(
@@ -349,6 +370,7 @@ public class ReferencedGcpResourceController extends ControllerBase
     ReferencedResource resource =
         referencedResourceService.validateReferencedResourceAndAction(
             userRequest, workspaceUuid, resourceUuid, SamWorkspaceAction.UPDATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspaceUuid);
     wsmResourceService.updateResource(
         userRequest,
         resource,
@@ -370,8 +392,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<Void> deleteBigQueryDataTableReference(
       UUID workspaceUuid, UUID resourceUuid) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
     referencedResourceService.deleteReferenceResourceForResourceType(
         workspaceUuid,
         resourceUuid,
@@ -387,8 +411,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<ApiGcpBigQueryDatasetResource> createBigQueryDatasetReference(
       UUID uuid, @Valid ApiCreateGcpBigQueryDatasetReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, uuid, SamWorkspaceAction.CREATE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, uuid, SamWorkspaceAction.CREATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
 
     // Construct a ReferenceBigQueryResource object from the API input
     var resource =
@@ -443,6 +469,7 @@ public class ReferencedGcpResourceController extends ControllerBase
     ReferencedResource resource =
         referencedResourceService.validateReferencedResourceAndAction(
             userRequest, workspaceUuid, resourceUuid, SamWorkspaceAction.UPDATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspaceUuid);
     wsmResourceService.updateResource(
         userRequest,
         resource,
@@ -463,8 +490,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<Void> deleteBigQueryDatasetReference(
       UUID workspaceUuid, UUID resourceUuid) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
     referencedResourceService.deleteReferenceResourceForResourceType(
         workspaceUuid, resourceUuid, WsmResourceType.REFERENCED_GCP_BIG_QUERY_DATASET, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -477,9 +506,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<ApiDataRepoSnapshotResource> createDataRepoSnapshotReference(
       UUID uuid, @Valid ApiCreateDataRepoSnapshotReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, uuid, SamWorkspaceAction.CREATE_REFERENCE);
-
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, uuid, SamWorkspaceAction.CREATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
     var resource =
         ReferencedDataRepoSnapshotResource.builder()
             .wsmResourceFields(
@@ -552,6 +582,7 @@ public class ReferencedGcpResourceController extends ControllerBase
     ReferencedResource resource =
         referencedResourceService.validateReferencedResourceAndAction(
             userRequest, workspaceUuid, resourceUuid, SamWorkspaceAction.UPDATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspaceUuid);
     wsmResourceService.updateResource(
         userRequest,
         resource,
@@ -572,8 +603,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<Void> deleteDataRepoSnapshotReference(
       UUID workspaceUuid, UUID resourceUuid) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
     referencedResourceService.deleteReferenceResourceForResourceType(
         workspaceUuid,
         resourceUuid,
@@ -589,8 +622,11 @@ public class ReferencedGcpResourceController extends ControllerBase
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     // For cloning, we need to check that the caller has both read access to the source workspace
     // and write access to the destination workspace.
-    workspaceService.validateCloneReferenceAction(
-        userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    Workspace workspace =
+        workspaceService.validateCloneReferenceAction(
+            userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    workspaceService.validateWorkspaceState(workspace);
+    workspaceService.validateWorkspaceState(body.getDestinationWorkspaceId());
     // Do this after permission check. If both permission check and this fail, it's better to show
     // permission check error.
     if (body.getCloningInstructions() != null) {
@@ -650,8 +686,11 @@ public class ReferencedGcpResourceController extends ControllerBase
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     // For cloning, we need to check that the caller has both read access to the source workspace
     // and write access to the destination workspace.
-    workspaceService.validateCloneReferenceAction(
-        userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    Workspace workspace =
+        workspaceService.validateCloneReferenceAction(
+            userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    workspaceService.validateWorkspaceState(workspace);
+    workspaceService.validateWorkspaceState(body.getDestinationWorkspaceId());
     // Do this after permission check. If both permission check and this fail, it's better to show
     // permission check error.
     if (body.getCloningInstructions() != null) {
@@ -715,8 +754,12 @@ public class ReferencedGcpResourceController extends ControllerBase
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     // For cloning, we need to check that the caller has both read access to the source workspace
     // and write access to the destination workspace.
-    workspaceService.validateCloneReferenceAction(
-        userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    Workspace workspace =
+        workspaceService.validateCloneReferenceAction(
+            userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    workspaceService.validateWorkspaceState(workspace);
+    workspaceService.validateWorkspaceState(body.getDestinationWorkspaceId());
+
     // Do this after permission check. If both permission check and this fail, it's better to show
     // permission check error.
     if (body.getCloningInstructions() != null) {
@@ -779,8 +822,12 @@ public class ReferencedGcpResourceController extends ControllerBase
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     // For cloning, we need to check that the caller has both read access to the source workspace
     // and write access to the destination workspace.
-    workspaceService.validateCloneReferenceAction(
-        userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    Workspace workspace =
+        workspaceService.validateCloneReferenceAction(
+            userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    workspaceService.validateWorkspaceState(workspace);
+    workspaceService.validateWorkspaceState(body.getDestinationWorkspaceId());
+
     // Do this after permission check. If both permission check and this fail, it's better to show
     // permission check error.
     if (body.getCloningInstructions() != null) {

--- a/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ReferencedGcpResourceController.java
@@ -759,7 +759,6 @@ public class ReferencedGcpResourceController extends ControllerBase
             userRequest, workspaceUuid, body.getDestinationWorkspaceId());
     workspaceService.validateWorkspaceState(workspace);
     workspaceService.validateWorkspaceState(body.getDestinationWorkspaceId());
-
     // Do this after permission check. If both permission check and this fail, it's better to show
     // permission check error.
     if (body.getCloningInstructions() != null) {
@@ -827,7 +826,6 @@ public class ReferencedGcpResourceController extends ControllerBase
             userRequest, workspaceUuid, body.getDestinationWorkspaceId());
     workspaceService.validateWorkspaceState(workspace);
     workspaceService.validateWorkspaceState(body.getDestinationWorkspaceId());
-
     // Do this after permission check. If both permission check and this fail, it's better to show
     // permission check error.
     if (body.getCloningInstructions() != null) {
@@ -893,6 +891,8 @@ public class ReferencedGcpResourceController extends ControllerBase
     // and write access to the destination workspace.
     workspaceService.validateCloneReferenceAction(
         userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    workspaceService.validateWorkspaceState(workspaceUuid);
+    workspaceService.validateWorkspaceState(body.getDestinationWorkspaceId());
     // Do this after permission check. If both permission check and this fail, it's better to show
     // permission check error.
     if (body.getCloningInstructions() != null) {
@@ -951,11 +951,14 @@ public class ReferencedGcpResourceController extends ControllerBase
   @Override
   public ResponseEntity<ApiGitRepoResource> createGitRepoReference(
       UUID workspaceUuid, @Valid ApiCreateGitRepoReferenceRequestBody body) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
+
     // Construct a ReferencedGitRepoResource object from the API input
     validationUtils.validateGitRepoUri(body.getGitrepo().getGitRepoUrl());
-    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
     ReferencedGitRepoResource resource =
         ReferencedGitRepoResource.builder()
             .wsmResourceFields(
@@ -1009,6 +1012,8 @@ public class ReferencedGcpResourceController extends ControllerBase
     ReferencedResource resource =
         referencedResourceService.validateReferencedResourceAndAction(
             userRequest, workspaceUuid, resourceUuid, SamWorkspaceAction.UPDATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspaceUuid);
+
     String gitRepoUrl = body.getGitRepoUrl();
     if (gitRepoUrl != null) {
       validationUtils.validateGitRepoUri(gitRepoUrl);
@@ -1032,8 +1037,11 @@ public class ReferencedGcpResourceController extends ControllerBase
   @Override
   public ResponseEntity<Void> deleteGitRepoReference(UUID workspaceUuid, UUID resourceUuid) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
+
     referencedResourceService.deleteReferenceResourceForResourceType(
         workspaceUuid, resourceUuid, WsmResourceType.REFERENCED_ANY_GIT_REPO, userRequest);
     return new ResponseEntity<>(HttpStatus.OK);
@@ -1048,6 +1056,8 @@ public class ReferencedGcpResourceController extends ControllerBase
     // and write access to the destination workspace.
     workspaceService.validateCloneReferenceAction(
         userRequest, workspaceUuid, body.getDestinationWorkspaceId());
+    workspaceService.validateWorkspaceState(workspaceUuid);
+    workspaceService.validateWorkspaceState(body.getDestinationWorkspaceId());
     // Do this after permission check. If both permission check and this fail, it's better to show
     // permission check error.
     if (body.getCloningInstructions() != null) {
@@ -1106,8 +1116,10 @@ public class ReferencedGcpResourceController extends ControllerBase
   public ResponseEntity<ApiTerraWorkspaceResource> createTerraWorkspaceReference(
       UUID workspaceUuid, @Valid ApiCreateTerraWorkspaceReferenceRequestBody body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.CREATE_REFERENCE);
+    workspaceService.validateWorkspaceState(workspace);
     UUID referencedWorkspaceId = body.getReferencedWorkspace().getReferencedWorkspaceId();
 
     // Will throw if the referenced workspace does not exist or workspace id is null.
@@ -1164,8 +1176,9 @@ public class ReferencedGcpResourceController extends ControllerBase
   @Override
   public ResponseEntity<Void> deleteTerraWorkspaceReference(UUID workspaceUuid, UUID resourceUuid) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.DELETE_REFERENCE);
     referencedResourceService.deleteReferenceResourceForResourceType(
         workspaceUuid, resourceUuid, WsmResourceType.REFERENCED_ANY_TERRA_WORKSPACE, userRequest);
     return new ResponseEntity<>(HttpStatus.OK);

--- a/service/src/main/java/bio/terra/workspace/app/controller/ResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ResourceApiController.java
@@ -28,6 +28,7 @@ import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.model.Workspace;
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.util.List;
@@ -130,9 +131,10 @@ public class ResourceApiController extends ControllerBase implements ResourceApi
   public ResponseEntity<Void> updateResourceProperties(
       UUID workspaceUuid, UUID resourceUuid, List<ApiProperty> properties) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
-
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(workspace);
     validatePropertiesUpdateRequestBody(properties);
     Map<String, String> propertiesMap = convertApiPropertyToMap(properties);
     ResourceValidationUtils.validateProperties(propertiesMap);
@@ -147,8 +149,10 @@ public class ResourceApiController extends ControllerBase implements ResourceApi
       UUID workspaceUuid, UUID resourceUuid, List<String> propertyKeys) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     validatePropertiesDeleteRequestBody(propertyKeys);
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(workspace);
     resourceService.deleteResourceProperties(workspaceUuid, resourceUuid, propertyKeys);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -323,12 +323,12 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     if (body.getUserFacingId() != null) {
       ControllerValidationUtils.validateUserFacingId(body.getUserFacingId());
     }
-    Workspace testWorkspace =
+    Workspace workspace =
         workspaceService.validateWorkspaceAndAction(
             userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
-    workspaceService.validateWorkspaceState(testWorkspace);
+    workspaceService.validateWorkspaceState(workspace);
 
-    Workspace workspace =
+    workspace =
         workspaceService.updateWorkspace(
             workspaceUuid,
             body.getUserFacingId(),

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -415,8 +415,10 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     if (body.getUserFacingId() != null) {
       ControllerValidationUtils.validateUserFacingId(body.getUserFacingId());
     }
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    Workspace testWorkspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(testWorkspace);
 
     Workspace workspace =
         workspaceService.updateWorkspace(
@@ -440,8 +442,10 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
       @RequestBody ApiWsmPolicyUpdateRequest body) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
 
-    workspaceService.validateMcWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.OWN);
+    Workspace workspace =
+        workspaceService.validateMcWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.OWN);
+    workspaceService.validateWorkspaceState(workspace);
 
     features.tpsEnabledCheck();
     TpsPolicyInputs adds = TpsApiConversionUtils.tpsFromApiTpsPolicyInputs(body.getAddAttributes());
@@ -464,6 +468,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     logger.info("Deleting workspace {} for {}", uuid, userRequest.getEmail());
     Workspace workspace =
         workspaceService.validateWorkspaceAndAction(userRequest, uuid, SamWorkspaceAction.DELETE);
+    workspaceService.validateWorkspaceState(workspace);
     workspaceService.deleteWorkspace(workspace, userRequest);
     logger.info("Deleted workspace {} for {}", uuid, userRequest.getEmail());
 
@@ -475,15 +480,14 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
   public ResponseEntity<Void> deleteWorkspaceProperties(
       @PathVariable("workspaceId") UUID workspaceUuid, @RequestBody List<String> propertyKeys) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.DELETE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.DELETE);
+    workspaceService.validateWorkspaceState(workspace);
     validatePropertiesDeleteRequestBody(propertyKeys);
     logger.info("Deleting the properties in workspace {}", workspaceUuid);
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.DELETE);
     workspaceService.deleteWorkspaceProperties(workspaceUuid, propertyKeys, userRequest);
     logger.info("Deleted the properties in workspace {}", workspaceUuid);
-
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -492,8 +496,10 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
   public ResponseEntity<Void> updateWorkspaceProperties(
       @PathVariable("workspaceId") UUID workspaceUuid, @RequestBody List<ApiProperty> properties) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    workspaceService.validateWorkspaceAndAction(
-        userRequest, workspaceUuid, SamWorkspaceAction.WRITE);
+    Workspace workspace =
+        workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(workspace);
     validatePropertiesUpdateRequestBody(properties);
     Map<String, String> propertyMap = convertApiPropertyToMap(properties);
     logger.info("Updating the properties {} in workspace {}", propertyMap, workspaceUuid);
@@ -506,7 +512,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
   @Traced
   @Override
   public ResponseEntity<Void> grantRole(
-      @PathVariable("workspaceId") UUID uuid,
+      @PathVariable("workspaceId") UUID workspaceUuid,
       @PathVariable("role") ApiIamRole role,
       @RequestBody ApiGrantRoleRequestBody body) {
     ControllerValidationUtils.validateEmail(body.getMemberEmail());
@@ -514,15 +520,19 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
       throw new InvalidRoleException(
           "Users cannot grant role APPLICATION. Use application registration instead.");
     }
+    workspaceService.validateWorkspaceState(workspaceUuid);
     // No additional authz check as this is just a wrapper around a Sam endpoint.
     SamRethrow.onInterrupted(
         () ->
             samService.grantWorkspaceRole(
-                uuid, getAuthenticatedInfo(), WsmIamRole.fromApiModel(role), body.getMemberEmail()),
+                workspaceUuid,
+                getAuthenticatedInfo(),
+                WsmIamRole.fromApiModel(role),
+                body.getMemberEmail()),
         "grantWorkspaceRole");
     workspaceActivityLogService.writeActivity(
         getAuthenticatedInfo(),
-        uuid,
+        workspaceUuid,
         OperationType.GRANT_WORKSPACE_ROLE,
         body.getMemberEmail(),
         ActivityLogChangedTarget.USER);
@@ -532,7 +542,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
   @Traced
   @Override
   public ResponseEntity<Void> removeRole(
-      @PathVariable("workspaceId") UUID uuid,
+      @PathVariable("workspaceId") UUID workspaceUuid,
       @PathVariable("role") ApiIamRole role,
       @PathVariable("memberEmail") String memberEmail) {
     ControllerValidationUtils.validateEmail(memberEmail);
@@ -542,7 +552,9 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     }
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     Workspace workspace =
-        workspaceService.validateMcWorkspaceAndAction(userRequest, uuid, SamWorkspaceAction.OWN);
+        workspaceService.validateMcWorkspaceAndAction(
+            userRequest, workspaceUuid, SamWorkspaceAction.OWN);
+    workspaceService.validateWorkspaceState(workspace);
     workspaceService.removeWorkspaceRoleFromUser(
         workspace, WsmIamRole.fromApiModel(role), memberEmail, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -576,6 +588,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     // Authorize creation of context in the workspace
     Workspace workspace =
         workspaceService.validateMcWorkspaceAndAction(userRequest, uuid, SamWorkspaceAction.WRITE);
+    workspaceService.validateWorkspaceState(workspace);
 
     // TODO: PF-2694 REST API part
     //  When we make the REST API changes, the spend profile will come with the create cloud context
@@ -662,7 +675,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     ControllerValidationUtils.validateCloudPlatform(cloudPlatform);
     Workspace workspace =
         workspaceService.validateMcWorkspaceAndAction(userRequest, uuid, SamWorkspaceAction.WRITE);
-
+    workspaceService.validateWorkspaceState(workspace);
     workspaceService.deleteCloudContext(
         workspace, CloudPlatform.fromApiCloudPlatform(cloudPlatform), userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -703,6 +716,7 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     final Workspace sourceWorkspace =
         workspaceService.validateWorkspaceAndAction(
             petRequest, workspaceUuid, SamWorkspaceAction.READ);
+    workspaceService.validateWorkspaceState(sourceWorkspace);
 
     // TODO: PF-2694 REST API part
     //  When we make the REST API changes, the spend profile will come with the source cloud context

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -4,7 +4,6 @@ import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertA
 import static bio.terra.workspace.common.utils.ControllerValidationUtils.validatePropertiesDeleteRequestBody;
 import static bio.terra.workspace.common.utils.ControllerValidationUtils.validatePropertiesUpdateRequestBody;
 
-import bio.terra.common.exception.ErrorReportException;
 import bio.terra.policy.model.TpsComponent;
 import bio.terra.policy.model.TpsObjectType;
 import bio.terra.policy.model.TpsPaoConflict;
@@ -35,15 +34,12 @@ import bio.terra.workspace.generated.model.ApiCreateWorkspaceV2Result;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
 import bio.terra.workspace.generated.model.ApiDeleteCloudContextV2Request;
 import bio.terra.workspace.generated.model.ApiDeleteWorkspaceV2Request;
-import bio.terra.workspace.generated.model.ApiErrorReport;
 import bio.terra.workspace.generated.model.ApiGcpContext;
 import bio.terra.workspace.generated.model.ApiGrantRoleRequestBody;
 import bio.terra.workspace.generated.model.ApiIamRole;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
 import bio.terra.workspace.generated.model.ApiJobResult;
 import bio.terra.workspace.generated.model.ApiMergeCheckRequest;
-import bio.terra.workspace.generated.model.ApiOperationState;
-import bio.terra.workspace.generated.model.ApiProperties;
 import bio.terra.workspace.generated.model.ApiProperty;
 import bio.terra.workspace.generated.model.ApiRegions;
 import bio.terra.workspace.generated.model.ApiRoleBinding;
@@ -52,7 +48,6 @@ import bio.terra.workspace.generated.model.ApiUpdateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescriptionList;
 import bio.terra.workspace.generated.model.ApiWsmPolicyExplainResult;
-import bio.terra.workspace.generated.model.ApiWsmPolicyInput;
 import bio.terra.workspace.generated.model.ApiWsmPolicyMergeCheckResult;
 import bio.terra.workspace.generated.model.ApiWsmPolicyUpdateRequest;
 import bio.terra.workspace.generated.model.ApiWsmPolicyUpdateResult;
@@ -89,7 +84,6 @@ import bio.terra.workspace.service.workspace.model.WorkspaceDescription;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import io.opencensus.contrib.spring.aop.Traced;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -270,92 +264,6 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
                                 workspaceAndHighestRole.missingAuthDomains()))
                     .toList());
     return new ResponseEntity<>(response, HttpStatus.OK);
-  }
-
-  @Traced
-  private ApiWorkspaceDescription buildWorkspaceDescription(
-      Workspace workspace, WsmIamRole highestRole) {
-    return buildWorkspaceDescription(
-        workspace, highestRole, /*missingAuthDomains=*/ Collections.emptyList());
-  }
-
-  @Traced
-  private ApiWorkspaceDescription buildWorkspaceDescription(
-      Workspace workspace, WsmIamRole highestRole, List<String> missingAuthDomains) {
-    UUID workspaceUuid = workspace.getWorkspaceId();
-    ApiGcpContext gcpContext =
-        gcpCloudContextService
-            .getGcpCloudContext(workspaceUuid)
-            .map(GcpCloudContext::toApi)
-            .orElse(null);
-
-    ApiAzureContext azureContext =
-        azureCloudContextService
-            .getAzureCloudContext(workspaceUuid)
-            .map(AzureCloudContext::toApi)
-            .orElse(null);
-
-    ApiAwsContext awsContext =
-        awsCloudContextService
-            .getAwsCloudContext(workspaceUuid)
-            .map(AwsCloudContext::toApi)
-            .orElse(null);
-
-    List<ApiWsmPolicyInput> workspacePolicies = null;
-    if (features.isTpsEnabled()) {
-      tpsApiDispatch.createPaoIfNotExist(workspaceUuid, TpsComponent.WSM, TpsObjectType.WORKSPACE);
-      TpsPaoGetResult workspacePao = tpsApiDispatch.getPao(workspaceUuid);
-      workspacePolicies = TpsApiConversionUtils.apiEffectivePolicyListFromTpsPao(workspacePao);
-    }
-
-    // When we have another cloud context, we will need to do a similar retrieval for it.
-    var lastChangeDetailsOptional =
-        workspaceActivityLogService.getLastUpdatedDetails(workspaceUuid);
-
-    if (highestRole == WsmIamRole.DISCOVERER) {
-      workspace = Workspace.stripWorkspaceForRequesterWithOnlyDiscovererRole(workspace);
-    }
-
-    // Convert the property map to API format
-    ApiProperties apiProperties = convertMapToApiProperties(workspace.getProperties());
-
-    // Construct the operation state
-    var opstate =
-        new ApiOperationState().jobId(workspace.flightId()).state(workspace.state().toApi());
-    ErrorReportException exception = workspace.error();
-    if (exception != null) {
-      opstate.errorReport(
-          new ApiErrorReport()
-              .message(exception.getMessage())
-              .statusCode(exception.getStatusCode().value())
-              .causes(exception.getCauses()));
-    }
-
-    return new ApiWorkspaceDescription()
-        .id(workspaceUuid)
-        .userFacingId(workspace.getUserFacingId())
-        .displayName(workspace.getDisplayName().orElse(null))
-        .description(workspace.getDescription().orElse(null))
-        .highestRole(highestRole.toApiModel())
-        .properties(apiProperties)
-        .spendProfile(workspace.getSpendProfileId().map(SpendProfileId::getId).orElse(null))
-        .stage(workspace.getWorkspaceStage().toApiModel())
-        .gcpContext(gcpContext)
-        .azureContext(azureContext)
-        .awsContext(awsContext)
-        .createdDate(workspace.createdDate())
-        .createdBy(workspace.createdByEmail())
-        .lastUpdatedDate(
-            lastChangeDetailsOptional
-                .map(ActivityLogChangeDetails::changeDate)
-                .orElse(workspace.createdDate()))
-        .lastUpdatedBy(
-            lastChangeDetailsOptional
-                .map(ActivityLogChangeDetails::actorEmail)
-                .orElse(workspace.createdByEmail()))
-        .policies(workspacePolicies)
-        .missingAuthDomains(missingAuthDomains)
-        .operationState(opstate);
   }
 
   @Traced

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -317,7 +317,7 @@ public class AzureStorageAccessService {
       UUID workspaceUuid, UUID storageContainerUuid, AuthenticatedUserRequest userRequest) {
     // Creating an AzureStorageContainerSasToken requires checking the user's access to both the
     // storage container and storage account resource
-    // TODO: Access control checks should be done in the controller layer
+    // TODO: PF-2823 Access control checks should be done in the controller layer
     final ControlledAzureStorageContainerResource storageContainerResource =
         controlledResourceMetadataManager
             .validateControlledResourceAndAction(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -317,6 +317,7 @@ public class AzureStorageAccessService {
       UUID workspaceUuid, UUID storageContainerUuid, AuthenticatedUserRequest userRequest) {
     // Creating an AzureStorageContainerSasToken requires checking the user's access to both the
     // storage container and storage account resource
+    // TODO: Access control checks should be done in the controller layer
     final ControlledAzureStorageContainerResource storageContainerResource =
         controlledResourceMetadataManager
             .validateControlledResourceAndAction(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -35,7 +35,6 @@ import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.spendprofile.SpendProfile;
 import bio.terra.workspace.service.stage.StageService;
 import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
-import bio.terra.workspace.service.workspace.exceptions.DuplicateWorkspaceException;
 import bio.terra.workspace.service.workspace.exceptions.InvalidCloudContextStateException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/AwsCloudContext.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/AwsCloudContext.java
@@ -74,9 +74,13 @@ public class AwsCloudContext implements CloudContext {
     return (T) this;
   }
 
-  // TODO: PF-2770 include the common fields in the API return
   public ApiAwsContext toApi() {
-    return (contextFields == null ? null : contextFields.toApi());
+    var awsContext = new ApiAwsContext();
+    awsContext.operationState(commonFields.toApi());
+    if (contextFields != null) {
+      contextFields.toApi(awsContext);
+    }
+    return awsContext;
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/AwsCloudContextFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/AwsCloudContextFields.java
@@ -53,8 +53,8 @@ public class AwsCloudContextFields {
     return environmentAlias;
   }
 
-  public ApiAwsContext toApi() {
-    return new ApiAwsContext()
+  public void toApi(ApiAwsContext awsContext) {
+    awsContext
         .majorVersion(majorVersion)
         .organizationId(organizationId)
         .accountId(accountId)

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/AzureCloudContext.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/AzureCloudContext.java
@@ -61,9 +61,13 @@ public class AzureCloudContext implements CloudContext {
     return (T) this;
   }
 
-  // TODO: PF-2770 include the common fields in the API return
   public ApiAzureContext toApi() {
-    return (contextFields == null ? null : contextFields.toApi());
+    var azureContext = new ApiAzureContext();
+    azureContext.operationState(commonFields.toApi());
+    if (contextFields != null) {
+      contextFields.toApi(azureContext);
+    }
+    return azureContext;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/AzureCloudContextFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/AzureCloudContextFields.java
@@ -36,8 +36,8 @@ public class AzureCloudContextFields {
     return azureResourceGroupId;
   }
 
-  public ApiAzureContext toApi() {
-    return new ApiAzureContext()
+  public void toApi(ApiAzureContext azureContext) {
+    azureContext
         .tenantId(azureTenantId)
         .subscriptionId(azureSubscriptionId)
         .resourceGroupId(azureResourceGroupId);

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextCommonFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextCommonFields.java
@@ -1,6 +1,8 @@
 package bio.terra.workspace.service.workspace.model;
 
 import bio.terra.common.exception.ErrorReportException;
+import bio.terra.workspace.generated.model.ApiErrorReport;
+import bio.terra.workspace.generated.model.ApiOperationState;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 
@@ -8,4 +10,17 @@ public record CloudContextCommonFields(
     SpendProfileId spendProfileId,
     WsmResourceState state,
     String flightId,
-    ErrorReportException error) {}
+    ErrorReportException error) {
+
+  public ApiOperationState toApi() {
+    var opstate = new ApiOperationState().jobId(flightId).state(state.toApi());
+    if (error != null) {
+      opstate.errorReport(
+          new ApiErrorReport()
+              .message(error().getMessage())
+              .statusCode(error().getStatusCode().value())
+              .causes(error().getCauses()));
+    }
+    return opstate;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/GcpCloudContext.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/GcpCloudContext.java
@@ -71,9 +71,13 @@ public class GcpCloudContext implements CloudContext {
     return (T) this;
   }
 
-  // TODO: PF-2770 include the common fields in the API return
   public ApiGcpContext toApi() {
-    return (contextFields == null ? null : contextFields.toApi());
+    var gcpContext = new ApiGcpContext();
+    gcpContext.operationState(commonFields.toApi());
+    if (contextFields != null) {
+      contextFields.toApi(gcpContext);
+    }
+    return gcpContext;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/GcpCloudContextFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/GcpCloudContextFields.java
@@ -48,8 +48,8 @@ public class GcpCloudContextFields {
     return samPolicyApplication;
   }
 
-  public ApiGcpContext toApi() {
-    return new ApiGcpContext().projectId(gcpProjectId);
+  public void toApi(ApiGcpContext gcpContext) {
+    gcpContext.projectId(gcpProjectId);
   }
 
   public String serialize() {

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
@@ -11,7 +11,11 @@ import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceFields;
 import bio.terra.workspace.service.resource.referenced.cloud.any.datareposnapshot.ReferencedDataRepoSnapshotResource;
+import bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo.ReferencedGitRepoResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable.ReferencedBigQueryDataTableResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.ReferencedGcsBucketResource;
+import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject.ReferencedGcsObjectResource;
 import java.util.Map;
 import java.util.UUID;
 
@@ -46,16 +50,65 @@ public class ReferenceResourceFixtures {
         UUID.randomUUID().toString());
   }
 
+  public static ReferencedGitRepoResource makeGitRepoResource(
+      UUID workspaceUuid, String gitRepoUrl) {
+    UUID resourceId = UUID.randomUUID();
+    String resourceName = "testgitrepo-" + resourceId;
+    return new ReferencedGitRepoResource(
+        makeDefaultWsmResourceFieldBuilder(workspaceUuid)
+            .resourceId(resourceId)
+            .name(resourceName)
+            .build(),
+        gitRepoUrl);
+  }
+
   public static ReferencedBigQueryDatasetResource makeReferencedBqDatasetResource(
       UUID workspaceId, String projectId, String bqDataset) {
     UUID resourceId = UUID.randomUUID();
     return new ReferencedBigQueryDatasetResource(
         makeDefaultWsmResourceFieldBuilder(workspaceId)
             .resourceId(resourceId)
-            .name("testbq-" + resourceId)
+            .name(TestUtils.appendRandomNumber("testbq_"))
             .build(),
         projectId,
         bqDataset);
+  }
+
+  public static ReferencedBigQueryDataTableResource makeReferencedBqDataTableResource(
+      UUID workspaceId, String projectId, String bqDataset, String file) {
+    UUID resourceId = UUID.randomUUID();
+
+    return new ReferencedBigQueryDataTableResource(
+        makeDefaultWsmResourceFieldBuilder(workspaceId)
+            .resourceId(resourceId)
+            .name(TestUtils.appendRandomNumber("testbq_"))
+            .build(),
+        projectId,
+        bqDataset,
+        file);
+  }
+
+  public static ReferencedGcsBucketResource makeReferencedGcsBucketResource(
+      UUID workspaceId, String bucketName) {
+    UUID resourceId = UUID.randomUUID();
+    return new ReferencedGcsBucketResource(
+        makeDefaultWsmResourceFieldBuilder(workspaceId)
+            .resourceId(resourceId)
+            .name(TestUtils.appendRandomNumber("testgcs"))
+            .build(),
+        bucketName);
+  }
+
+  public static ReferencedGcsObjectResource makeReferencedGcsObjectResource(
+      UUID workspaceId, String bucketName, String file) {
+    UUID resourceId = UUID.randomUUID();
+    return new ReferencedGcsObjectResource(
+        makeDefaultWsmResourceFieldBuilder(workspaceId)
+            .resourceId(resourceId)
+            .name(TestUtils.appendRandomNumber("testgcs"))
+            .build(),
+        bucketName,
+        file);
   }
 
   public static ApiReferenceResourceCommonFields makeDefaultReferencedResourceFieldsApi() {

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -228,18 +228,32 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/cloudcontexts/GCP";
   public static final String GET_CLOUD_CONTEXT_PATH_FORMAT =
       "/api/workspaces/v1/%s/cloudcontexts/result/%s";
-  public static final String CREATE_AZURE_IP_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/ip";
   public static final String CREATE_AZURE_DISK_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/disks";
-  public static final String CREATE_AZURE_NETWORK_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/network";
   public static final String CREATE_AZURE_VM_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/vm";
   public static final String CREATE_AZURE_SAS_TOKEN_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/getSasToken";
   public static final String CREATE_AZURE_BATCH_POOL_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/batchpool";
+  public static final String CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer";
+  public static final String AZURE_BATCH_POOL_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/batchpool/%s";
+  public static final String AZURE_DISK_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/disks/%s";
+  public static final String AZURE_STORAGE_CONTAINER_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s";
+  public static final String AZURE_VM_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/vm/%s";
+  public static final String CREATE_AWS_STORAGE_FOLDERS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/aws/storageFolder";
+  public static final String AWS_STORAGE_FOLDERS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/aws/storageFolder/%s";
+  public static final String CREATE_AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/aws/notebook";
+  public static final String AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/aws/notebook/%s";
   public static final String GET_REFERENCED_GCP_GCS_BUCKET_FORMAT =
       "/api/workspaces/v1/%s/resources/referenced/gcp/buckets/%s";
   public static final String CLONE_CONTROLLED_GCP_GCS_BUCKET_FORMAT =
@@ -260,6 +274,8 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/%s/properties";
   public static final String CONTROLLED_GCP_AI_NOTEBOOKS_V1_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/gcp/ai-notebook-instances";
+  public static final String CONTROLLED_GCP_AI_NOTEBOOK_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/ai-notebook-instances/%s";
   public static final String CONTROLLED_GCP_AI_NOTEBOOKS_V1_RESULT_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/gcp/ai-notebook-instances/create-result/%s";
   public static final String CONTROLLED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT =
@@ -819,7 +835,7 @@ public class MockMvcUtils {
             serializedResponse, ApiCreatedControlledGcpAiNotebookInstanceResult.class);
     String jobId = result.getJobReport().getId();
     while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
-      Thread.sleep(/*millis=*/ 5000);
+      TimeUnit.SECONDS.sleep(5);
       result = getAiNotebookInstanceResult(userRequest, workspaceId, jobId);
     }
     assertEquals(jobStatus, result.getJobReport().getStatus());
@@ -2311,7 +2327,7 @@ public class MockMvcUtils {
    * Expect a code when updating, and return the serialized API resource if expected code is
    * successful.
    */
-  private <T> T updateResource(
+  public <T> T updateResource(
       Class<T> classType,
       String pathFormat,
       UUID workspaceId,
@@ -2720,7 +2736,22 @@ public class MockMvcUtils {
         .getContentAsString();
   }
 
-  /** Posts http request and expect error thrown. */
+  /** Patch http request and expect error thrown. */
+  public void patchExpect(
+      AuthenticatedUserRequest userRequest, String request, String api, int httpStatus)
+      throws Exception {
+    mockMvc
+        .perform(
+            addAuth(
+                patch(api)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .content(request),
+                userRequest))
+        .andExpect(status().is(httpStatus));
+  }
+
   public void postExpect(
       AuthenticatedUserRequest userRequest, String request, String api, int httpStatus)
       throws Exception {

--- a/service/src/test/java/bio/terra/workspace/db/FolderDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/FolderDaoTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.db;
 
 import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
-import static bio.terra.workspace.unit.WorkspaceUnitTestUtils.createWorkspaceWithoutGcpContext;
+import static bio.terra.workspace.unit.WorkspaceUnitTestUtils.createWorkspaceWithoutCloudContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -32,7 +32,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void createFolder_returnSameFolder() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder =
         getFolder(
             "foo",
@@ -47,7 +47,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void getFolder_createdDateNotNull() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder =
         getFolder(
             "foo",
@@ -64,7 +64,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void createFolder_duplicateDisplayName_fails() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder = getFolder("foo", workspaceUuid);
     var secondFolder = getFolder("foo", workspaceUuid);
     folderDao.createFolder(folder);
@@ -75,7 +75,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void createFolder_duplicateFolderId_fails() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder = getFolder("foo", workspaceUuid);
     folderDao.createFolder(folder);
 
@@ -84,7 +84,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void createFolder_duplicateName_fails() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder = getFolder("foo", workspaceUuid);
     var secondFolder = getFolder("foo", workspaceUuid);
     folderDao.createFolder(folder);
@@ -95,7 +95,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void createFolder_multipleFoldersAndLayers() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder = getFolder("foo", workspaceUuid);
     var secondFolder = getFolder("bar", workspaceUuid);
 
@@ -112,8 +112,8 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void listFolders_allFoldersInTheSameWorkspaceListed() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
-    UUID secondWorkspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
+    UUID secondWorkspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder = getFolder("foo", workspaceUuid);
     var secondFolder = getFolder("bar", workspaceUuid);
     var thirdFolder = getFolder("foo", secondWorkspaceUuid);
@@ -133,7 +133,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void listFolders_listsSubFolders() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder = getFolder("foo", workspaceUuid);
     // foo/bar
     var secondFolder = getFolder("bar", workspaceUuid, folder.id());
@@ -163,7 +163,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void createFolder_parentFolderNotExist_returnsEmptyList() {
-    UUID workspaceId = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceId = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder = getFolder("foo", workspaceId, UUID.randomUUID());
 
     assertThrows(FolderNotFoundException.class, () -> folderDao.createFolder(folder));
@@ -171,7 +171,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void updateFolder_updatesSuccessfully() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     Folder folder = getFolder("foo", workspaceUuid);
     Folder secondFolder = getFolder("bar", workspaceUuid);
     Folder createdFolder = folderDao.createFolder(folder);
@@ -208,7 +208,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void updateFolderProperties_updatesSuccessfully() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     Folder folder = getFolder("foo", workspaceUuid);
     Folder createdFolder = folderDao.createFolder(folder);
 
@@ -222,7 +222,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void updateFolderProperties_folderDoesNotExist_throwsFolderNotFoundException() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
 
     assertThrows(
         FolderNotFoundException.class,
@@ -233,7 +233,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void updateFolderProperties_noUpdate_throwsMissingRequiredFieldsException() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
 
     assertThrows(
         MissingRequiredFieldsException.class,
@@ -242,7 +242,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void deleteFolderProperties_updatesSuccessfully() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     Folder folder = getFolder("foo", workspaceUuid);
     Folder createdFolder = folderDao.createFolder(folder);
     assertEquals("bar", createdFolder.properties().get("foo"));
@@ -255,7 +255,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void deleteFolderProperties_folderNotExist_throwsFolderNotFoundException() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
 
     assertThrows(
         FolderNotFoundException.class,
@@ -266,7 +266,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void deleteFolderProperties_nothingToDelete_throwsMissingRequiredFieldsException() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
 
     assertThrows(
         MissingRequiredFieldsException.class,
@@ -275,7 +275,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void updateFolder_formCycle_throwsBadRequestException() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     Folder folder = getFolder("foo", workspaceUuid);
     Folder secondFolder = getFolder("bar", workspaceUuid, /*parentFolderId=*/ folder.id());
     Folder thirdFolder = getFolder("garr", workspaceUuid, /*parentFolderId=*/ secondFolder.id());
@@ -334,7 +334,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void updateFolder_duplicateFolderName_throwsException() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     Folder folder = getFolder("foo", workspaceUuid);
     Folder secondFolder = getFolder("bar", workspaceUuid);
     Folder createdFolder = folderDao.createFolder(folder);
@@ -358,7 +358,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void updateFolder_noFieldsAreUpdated_throwMissingFieldsException() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     Folder folder = getFolder("foo", workspaceUuid);
     Folder createdFolder = folderDao.createFolder(folder);
 
@@ -383,7 +383,7 @@ public class FolderDaoTest extends BaseUnitTest {
             folderDao.getFolderRequired(
                 /*workspaceId=*/ UUID.randomUUID(), /*folderId=*/ UUID.randomUUID()));
 
-    UUID workspaceId = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceId = createWorkspaceWithoutCloudContext(workspaceDao);
 
     assertThrows(
         FolderNotFoundException.class,
@@ -392,7 +392,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void deleteFoldersRecursive_subFolderDeleted() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder = getFolder("foo", workspaceUuid);
     // second and third folders are under folder foo.
     var secondFolder = getFolder("bar", workspaceUuid, folder.id());
@@ -411,14 +411,14 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void deleteFoldersRecursive_invalidFolder_nothingIsDeleted() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
 
     assertFalse(folderDao.deleteFoldersRecursive(workspaceUuid, UUID.randomUUID()));
   }
 
   @Test
   public void deleteAllFolders_noFolder_returnsFalse() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
 
     assertFalse(folderDao.deleteAllFolders(workspaceUuid));
   }
@@ -430,7 +430,7 @@ public class FolderDaoTest extends BaseUnitTest {
 
   @Test
   public void deleteAllFolders_allFoldersAreDeletedInTheWorkspace() {
-    UUID workspaceUuid = createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspaceUuid = createWorkspaceWithoutCloudContext(workspaceDao);
     var folder = getFolder("foo", workspaceUuid);
     // second and third folders are under folder foo.
     var secondFolder = getFolder("bar", workspaceUuid, folder.id());

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -152,9 +152,9 @@ class WorkspaceDaoTest extends BaseUnitTest {
 
   @Test
   void getWorkspaceToCloudContextMap_getAllGcpCloudContexts() {
-    UUID workspace1 = WorkspaceUnitTestUtils.createWorkspaceWithoutGcpContext(workspaceDao);
-    UUID workspace2 = WorkspaceUnitTestUtils.createWorkspaceWithoutGcpContext(workspaceDao);
-    UUID workspace3 = WorkspaceUnitTestUtils.createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspace1 = WorkspaceUnitTestUtils.createWorkspaceWithoutCloudContext(workspaceDao);
+    UUID workspace2 = WorkspaceUnitTestUtils.createWorkspaceWithoutCloudContext(workspaceDao);
+    UUID workspace3 = WorkspaceUnitTestUtils.createWorkspaceWithoutCloudContext(workspaceDao);
 
     String project1 = "gcp-project-1";
     String project2 = "gcp-project-2";

--- a/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/JobServiceTest.java
@@ -110,14 +110,14 @@ class JobServiceTest extends BaseUnitTest {
     // The fids list should be in exactly the same order as the database ordered by submit time.
 
     List<String> jobIds1 = new ArrayList<>();
-    UUID workspace1 = WorkspaceUnitTestUtils.createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspace1 = WorkspaceUnitTestUtils.createWorkspaceWithoutCloudContext(workspaceDao);
     for (int i = 0; i < 3; i++) {
       String jobId = runFlight(workspace1, makeDescription(i));
       jobIds1.add(jobId);
     }
 
     List<String> jobIds2 = new ArrayList<>();
-    UUID workspace2 = WorkspaceUnitTestUtils.createWorkspaceWithoutGcpContext(workspaceDao);
+    UUID workspace2 = WorkspaceUnitTestUtils.createWorkspaceWithoutCloudContext(workspaceDao);
 
     for (int i = 0; i < 4; i++) {
       String jobId = runFlight(workspace2, makeDescription(i));

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AnyResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AnyResourceStateFailureTest.java
@@ -1,0 +1,292 @@
+package bio.terra.workspace.service.resource.statetests;
+
+import static bio.terra.workspace.common.fixtures.ReferenceResourceFixtures.makeDefaultReferencedResourceFieldsApi;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_FLEXIBLE_RESOURCES_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_DATA_REPO_SNAPSHOTS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_DATA_REPO_SNAPSHOT_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATA_TABLES_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GIT_REPOS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GIT_REPO_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDataTableReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDatasetReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpGcsBucketReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpGcsObjectReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGitRepoReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiDataRepoSnapshotAttributes;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableAttributes;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetAttributes;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketAttributes;
+import bio.terra.workspace.generated.model.ApiGcpGcsObjectAttributes;
+import bio.terra.workspace.generated.model.ApiGitRepoAttributes;
+import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
+import bio.terra.workspace.generated.model.ApiUpdateBigQueryDataTableReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiUpdateBigQueryDatasetReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiUpdateDataRepoSnapshotReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiUpdateGcsBucketReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiUpdateGitRepoReferenceRequestBody;
+import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class AnyResourceStateFailureTest extends BaseUnitTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired ReferencedResourceService referencedResourceService;
+  @Autowired ResourceDao resourceDao;
+  @Autowired private WorkspaceDao workspaceDao;
+
+  private static final String RESOURCE_NAME = "resourcename";
+  private StateTestUtils stateTestUtils;
+  private ApiReferenceResourceCommonFields refMetadata;
+
+  @BeforeEach
+  void setup() throws Exception {
+    // Construct after the autowiring is done
+    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils);
+
+    // Everything is authorized!
+    when(mockSamService().isAuthorized(any(), any(), any(), any())).thenReturn(true);
+    when(mockSamService().getUserStatusInfo(any()))
+        .thenReturn(
+            new UserStatusInfo()
+                .userEmail(USER_REQUEST.getEmail())
+                .userSubjectId(USER_REQUEST.getSubjectId()));
+    refMetadata = makeDefaultReferencedResourceFieldsApi().name(RESOURCE_NAME);
+  }
+
+  @Test
+  void testNoContextResourceCreateValidation() throws Exception {
+    // Fake up a CREATING workspace
+    Workspace workspace = WorkspaceFixtures.createDefaultMcWorkspace();
+    var flightId = UUID.randomUUID().toString();
+    workspaceDao.createWorkspaceStart(workspace, /* applicationIds */ null, flightId);
+
+    // ANY-Controlled Flexible
+    var flexRequest =
+        mockMvcUtils.createFlexibleResourceRequestBody(
+            RESOURCE_NAME, "terra", "footype", "foodata".getBytes(StandardCharsets.UTF_8));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(flexRequest),
+        CONTROLLED_FLEXIBLE_RESOURCES_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+
+    // ANY-Referenced Data Repo Snapshot
+    ApiCreateDataRepoSnapshotReferenceRequestBody tdrRequest =
+        new ApiCreateDataRepoSnapshotReferenceRequestBody()
+            .metadata(makeDefaultReferencedResourceFieldsApi().name(RESOURCE_NAME))
+            .snapshot(
+                new ApiDataRepoSnapshotAttributes()
+                    .instanceName("terra")
+                    .snapshot("fake-snapshot"));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(tdrRequest),
+        REFERENCED_DATA_REPO_SNAPSHOTS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+
+    // ANY-Referenced Git Repo
+    var gitRequest =
+        new ApiCreateGitRepoReferenceRequestBody()
+            .metadata(makeDefaultReferencedResourceFieldsApi().name(RESOURCE_NAME))
+            .gitrepo(new ApiGitRepoAttributes().gitRepoUrl("fake-url"));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(gitRequest),
+        REFERENCED_GIT_REPOS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+
+    // GCP-Referenced BQ dataset
+    var refBqDatasetRequest =
+        new ApiCreateGcpBigQueryDatasetReferenceRequestBody()
+            .metadata(refMetadata)
+            .dataset(
+                new ApiGcpBigQueryDatasetAttributes()
+                    .projectId("fake-project-id")
+                    .datasetId("fake-dataset"));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(refBqDatasetRequest),
+        REFERENCED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+
+    // GCP-Referenced BQ data table
+    var refBqDataTableRequest =
+        new ApiCreateGcpBigQueryDataTableReferenceRequestBody()
+            .metadata(refMetadata)
+            .dataTable(
+                new ApiGcpBigQueryDataTableAttributes()
+                    .projectId("fake-project-id")
+                    .datasetId("fake-dataset")
+                    .dataTableId("fake-table"));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(refBqDataTableRequest),
+        REFERENCED_GCP_BIG_QUERY_DATA_TABLES_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+
+    // GCP-Referenced Bucket
+    var refBucketRequest =
+        new ApiCreateGcpGcsBucketReferenceRequestBody()
+            .metadata(refMetadata)
+            .bucket(new ApiGcpGcsBucketAttributes().bucketName("fake-bucket"));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(refBucketRequest),
+        REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+
+    // GCP-Referenced Bucket Object
+    var refBucketObjectRequest =
+        new ApiCreateGcpGcsObjectReferenceRequestBody()
+            .metadata(refMetadata)
+            .file(new ApiGcpGcsObjectAttributes().bucketName("fake-bucket").fileName("fake-file"));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(refBucketObjectRequest),
+        REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+  }
+
+  @Test
+  void testNoContextResourceModifyValidation() throws Exception {
+    // Fake up a workspace
+    Workspace workspace = WorkspaceFixtures.createDefaultMcWorkspace();
+    UUID workspaceUuid = workspace.workspaceId();
+    WorkspaceFixtures.createWorkspaceInDb(workspace, workspaceDao);
+
+    // Create fake no-context resources
+
+    // ANY-Controlled Flexible
+    var flexResource =
+        ControlledResourceFixtures.makeDefaultFlexResourceBuilder(workspaceUuid).build();
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, flexResource);
+
+    // ANY-Referenced Data Repo Snapshot
+    var tdrResource = ReferenceResourceFixtures.makeDataRepoSnapshotResource(workspaceUuid);
+    referencedResourceService.createReferenceResource(tdrResource, USER_REQUEST);
+
+    // ANY-Referenced Git Repo
+    var gitResource = ReferenceResourceFixtures.makeGitRepoResource(workspaceUuid, "fake-url");
+    referencedResourceService.createReferenceResource(gitResource, USER_REQUEST);
+
+    // GCP-Referenced BQ dataset
+    var bqResource =
+        ReferenceResourceFixtures.makeReferencedBqDatasetResource(
+            workspaceUuid, "fake-project", "fakedataset");
+    referencedResourceService.createReferenceResource(bqResource, USER_REQUEST);
+
+    // GCP-Referenced BQ data table
+    var bqTable =
+        ReferenceResourceFixtures.makeReferencedBqDataTableResource(
+            workspaceUuid, "fake-project", "fakedataset", "fakefile");
+    referencedResourceService.createReferenceResource(bqTable, USER_REQUEST);
+
+    // GCP-Referenced Bucket
+    var gcsBucket =
+        ReferenceResourceFixtures.makeReferencedGcsBucketResource(workspaceUuid, "fake-bucket");
+    referencedResourceService.createReferenceResource(gcsBucket, USER_REQUEST);
+
+    // GCP-Referenced Bucket Object
+    var gcsObject =
+        ReferenceResourceFixtures.makeReferencedGcsObjectResource(
+            workspaceUuid, "fake-bucket", "fake-file");
+    referencedResourceService.createReferenceResource(gcsObject, USER_REQUEST);
+
+    // Set workspace into deleting state
+    var flightId = UUID.randomUUID().toString();
+    workspaceDao.deleteWorkspaceStart(workspaceUuid, flightId);
+
+    // ANY-Controlled Flexible
+    mockMvcUtils.updateFlexibleResourceExpect(
+        workspaceUuid,
+        flexResource.getResourceId(),
+        null,
+        null,
+        null,
+        null,
+        HttpStatus.SC_CONFLICT);
+    stateTestUtils.deleteResourceExpectConflict(
+        workspaceUuid, flexResource.getResourceId(), REFERENCED_DATA_REPO_SNAPSHOT_V1_PATH_FORMAT);
+
+    // ANY-Referenced Data Repo Snapshot
+    var tdrUpdateRequest = new ApiUpdateDataRepoSnapshotReferenceRequestBody().snapshot("foobar");
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        tdrResource.getResourceId(),
+        REFERENCED_DATA_REPO_SNAPSHOT_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(tdrUpdateRequest));
+    stateTestUtils.deleteResourceExpectConflict(
+        workspaceUuid, tdrResource.getResourceId(), REFERENCED_DATA_REPO_SNAPSHOT_V1_PATH_FORMAT);
+
+    // ANY-Referenced Git Repo
+    var gitUpdateRequest = new ApiUpdateGitRepoReferenceRequestBody().gitRepoUrl("new-fake-url");
+    stateTestUtils.patchResourceExpectConflict(
+        workspaceUuid,
+        gitResource.getResourceId(),
+        REFERENCED_GIT_REPO_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(gitUpdateRequest));
+    stateTestUtils.deleteResourceExpectConflict(
+        workspaceUuid, gitResource.getResourceId(), REFERENCED_GIT_REPO_V1_PATH_FORMAT);
+
+    // GCP-Referenced BQ dataset
+    var bqUpdateRequest = new ApiUpdateBigQueryDatasetReferenceRequestBody().datasetId("foo");
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        bqResource.getResourceId(),
+        REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(bqUpdateRequest));
+    stateTestUtils.deleteResourceExpectConflict(
+        workspaceUuid, bqResource.getResourceId(), REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT);
+
+    // GCP-Referenced BQ data table
+    var bqTableUpdateRequest =
+        new ApiUpdateBigQueryDataTableReferenceRequestBody().datasetId("foo");
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        bqTable.getResourceId(),
+        REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(bqTableUpdateRequest));
+    stateTestUtils.deleteResourceExpectConflict(
+        workspaceUuid, bqTable.getResourceId(), REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT);
+
+    // GCP-Referenced Bucket
+    var bucketUpdateRequest = new ApiUpdateGcsBucketReferenceRequestBody().bucketName("foo");
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        bqResource.getResourceId(),
+        REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(bqTableUpdateRequest));
+    stateTestUtils.deleteResourceExpectConflict(
+        workspaceUuid,
+        bqResource.getResourceId(),
+        REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT);
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AwsResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AwsResourceStateFailureTest.java
@@ -1,0 +1,155 @@
+package bio.terra.workspace.service.resource.statetests;
+
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi;
+import static bio.terra.workspace.common.utils.MockMvcUtils.AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.AWS_STORAGE_FOLDERS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AWS_STORAGE_FOLDERS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.generated.model.ApiAccessScope;
+import bio.terra.workspace.generated.model.ApiAwsS3StorageFolderCreationParameters;
+import bio.terra.workspace.generated.model.ApiAwsSageMakerNotebookCreationParameters;
+import bio.terra.workspace.generated.model.ApiCreateControlledAwsS3StorageFolderRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledAwsSageMakerNotebookRequestBody;
+import bio.terra.workspace.generated.model.ApiDeleteControlledAwsResourceRequestBody;
+import bio.terra.workspace.generated.model.ApiJobControl;
+import bio.terra.workspace.service.features.FeatureService;
+import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class AwsResourceStateFailureTest extends BaseUnitTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired ReferencedResourceService referencedResourceService;
+  @Autowired ResourceDao resourceDao;
+  @Autowired private WorkspaceDao workspaceDao;
+
+  @MockBean FeatureService mockFeatureService;
+
+  private final UUID billingProfileUuid = UUID.randomUUID();
+  private final SpendProfileId billingProfileId = new SpendProfileId(billingProfileUuid.toString());
+  private StateTestUtils stateTestUtils;
+
+  @BeforeEach
+  void setup() throws Exception {
+    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils);
+
+    // Force aws enabled on for unit test
+    when(mockFeatureService.awsEnabled()).thenReturn(true);
+
+    // Everything is authorized!
+    when(mockSamService().isAuthorized(any(), any(), any(), any())).thenReturn(true);
+    when(mockSamService().getUserStatusInfo(any()))
+        .thenReturn(
+            new UserStatusInfo()
+                .userEmail(USER_REQUEST.getEmail())
+                .userSubjectId(USER_REQUEST.getSubjectId()));
+    when(mockSamService().getUserEmailFromSamAndRethrowOnInterrupt(any()))
+        .thenReturn(USER_REQUEST.getEmail());
+  }
+
+  @Test
+  void testAwsContextResourceCreateValidation() throws Exception {
+    // Fake up a READY workspace
+    Workspace workspace = WorkspaceFixtures.createDefaultMcWorkspace(billingProfileId);
+    UUID workspaceUuid = workspace.workspaceId();
+    WorkspaceFixtures.createWorkspaceInDb(workspace, workspaceDao);
+    // Fake up a CREATING cloud context
+    var createContextFlightId = UUID.randomUUID().toString();
+    workspaceDao.createCloudContextStart(
+        workspaceUuid, CloudPlatform.AWS, billingProfileId, createContextFlightId);
+
+    // AWS-storage
+    var storageRequest =
+        new ApiCreateControlledAwsS3StorageFolderRequestBody()
+            .common(makeDefaultControlledResourceFieldsApi())
+            .awsS3StorageFolder(new ApiAwsS3StorageFolderCreationParameters().folderName("foo"));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(storageRequest),
+        CREATE_AWS_STORAGE_FOLDERS_PATH_FORMAT.formatted(workspaceUuid),
+        HttpStatus.SC_CONFLICT);
+
+    // AWS-notebook
+    var vmRequest =
+        new ApiCreateControlledAwsSageMakerNotebookRequestBody()
+            .common(
+                makeDefaultControlledResourceFieldsApi().accessScope(ApiAccessScope.PRIVATE_ACCESS))
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()))
+            .awsSageMakerNotebook(
+                new ApiAwsSageMakerNotebookCreationParameters().instanceName("foo"));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(vmRequest),
+        CREATE_AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT.formatted(workspaceUuid),
+        HttpStatus.SC_CONFLICT);
+  }
+
+  @Test
+  void testAwsResourceModifyValidation() throws Exception {
+    // Fake up a READY workspace and a READY cloud context
+    Workspace workspace = WorkspaceFixtures.createDefaultMcWorkspace(billingProfileId);
+    UUID workspaceUuid = workspace.workspaceId();
+    WorkspaceFixtures.createWorkspaceInDb(workspace, workspaceDao);
+    WorkspaceUnitTestUtils.createAwsCloudContextInDatabase(
+        workspaceDao, workspaceUuid, billingProfileId);
+
+    // Create the resources in the database
+    // AWS-Storage
+    var storageResource =
+        ControlledResourceFixtures.makeDefaultAwsS3StorageFolderResource(workspaceUuid);
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, storageResource);
+
+    // AWS-Notebook
+    var notebookResource =
+        ControlledResourceFixtures.makeDefaultAwsSagemakerNotebookResource(workspaceUuid);
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, notebookResource);
+
+    // Set cloud context info deleting state
+    var flightId = UUID.randomUUID().toString();
+    workspaceDao.deleteCloudContextStart(workspaceUuid, CloudPlatform.AWS, flightId);
+
+    // AWS-Storage
+    var storageDeleteBody =
+        new ApiDeleteControlledAwsResourceRequestBody()
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        storageResource.getResourceId(),
+        AWS_STORAGE_FOLDERS_PATH_FORMAT,
+        objectMapper.writeValueAsString(storageDeleteBody));
+
+    // AWS-Notebook
+    var notebookDeleteBody =
+        new ApiDeleteControlledAwsResourceRequestBody()
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        notebookResource.getResourceId(),
+        AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT,
+        objectMapper.writeValueAsString(notebookDeleteBody));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AzureResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AzureResourceStateFailureTest.java
@@ -1,0 +1,220 @@
+package bio.terra.workspace.service.resource.statetests;
+
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi;
+import static bio.terra.workspace.common.utils.MockMvcUtils.AZURE_BATCH_POOL_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.AZURE_DISK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.AZURE_STORAGE_CONTAINER_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_BATCH_POOL_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_DISK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
+import bio.terra.landingzone.service.landingzone.azure.model.LandingZone;
+import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceBatchPoolFixtures;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.generated.model.ApiCreateControlledAzureBatchPoolRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledAzureDiskRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledAzureStorageContainerRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledAzureVmRequestBody;
+import bio.terra.workspace.generated.model.ApiDeleteControlledAzureResourceRequest;
+import bio.terra.workspace.generated.model.ApiJobControl;
+import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
+import com.azure.core.management.Region;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class AzureResourceStateFailureTest extends BaseUnitTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired ReferencedResourceService referencedResourceService;
+  @Autowired ResourceDao resourceDao;
+  @Autowired private WorkspaceDao workspaceDao;
+
+  @MockBean LandingZoneService mockLandingZoneService;
+
+  private final UUID billingProfileUuid = UUID.randomUUID();
+  private final SpendProfileId billingProfileId = new SpendProfileId(billingProfileUuid.toString());
+  private StateTestUtils stateTestUtils;
+
+  @BeforeEach
+  void setup() throws Exception {
+    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils);
+
+    // Everything is authorized!
+    when(mockSamService().isAuthorized(any(), any(), any(), any())).thenReturn(true);
+    when(mockSamService().getUserStatusInfo(any()))
+        .thenReturn(
+            new UserStatusInfo()
+                .userEmail(USER_REQUEST.getEmail())
+                .userSubjectId(USER_REQUEST.getSubjectId()));
+    when(mockSamService().getUserEmailFromSamAndRethrowOnInterrupt(any()))
+        .thenReturn(USER_REQUEST.getEmail());
+    when(mockLandingZoneService.getLandingZonesByBillingProfile(any(), any()))
+        .thenReturn(
+            List.of(
+                LandingZone.builder()
+                    .landingZoneId(UUID.randomUUID())
+                    .billingProfileId(billingProfileUuid)
+                    .definition("definition")
+                    .version("1")
+                    .createdDate(Instant.now().atOffset(ZoneOffset.UTC))
+                    .build()));
+    when(mockLandingZoneService.getLandingZoneRegion(any(), any()))
+        .thenReturn(Region.GERMANY_CENTRAL.name());
+  }
+
+  @Test
+  void testAzureContextResourceCreateValidation() throws Exception {
+    // Fake up a READY workspace
+    Workspace workspace = WorkspaceFixtures.createDefaultMcWorkspace(billingProfileId);
+    UUID workspaceUuid = workspace.workspaceId();
+    WorkspaceFixtures.createWorkspaceInDb(workspace, workspaceDao);
+    // Fake up a CREATING cloud context
+    var createContextFlightId = UUID.randomUUID().toString();
+    workspaceDao.createCloudContextStart(
+        workspaceUuid, CloudPlatform.AZURE, billingProfileId, createContextFlightId);
+
+    // AZURE-Controlled Batch
+    var batchRequest =
+        new ApiCreateControlledAzureBatchPoolRequestBody()
+            .common(makeDefaultControlledResourceFieldsApi())
+            .azureBatchPool(
+                ControlledResourceBatchPoolFixtures.createBatchPoolWithRequiredParameters());
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(batchRequest),
+        CREATE_AZURE_BATCH_POOL_PATH_FORMAT.formatted(workspaceUuid),
+        HttpStatus.SC_CONFLICT);
+
+    // AZURE-Controlled Disk
+    var diskRequest =
+        new ApiCreateControlledAzureDiskRequestBody()
+            .common(makeDefaultControlledResourceFieldsApi())
+            .azureDisk(ControlledResourceFixtures.getAzureDiskCreationParameters());
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(diskRequest),
+        CREATE_AZURE_DISK_PATH_FORMAT.formatted(workspaceUuid),
+        HttpStatus.SC_CONFLICT);
+
+    // AZURE-Storage Container
+    var storageRequest =
+        new ApiCreateControlledAzureStorageContainerRequestBody()
+            .common(makeDefaultControlledResourceFieldsApi())
+            .azureStorageContainer(
+                ControlledResourceFixtures.getAzureStorageContainerCreationParameters());
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(storageRequest),
+        CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT.formatted(workspaceUuid),
+        HttpStatus.SC_CONFLICT);
+
+    // AZURE-VM
+    var vmRequest =
+        new ApiCreateControlledAzureVmRequestBody()
+            .common(makeDefaultControlledResourceFieldsApi())
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()))
+            .azureVm(ControlledResourceFixtures.getAzureVmCreationParameters());
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(vmRequest),
+        CREATE_AZURE_VM_PATH_FORMAT.formatted(workspaceUuid),
+        HttpStatus.SC_CONFLICT);
+  }
+
+  @Test
+  void testAzureResourceModifyValidation() throws Exception {
+    // Fake up a READY workspace and a READY cloud context
+    Workspace workspace = WorkspaceFixtures.createDefaultMcWorkspace(billingProfileId);
+    UUID workspaceUuid = workspace.workspaceId();
+    WorkspaceFixtures.createWorkspaceInDb(workspace, workspaceDao);
+    WorkspaceUnitTestUtils.createAzureCloudContextInDatabase(
+        workspaceDao, workspaceUuid, billingProfileId);
+
+    // Create the resources in the database
+    // AZURE-Controlled Batch
+    var batchResource = ControlledResourceFixtures.makeDefaultAzureBatchPoolResource(workspaceUuid);
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, batchResource);
+
+    // AZURE-Controlled Disk
+    var diskResource =
+        ControlledResourceFixtures.makeDefaultAzureDiskBuilder(
+                ControlledResourceFixtures.getAzureDiskCreationParameters(), workspaceUuid)
+            .build();
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, diskResource);
+
+    // AZURE-Storage Container
+    var storageResource =
+        ControlledResourceFixtures.makeDefaultAzureStorageContainerResourceBuilder(workspaceUuid)
+            .build();
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, storageResource);
+
+    // AZURE-VM
+    var vmResource = ControlledResourceFixtures.makeAzureVm(workspaceUuid);
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, vmResource);
+
+    // Set cloud context info deleting state
+    var flightId = UUID.randomUUID().toString();
+    workspaceDao.deleteCloudContextStart(workspaceUuid, CloudPlatform.AZURE, flightId);
+
+    // AZURE-Controlled Batch
+    stateTestUtils.deleteResourceExpectConflict(
+        workspaceUuid, batchResource.getResourceId(), AZURE_BATCH_POOL_PATH_FORMAT);
+
+    // AZURE-Controlled Disk
+    var diskDeleteBody =
+        new ApiDeleteControlledAzureResourceRequest()
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        diskResource.getResourceId(),
+        AZURE_DISK_PATH_FORMAT,
+        objectMapper.writeValueAsString(diskDeleteBody));
+
+    // AZURE-Storage Container
+    var storageDeleteBody =
+        new ApiDeleteControlledAzureResourceRequest()
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        storageResource.getResourceId(),
+        AZURE_STORAGE_CONTAINER_PATH_FORMAT,
+        objectMapper.writeValueAsString(storageDeleteBody));
+
+    // AZURE-VM
+    var vmDeleteBody =
+        new ApiDeleteControlledAzureResourceRequest()
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        vmResource.getResourceId(),
+        AZURE_VM_PATH_FORMAT,
+        objectMapper.writeValueAsString(vmDeleteBody));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
@@ -1,0 +1,215 @@
+package bio.terra.workspace.service.resource.statetests;
+
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.defaultNotebookCreationParameters;
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_AI_NOTEBOOKS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_AI_NOTEBOOK_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
+import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.common.utils.TestUtils;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
+import bio.terra.workspace.generated.model.ApiCreateControlledGcpAiNotebookInstanceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledGcpBigQueryDatasetRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledGcpGcsBucketRequestBody;
+import bio.terra.workspace.generated.model.ApiDeleteControlledGcpAiNotebookInstanceRequest;
+import bio.terra.workspace.generated.model.ApiDeleteControlledGcpGcsBucketRequest;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetUpdateParameters;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketUpdateParameters;
+import bio.terra.workspace.generated.model.ApiJobControl;
+import bio.terra.workspace.generated.model.ApiUpdateControlledGcpAiNotebookInstanceRequestBody;
+import bio.terra.workspace.generated.model.ApiUpdateControlledGcpBigQueryDatasetRequestBody;
+import bio.terra.workspace.generated.model.ApiUpdateControlledGcpGcsBucketRequestBody;
+import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
+import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import bio.terra.workspace.unit.WorkspaceUnitTestUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class GcpResourceStateFailureTest extends BaseUnitTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired ReferencedResourceService referencedResourceService;
+  @Autowired ResourceDao resourceDao;
+  @Autowired private WorkspaceDao workspaceDao;
+
+  @MockBean private LandingZoneService mockLandingZoneService;
+
+  private static final String RESOURCE_NAME = "resourcename";
+  private StateTestUtils stateTestUtils;
+
+  @BeforeEach
+  void setup() throws Exception {
+    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils);
+    // Everything is authorized!
+    when(mockSamService().isAuthorized(any(), any(), any(), any())).thenReturn(true);
+    when(mockSamService().getUserStatusInfo(any()))
+        .thenReturn(
+            new UserStatusInfo()
+                .userEmail(USER_REQUEST.getEmail())
+                .userSubjectId(USER_REQUEST.getSubjectId()));
+    when(mockSamService().getUserEmailFromSamAndRethrowOnInterrupt(any()))
+        .thenReturn(USER_REQUEST.getEmail());
+  }
+
+  @Test
+  void testGcpContextResourceCreateValidation() throws Exception {
+    // Fake up a READY workspace
+    Workspace workspace = WorkspaceFixtures.createDefaultMcWorkspace();
+    WorkspaceFixtures.createWorkspaceInDb(workspace, workspaceDao);
+    // Fake up a CREATING cloud context
+    var createContextFlightId = UUID.randomUUID().toString();
+    workspaceDao.createCloudContextStart(
+        workspace.getWorkspaceId(),
+        CloudPlatform.GCP,
+        WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID,
+        createContextFlightId);
+
+    // GCP-Controlled Notebook
+    var notebookRequest =
+        new ApiCreateControlledGcpAiNotebookInstanceRequestBody()
+            .common(
+                makeDefaultControlledResourceFieldsApi()
+                    .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE.toApiModel())
+                    .name(TestUtils.appendRandomNumber("ai-notebook")))
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()))
+            .aiNotebookInstance(
+                defaultNotebookCreationParameters()
+                    .instanceId(TestUtils.appendRandomNumber("instance-id")));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(notebookRequest),
+        CONTROLLED_GCP_AI_NOTEBOOKS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+
+    // GCP-Controlled BigQuery
+    var bqParameters = new ApiGcpBigQueryDatasetCreationParameters().datasetId("fake-dataset");
+    var bqRequest =
+        new ApiCreateControlledGcpBigQueryDatasetRequestBody()
+            .common(makeDefaultControlledResourceFieldsApi().name(RESOURCE_NAME))
+            .dataset(bqParameters);
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(bqRequest),
+        CONTROLLED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+
+    // GCP-Controlled Bucket
+    var bucketRequest =
+        new ApiCreateControlledGcpGcsBucketRequestBody()
+            .common(makeDefaultControlledResourceFieldsApi().name(RESOURCE_NAME))
+            .gcsBucket(new ApiGcpGcsBucketCreationParameters().name("fake-bucket-name"));
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        objectMapper.writeValueAsString(bucketRequest),
+        CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        HttpStatus.SC_CONFLICT);
+  }
+
+  @Test
+  void testGcpResourceModifyValidation() throws Exception {
+    // Fake up a READY workspace and a READY cloud context
+    UUID workspaceUuid = WorkspaceUnitTestUtils.createWorkspaceWithGcpContext(workspaceDao);
+
+    // Create the resources in the database
+    // GCP-Controlled Notebook
+    var notebookResource =
+        ControlledResourceFixtures.makeDefaultAiNotebookInstance(workspaceUuid).build();
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, notebookResource);
+
+    // GCP-Controlled BigQuery
+    var bqResource =
+        ControlledResourceFixtures.makeDefaultControlledBqDatasetBuilder(workspaceUuid).build();
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, bqResource);
+
+    // GCP-Controlled Bucket
+    var bucketResource =
+        ControlledResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceUuid).build();
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, bucketResource);
+
+    // Set cloud context info deleting state
+    var flightId = UUID.randomUUID().toString();
+    workspaceDao.deleteCloudContextStart(workspaceUuid, CloudPlatform.GCP, flightId);
+
+    // GCP-Controlled Notebook
+    var notebookRequestBody =
+        new ApiUpdateControlledGcpAiNotebookInstanceRequestBody().name("foobar");
+    stateTestUtils.updateControlledResource(
+        ApiGcpBigQueryDatasetResource.class,
+        workspaceUuid,
+        notebookResource.getResourceId(),
+        CONTROLLED_GCP_AI_NOTEBOOK_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(notebookRequestBody));
+    var notebookDeleteBody =
+        new ApiDeleteControlledGcpAiNotebookInstanceRequest()
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        notebookResource.getResourceId(),
+        CONTROLLED_GCP_AI_NOTEBOOK_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(notebookDeleteBody));
+
+    // GCP-Controlled BigQuery
+    var bqRequestBody =
+        new ApiUpdateControlledGcpBigQueryDatasetRequestBody()
+            .updateParameters(
+                new ApiGcpBigQueryDatasetUpdateParameters()
+                    .cloningInstructions(ApiCloningInstructionsEnum.RESOURCE));
+    stateTestUtils.updateControlledResource(
+        ApiGcpBigQueryDatasetResource.class,
+        workspaceUuid,
+        bqResource.getResourceId(),
+        CONTROLLED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(bqRequestBody));
+    stateTestUtils.deleteResourceExpectConflict(
+        workspaceUuid, bqResource.getResourceId(), CONTROLLED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT);
+
+    // GCP-Controlled bucket
+    var bucketRequestBody =
+        new ApiUpdateControlledGcpGcsBucketRequestBody()
+            .updateParameters(
+                new ApiGcpGcsBucketUpdateParameters()
+                    .cloningInstructions(ApiCloningInstructionsEnum.RESOURCE));
+    stateTestUtils.updateControlledResource(
+        ApiGcpGcsBucketResource.class,
+        workspaceUuid,
+        bucketResource.getResourceId(),
+        CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(bucketRequestBody));
+    var bucketDeleteBody =
+        new ApiDeleteControlledGcpGcsBucketRequest()
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    stateTestUtils.postResourceExpectConflict(
+        workspaceUuid,
+        notebookResource.getResourceId(),
+        CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT,
+        objectMapper.writeValueAsString(bucketDeleteBody));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/StateTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/StateTestUtils.java
@@ -1,0 +1,63 @@
+package bio.terra.workspace.service.resource.statetests;
+
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.workspace.common.utils.MockMvcUtils;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class StateTestUtils {
+  private final MockMvc mockMvc;
+  private final MockMvcUtils mockMvcUtils;
+
+  public StateTestUtils(MockMvc mockMvc, MockMvcUtils mockMvcUtils) {
+    this.mockMvc = mockMvc;
+    this.mockMvcUtils = mockMvcUtils;
+  }
+
+  void patchResourceExpectConflict(
+      UUID workspaceId, UUID resourceId, String pathFormat, String request) throws Exception {
+    mockMvcUtils.patchExpect(
+        USER_REQUEST,
+        request,
+        pathFormat.formatted(workspaceId, resourceId),
+        HttpStatus.SC_CONFLICT);
+  }
+
+  void postResourceExpectConflict(
+      UUID workspaceId, UUID resourceId, String pathFormat, String request) throws Exception {
+    mockMvcUtils.postExpect(
+        USER_REQUEST,
+        request,
+        pathFormat.formatted(workspaceId, resourceId),
+        HttpStatus.SC_CONFLICT);
+  }
+
+  void deleteResourceExpectConflict(UUID workspaceId, UUID resourceId, String pathFormat)
+      throws Exception {
+    mockMvc
+        .perform(
+            MockMvcUtils.addAuth(
+                delete(String.format(pathFormat, workspaceId, resourceId)), USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_CONFLICT));
+  }
+
+  void createControlledResourceInDb(WsmResource resource, ResourceDao resourceDao) {
+    // insertControlledResourceRow
+    String flightId = UUID.randomUUID().toString();
+    resourceDao.createResourceStart(resource, flightId);
+    resourceDao.createResourceSuccess(resource, flightId);
+  }
+
+  <T> void updateControlledResource(
+      Class<T> clazz, UUID workspaceUuid, UUID resourceId, String pathFormat, String body)
+      throws Exception {
+    mockMvcUtils.updateResource(
+        clazz, pathFormat, workspaceUuid, resourceId, body, USER_REQUEST, HttpStatus.SC_CONFLICT);
+  }
+}


### PR DESCRIPTION
This PR includes two things:
1. Exposes cloud context and workspace state information (state, flightid, error) through the REST API.
2. Validates workspace and cloud context state in the controller layer.

I made a unit tests to verify the state validation in the controller. As resources and/or update operations on existing resources are added, they will need to include appropriate state validation and get added to those tests.

FYI: @dexamundsen @aherbst-broad 