### PR TITLE
Add update endpoints for aws s3 storage folder + sagemaker notebook

### DIFF
--- a/openapi/src/parts/controlled_aws_s3_storage_folder.yaml
+++ b/openapi/src/parts/controlled_aws_s3_storage_folder.yaml
@@ -62,6 +62,25 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+    patch:
+      summary: Update a controlled AWS S3 Storage resource.
+      operationId: updateAwsS3StorageFolder
+      tags: [ ControlledAwsResource ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateControlledAwsS3StorageFolderRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/UpdateControlledAwsS3StorageFolderResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
     post:
       summary: | 
         Delete a controlled AWS S3 Storage resource. This is async, because the 
@@ -171,6 +190,17 @@ components:
         awsS3StorageFolder:
           $ref: '#/components/schemas/AwsS3StorageFolderResource'
 
+    UpdateControlledAwsS3StorageFolderRequestBody:
+      type: object
+      description: Update an AWS S3 Storage folder's metadata.
+      properties:
+        name:
+          description: Optional. New name to give to this resource. The resource name will not be updated if this is omitted.
+          type: string
+        description:
+          description: Optional. New description to give to this resource. The resource description will not be updated if this is omitted.
+          type: string
+
   responses:
     CreateControlledAwsS3StorageFolderResponse:
       description: Response to create controlled AWS S3 Storage Folder resource.
@@ -181,6 +211,13 @@ components:
 
     GetControlledAwsS3StorageFolderResponse:
       description: Response to get AWS S3 Storage Folder resource.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AwsS3StorageFolderResource'
+
+    UpdateControlledAwsS3StorageFolderResponse:
+      description: Response for an AWS S3 Storage Folder update.
       content:
         application/json:
           schema:

--- a/openapi/src/parts/controlled_aws_s3_storage_folder.yaml
+++ b/openapi/src/parts/controlled_aws_s3_storage_folder.yaml
@@ -79,6 +79,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     post:

--- a/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
+++ b/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
@@ -105,6 +105,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     post:

--- a/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
+++ b/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
@@ -88,6 +88,25 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+    patch:
+      summary: Update a controlled AWS SageMaker Notebook resource.
+      operationId: updateAwsSageMakerNotebook
+      tags: [ ControlledAwsResource ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateControlledAwsSageMakerNotebookRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/UpdateControlledAwsSageMakerNotebookResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
     post:
       summary: |
         Delete a controlled AWS SageMaker Notebook resource. This is async, because the 
@@ -202,6 +221,17 @@ components:
         awsSageMakerNotebook:
           $ref: '#/components/schemas/AwsSageMakerNotebookResource'
 
+    UpdateControlledAwsSageMakerNotebookRequestBody:
+      type: object
+      description: Update an AWS SageMaker Notebook resource's metadata.
+      properties:
+        name:
+          description: Optional. New name to give to this resource. The resource name will not be updated if this is omitted.
+          type: string
+        description:
+          description: Optional. New description to give to this resource. The resource description will not be updated if this is omitted.
+          type: string
+
   responses:
     CreateControlledAwsSageMakerNotebookResponse:
       description: Response to create controlled AWS SageMaker Notebook instance resource.
@@ -212,6 +242,13 @@ components:
 
     GetControlledAwsSageMakerNotebookResponse:
       description: Response to get AWS SageMaker Notebook resource.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AwsSageMakerNotebookResource'
+
+    UpdateControlledAwsSageMakerNotebookResponse:
+      description: Response for an AWS SageMaker Notebook update.
       content:
         application/json:
           schema:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -23,6 +23,7 @@ import bio.terra.workspace.generated.model.ApiDeleteControlledAwsResourceResult;
 import bio.terra.workspace.generated.model.ApiGenerateAwsResourceCloudNameRequestBody;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport;
+import bio.terra.workspace.generated.model.ApiUpdateControlledAwsS3StorageFolderRequestBody;
 import bio.terra.workspace.service.features.FeatureService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
@@ -32,6 +33,7 @@ import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceA
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.AwsResourceValidationUtils;
+import bio.terra.workspace.service.resource.WsmResourceService;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.aws.AwsResourceConstants;
@@ -43,6 +45,7 @@ import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
+import bio.terra.workspace.service.resource.model.CommonUpdateParameters;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
@@ -77,6 +80,8 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
 
   private final Logger logger = LoggerFactory.getLogger(ControlledAwsResourceApiController.class);
 
+  private final WsmResourceService wsmResourceService;
+
   private final AwsCloudContextService awsCloudContextService;
 
   @Autowired
@@ -91,6 +96,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
       ControlledResourceService controlledResourceService,
       ControlledResourceMetadataManager controlledResourceMetadataManager,
       WorkspaceService workspaceService,
+      WsmResourceService wsmResourceService,
       AwsCloudContextService awsCloudContextService) {
     super(
         authenticatedUserRequestFactory,
@@ -103,6 +109,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
         controlledResourceService,
         controlledResourceMetadataManager,
         workspaceService);
+    this.wsmResourceService = wsmResourceService;
     this.awsCloudContextService = awsCloudContextService;
   }
 
@@ -314,6 +321,41 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
                 SamConstants.SamControlledResourceActions.READ_ACTION)
             .castByEnum(WsmResourceType.CONTROLLED_AWS_S3_STORAGE_FOLDER);
     return new ResponseEntity<>(resource.toApiResource(), HttpStatus.OK);
