### PR TITLE
PF-2831: throw 409 when we have a conflicted resource name

### DIFF
--- a/openapi/src/parts/controlled_gcp_ai_notebook_instance.yaml
+++ b/openapi/src/parts/controlled_gcp_ai_notebook_instance.yaml
@@ -106,6 +106,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
 

--- a/openapi/src/parts/controlled_gcp_big_query_dataset.yaml
+++ b/openapi/src/parts/controlled_gcp_big_query_dataset.yaml
@@ -58,6 +58,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:

--- a/openapi/src/parts/controlled_gcp_gcs_bucket.yaml
+++ b/openapi/src/parts/controlled_gcp_gcs_bucket.yaml
@@ -54,6 +54,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     post:

--- a/openapi/src/parts/referenced_datarepo_snapshots.yaml
+++ b/openapi/src/parts/referenced_datarepo_snapshots.yaml
@@ -59,6 +59,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:

--- a/openapi/src/parts/referenced_gcp_big_query_data_table.yaml
+++ b/openapi/src/parts/referenced_gcp_big_query_data_table.yaml
@@ -61,6 +61,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:

--- a/openapi/src/parts/referenced_gcp_big_query_dataset.yaml
+++ b/openapi/src/parts/referenced_gcp_big_query_dataset.yaml
@@ -58,6 +58,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:

--- a/openapi/src/parts/referenced_gcp_gcs_bucket.yaml
+++ b/openapi/src/parts/referenced_gcp_gcs_bucket.yaml
@@ -58,6 +58,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:

--- a/openapi/src/parts/referenced_gcp_gcs_bucket_object.yaml
+++ b/openapi/src/parts/referenced_gcp_gcs_bucket_object.yaml
@@ -59,6 +59,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:

--- a/openapi/src/parts/referenced_git_repo.yaml
+++ b/openapi/src/parts/referenced_git_repo.yaml
@@ -58,6 +58,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -644,7 +644,15 @@ public class ResourceDao {
           .addValue("workspace_id", workspaceUuid.toString())
           .addValue("resource_id", resourceId.toString());
 
-      int rowsAffected = jdbcTemplate.update(sb.toString(), params);
+      int rowsAffected = 0;
+      try {
+        rowsAffected = jdbcTemplate.update(sb.toString(), params);
+      } catch (DuplicateKeyException e) {
+        throw new DuplicateResourceException(
+            String.format(
+                "A resource already exists in the workspace that has the same name (%s)",
+                dbUpdater.getUpdatedName()));
+      }
       boolean updated = rowsAffected > 0;
 
       logger.info(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiBqDatasetEquals;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,6 +22,7 @@ import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
+import bio.terra.workspace.generated.model.ApiUpdateBigQueryDatasetReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -177,6 +179,34 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
         RESOURCE_DESCRIPTION,
         ApiCloningInstructionsEnum.NOTHING,
         sourceDatasetName);
+  }
+
+  @Test
+  public void update_throws409() throws Exception {
+    var newName = TestUtils.appendRandomNumber("newdataSetresourcename");
+    mockMvcUtils.createReferencedBqDataset(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId,
+        newName,
+        projectId,
+        sourceDatasetName);
+
+    mockMvcUtils.postExpect(
+        userAccessUtils.defaultUserAuthRequest(),
+        objectMapper.writeValueAsString(
+            new ApiUpdateBigQueryDatasetReferenceRequestBody().name(newName)),
+        String.format(
+            REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT,
+            workspaceId,
+            sourceResource.getMetadata().getResourceId()),
+        HttpStatus.SC_CONFLICT);
+
+    ApiGcpBigQueryDatasetResource gotResource =
+        mockMvcUtils.getReferencedBqDataset(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspaceId,
+            sourceResource.getMetadata().getResourceId());
+    assertEquals(sourceResourceName, gotResource.getMetadata().getName());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableConnectedTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiBqDataTableEquals;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,6 +22,7 @@ import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableResource;
 import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
+import bio.terra.workspace.generated.model.ApiUpdateBigQueryDatasetReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -184,6 +186,35 @@ public class ReferencedGcpResourceControllerBqTableConnectedTest extends BaseCon
         projectId,
         sourceDatasetName,
         sourceTableId);
