### PR TITLE
[PF-2825] Fix resource clone state checks and test

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
@@ -251,8 +251,8 @@ public class ControlledFlexibleResourceApiController extends ControlledResourceC
         new ApiCloneControlledFlexibleResourceResult()
             .resource(clonedFlexResource.toApiResource())
             .effectiveCloningInstructions(cloningInstructions.toApiModel())
-            .sourceWorkspaceId(resourceUuid)
-            .sourceResourceId(workspaceUuid);
+            .sourceWorkspaceId(workspaceUuid)
+            .sourceResourceId(resourceUuid);
 
     return new ResponseEntity<>(result, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
@@ -23,16 +23,15 @@ import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadat
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource.ControlledFlexibleResource;
 import bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource.FlexResourceCreationParameters;
-import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.CommonUpdateParameters;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import io.opencensus.contrib.spring.aop.Traced;
-import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -210,39 +209,29 @@ public class ControlledFlexibleResourceApiController extends ControlledResourceC
       UUID workspaceUuid,
       UUID resourceUuid,
       @Valid ApiCloneControlledFlexibleResourceRequest body) {
+    logger.info(
+        "Cloning flex resource resourceId {} workspaceUuid {}", resourceUuid, workspaceUuid);
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-
-    // Do a permission check before validating the cloning instructions.
-    // It's preferable to throw a permission error first.
-    controlledResourceMetadataManager.validateCloneAction(
-        userRequest, workspaceUuid, body.getDestinationWorkspaceId(), resourceUuid);
+    ControlledFlexibleResource resource =
+        controlledResourceMetadataManager
+            .validateCloneAction(
+                userRequest, workspaceUuid, body.getDestinationWorkspaceId(), resourceUuid)
+            .castByEnum(WsmResourceType.CONTROLLED_FLEXIBLE_RESOURCE);
+    CloningInstructions cloningInstructions =
+        resource.computeCloningInstructions(body.getCloningInstructions());
+    ResourceValidationUtils.validateCloningInstructions(
+        StewardshipType.CONTROLLED, cloningInstructions);
     workspaceService.validateWorkspaceState(workspaceUuid);
-    workspaceService.validateWorkspaceState(body.getDestinationWorkspaceId());
-
-    if (body.getCloningInstructions() != null) {
-      ResourceValidationUtils.validateCloningInstructions(
-          StewardshipType.CONTROLLED,
-          CloningInstructions.fromApiModel(body.getCloningInstructions()));
-    }
-
-    ControlledResource sourceFlexResource =
-        controlledResourceService.getControlledResource(workspaceUuid, resourceUuid);
-
-    CloningInstructions effectiveCloningInstructions =
-        Optional.ofNullable(body.getCloningInstructions())
-            .map(CloningInstructions::fromApiModel)
-            .orElse(sourceFlexResource.getCloningInstructions());
-
-    UUID sourceResourceId = sourceFlexResource.getResourceId();
-    UUID sourceWorkspaceId = sourceFlexResource.getWorkspaceId();
+    workspaceService.validateCloneWorkspaceAndContextState(
+        body.getDestinationWorkspaceId(), CloudPlatform.ANY, cloningInstructions);
 
     // If COPY_NOTHING return an empty result (no-op).
-    if (effectiveCloningInstructions == CloningInstructions.COPY_NOTHING) {
+    if (cloningInstructions == CloningInstructions.COPY_NOTHING) {
       ApiCloneControlledFlexibleResourceResult emptyResult =
           new ApiCloneControlledFlexibleResourceResult()
               .effectiveCloningInstructions(CloningInstructions.COPY_NOTHING.toApiModel())
-              .sourceResourceId(sourceResourceId)
-              .sourceWorkspaceId(sourceWorkspaceId)
+              .sourceResourceId(resourceUuid)
+              .sourceWorkspaceId(workspaceUuid)
               .resource(null);
       return new ResponseEntity<>(emptyResult, HttpStatus.OK);
     }
@@ -250,21 +239,20 @@ public class ControlledFlexibleResourceApiController extends ControlledResourceC
     // Otherwise start a flight to clone the flex resource.
     ControlledFlexibleResource clonedFlexResource =
         controlledResourceService.cloneFlexResource(
-            workspaceUuid,
-            resourceUuid,
+            resource,
             body.getDestinationWorkspaceId(),
             UUID.randomUUID(),
             userRequest,
             body.getName(),
             body.getDescription(),
-            body.getCloningInstructions());
+            cloningInstructions);
 
     ApiCloneControlledFlexibleResourceResult result =
         new ApiCloneControlledFlexibleResourceResult()
             .resource(clonedFlexResource.toApiResource())
-            .effectiveCloningInstructions(effectiveCloningInstructions.toApiModel())
-            .sourceWorkspaceId(sourceResourceId)
-            .sourceResourceId(sourceWorkspaceId);
+            .effectiveCloningInstructions(cloningInstructions.toApiModel())
+            .sourceWorkspaceId(resourceUuid)
+            .sourceResourceId(workspaceUuid);
 
     return new ResponseEntity<>(result, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/CommonUpdateParameters.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/CommonUpdateParameters.java
@@ -7,7 +7,8 @@ import javax.annotation.Nullable;
 
 /**
  * Class for assembling common update parameters from an update request. The setters perform
- * validation.
+ * validation. The class stores the cloning instruction as the DB string so it can be null. Various
+ * getters do the conversions to CloningInstructions
  */
 public class CommonUpdateParameters {
   private @Nullable String name;

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.common.utils.ErrorReportUtils;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.db.exception.InvalidMetadataException;
 import bio.terra.workspace.db.model.DbResource;
+import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiProperties;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.generated.model.ApiResourceLineage;
@@ -344,6 +345,13 @@ public abstract class WsmResource {
       throw new InvalidMetadataException("Resource is not a controlled resource");
     }
     return (ControlledResource) this;
+  }
+
+  public CloningInstructions computeCloningInstructions(
+      @Nullable ApiCloningInstructionsEnum apiCloningInstructions) {
+    return Optional.ofNullable(apiCloningInstructions)
+        .map(CloningInstructions::fromApiModel)
+        .orElse(getCloningInstructions());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -359,6 +359,27 @@ public class WorkspaceService {
   }
 
   /**
+   * Validate the workspace state and possibly the cloud context of the target of a clone. If the
+   * cloud platform is ANY or we are not creating a new controlled resource, then we do not require
+   * a target cloud context.
+   *
+   * @param workspaceUuid target workspace
+   * @param cloudPlatform cloud platform
+   * @param cloningInstructions cloniing instructions
+   */
+  public void validateCloneWorkspaceAndContextState(
+      UUID workspaceUuid, CloudPlatform cloudPlatform, CloningInstructions cloningInstructions) {
+    // If we do not require a target cloud context, just check the workspace
+    if (cloudPlatform == CloudPlatform.ANY
+        || (cloningInstructions != CloningInstructions.COPY_DEFINITION
+            && cloningInstructions != CloningInstructions.COPY_RESOURCE)) {
+      validateWorkspaceState(workspaceUuid);
+    } else {
+      validateWorkspaceAndContextState(workspaceUuid, cloudPlatform);
+    }
+  }
+
+  /**
    * A special case of {@code validateWorkspaceAndAction} for clone operations.
    *
    * <p>Unlike most other operations, cloning requires two authz checks: read access to the source

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -318,6 +318,23 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
   }
 
   @Test
+  public void clone_requestContainsInvalidField_throws400() throws Exception {
+    mockMvcUtils.cloneControlledBqDatasetAsync(
+        userAccessUtils.defaultUser().getAuthenticatedRequest(),
+        /*sourceWorkspaceId=*/ workspaceId,
+        /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
+        /*destWorkspaceId=*/ workspaceId2,
+        ApiCloningInstructionsEnum.REFERENCE,
+        /*destResourceName=*/ null,
+        /*destDatasetName=*/ "invalidDatabaseNameSet",
+        /*destLocation=*/ null,
+        /*defaultTableLifetime=*/ null,
+        /*defaultPartitionLifetime=*/ null,
+        List.of(HttpStatus.SC_BAD_REQUEST),
+        /*shouldUndo=*/ false);
+  }
+
+  @Test
   public void clone_userWithWriteAccessOnDestWorkspace_succeeds() throws Exception {
     var destResourceName = TestUtils.appendRandomNumber("clonedbq");
     AuthenticatedUserRequest userRequest = userAccessUtils.secondUser().getAuthenticatedRequest();

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -469,6 +469,22 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
   }
 
   @Test
+  public void cloneGcsBucket_badRequest_throws400() throws Exception {
+    // Cannot set bucketName for COPY_REFERENCE clone
+    mockMvcUtils.cloneControlledGcsBucketAsync(
+        userAccessUtils.defaultUser().getAuthenticatedRequest(),
+        /*sourceWorkspaceId=*/ workspaceId,
+        sourceBucket.getMetadata().getResourceId(),
+        /*destWorkspaceId=*/ workspaceId,
+        ApiCloningInstructionsEnum.REFERENCE,
+        /*destResourceName=*/ null,
+        "invalidSetBucketName",
+        /*destLocation=*/ null,
+        List.of(HttpStatus.SC_BAD_REQUEST),
+        /*shouldUndo=*/ false);
+  }
+
+  @Test
   public void clone_copyNothing() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
@@ -21,7 +21,6 @@ import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiAiNotebookCloudId;
 import bio.terra.workspace.generated.model.ApiBqDatasetCloudId;
-import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiCreateControlledGcpBigQueryDatasetRequestBody;
 import bio.terra.workspace.generated.model.ApiGcsBucketCloudName;
 import bio.terra.workspace.generated.model.ApiGenerateGcpAiNotebookCloudIdRequestBody;
@@ -72,40 +71,6 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
                 .userSubjectId(USER_REQUEST.getSubjectId()));
     when(mockSamService().getUserEmailFromSamAndRethrowOnInterrupt(any()))
         .thenReturn(USER_REQUEST.getEmail());