+  }
+
+  @Traced
+  @Override
+  public ResponseEntity<ApiAwsS3StorageFolderResource> updateAwsS3StorageFolder(
+      UUID workspaceUuid,
+      UUID resourceUuid,
+      @Valid ApiUpdateControlledAwsS3StorageFolderRequestBody body) {
+    logger.info(
+        "Updating AWS S3 Storage Folder resourceId {} workspaceUuid {}",
+        resourceUuid,
+        workspaceUuid);
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    workspaceService.validateWorkspaceAndContextState(workspaceUuid, CloudPlatform.AWS);
+
+    ControlledAwsS3StorageFolderResource resource =
+        controlledResourceMetadataManager
+            .validateControlledResourceAndAction(
+                userRequest,
+                workspaceUuid,
+                resourceUuid,
+                SamConstants.SamControlledResourceActions.READ_ACTION)
+            .castByEnum(WsmResourceType.CONTROLLED_AWS_S3_STORAGE_FOLDER);
+
+    CommonUpdateParameters commonUpdateParameters =
+        new CommonUpdateParameters().setName(body.getName()).setDescription(body.getDescription());
+
+    wsmResourceService.updateResource(userRequest, resource, commonUpdateParameters, null);
+
+    ControlledAwsS3StorageFolderResource updatedResource =
+        controlledResourceService
+            .getControlledResource(workspaceUuid, resourceUuid)
+            .castByEnum(WsmResourceType.CONTROLLED_AWS_S3_STORAGE_FOLDER);
+
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Traced

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -562,7 +562,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
     ControlledAwsSageMakerNotebookResource updatedResource =
         controlledResourceService
             .getControlledResource(workspaceUuid, resourceUuid)
-            .castByEnum(WsmResourceType.CONTROLLED_AWS_S3_STORAGE_FOLDER);
+            .castByEnum(WsmResourceType.CONTROLLED_AWS_SAGEMAKER_NOTEBOOK);
 
     return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -24,6 +24,7 @@ import bio.terra.workspace.generated.model.ApiGenerateAwsResourceCloudNameReques
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.generated.model.ApiUpdateControlledAwsS3StorageFolderRequestBody;
+import bio.terra.workspace.generated.model.ApiUpdateControlledAwsSageMakerNotebookRequestBody;
 import bio.terra.workspace.service.features.FeatureService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
@@ -342,7 +343,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
                 userRequest,
                 workspaceUuid,
                 resourceUuid,
-                SamConstants.SamControlledResourceActions.READ_ACTION)
+                SamConstants.SamControlledResourceActions.EDIT_ACTION)
             .castByEnum(WsmResourceType.CONTROLLED_AWS_S3_STORAGE_FOLDER);
 
     CommonUpdateParameters commonUpdateParameters =
@@ -529,6 +530,41 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
                 SamConstants.SamControlledResourceActions.READ_ACTION)
             .castByEnum(WsmResourceType.CONTROLLED_AWS_SAGEMAKER_NOTEBOOK);
     return new ResponseEntity<>(resource.toApiResource(), HttpStatus.OK);
