### PR TITLE
[PF-2740] Ensure flight id check on delete success

### DIFF
--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -165,9 +165,12 @@ public class ResourceDao {
    * @param resourceId resource id
    */
   @WriteTransaction
-  public void deleteResourceSuccess(UUID workspaceUuid, UUID resourceId) {
+  public void deleteResourceSuccess(UUID workspaceUuid, UUID resourceId, String flightId) {
     DbResource dbResource = getDbResourceFromIds(workspaceUuid, resourceId);
     if (!stateDao.isResourceInState(dbResource, WsmResourceState.NOT_EXISTS, /*flightId=*/ null)) {
+      // Validate the state transition to not exists
+      stateDao.updateState(
+          dbResource, flightId, /*targetFlightId=*/ null, WsmResourceState.NOT_EXISTS, null);
       deleteResourceWorker(workspaceUuid, resourceId, /*resourceType=*/ null);
     }
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteMetadataStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteMetadataStep.java
@@ -27,7 +27,7 @@ public class DeleteMetadataStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    resourceDao.deleteResourceSuccess(workspaceUuid, resourceId);
+    resourceDao.deleteResourceSuccess(workspaceUuid, resourceId, flightContext.getFlightId());
     return StepResult.getStepResultSuccess();
   }
 


### PR DESCRIPTION
I missed the flightId check on the delete success case in resources. Noticed it when doing cloud context.
This is a small fix to properly check the flight id.