+  }
+
+  @Test
+  public void update_throws409() throws Exception {
+    var newName = TestUtils.appendRandomNumber("newdatatableresourcename");
+    mockMvcUtils.createReferencedBqTable(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId,
+        newName,
+        projectId,
+        sourceDatasetName,
+        sourceTableId);
+
+    mockMvcUtils.postExpect(
+        userAccessUtils.defaultUserAuthRequest(),
+        objectMapper.writeValueAsString(
+            new ApiUpdateBigQueryDatasetReferenceRequestBody().name(newName)),
+        String.format(
+            REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT,
+            workspaceId,
+            sourceResource.getMetadata().getResourceId()),
+        HttpStatus.SC_CONFLICT);
+
+    ApiGcpBigQueryDataTableResource gotResource =
+        mockMvcUtils.getReferencedBqTable(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspaceId,
+            sourceResource.getMetadata().getResourceId());
+    assertEquals(sourceResourceName, gotResource.getMetadata().getName());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_DATA_REPO_SNAPSHOT_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiDataRepoEquals;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,6 +21,7 @@ import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
 import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
+import bio.terra.workspace.generated.model.ApiUpdateBigQueryDatasetReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -173,6 +175,35 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
         sourceSnapshot,
         sourceInstanceName,
         ApiCloningInstructionsEnum.NOTHING);
+  }
+
+  @Test
+  public void update_throws409() throws Exception {
+    var newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
+    mockMvcUtils.createReferencedDataRepoSnapshot(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId,
+        ApiCloningInstructionsEnum.REFERENCE,
+        newName,
+        sourceInstanceName,
+        sourceSnapshot);
+
+    mockMvcUtils.postExpect(
+        userAccessUtils.defaultUserAuthRequest(),
+        objectMapper.writeValueAsString(
+            new ApiUpdateBigQueryDatasetReferenceRequestBody().name(newName)),
+        String.format(
+            REFERENCED_DATA_REPO_SNAPSHOT_V1_PATH_FORMAT,
+            workspaceId,
+            sourceResource.getMetadata().getResourceId()),
+        HttpStatus.SC_CONFLICT);
+
+    ApiDataRepoSnapshotResource gotResource =
+        mockMvcUtils.getReferencedDataRepoSnapshot(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspaceId,
+            sourceResource.getMetadata().getResourceId());
+    assertEquals(sourceResourceName, gotResource.getMetadata().getName());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_BUCKET_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiGcsBucketEquals;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,6 +22,7 @@ import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
+import bio.terra.workspace.generated.model.ApiUpdateBigQueryDatasetReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -218,6 +220,30 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         RESOURCE_DESCRIPTION,
         sourceBucketName,
         ApiCloningInstructionsEnum.NOTHING);
+  }
+
+  @Test
+  public void update_throws409() throws Exception {
+    var newName = TestUtils.appendRandomNumber("newgcsbucketresourcename");
+    mockMvcUtils.createReferencedGcsBucket(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId, newName, sourceBucketName);
+
+    mockMvcUtils.postExpect(
+        userAccessUtils.defaultUserAuthRequest(),
+        objectMapper.writeValueAsString(
+            new ApiUpdateBigQueryDatasetReferenceRequestBody().name(newName)),
+        String.format(
+            REFERENCED_GCP_GCS_BUCKET_V1_PATH_FORMAT,
+            workspaceId,
+            sourceResource.getMetadata().getResourceId()),
+        HttpStatus.SC_CONFLICT);
+
+    ApiGcpGcsBucketResource gotResource =
+        mockMvcUtils.getReferencedGcsBucket(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspaceId,
+            sourceResource.getMetadata().getResourceId());
+    assertEquals(sourceResourceName, gotResource.getMetadata().getName());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
+import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GIT_REPO_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -19,6 +20,7 @@ import bio.terra.workspace.generated.model.ApiGitRepoResource;
 import bio.terra.workspace.generated.model.ApiResourceLineage;
 import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
+import bio.terra.workspace.generated.model.ApiUpdateBigQueryDatasetReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -170,6 +172,30 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
         sourceGitRepoUrl,
         ApiCloningInstructionsEnum.NOTHING,
         userAccessUtils.defaultUserAuthRequest());
+  }
+
+  @Test
+  public void update_throws409() throws Exception {
+    var newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
+    mockMvcUtils.createReferencedGitRepo(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId, newName, sourceGitRepoUrl);
+
+    mockMvcUtils.updateResource(
+        ApiGitRepoResource.class,
+        REFERENCED_GIT_REPO_V1_PATH_FORMAT,
+        workspaceId,
+        sourceResource.getMetadata().getResourceId(),
+        objectMapper.writeValueAsString(
+            new ApiUpdateBigQueryDatasetReferenceRequestBody().name(newName)),
+        userAccessUtils.defaultUserAuthRequest(),
+        HttpStatus.SC_CONFLICT);
+
+    ApiGitRepoResource gotResource =
+        mockMvcUtils.getReferencedGitRepo(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspaceId,
+            sourceResource.getMetadata().getResourceId());
+    assertEquals(sourceResourceName, gotResource.getMetadata().getName());
   }
 
   @Test


### PR DESCRIPTION
Ran connectedPlus test locally.