+  }
+
+  @Traced
+  @Override
+  public ResponseEntity<ApiAwsSageMakerNotebookResource> updateAwsSageMakerNotebook(
+      UUID workspaceUuid,
+      UUID resourceUuid,
+      @Valid ApiUpdateControlledAwsSageMakerNotebookRequestBody body) {
+    logger.info(
+        "Updating AWS SageMaker Notebook resourceId {} workspaceUuid {}",
+        resourceUuid,
+        workspaceUuid);
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    workspaceService.validateWorkspaceAndContextState(workspaceUuid, CloudPlatform.AWS);
+
+    ControlledAwsSageMakerNotebookResource resource =
+        controlledResourceMetadataManager
+            .validateControlledResourceAndAction(
+                userRequest,
+                workspaceUuid,
+                resourceUuid,
+                SamConstants.SamControlledResourceActions.EDIT_ACTION)
+            .castByEnum(WsmResourceType.CONTROLLED_AWS_SAGEMAKER_NOTEBOOK);
+
+    CommonUpdateParameters commonUpdateParameters =
+        new CommonUpdateParameters().setName(body.getName()).setDescription(body.getDescription());
+
+    wsmResourceService.updateResource(userRequest, resource, commonUpdateParameters, null);
+
+    ControlledAwsSageMakerNotebookResource updatedResource =
+        controlledResourceService
+            .getControlledResource(workspaceUuid, resourceUuid)
+            .castByEnum(WsmResourceType.CONTROLLED_AWS_S3_STORAGE_FOLDER);
+
+    return new ResponseEntity<>(updatedResource.toApiResource(), HttpStatus.OK);
   }
 
   @Traced

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
@@ -153,8 +153,7 @@ public class ControlledAwsS3StorageFolderResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public void addUpdateSteps(UpdateResourceFlight flight, FlightBeanBag flightBeanBag) {
-    // TODO(TERRA-315) Add support for UpdateAwsS3StorageFolder
-    throw new ApiException("addUpdateSteps NotImplemented");
+    // TODO(TERRA-315) Determine if we need to support updating the storage folder prefix
   }
 
   public ApiAwsS3StorageFolderAttributes toApiAttributes() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.aws.s3StorageFolder;
 
-import bio.terra.common.exception.ApiException;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.stairway.RetryRule;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.aws.sageMakerNotebook;
 
-import bio.terra.common.exception.ApiException;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.stairway.RetryRule;
@@ -131,15 +130,15 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
       String petSaEmail,
       AuthenticatedUserRequest userRequest,
       FlightBeanBag flightBeanBag) {
-    // RetryRule cloudRetry = RetryRules.cloud();
-    // flight.addStep(
-    //     new CreateAwsSageMakerNotebookStep(
-    //         this,
-    //         flightBeanBag.getAwsCloudContextService(),
-    //         userRequest,
-    //         flightBeanBag.getSamService(),
-    //         flightBeanBag.getCliConfiguration()),
-    //     cloudRetry);
+    RetryRule cloudRetry = RetryRules.cloud();
+    flight.addStep(
+        new CreateAwsSageMakerNotebookStep(
+            this,
+            flightBeanBag.getAwsCloudContextService(),
+            userRequest,
+            flightBeanBag.getSamService(),
+            flightBeanBag.getCliConfiguration()),
+        cloudRetry);
   }
 
   /** {@inheritDoc} */

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
@@ -131,15 +131,15 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
       String petSaEmail,
       AuthenticatedUserRequest userRequest,
       FlightBeanBag flightBeanBag) {
-    RetryRule cloudRetry = RetryRules.cloud();
-    flight.addStep(
-        new CreateAwsSageMakerNotebookStep(
-            this,
-            flightBeanBag.getAwsCloudContextService(),
-            userRequest,
-            flightBeanBag.getSamService(),
-            flightBeanBag.getCliConfiguration()),
-        cloudRetry);
+    // RetryRule cloudRetry = RetryRules.cloud();
+    // flight.addStep(
+    //     new CreateAwsSageMakerNotebookStep(
+    //         this,
+    //         flightBeanBag.getAwsCloudContextService(),
+    //         userRequest,
+    //         flightBeanBag.getSamService(),
+    //         flightBeanBag.getCliConfiguration()),
+    //     cloudRetry);
   }
 
   /** {@inheritDoc} */
