### PR TITLE
[PF-2784] Add retries to TpsApiDispatch

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/AdminApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/AdminApiController.java
@@ -2,13 +2,13 @@ package bio.terra.workspace.app.controller;
 
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.app.controller.shared.JobApiUtils;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.generated.controller.AdminApi;
 import bio.terra.workspace.generated.model.ApiJobResult;
 import bio.terra.workspace.service.admin.AdminService;
 import bio.terra.workspace.service.features.FeatureService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
 import io.opencensus.contrib.spring.aop.Traced;
@@ -46,7 +46,7 @@ public class AdminApiController extends ControllerBase implements AdminApi {
   @Override
   public ResponseEntity<ApiJobResult> syncIamRoles(Boolean wetRun) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    SamRethrow.onInterrupted(
+    Rethrow.onInterrupted(
         () -> samService.checkAdminAuthz(userRequest), "check whether the user has admin access");
 
     String jobId =
@@ -63,7 +63,7 @@ public class AdminApiController extends ControllerBase implements AdminApi {
 
   private ResponseEntity<ApiJobResult> getApiJobResult(String jobId) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    SamRethrow.onInterrupted(
+    Rethrow.onInterrupted(
         () -> samService.checkAdminAuthz(userRequest), "check whether the user has admin access");
     ApiJobResult response = jobApiUtils.fetchJobResult(jobId);
     return new ResponseEntity<>(response, getAsyncResponseCode(response.getJobReport()));

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControllerBase.java
@@ -7,13 +7,13 @@ import bio.terra.workspace.app.controller.shared.ControllerUtils;
 import bio.terra.workspace.app.controller.shared.JobApiUtils;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.ControllerValidationUtils;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.generated.model.ApiPrivateResourceUser;
 import bio.terra.workspace.service.features.FeatureService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.iam.model.SamConstants;
@@ -154,7 +154,7 @@ public class ControllerBase {
 
         // Validate that the assigned user is a member of the workspace. It must have at least
         // READ action.
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.userIsAuthorized(
                     SamConstants.SamResource.WORKSPACE,

--- a/service/src/main/java/bio/terra/workspace/app/controller/PolicyApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/PolicyApiController.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import bio.terra.policy.model.TpsLocation;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.generated.controller.PolicyApi;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiRegions;
@@ -26,7 +27,11 @@ public class PolicyApiController implements PolicyApi {
   public ResponseEntity<ApiWsmPolicyLocation> getLocationInfo(
       ApiCloudPlatform platform, @Nullable String location) {
     TpsLocation tpsLocation =
-        tpsApiDispatch.getLocationInfo(CloudPlatform.fromApiCloudPlatform(platform), location);
+        Rethrow.onInterrupted(
+            () ->
+                tpsApiDispatch.getLocationInfo(
+                    CloudPlatform.fromApiCloudPlatform(platform), location),
+            "getLocationInfo");
 
     return new ResponseEntity<>(convertTpsToWsmPolicyLocation(tpsLocation), HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -9,6 +9,7 @@ import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.exception.FeatureNotSupportedException;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.generated.model.ApiAwsContext;
 import bio.terra.workspace.generated.model.ApiAzureContext;
 import bio.terra.workspace.generated.model.ApiGcpContext;
@@ -154,8 +155,13 @@ public class WorkspaceApiUtils {
 
     List<ApiWsmPolicyInput> workspacePolicies = null;
     if (features.isTpsEnabled()) {
-      tpsApiDispatch.createPaoIfNotExist(workspaceUuid, TpsComponent.WSM, TpsObjectType.WORKSPACE);
-      TpsPaoGetResult workspacePao = tpsApiDispatch.getPao(workspaceUuid);
+      Rethrow.onInterrupted(
+          () ->
+              tpsApiDispatch.createPaoIfNotExist(
+                  workspaceUuid, TpsComponent.WSM, TpsObjectType.WORKSPACE),
+          "createPaoIfNotExist");
+      TpsPaoGetResult workspacePao =
+          Rethrow.onInterrupted(() -> tpsApiDispatch.getPao(workspaceUuid), "getPao");
       workspacePolicies = TpsApiConversionUtils.apiEffectivePolicyListFromTpsPao(workspacePao);
     }
 

--- a/service/src/main/java/bio/terra/workspace/common/utils/Rethrow.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/Rethrow.java
@@ -1,13 +1,13 @@
-package bio.terra.workspace.service.iam;
+package bio.terra.workspace.common.utils;
 
-import bio.terra.common.sam.exception.SamExceptionFactory;
+import bio.terra.workspace.common.exception.InternalLogicException;
 
 /**
- * When we use Sam in flights, we want to let InterruptedException fly and be caught by Stairway.
- * However, when we use Sam outside of flights, we want to propagate the Interrupted exception.
- * These static methods perform that propagation.
+ * When we use Sam or TPS in flights, we want to let InterruptedException fly and be caught by
+ * Stairway. However, when we use them outside of flights, we want to propagate the Interrupted
+ * exception. These static methods perform that propagation.
  */
-public class SamRethrow {
+public class Rethrow {
 
   /**
    * For use with onInterrupted methods.
@@ -29,9 +29,9 @@ public class SamRethrow {
    * so the interruption is unexpected and should be surfaced all the way up as an unchecked
    * exception, which this function does.
    *
-   * <p>Usage: SamRethrow.onInterrupted(() -> samService.isAuthorized(...), "isAuthorized")) {
+   * <p>Usage: Rethrow.onInterrupted(() -> samService.isAuthorized(...), "isAuthorized")) {
    *
-   * @param function The SamService function to call.
+   * @param function The service function to call.
    * @param operation The name of the function to use in the error message.
    * @param <T> The return type of the function to call.
    * @return The return value of the function to call.
@@ -40,21 +40,21 @@ public class SamRethrow {
     try {
       return function.apply();
     } catch (InterruptedException e) {
-      throw SamExceptionFactory.create("Interrupted during Sam operation " + operation, e);
+      throw new InternalLogicException("Interrupted during operation " + operation, e);
     }
   }
 
   /**
    * Like above, but for functions that return void.
    *
-   * @param function The SamService function to call.
+   * @param function The service function to call.
    * @param operation The name of the function to use in the error message.
    */
   public static void onInterrupted(VoidInterruptedSupplier function, String operation) {
     try {
       function.apply();
     } catch (InterruptedException e) {
-      throw SamExceptionFactory.create("Interrupted during Sam operation " + operation, e);
+      throw new InternalLogicException("Interrupted during operation " + operation, e);
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -12,6 +12,7 @@ import bio.terra.common.tracing.OkHttpClientTracingInterceptor;
 import bio.terra.workspace.app.configuration.external.SamConfiguration;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.GcpUtils;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.iam.model.RoleBinding;
@@ -66,7 +67,7 @@ import org.springframework.stereotype.Component;
  * interpreted by the functions in this class.
  *
  * <p>This class is used both by Flights and outside of Flights. Flights need the
- * InterruptedExceptions to be thrown. Outside of flights, use the SamRethrow.onInterrupted. See
+ * InterruptedExceptions to be thrown. Outside of flights, use the Rethrow.onInterrupted. See
  * comment there for more detail.
  */
 @Component
@@ -163,8 +164,7 @@ public class SamService {
    * flight as we don't need to retry when `InterruptException` happens outside a flight.
    */
   public String getUserEmailFromSamAndRethrowOnInterrupt(AuthenticatedUserRequest userRequest) {
-    return SamRethrow.onInterrupted(
-        () -> getUserEmailFromSam(userRequest), "Get user email from SAM");
+    return Rethrow.onInterrupted(() -> getUserEmailFromSam(userRequest), "Get user email from SAM");
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/logging/WorkspaceActivityLogService.java
+++ b/service/src/main/java/bio/terra/workspace/service/logging/WorkspaceActivityLogService.java
@@ -2,10 +2,10 @@ package bio.terra.workspace.service.logging;
 
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
 import bio.terra.workspace.common.logging.model.ActivityLogChangedTarget;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.db.model.DbWorkspaceActivityLog;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import io.opencensus.contrib.spring.aop.Traced;
@@ -35,7 +35,7 @@ public class WorkspaceActivityLogService {
       String changeSubjectId,
       ActivityLogChangedTarget objectType) {
     UserStatusInfo userStatusInfo =
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () -> samService.getUserStatusInfo(userRequest), "Get user status info from SAM");
     workspaceActivityLogDao.writeActivity(
         workspaceUuid,

--- a/service/src/main/java/bio/terra/workspace/service/petserviceaccount/PetSaService.java
+++ b/service/src/main/java/bio/terra/workspace/service/petserviceaccount/PetSaService.java
@@ -5,10 +5,10 @@ import bio.terra.common.exception.ConflictException;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.utils.GcpUtils;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.grant.GrantService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
@@ -104,7 +104,7 @@ public class PetSaService {
     if (maybePetSaName.isEmpty()) {
       if (eTag == null) {
         String saEmail =
-            SamRethrow.onInterrupted(
+            Rethrow.onInterrupted(
                 () -> samService.getOrCreatePetSaEmail(projectId, userReq.getRequiredToken()),
                 "enablePet");
         maybePetSaName =
@@ -119,7 +119,7 @@ public class PetSaService {
     ServiceAccountName petSaName = maybePetSaName.get();
 
     String proxyGroupEmail =
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () -> samService.getProxyGroupEmail(userToEnableEmail, userReq.getRequiredToken()),
             "enablePet");
     String proxyGroupMember = GcpUtils.toGroupMember(proxyGroupEmail);
@@ -204,7 +204,7 @@ public class PetSaService {
       AuthenticatedUserRequest userRequest,
       @Nullable String eTag) {
     String proxyGroupEmail =
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () -> samService.getProxyGroupEmail(userToDisableEmail, userRequest.getRequiredToken()),
             "disablePet");
 
@@ -283,7 +283,7 @@ public class PetSaService {
   public Optional<ServiceAccountName> getUserPetSa(
       String projectId, String userEmail, AuthenticatedUserRequest userRequest) {
     Optional<ServiceAccountName> constructedSa =
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () -> samService.constructUserPetSaEmail(projectId, userEmail, userRequest),
             "getUserPetSa");
 
@@ -304,7 +304,7 @@ public class PetSaService {
         .getGcpProject(workspaceUuid)
         .map(
             projectId ->
-                SamRethrow.onInterrupted(
+                Rethrow.onInterrupted(
                     () -> samService.getOrCreatePetSaCredentials(projectId, userRequest),
                     "getWorkspacePetCredentials"));
   }

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
@@ -1,0 +1,145 @@
+package bio.terra.workspace.service.policy;
+
+import static java.time.Instant.now;
+
+import bio.terra.policy.client.ApiException;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is a clone of the TCL SamRetry. Since the definition of ApiException is different
+ * (even though it is nearly identical), we cannot just use that code.
+ */
+public class TpsRetry {
+  private static final Logger logger = LoggerFactory.getLogger(TpsRetry.class);
+
+  // The retry function starts with INITIAL_WAIT between retries, and doubles that until it
+  // reaches MAXIMUM_WAIT, after which all retries are MAXIMUM_WAIT apart.
+  private static final Duration MAXIMUM_WAIT = Duration.ofSeconds(30);
+  private static final Duration INITIAL_WAIT = Duration.ofSeconds(10);
+  private static final Duration OPERATION_TIMEOUT = Duration.ofSeconds(300);
+
+  // Tps calls which timeout will throw ApiExceptions wrapping SocketTimeoutExceptions and will have
+  // an errorCode 0. This isn't a real HTTP status code, but we can check for it anyway.
+  private static final int TIMEOUT_STATUS_CODE = 0;
+
+  private final Instant operationTimeout;
+
+  // How long to wait between retries.
+  private Duration retryDuration;
+
+  TpsRetry() {
+    this.operationTimeout = now().plus(OPERATION_TIMEOUT);
+    this.retryDuration = INITIAL_WAIT;
+  }
+
+  protected TpsRetry(Duration timeout) {
+    this.operationTimeout = now().plus(timeout);
+    this.retryDuration = INITIAL_WAIT;
+  }
+
+  @FunctionalInterface
+  public interface TpsVoidFunction {
+    void apply() throws ApiException, InterruptedException;
+  }
+
+  @FunctionalInterface
+  public interface TpsFunction<R> {
+    R apply() throws ApiException, InterruptedException;
+  }
+
+  /**
+   * Requests made through the Tps client library sometimes fail with timeouts, generally due to
+   * transient network or connection issues. When this happens, the client library will throw an API
+   * exceptions with status code 0 wrapping a SocketTimeoutException. These errors should always be
+   * retried.
+   */
+  public static boolean isTimeoutException(ApiException apiException) {
+    return apiException.getCode() == TIMEOUT_STATUS_CODE
+        && apiException.getCause() instanceof SocketTimeoutException;
+  }
+
+  public static <T> T retry(TpsRetry.TpsFunction<T> function)
+      throws ApiException, InterruptedException {
+    TpsRetry TpsRetry = new TpsRetry();
+    return TpsRetry.perform(function);
+  }
+
+  public static <T> T retry(TpsRetry.TpsFunction<T> function, Duration timeout)
+      throws ApiException, InterruptedException {
+    TpsRetry TpsRetry = new TpsRetry(timeout);
+    return TpsRetry.perform(function);
+  }
+
+  public static void retry(TpsRetry.TpsVoidFunction function)
+      throws ApiException, InterruptedException {
+    TpsRetry TpsRetry = new TpsRetry();
+    TpsRetry.performVoid(function);
+  }
+
+  public static void retry(TpsRetry.TpsVoidFunction function, Duration timeout)
+      throws ApiException, InterruptedException {
+    TpsRetry TpsRetry = new TpsRetry(timeout);
+    TpsRetry.performVoid(function);
+  }
+
+  private <T> T perform(TpsRetry.TpsFunction<T> function)
+      throws ApiException, InterruptedException {
+    while (true) {
+      try {
+        return function.apply();
+      } catch (ApiException ex) {
+        if (isRetryable(ex)) {
+          logger.info("TpsRetry: caught retry-able exception: ", ex);
+          sleepOrTimeoutBeforeRetrying(ex);
+        } else {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private boolean isRetryable(ApiException apiException) {
+    return isTimeoutException(apiException)
+        || apiException.getCode() == HttpStatus.SC_INTERNAL_SERVER_ERROR
+        || apiException.getCode() == HttpStatus.SC_BAD_GATEWAY
+        || apiException.getCode() == HttpStatus.SC_SERVICE_UNAVAILABLE
+        || apiException.getCode() == HttpStatus.SC_GATEWAY_TIMEOUT;
+  }
+
+  private void performVoid(TpsRetry.TpsVoidFunction function)
+      throws ApiException, InterruptedException {
+    perform(
+        () -> {
+          function.apply();
+          return null;
+        });
+  }
+
+  /**
+   * Given an exception from Tps, either timeout and rethrow the error from Tps or sleep for
+   * retryDuration. If the thread times out while sleeping, throw the initial exception.
+   *
+   * @param previousException The error Tps threw
+   * @throws ApiException InterruptedException
+   */
+  private void sleepOrTimeoutBeforeRetrying(ApiException previousException)
+      throws ApiException, InterruptedException {
+    if (operationTimeout.minus(retryDuration).isBefore(now())) {
+      logger.error("TpsRetry: operation timed out after " + operationTimeout.toString());
+      // If we timed out, throw the error from Tps that caused us to need to retry.
+      throw previousException;
+    }
+    logger.info("TpsRetry: sleeping " + retryDuration.getSeconds() + " seconds");
+    TimeUnit.SECONDS.sleep(retryDuration.getSeconds());
+    retryDuration = retryDuration.plus(INITIAL_WAIT);
+    if (retryDuration.compareTo(MAXIMUM_WAIT) > 0) {
+      retryDuration = MAXIMUM_WAIT;
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
@@ -124,6 +124,8 @@ public class TpsRetry {
   /**
    * Given an exception from Tps, either timeout and rethrow the error from Tps or sleep for
    * retryDuration. If the thread times out while sleeping, throw the initial exception.
+   * <p> With the current values of INITIAL_WAIT and MAXIMUM_WAIT, this will
+   * sleep 10, 20, 30, 30, 30... seconds.
    *
    * @param previousException The error Tps threw
    * @throws ApiException InterruptedException

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
@@ -124,8 +124,9 @@ public class TpsRetry {
   /**
    * Given an exception from Tps, either timeout and rethrow the error from Tps or sleep for
    * retryDuration. If the thread times out while sleeping, throw the initial exception.
-   * <p> With the current values of INITIAL_WAIT and MAXIMUM_WAIT, this will
-   * sleep 10, 20, 30, 30, 30... seconds.
+   *
+   * <p>With the current values of INITIAL_WAIT and MAXIMUM_WAIT, this will sleep 10, 20, 30, 30,
+   * 30... seconds.
    *
    * @param previousException The error Tps threw
    * @throws ApiException InterruptedException

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
@@ -125,8 +125,8 @@ public class TpsRetry {
    * Given an exception from Tps, either timeout and rethrow the error from Tps or sleep for
    * retryDuration. If the thread times out while sleeping, throw the initial exception.
    *
-   * <p>With the current values of INITIAL_WAIT and MAXIMUM_WAIT, this will sleep 10, 20, 30, 30,
-   * 30... seconds.
+   * <p>With the current values of INITIAL_WAIT and MAXIMUM_WAIT, this will sleep with the pattern
+   * 10, 20, 30, 30, 30... seconds.
    *
    * @param previousException The error Tps threw
    * @throws ApiException InterruptedException

--- a/service/src/main/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupService.java
+++ b/service/src/main/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupService.java
@@ -3,12 +3,12 @@ package bio.terra.workspace.service.privateresource;
 import bio.terra.common.logging.LoggingUtils;
 import bio.terra.common.sam.exception.SamNotFoundException;
 import bio.terra.workspace.app.configuration.external.PrivateResourceCleanupConfiguration;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.db.CronjobDao;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.db.WorkspaceDao.WorkspaceUserPair;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants.SamResource;
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
@@ -110,7 +110,7 @@ public class PrivateResourceCleanupService {
     for (WorkspaceUserPair workspaceUserPair : resourcesToValidate) {
       try {
         boolean userHasPermission =
-            SamRethrow.onInterrupted(
+            Rethrow.onInterrupted(
                 () ->
                     samService.checkAuthAsWsmSa(
                         SamResource.WORKSPACE,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceMetadataManager.java
@@ -2,11 +2,11 @@ package bio.terra.workspace.service.resource.controlled;
 
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.workspace.common.exception.InternalLogicException;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.db.ApplicationDao;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.exception.ResourceStateConflictException;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceActions;
@@ -122,7 +122,7 @@ public class ControlledResourceMetadataManager {
           // Broken user resource. The Sam resource for this resource may not exist.
           // Either it failed to get created or we undid it on the way out of the
           // flight. So we base the authz check on the user's permission on the workspace.
-          SamRethrow.onInterrupted(
+          Rethrow.onInterrupted(
               () ->
                   samService.checkAuthz(
                       userRequest,
@@ -140,7 +140,7 @@ public class ControlledResourceMetadataManager {
 
   private void checkResourceAuthz(
       AuthenticatedUserRequest userRequest, String samName, UUID resourceId, String action) {
-    SamRethrow.onInterrupted(
+    Rethrow.onInterrupted(
         () -> samService.checkAuthz(userRequest, samName, resourceId.toString(), action),
         "checkAuthz");
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -6,6 +6,7 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.GcpUtils;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.db.ApplicationDao;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.generated.model.ApiAwsSageMakerNotebookCreationParameters;
@@ -15,7 +16,6 @@ import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParam
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.service.grant.GrantService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.job.JobBuilder;
@@ -441,7 +441,7 @@ public class ControlledResourceService {
         commonCreationJobBuilder(
             resource, privateResourceIamRole, jobControl, resultPath, userRequest);
     String petSaEmail =
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.getOrCreatePetSaEmail(
                     resource.getProjectId(), userRequest.getRequiredToken()),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -5,10 +5,10 @@ import bio.terra.common.iam.BearerToken;
 import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
@@ -86,7 +86,7 @@ public class AzureStorageAccessService {
       String samResourceName,
       String desiredPermissions) {
     final List<String> containerActions =
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.listResourceActions(
                     userRequest, samResourceName, storageContainerUuid.toString()),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/AssignManagedIdentityAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/AssignManagedIdentityAzureVmStep.java
@@ -5,8 +5,8 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
@@ -49,7 +49,7 @@ public class AssignManagedIdentityAzureVmStep implements Step {
       MsiManager msiManager = crlService.getMsiManager(azureCloudContext, azureConfig);
 
       String petManagedIdentityId =
-          SamRethrow.onInterrupted(
+          Rethrow.onInterrupted(
               () ->
                   samService.getOrCreateUserManagedIdentityForUser(
                       resource.getAssignedUser().get(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDifferentRegionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDifferentRegionStep.java
@@ -7,9 +7,9 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.common.utils.RetryUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
@@ -85,7 +85,7 @@ public class CopyBigQueryDatasetDifferentRegionStep implements Step {
     try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
       ProjectName parent = ProjectName.of(destinationProjectId);
       String petSaEmail =
-          SamRethrow.onInterrupted(
+          Rethrow.onInterrupted(
               () ->
                   samService.getOrCreatePetSaEmail(
                       destinationProjectId, userRequest.getRequiredToken()),

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -7,8 +7,8 @@ import bio.terra.profile.client.ApiException;
 import bio.terra.profile.model.CreateProfileRequest;
 import bio.terra.profile.model.ProfileModel;
 import bio.terra.workspace.app.configuration.external.SpendProfileConfiguration;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.spendprofile.exceptions.BillingProfileManagerServiceAPIException;
@@ -84,7 +84,7 @@ public class SpendProfileService {
 
     SpendProfile spend = null;
     if (spendProfiles.containsKey(spendProfileId)) {
-      if (!SamRethrow.onInterrupted(
+      if (!Rethrow.onInterrupted(
           () ->
               samService.isAuthorized(
                   userRequest,
@@ -99,7 +99,7 @@ public class SpendProfileService {
       // profiles returned from BPM means we are auth'ed
       spend = getSpendProfileFromBpm(userRequest, spendProfileId);
     } else {
-      if (!SamRethrow.onInterrupted(
+      if (!Rethrow.onInterrupted(
           () ->
               samService.isAuthorized(
                   userRequest,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -12,12 +12,12 @@ import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.policy.model.TpsUpdateMode;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.logging.model.ActivityLogChangedTarget;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.db.ApplicationDao;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.db.model.DbCloudContext;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
@@ -264,7 +264,7 @@ public class WorkspaceService {
         workspaceUuid,
         action);
     Workspace workspace = workspaceDao.getWorkspace(workspaceUuid);
-    SamRethrow.onInterrupted(
+    Rethrow.onInterrupted(
         () ->
             samService.checkAuthz(
                 userRequest, SamConstants.SamResource.WORKSPACE, workspaceUuid.toString(), action),
@@ -393,7 +393,7 @@ public class WorkspaceService {
       AuthenticatedUserRequest userRequest, int offset, int limit, WsmIamRole minimumHighestRole) {
     // In general, highest SAM role should be fetched in controller. Fetch here to save a SAM call.
     Map<UUID, WorkspaceDescription> samWorkspacesResponse =
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () -> samService.listWorkspaceIdsAndHighestRoles(userRequest, minimumHighestRole),
             "listWorkspaceIds");
 
@@ -424,7 +424,7 @@ public class WorkspaceService {
     // This is one exception where we need to do an authz check inside a service instead of a
     // controller. This is because checks with Sam require the workspace ID, but until we read from
     // WSM's database we only have the user-facing ID.
-    SamRethrow.onInterrupted(
+    Rethrow.onInterrupted(
         () ->
             samService.checkAuthz(
                 userRequest,
@@ -439,7 +439,7 @@ public class WorkspaceService {
   public WsmIamRole getHighestRole(UUID uuid, AuthenticatedUserRequest userRequest) {
     logger.info("getHighestRole - userRequest: {}\nuserFacingId: {}", userRequest, uuid.toString());
     List<WsmIamRole> requesterRoles =
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.listRequesterRoles(
                     userRequest, SamConstants.SamResource.WORKSPACE, uuid.toString()),
@@ -725,12 +725,23 @@ public class WorkspaceService {
         sourcePaoId.getObjectId(),
         userRequest.getEmail());
 
-    tpsApiDispatch.createPaoIfNotExist(
-        sourcePaoId.getObjectId(), sourcePaoId.getComponent(), sourcePaoId.getObjectType());
-    tpsApiDispatch.createPaoIfNotExist(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
+    Rethrow.onInterrupted(
+        () ->
+            tpsApiDispatch.createPaoIfNotExist(
+                sourcePaoId.getObjectId(), sourcePaoId.getComponent(), sourcePaoId.getObjectType()),
+        "createPaoIfNotExist");
+    Rethrow.onInterrupted(
+        () ->
+            tpsApiDispatch.createPaoIfNotExist(
+                workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE),
+        "createPaoIfNotExist");
 
     TpsPaoUpdateResult dryRun =
-        tpsApiDispatch.linkPao(workspaceId, sourcePaoId.getObjectId(), TpsUpdateMode.DRY_RUN);
+        Rethrow.onInterrupted(
+            () ->
+                tpsApiDispatch.linkPao(
+                    workspaceId, sourcePaoId.getObjectId(), TpsUpdateMode.DRY_RUN),
+            "linkPao");
 
     if (!dryRun.getConflicts().isEmpty() && tpsUpdateMode != TpsUpdateMode.DRY_RUN) {
       throw new PolicyConflictException(
@@ -744,7 +755,9 @@ public class WorkspaceService {
       return dryRun;
     } else {
       var updateResult =
-          tpsApiDispatch.linkPao(workspaceId, sourcePaoId.getObjectId(), tpsUpdateMode);
+          Rethrow.onInterrupted(
+              () -> tpsApiDispatch.linkPao(workspaceId, sourcePaoId.getObjectId(), tpsUpdateMode),
+              "linkPao");
       if (Boolean.TRUE.equals(updateResult.isUpdateApplied())) {
         workspaceActivityLogService.writeActivity(
             userRequest,
@@ -778,8 +791,11 @@ public class WorkspaceService {
     logger.info("Updating workspace policies {} for {}", workspaceUuid, userRequest.getEmail());
 
     var dryRun =
-        tpsApiDispatch.updatePao(
-            workspaceUuid, addAttributes, removeAttributes, TpsUpdateMode.DRY_RUN);
+        Rethrow.onInterrupted(
+            () ->
+                tpsApiDispatch.updatePao(
+                    workspaceUuid, addAttributes, removeAttributes, TpsUpdateMode.DRY_RUN),
+            "updatePao");
 
     if (!dryRun.getConflicts().isEmpty() && updateMode != TpsUpdateMode.DRY_RUN) {
       throw new PolicyConflictException(
@@ -793,7 +809,11 @@ public class WorkspaceService {
       return dryRun;
     } else {
       var result =
-          tpsApiDispatch.updatePao(workspaceUuid, addAttributes, removeAttributes, updateMode);
+          Rethrow.onInterrupted(
+              () ->
+                  tpsApiDispatch.updatePao(
+                      workspaceUuid, addAttributes, removeAttributes, updateMode),
+              "updatePao");
 
       if (Boolean.TRUE.equals(result.isUpdateApplied())) {
         workspaceActivityLogService.writeActivity(

--- a/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
@@ -84,7 +84,7 @@ public class PolicyValidatorTest extends BaseUnitTest {
   }
 
   @Test
-  void validateWorkspaceConformsToRegionPolicy_valid() {
+  void validateWorkspaceConformsToRegionPolicy_valid() throws Exception {
     var spendProfileId = new SpendProfileId(UUID.randomUUID().toString());
     var workspace =
         defaultWorkspaceBuilder(UUID.randomUUID()).spendProfileId(spendProfileId).build();
@@ -115,7 +115,7 @@ public class PolicyValidatorTest extends BaseUnitTest {
   }
 
   @Test
-  void validateWorkspaceConformsToRegionPolicy_invalidResources() {
+  void validateWorkspaceConformsToRegionPolicy_invalidResources() throws Exception {
     var spendProfileId = new SpendProfileId(UUID.randomUUID().toString());
     var workspace =
         defaultWorkspaceBuilder(UUID.randomUUID()).spendProfileId(spendProfileId).build();
@@ -148,7 +148,7 @@ public class PolicyValidatorTest extends BaseUnitTest {
   }
 
   @Test
-  void validateWorkspaceConformsToRegionPolicy_invalidLandingZone() {
+  void validateWorkspaceConformsToRegionPolicy_invalidLandingZone() throws Exception {
     var spendProfileId = new SpendProfileId(UUID.randomUUID().toString());
     var workspace =
         defaultWorkspaceBuilder(UUID.randomUUID()).spendProfileId(spendProfileId).build();

--- a/service/src/test/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupServiceTest.java
@@ -9,13 +9,13 @@ import bio.terra.workspace.app.configuration.external.PrivateResourceCleanupConf
 import bio.terra.workspace.app.configuration.external.SamConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.db.ApplicationDao;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceActions;
@@ -111,7 +111,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
     // Add second user to group
     addUserToGroup(groupName, userAccessUtils.getSecondUserEmail(), ownerGroupApi);
     // Add group to workspace as writer
-    SamRethrow.onInterrupted(
+    Rethrow.onInterrupted(
         () ->
             samService.grantWorkspaceRole(
                 workspace.getWorkspaceId(),
@@ -140,7 +140,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
         userAccessUtils.defaultUserAuthRequest(),
         creationParameters);
     // Verify second user can read the private resource in Sam.
-    SamRethrow.onInterrupted(
+    Rethrow.onInterrupted(
         () ->
             samService.checkAuthz(
                 userAccessUtils.secondUserAuthRequest(),
@@ -153,7 +153,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
     // Verify second user is no longer in workspace, but still has resource access because cleanup
     // hasn't run yet.
     assertFalse(
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.isAuthorized(
                     userAccessUtils.secondUserAuthRequest(),
@@ -162,7 +162,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
                     SamWorkspaceAction.READ),
             "checkResourceAuth"));
     assertTrue(
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.isAuthorized(
                     userAccessUtils.secondUserAuthRequest(),
@@ -176,7 +176,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
     privateResourceCleanupService.cleanupResourcesSuppressExceptions();
     // Verify second user can no longer read the resource.
     assertFalse(
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.isAuthorized(
                     userAccessUtils.secondUserAuthRequest(),
@@ -199,7 +199,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
     // Add second user to group
     addUserToGroup(groupName, userAccessUtils.getSecondUserEmail(), ownerGroupApi);
     // Add group to workspace as writer
-    SamRethrow.onInterrupted(
+    Rethrow.onInterrupted(
         () ->
             samService.grantWorkspaceRole(
                 workspace.getWorkspaceId(),
@@ -242,7 +242,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
         resource, ControlledResourceIamRole.WRITER, appRequest, creationParameters);
 
     // Verify second user can read the private resource in Sam.
-    SamRethrow.onInterrupted(
+    Rethrow.onInterrupted(
         () ->
             samService.checkAuthz(
                 userAccessUtils.secondUserAuthRequest(),
@@ -255,7 +255,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
     // Verify second user is no longer in workspace, but still has resource access because cleanup
     // hasn't run yet.
     assertFalse(
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.isAuthorized(
                     userAccessUtils.secondUserAuthRequest(),
@@ -264,7 +264,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
                     SamWorkspaceAction.READ),
             "checkResourceAuth"));
     assertTrue(
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.isAuthorized(
                     userAccessUtils.secondUserAuthRequest(),
@@ -278,7 +278,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
     privateResourceCleanupService.cleanupResourcesSuppressExceptions();
     // Verify second user can no longer read the resource.
     assertFalse(
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.isAuthorized(
                     userAccessUtils.secondUserAuthRequest(),
@@ -295,7 +295,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
     // Application can still read the resource, because applications have EDITOR role on their
     // application-private resources.
     assertTrue(
-        SamRethrow.onInterrupted(
+        Rethrow.onInterrupted(
             () ->
                 samService.isAuthorized(
                     appRequest,

--- a/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
@@ -473,7 +473,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
   }
 
   @Test
-  public void validateRegionGCP() {
+  public void validateRegionGCP() throws Exception {
     var testRegions = List.of("us", "us-central1", "us-east1-a");
     UUID workspaceId = UUID.randomUUID();
 
@@ -491,7 +491,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
   }
 
   @Test
-  public void validateRegionAzure() {
+  public void validateRegionAzure() throws Exception {
     var testRegions = List.of(Region.US_EAST, Region.US_EAST2);
     UUID workspaceId = UUID.randomUUID();
 
@@ -509,7 +509,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
   }
 
   @Test
-  public void validateRegion_invalid_throws() {
+  public void validateRegion_invalid_throws() throws Exception {
     UUID workspaceId = UUID.randomUUID();
     TpsPaoGetResult pao = new TpsPaoGetResult().objectId(workspaceId);
     when(mockTpsApiDispatch().listValidRegions(workspaceId, CloudPlatform.GCP))

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceUnitTest.java
@@ -85,7 +85,7 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   }
 
   @Test
-  void linkPolicies_dryRun() {
+  void linkPolicies_dryRun() throws Exception {
     Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     when(mockWorkspaceDao.getWorkspace(workspace.workspaceId())).thenReturn(workspace);
 
@@ -107,7 +107,7 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   }
 
   @Test
-  void linkPolicies_policyConflict() {
+  void linkPolicies_policyConflict() throws Exception {
     Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     when(mockWorkspaceDao.getWorkspace(workspace.workspaceId())).thenReturn(workspace);
 
@@ -138,7 +138,7 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   }
 
   @Test
-  void linkPolicies_workspaceConflict() {
+  void linkPolicies_workspaceConflict() throws Exception {
     Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     when(mockWorkspaceDao.getWorkspace(workspace.workspaceId())).thenReturn(workspace);
 
@@ -163,7 +163,7 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   }
 
   @Test
-  void linkPolicies_applied() {
+  void linkPolicies_applied() throws Exception {
     Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     when(mockWorkspaceDao.getWorkspace(workspace.workspaceId())).thenReturn(workspace);
 
@@ -195,7 +195,7 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   }
 
   @Test
-  void updatePolicies_dryRun() {
+  void updatePolicies_dryRun() throws Exception {
     Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     when(mockWorkspaceDao.getWorkspace(workspace.workspaceId())).thenReturn(workspace);
 
@@ -215,7 +215,7 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   }
 
   @Test
-  void updatePolicies_policyConflict() {
+  void updatePolicies_policyConflict() throws Exception {
     Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     when(mockWorkspaceDao.getWorkspace(workspace.workspaceId())).thenReturn(workspace);
 
@@ -244,7 +244,7 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   }
 
   @Test
-  void updatePolicies_workspaceConflict() {
+  void updatePolicies_workspaceConflict() throws Exception {
     Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     when(mockWorkspaceDao.getWorkspace(workspace.workspaceId())).thenReturn(workspace);
 
@@ -267,7 +267,7 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   }
 
   @Test
-  void updatePolicies_applied() {
+  void updatePolicies_applied() throws Exception {
     Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
     when(mockWorkspaceDao.getWorkspace(workspace.workspaceId())).thenReturn(workspace);
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/CreateGcpContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/CreateGcpContextFlightTest.java
@@ -16,11 +16,11 @@ import bio.terra.stairway.exception.MakeFlightException;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamRethrow;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobService;
@@ -267,7 +267,7 @@ class CreateGcpContextFlightTest extends BaseConnectedTest {
                     Function.identity(),
                     role ->
                         "group:"
-                            + SamRethrow.onInterrupted(
+                            + Rethrow.onInterrupted(
                                 () ->
                                     samService.syncWorkspacePolicy(
                                         workspaceUuid,


### PR DESCRIPTION
This PR adds retries to `TpsApiDispatch`. I considered re-implementing `SamRetry` to use the `RetryUtils`, but decided it wasn't a good fit. Also, `SamRetry` has been working well - it ain't broken, so don't "fix" it.

I looked for a way to share retry code between Sam and TPS. Both are doing exactly the same thing to different instances of `ApiException`. I decided the complexity wasn't worth the effort. So...
- Copied `SamRetry` into `TpsRetry` and cleaned up naming and typing of the `ApiException`.
- Implemented the retry inside of `TpsApiDispatch`
- Copied `SamRethrow` into `Rethrow` and moved it to common utils.
- Global replace of `SamRethrow` with `Rethrow`
- Add `Rethrow` wrapping around all the places where we use TPS that are not in flights. I considered putting the `Rethrow` inside some `TpsApiDispatch` methods, but decided that could lead to developer confusion.
- Added `throws Exception` to a bunch of tests to fix compiler complaints about unhandled `InterruptedException` in tests