-  }
-
-  @Test
-  public void cloneControlledBqDataset_requestContainsInvalidField_throws400() throws Exception {
-    // Cannot set destinationDatasetName for COPY_REFERENCE clone
-    mockMvcUtils.cloneControlledBqDatasetAsync(
-        USER_REQUEST,
-        /*sourceWorkspaceId=*/ UUID.randomUUID(),
-        /*sourceResourceId=*/ UUID.randomUUID(),
-        /*destWorkspaceId=*/ UUID.randomUUID(),
-        ApiCloningInstructionsEnum.REFERENCE,
-        /*destResourceName=*/ null,
-        "datasetName",
-        /*destLocation=*/ null,
-        /*defaultTableLifetime=*/ null,
-        /*defaultPartitionLifetime=*/ null,
-        List.of(HttpStatus.SC_BAD_REQUEST),
-        /*shouldUndo=*/ false);
-  }
-
-  @Test
-  public void cloneGcsBucket_badRequest_throws400() throws Exception {
-    // Cannot set bucketName for COPY_REFERENCE clone
-    mockMvcUtils.cloneControlledGcsBucketAsync(
-        USER_REQUEST,
-        /*sourceWorkspaceId=*/ UUID.randomUUID(),
-        /*sourceResourceId=*/ UUID.randomUUID(),
-        /*destWorkspaceId=*/ UUID.randomUUID(),
-        ApiCloningInstructionsEnum.REFERENCE,
-        /*destResourceName=*/ null,
-        "bucketName",
-        /*destLocation=*/ null,
-        List.of(HttpStatus.SC_BAD_REQUEST),
-        /*shouldUndo=*/ false);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -246,6 +246,8 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s";
   public static final String AZURE_VM_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/vm/%s";
+  public static final String CLONE_AZURE_STORAGE_CONTAINER_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/clone";
   public static final String CREATE_AWS_STORAGE_FOLDERS_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/aws/storageFolder";
   public static final String AWS_STORAGE_FOLDERS_PATH_FORMAT =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
@@ -19,7 +19,6 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.generated.model.ApiClonedControlledGcpGcsBucket;
-import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketUpdateParameters;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.service.crl.CrlService;
@@ -38,6 +37,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.Updat
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.resource.flight.UpdateFinishStep;
 import bio.terra.workspace.service.resource.flight.UpdateStartStep;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.CommonUpdateParameters;
 import bio.terra.workspace.service.resource.model.ResourceLineageEntry;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
@@ -182,8 +182,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
     // clone bucket once
     String jobId =
         controlledResourceService.cloneGcsBucket(
-            workspaceId,
-            createdBucket.getResourceId(),
+            createdBucket,
             workspaceId, // copy back into same workspace
             UUID.randomUUID(),
             new ApiJobControl().id(UUID.randomUUID().toString()),
@@ -192,7 +191,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
             "A bucket cloned individually into the same workspace.",
             "cloned-bucket-" + UUID.randomUUID().toString().toLowerCase(),
             destinationLocation,
-            ApiCloningInstructionsEnum.RESOURCE);
+            CloningInstructions.COPY_RESOURCE);
 
     jobService.waitForJob(jobId);
     FlightState flightState = stairwayComponent.get().getFlightState(jobId);