@@ -169,8 +169,7 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
   /** {@inheritDoc} */
   @Override
   public void addUpdateSteps(UpdateResourceFlight flight, FlightBeanBag flightBeanBag) {
-    // TODO(TERRA-223) Add support for UpdateAwsSageMakerNotebook
-    throw new ApiException("addUpdateSteps NotImplemented");
+    // TODO(TERRA-223) Add support for updating cloud metadata for sagemaker notebooks
   }
 
   public ApiAwsSageMakerNotebookAttributes toApiAttributes() {


### PR DESCRIPTION
For s3 storage folders and sagemaker notebook resources:
- Add update endpoints to swagger
- Add update controller method that calls update resource flights with just common update parameters (name, description)
- Remove error throw from s3 folder and sagemaker resource `updateSteps`
- leaving `updateSteps` todos up if/when we need to add cloud resource update steps.

Since these endpoints only call the shared update resource flight without any additional steps, how would we test?

Tested locally:
PATCH `/api/workspaces/v1/[workspaceId]/resources/controlled/aws/storageFolder/[resourceid]`
```
request body:
{
	"name": "new-aws-storage-folder",
	"description": "testing description"
}

response body:
{
	"metadata": {
		"workspaceId": "0d9d305a-bb09-4da0-a3d6-95d0d448a810",
		"resourceId": "4560983c-685e-4abc-9270-cd7c13fcb977",
		"name": "new-aws-storage-folder",
		"description": "testing description",
		"resourceType": "AWS_S3_STORAGE_FOLDER",
		"stewardshipType": "CONTROLLED",
		"cloudPlatform": "AWS",
		"cloningInstructions": "COPY_NOTHING",
		"controlledResourceMetadata": {
			"accessScope": "SHARED_ACCESS",
			"managedBy": "USER",
			"privateResourceUser": {},
			"privateResourceState": "NOT_APPLICABLE",
			"region": "us-east-1"
		},
		"resourceLineage": [],
		"properties": [],
		"createdBy": "rogerwangcs@google.com",
		"createdDate": "2023-06-07T21:06:07.669941Z",
		"lastUpdatedBy": "rogerwangcs@google.com",
		"lastUpdatedDate": "2023-06-08T12:52:43.66046Z",
		"state": "READY"
	},
	"attributes": {
		"bucketName": "v0-saas-devel-us-east-1-terra",
		"prefix": "test-update-storage-folder-0"
	}
}
```

PATCH `/api/workspaces/v1/[workspaceId]/resources/controlled/aws/storageFolder/[resourceid]`
```
request body:
{
	"name": "new-sagemaker-notebook-name",
	"description": "testing"
}

response body:
{
	"metadata": {
		"workspaceId": "0d9d305a-bb09-4da0-a3d6-95d0d448a810",
		"resourceId": "d14c9bc8-cf1e-4963-b602-fc748e9462ca",
		"name": "new-sagemaker-notebook-name",
		"description": "testing",
		"resourceType": "AWS_SAGEMAKER_NOTEBOOK",
		"stewardshipType": "CONTROLLED",
		"cloudPlatform": "AWS",
		"cloningInstructions": "COPY_NOTHING",
		"controlledResourceMetadata": {
			"accessScope": "PRIVATE_ACCESS",
			"managedBy": "USER",
			"privateResourceUser": {
				"userName": "rogerwangcs@google.com"
			},
			"privateResourceState": "ACTIVE",
			"region": "us-east-1"
		},
		"resourceLineage": [],
		"properties": [],
		"createdBy": "rogerwangcs@google.com",
		"createdDate": "2023-06-08T13:43:22.921959Z",
		"lastUpdatedBy": "rogerwangcs@google.com",
		"lastUpdatedDate": "2023-06-08T14:07:37.64493Z",
		"state": "READY"
	},
	"attributes": {
		"instanceName": "test-sagemaker-nb-update",
		"instanceType": "ml.t2.medium"
	}
}
```