@@ -214,8 +213,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
     // clone twice.
     String jobId2 =
         controlledResourceService.cloneGcsBucket(
-            workspaceId,
-            firstClonedBucketResourceId,
+            firstClonedBucket,
             workspaceId, // copy back into same workspace
             UUID.randomUUID(),
             new ApiJobControl().id(UUID.randomUUID().toString()),
@@ -224,7 +222,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
             "A bucket cloned individually into the same workspace.",
             "second-cloned-bucket-" + UUID.randomUUID().toString().toLowerCase(),
             destinationLocation,
-            ApiCloningInstructionsEnum.RESOURCE);
+            CloningInstructions.COPY_RESOURCE);
 
     jobService.waitForJob(jobId2);
     FlightState flightState2 = stairwayComponent.get().getFlightState(jobId2);

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/StateTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/StateTestUtils.java
@@ -5,8 +5,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.workspace.common.utils.MockMvcUtils;
-import bio.terra.workspace.db.ResourceDao;
-import bio.terra.workspace.service.resource.model.WsmResource;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
@@ -45,13 +43,6 @@ public class StateTestUtils {
             MockMvcUtils.addAuth(
                 delete(String.format(pathFormat, workspaceId, resourceId)), USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_CONFLICT));
-  }
-
-  void createControlledResourceInDb(WsmResource resource, ResourceDao resourceDao) {
-    // insertControlledResourceRow
-    String flightId = UUID.randomUUID().toString();
-    resourceDao.createResourceStart(resource, flightId);
-    resourceDao.createResourceSuccess(resource, flightId);
   }
 
   <T> void updateControlledResource(


### PR DESCRIPTION
FullIntegration failed because my new workspace/cloud context state check was requiring a cloud context for the target of a clone, even if the clone was making a reference.

This fix adds a new validation method that uses the cloning instructions to decide how much to check.

A couple of consequences of this change. Previously, the effective cloning instructions were calculated in the service layer. Now I need it in the controller. To compute it, I need to fetch the actual resource. What I found was that another validation was already returning the resource, but it was not received in a variable. So the code went and retrieved it **again** in the service layer. So I changes service APIs to take the whole resource and the computed cloning instructions.

A couple of unit tests failed, because the new error checking happens before the test. I moved those to connected tests.
I added two new unit tests for testing that the clone test is working.

p.s., this does not address missing checks for reference clones and grant/revoke.