### PR TITLE
[BENCH-114] Move Cloud specific functions to separate file ResourceValidationUtils

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -262,7 +262,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
     workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
-    AzureResourceValidationUtils.validateApiAzureVmCreationParameters(body.getAzureVm());
+    AzureResourceValidationUtils.validate(body.getAzureVm());
     ControlledAzureVmResource resource =
         buildControlledAzureVmResource(body.getAzureVm(), commonFields);
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -40,6 +40,7 @@ import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.SamConstants.SamControlledResourceActions;
 import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.AzureResourceValidationUtils;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
@@ -261,7 +262,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
     workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
-    ResourceValidationUtils.validateApiAzureVmCreationParameters(body.getAzureVm());
+    AzureResourceValidationUtils.validateApiAzureVmCreationParameters(body.getAzureVm());
     ControlledAzureVmResource resource =
         buildControlledAzureVmResource(body.getAzureVm(), commonFields);
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AwsResourceValidationUtils.java
@@ -14,7 +14,7 @@ public class AwsResourceValidationUtils {
       Pattern.compile("[{}^%`<>~#|@*+\\[\\]\"\'\\\\/]");
 
   // https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateNotebookInstance.html#sagemaker-CreateNotebookInstance-request-NotebookInstanceName
-  protected static final Pattern sageMakerInstanceNamePattern =
+  private static final Pattern sageMakerInstanceNamePattern =
       Pattern.compile("^[a-zA-Z0-9](-*[a-zA-Z0-9])*");
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/resource/AzureResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AzureResourceValidationUtils.java
@@ -168,7 +168,8 @@ public class AzureResourceValidationUtils {
             && !StringUtils.isEmpty(vmImage.getOffer())
             && !StringUtils.isEmpty(vmImage.getSku())
             && !StringUtils.isEmpty(vmImage.getVersion()))) {
-      ResourceValidationUtils.checkFieldNonNull(apiAzureVmCreationParameters.getVmUser(), "vmUser");
+      ResourceValidationUtils.checkFieldNonNull(
+          apiAzureVmCreationParameters.getVmUser(), "vmUser", "ApiAzureVmCreationParameters");
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/AzureResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AzureResourceValidationUtils.java
@@ -11,51 +11,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/** A collection of static Azure resource validation functions */
+/** A collection of static validation functions specific to Azure */
 @Component
 public class AzureResourceValidationUtils {
   private static final Logger logger = LoggerFactory.getLogger(AzureResourceValidationUtils.class);
 
-  /**
-   * Azure Storage Account name validation valid. An storage account name must be between 3-24
-   * characters in length and may contain numbers and lowercase letters only.
-   */
-  public static final Pattern AZURE_STORAGE_ACCOUNT_NAME_VALIDATION_PATTERN =
-      Pattern.compile("^[a-z0-9]{3,24}$");
-
-  /**
-   * Azure Storage Container name validation. A storage container name must be between 3-63
-   * characters in length and may contain numbers, lowercase letters, and dash (-) characters only.
-   * It must start and end with a letter or number. Matching this pattern is necessary but not
-   * sufficient for a valid container name (in particular, the dash character must be immediately
-   * preceded and followed by a letter or number; consecutive dashes are not permitted).
-   */
-  public static final Pattern AZURE_STORAGE_CONTAINER_NAME_VALIDATION_PATTERN =
-      Pattern.compile("^[a-z0-9][-a-z0-9]{1,61}[a-z0-9]$");
-
-  public static final Pattern AZURE_RELAY_NAMESPACE_PATTERN =
+  private static final Pattern AZURE_RELAY_NAMESPACE_PATTERN =
       Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-]{0,78}[a-zA-Z0-9]$");
-
-  /** Batch Pool id must be -64 characters, using letters, numbers, dashes, and underscores */
-  public static final Pattern AZURE_BATCH_POOL_ID_VALIDATION_PATTERN =
-      Pattern.compile("^[-_a-zA-Z0-9]{0,63}$");
-
-  private static final int MAX_AZURE_BATCH_POOL_DISPLAY_NAME = 1024;
-
-  /**
-   * See
-   * https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
-   * for azure resource rules
-   */
-  public static void validateAzureIPorSubnetName(String name) {
-    Pattern pattern = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-_.]{0,78}[a-zA-Z0-9_]$");
-
-    if (!pattern.matcher(name).matches()) {
-      logger.warn("Invalid Azure IP or Subnet name {}", name);
-      throw new InvalidReferenceException(
-          "Invalid Azure IP or Subnet name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
-    }
-  }
 
   /**
    * See
@@ -82,24 +44,6 @@ public class AzureResourceValidationUtils {
     }
   }
 
-  public static void validateAzureDiskName(String name) {
-    Pattern pattern = Pattern.compile("^[a-zA-Z0-9-_]{0,80}$");
-
-    if (!pattern.matcher(name).matches()) {
-      logger.warn("Invalid Disk name {}", name);
-      throw new InvalidReferenceException(
-          "Invalid Azure Disk name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
-    }
-  }
-
-  public static void validateAzureBatchPoolId(String id) {
-    if (!AZURE_BATCH_POOL_ID_VALIDATION_PATTERN.matcher(id).matches()) {
-      logger.warn("Invalid Azure Batch Pool id {}", id);
-      throw new InvalidReferenceException(
-          "Invalid Azure Batch Pool id specified. Name must be 1 to 64 alphanumeric characters or underscores or dashes.");
-    }
-  }
-
   public static void validateAzureCidrBlock(String range) {
     Pattern pattern =
         Pattern.compile(
@@ -112,12 +56,24 @@ public class AzureResourceValidationUtils {
     }
   }
 
-  public static void validateAzureBatchPoolDisplayName(@Nullable String displayName) {
-    if (displayName != null && displayName.length() > MAX_AZURE_BATCH_POOL_DISPLAY_NAME) {
-      throw new InvalidNameException(
-          "Invalid display name specified. Display name must be under 1024 characters.");
-    }
-  }
+  // Azure Storage
+
+  /**
+   * Azure Storage Account name validation valid. An storage account name must be between 3-24
+   * characters in length and may contain numbers and lowercase letters only.
+   */
+  private static final Pattern AZURE_STORAGE_ACCOUNT_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[a-z0-9]{3,24}$");
+
+  /**
+   * Azure Storage Container name validation. A storage container name must be between 3-63
+   * characters in length and may contain numbers, lowercase letters, and dash (-) characters only.
+   * It must start and end with a letter or number. Matching this pattern is necessary but not
+   * sufficient for a valid container name (in particular, the dash character must be immediately
+   * preceded and followed by a letter or number; consecutive dashes are not permitted).
+   */
+  private static final Pattern AZURE_STORAGE_CONTAINER_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[a-z0-9][-a-z0-9]{1,61}[a-z0-9]$");
 
   public static void validateAzureStorageAccountName(String storageAccountName) {
     if (!AZURE_STORAGE_ACCOUNT_NAME_VALIDATION_PATTERN.matcher(storageAccountName).matches()) {
@@ -137,8 +93,59 @@ public class AzureResourceValidationUtils {
     }
   }
 
-  public static void validateApiAzureVmCreationParameters(
-      ApiAzureVmCreationParameters apiAzureVmCreationParameters) {
+  // Azure Disk
+
+  public static void validateAzureDiskName(String name) {
+    Pattern pattern = Pattern.compile("^[a-zA-Z0-9-_]{0,80}$");
+
+    if (!pattern.matcher(name).matches()) {
+      logger.warn("Invalid Disk name {}", name);
+      throw new InvalidReferenceException(
+          "Invalid Azure Disk name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
+    }
+  }
+
+  // Azure Batch pool
+
+  /** Batch Pool id must be -64 characters, using letters, numbers, dashes, and underscores */
+  private static final Pattern AZURE_BATCH_POOL_ID_VALIDATION_PATTERN =
+      Pattern.compile("^[-_a-zA-Z0-9]{0,63}$");
+
+  private static final int AZURE_MAX_BATCH_POOL_DISPLAY_NAME = 1024;
+
+  public static void validateAzureBatchPoolId(String id) {
+    if (!AZURE_BATCH_POOL_ID_VALIDATION_PATTERN.matcher(id).matches()) {
+      logger.warn("Invalid Azure Batch Pool id {}", id);
+      throw new InvalidReferenceException(
+          "Invalid Azure Batch Pool id specified. Name must be 1 to 64 alphanumeric characters or underscores or dashes.");
+    }
+  }
+
+  public static void validateAzureBatchPoolDisplayName(@Nullable String displayName) {
+    if (displayName != null && displayName.length() > AZURE_MAX_BATCH_POOL_DISPLAY_NAME) {
+      throw new InvalidNameException(
+          "Invalid display name specified. Display name must be under 1024 characters.");
+    }
+  }
+
+  // Azure VM
+
+  /**
+   * See
+   * https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+   * for azure resource rules
+   */
+  public static void validateAzureIPorSubnetName(String name) {
+    Pattern pattern = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-_.]{0,78}[a-zA-Z0-9_]$");
+
+    if (!pattern.matcher(name).matches()) {
+      logger.warn("Invalid Azure IP or Subnet name {}", name);
+      throw new InvalidReferenceException(
+          "Invalid Azure IP or Subnet name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
+    }
+  }
+
+  public static void validate(ApiAzureVmCreationParameters apiAzureVmCreationParameters) {
     var vmImage = apiAzureVmCreationParameters.getVmImage();
     if (StringUtils.isEmpty(vmImage.getUri())
         && StringUtils.isEmpty(vmImage.getPublisher())

--- a/service/src/main/java/bio/terra/workspace/service/resource/AzureResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AzureResourceValidationUtils.java
@@ -1,0 +1,167 @@
+package bio.terra.workspace.service.resource;
+
+import bio.terra.common.exception.MissingRequiredFieldException;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
+import bio.terra.workspace.service.resource.exception.InvalidNameException;
+import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** A collection of static Azure resource validation functions */
+@Component
+public class AzureResourceValidationUtils {
+  private static final Logger logger = LoggerFactory.getLogger(AzureResourceValidationUtils.class);
+
+  /**
+   * Azure Storage Account name validation valid. An storage account name must be between 3-24
+   * characters in length and may contain numbers and lowercase letters only.
+   */
+  public static final Pattern AZURE_STORAGE_ACCOUNT_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[a-z0-9]{3,24}$");
+
+  /**
+   * Azure Storage Container name validation. A storage container name must be between 3-63
+   * characters in length and may contain numbers, lowercase letters, and dash (-) characters only.
+   * It must start and end with a letter or number. Matching this pattern is necessary but not
+   * sufficient for a valid container name (in particular, the dash character must be immediately
+   * preceded and followed by a letter or number; consecutive dashes are not permitted).
+   */
+  public static final Pattern AZURE_STORAGE_CONTAINER_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[a-z0-9][-a-z0-9]{1,61}[a-z0-9]$");
+
+  public static final Pattern AZURE_RELAY_NAMESPACE_PATTERN =
+      Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-]{0,78}[a-zA-Z0-9]$");
+
+  /** Batch Pool id must be -64 characters, using letters, numbers, dashes, and underscores */
+  public static final Pattern AZURE_BATCH_POOL_ID_VALIDATION_PATTERN =
+      Pattern.compile("^[-_a-zA-Z0-9]{0,63}$");
+
+  private static final int MAX_AZURE_BATCH_POOL_DISPLAY_NAME = 1024;
+
+  /**
+   * See
+   * https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+   * for azure resource rules
+   */
+  public static void validateAzureIPorSubnetName(String name) {
+    Pattern pattern = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-_.]{0,78}[a-zA-Z0-9_]$");
+
+    if (!pattern.matcher(name).matches()) {
+      logger.warn("Invalid Azure IP or Subnet name {}", name);
+      throw new InvalidReferenceException(
+          "Invalid Azure IP or Subnet name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
+    }
+  }
+
+  /**
+   * See
+   * https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+   * for azure resource rules
+   */
+  public static void validateAzureNamespace(String name) {
+    if (!AZURE_RELAY_NAMESPACE_PATTERN.matcher(name).matches()
+        || name.length() > 50
+        || name.length() < 6) {
+      logger.warn("Invalid Azure Namespace {}", name);
+      throw new InvalidReferenceException(
+          "Invalid Azure Namespace specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
+    }
+  }
+
+  public static void validateAzureNetworkName(String name) {
+    Pattern pattern = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}[a-zA-Z0-9_]$");
+
+    if (!pattern.matcher(name).matches()) {
+      logger.warn("Invalid Azure network name {}", name);
+      throw new InvalidReferenceException(
+          "Invalid Azure network name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
+    }
+  }
+
+  public static void validateAzureDiskName(String name) {
+    Pattern pattern = Pattern.compile("^[a-zA-Z0-9-_]{0,80}$");
+
+    if (!pattern.matcher(name).matches()) {
+      logger.warn("Invalid Disk name {}", name);
+      throw new InvalidReferenceException(
+          "Invalid Azure Disk name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
+    }
+  }
+
+  public static void validateAzureBatchPoolId(String id) {
+    if (!AZURE_BATCH_POOL_ID_VALIDATION_PATTERN.matcher(id).matches()) {
+      logger.warn("Invalid Azure Batch Pool id {}", id);
+      throw new InvalidReferenceException(
+          "Invalid Azure Batch Pool id specified. Name must be 1 to 64 alphanumeric characters or underscores or dashes.");
+    }
+  }
+
+  public static void validateAzureCidrBlock(String range) {
+    Pattern pattern =
+        Pattern.compile(
+            "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(\\d|[1-2]\\d|3[0-2]))$");
+
+    if (!pattern.matcher(range).matches()) {
+      logger.warn("Invalid CIDR block {}", range);
+      throw new InvalidReferenceException(
+          "Invalid Azure CIDR block specified. See documentation for full specification https://stackoverflow.com/questions/18608165/cidr-notation-and-ip-range-validator-pattern/18611259.");
+    }
+  }
+
+  public static void validateAzureBatchPoolDisplayName(@Nullable String displayName) {
+    if (displayName != null && displayName.length() > MAX_AZURE_BATCH_POOL_DISPLAY_NAME) {
+      throw new InvalidNameException(
+          "Invalid display name specified. Display name must be under 1024 characters.");
+    }
+  }
+
+  public static void validateAzureStorageAccountName(String storageAccountName) {
+    if (!AZURE_STORAGE_ACCOUNT_NAME_VALIDATION_PATTERN.matcher(storageAccountName).matches()) {
+      logger.warn("Invalid Storage Account name: {}", storageAccountName);
+      throw new InvalidReferenceException(
+          "Invalid Azure Storage Account name. The name must be 3 to 24 alphanumeric lower case characters.");
+    }
+  }
+
+  public static void validateAzureStorageContainerName(String storageContainerName) {
+    if (!AZURE_STORAGE_CONTAINER_NAME_VALIDATION_PATTERN.matcher(storageContainerName).matches()
+        || storageContainerName.contains("--")) {
+      logger.warn("Invalid Storage Container name: {}", storageContainerName);
+      throw new InvalidReferenceException(
+          "Invalid Azure Storage Container name. The name must be 3 to 63 alphanumeric lower case characters "
+              + "or dashes, must start and end with a letter or number, and cannot contain consecutive dashes.");
+    }
+  }
+
+  public static void validateApiAzureVmCreationParameters(
+      ApiAzureVmCreationParameters apiAzureVmCreationParameters) {
+    var vmImage = apiAzureVmCreationParameters.getVmImage();
+    if (StringUtils.isEmpty(vmImage.getUri())
+        && StringUtils.isEmpty(vmImage.getPublisher())
+        && StringUtils.isEmpty(vmImage.getOffer())
+        && StringUtils.isEmpty(vmImage.getSku())
+        && StringUtils.isEmpty(vmImage.getVersion())) {
+      throw new MissingRequiredFieldException(
+          "Missing required fields for vmImage. Either uri or publisher, offer, sku, version should be defined.");
+    }
+    if (StringUtils.isEmpty(vmImage.getUri())
+        && (StringUtils.isEmpty(vmImage.getPublisher())
+            || StringUtils.isEmpty(vmImage.getOffer())
+            || StringUtils.isEmpty(vmImage.getSku())
+            || StringUtils.isEmpty(vmImage.getVersion()))) {
+      throw new MissingRequiredFieldException(
+          "Missing required fields for vmImage. Publisher, offer, sku, version should be defined.");
+    }
+    if (StringUtils.isEmpty(vmImage.getUri())
+        && (!StringUtils.isEmpty(vmImage.getPublisher())
+            && !StringUtils.isEmpty(vmImage.getOffer())
+            && !StringUtils.isEmpty(vmImage.getSku())
+            && !StringUtils.isEmpty(vmImage.getVersion()))) {
+      ResourceValidationUtils.checkFieldNonNull(apiAzureVmCreationParameters.getVmUser(), "vmUser");
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/GcpResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/GcpResourceValidationUtils.java
@@ -1,0 +1,214 @@
+package bio.terra.workspace.service.resource;
+
+import bio.terra.common.exception.InconsistentFieldsException;
+import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
+import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
+import bio.terra.workspace.service.resource.exception.InvalidNameException;
+import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** A collection of static validation functions specific to GCP */
+@Component
+public class GcpResourceValidationUtils {
+  private static final Logger logger = LoggerFactory.getLogger(GcpResourceValidationUtils.class);
+
+  // GCS Bucket
+
+  private static final String GOOG_PREFIX = "goog";
+
+  private static final ImmutableList<String> GOOGLE_NAMES = ImmutableList.of("google", "g00gle");
+
+  /**
+   * GCS bucket name validation is somewhat complex due to rules about usage of "." and restricted
+   * names like "goog", but as a baseline they must be 3-222 characters long using lowercase
+   * letters, numbers, dashes, underscores, and dots, and must start and end with a letter or
+   * number. Matching this pattern is necessary but not sufficient for a valid bucket name.
+   */
+  private static final Pattern GCS_REFERENCED_BUCKET_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[a-z0-9][-_.a-z0-9]{1,220}[a-z0-9]$");
+
+  /**
+   * Similar to REFERENCED_BUCKET_NAME_VALIDATION_PATTERN, except prohibits underscores. GCP
+   * recommends against underscores in bucket names because DNS hostnames can't have underscores. In
+   * particular, Nextflow fails if bucket name has underscore (because bucket name isn't valid DNS
+   * hostname.)
+   */
+  private static final Pattern GCS_CONTROLLED_BUCKET_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[a-z0-9][-.a-z0-9]{1,220}[a-z0-9]$");
+
+  private static final String GCS_REFERENCED_BUCKET_NAME_VALIDATION_FAILURE_ERROR =
+      "Invalid GCS bucket name specified. Names must be 3-222 lowercase letters, numbers, dashes, and underscores. See Google documentation for the full specification.";
+
+  private static final String GCS_CONTROLLED_BUCKET_NAME_VALIDATION_FAILURE_ERROR =
+      "Invalid GCS bucket name specified. Names must be 3-222 lowercase letters, numbers, and dashes. See Google documentation for the full specification.";
+
+  public static void validateGcsBucketNameDisallowUnderscore(String name) {
+    validateGcsBucketName(
+        name,
+        GCS_CONTROLLED_BUCKET_NAME_VALIDATION_PATTERN,
+        GCS_CONTROLLED_BUCKET_NAME_VALIDATION_FAILURE_ERROR);
+  }
+
+  public static void validateGcsBucketNameAllowsUnderscore(String name) {
+    validateGcsBucketName(
+        name,
+        GCS_REFERENCED_BUCKET_NAME_VALIDATION_PATTERN,
+        GCS_REFERENCED_BUCKET_NAME_VALIDATION_FAILURE_ERROR);
+  }
+
+  /**
+   * Validates gcs-bucket name following Google documentation
+   * https://cloud.google.com/storage/docs/naming-buckets#requirements on a best-effort base.
+   *
+   * <p>This method DOES NOT guarantee that the bucket name is valid.
+   *
+   * @param name gcs-bucket name
+   * @param validationFailureError validationFailureError
+   * @throws InvalidNameException throws exception when the bucket name fails to conform to the
+   *     Google naming convention for bucket name.
+   */
+  @VisibleForTesting
+  public static void validateGcsBucketName(
+      String name, Pattern validationPattern, String validationFailureError) {
+    if (StringUtils.isEmpty(name) || !validationPattern.matcher(name).matches()) {
+      logger.warn("Invalid bucket name {}", name);
+      throw new InvalidNameException(validationFailureError);
+    }
+    for (String s : name.split("\\.")) {
+      if (s.length() > 63) {
+        logger.warn("Invalid bucket name {}", name);
+        throw new InvalidNameException(
+            "Invalid GCS bucket name specified. Names containing dots can contain up to 222 characters, but each dot-separated component can be no longer than 63 characters. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
+      }
+    }
+    if (name.startsWith(GOOG_PREFIX)) {
+      logger.warn("Invalid bucket name {}", name);
+      throw new InvalidNameException(
+          "Invalid GCS bucket name specified. Bucket names cannot have prefix goog. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
+    }
+    for (String google : GOOGLE_NAMES) {
+      if (name.contains(google)) {
+        logger.warn("Invalid bucket name {}", name);
+        throw new InvalidNameException(
+            "Invalid GCS bucket name specified. Bucket names cannot contains google or mis-spelled google. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
+      }
+    }
+  }
+
+  // GCS Object
+
+  /**
+   * Magic prefix for ACME HTTP challenge.
+   *
+   * <p>See https://tools.ietf.org/html/draft-ietf-acme-acme-09#section-8.3
+   */
+  private static final String ACME_CHALLENGE_PREFIX = ".well-known/acme-challenge/";
+
+  // An object named "." or ".." is nearly impossible for a user to delete.
+  private static final ImmutableList<String> DISALLOWED_OBJECT_NAMES = ImmutableList.of(".", "..");
+
+  /**
+   * Validate GCS object name.
+   *
+   * @param objectName full path to the object in the bucket
+   * @throws InvalidNameException InvalidNameException
+   */
+  public static void validateGcsObjectName(String objectName) {
+    int nameLength = objectName.getBytes(StandardCharsets.UTF_8).length;
+    if (nameLength < 1 || nameLength > 1024) {
+      throw new InvalidNameException(
+          "bucket object names must contain any sequence of valid Unicode characters, of length 1-1024 bytes when UTF-8 encoded");
+    }
+    if (objectName.startsWith(ACME_CHALLENGE_PREFIX)) {
+      throw new InvalidNameException(
+          "bucket object name cannot start with .well-known/acme-challenge/");
+    }
+    for (String disallowedObjectName : DISALLOWED_OBJECT_NAMES) {
+      if (disallowedObjectName.equals(objectName)) {
+        throw new InvalidNameException("bucket object name cannot be . or ..");
+      }
+    }
+  }
+
+  // BQ DataSet
+
+  /**
+   * BigQuery datasets must be 1-1024 characters, using letters (upper or lowercase), numbers, and
+   * underscores.
+   */
+  private static final Pattern GCP_BQ_DATASET_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[_a-zA-Z0-9]{1,1024}$");
+
+  public static void validateBqDatasetName(String name) {
+    if (StringUtils.isEmpty(name)
+        || !GCP_BQ_DATASET_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
+      logger.warn("Invalid BQ name {}", name);
+      throw new InvalidReferenceException(
+          "Invalid BQ dataset name specified. Name must be 1 to 1024 alphanumeric characters or underscores.");
+    }
+  }
+
+  // BQ DataTable
+
+  /**
+   * BigQuery data table name must be 1-1024 characters, contains Unicode characters in category L
+   * (letter), M (mark), N (number), Pc (connector, including underscore), Pd (dash), Zs (space).
+   */
+  private static final Pattern BQ_DATATABLE_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[\\p{L}\\p{N}\\p{Pc}\\p{Pd}\\p{Zs}\\p{M}]{1,1024}$");
+
+  public static void validateBqDataTableName(String name) {
+    if (StringUtils.isEmpty(name)
+        || !BQ_DATATABLE_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
+      logger.warn("Invalid data table name {}", name);
+      throw new InvalidNameException(
+          "Invalid BQ table name specified. Name must be 1-1024 characters, contains Unicode characters in category L"
+              + " (letter), M (mark), N (number), Pc (connector, including underscore), Pd (dash), Zs (space)");
+    }
+  }
+
+  // AI Notebook
+
+  /**
+   * AI Notebook instances must be 1-63 characters, using lower case letters, numbers, and dashes.
+   * The first character must be a lower case letter, and the last character must not be a dash.
+   */
+  private static final Pattern AI_NOTEBOOK_INSTANCE_NAME_VALIDATION_PATTERN =
+      Pattern.compile("(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)");
+
+  public static void validateAiNotebookInstanceId(String name) {
+    if (!AI_NOTEBOOK_INSTANCE_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
+      logger.warn("Invalid AI Notebook instance ID {}", name);
+      throw new InvalidReferenceException(
+          "Invalid AI Notebook instance ID specified. ID must be 1 to 63 alphanumeric lower case characters or dashes, where the first character is a lower case letter.");
+    }
+  }
+
+  public static void validate(ApiGcpAiNotebookInstanceCreationParameters creationParameters) {
+    validateAiNotebookInstanceId(creationParameters.getInstanceId());
+    // OpenApi one-of fields aren't being generated correctly, so we do manual one-of fields.
+    if ((creationParameters.getVmImage() == null)
+        == (creationParameters.getContainerImage() == null)) {
+      throw new InconsistentFieldsException(
+          "Exactly one of vmImage or containerImage must be specified.");
+    }
+    validate(creationParameters.getVmImage());
+  }
+
+  private static void validate(ApiGcpAiNotebookInstanceVmImage vmImage) {
+    if (vmImage == null) {
+      return;
+    }
+    if ((vmImage.getImageName() == null) == (vmImage.getImageFamily() == null)) {
+      throw new InconsistentFieldsException(
+          "Exactly one of imageName or imageFamily must be specified for a valid vmImage.");
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -50,15 +50,19 @@ public class ResourceValidationUtils {
 
   // General validation functions
 
-  public static <T> void checkFieldNonNull(@Nullable T fieldValue, String fieldName) {
-    checkFieldNonNull(fieldValue, fieldName, "Resource");
-  }
-
   public static <T> void checkFieldNonNull(
       @Nullable T fieldValue, String fieldName, String resourceDescriptor) {
     if (fieldValue == null) {
       throw new MissingRequiredFieldException(
           String.format("Missing required field '%s' for %s", fieldName, resourceDescriptor));
+    }
+  }
+
+  public static void checkStringNonEmpty(
+      @Nullable String fieldValue, String fieldName, String resourceDescriptor) {
+    if (StringUtils.isEmpty(fieldValue)) {
+      throw new MissingRequiredFieldException(
+          String.format("Missing required string '%s' for %s", fieldName, resourceDescriptor));
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -3,7 +3,6 @@ package bio.terra.workspace.service.resource;
 import static bio.terra.workspace.service.workspace.model.WorkspaceConstants.ResourceProperties.FOLDER_ID_KEY;
 
 import bio.terra.common.exception.BadRequestException;
-import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.common.exception.ValidationException;
 import bio.terra.policy.model.TpsComponent;
@@ -13,8 +12,6 @@ import bio.terra.workspace.common.utils.GcpUtils;
 import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.exception.FieldSizeExceededException;
-import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
-import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
 import bio.terra.workspace.service.resource.controlled.exception.RegionNotAllowedException;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
@@ -23,11 +20,8 @@ import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,77 +38,7 @@ import org.springframework.stereotype.Component;
 /** A collection of static validation functions */
 @Component
 public class ResourceValidationUtils {
-  // TODO(TERRA-114) Move Cloud specific functions to separate file
   private static final Logger logger = LoggerFactory.getLogger(ResourceValidationUtils.class);
-
-  /**
-   * GCS bucket name validation is somewhat complex due to rules about usage of "." and restricted
-   * names like "goog", but as a baseline they must be 3-222 characters long using lowercase
-   * letters, numbers, dashes, underscores, and dots, and must start and end with a letter or
-   * number. Matching this pattern is necessary but not sufficient for a valid bucket name.
-   */
-  public static final Pattern REFERENCED_BUCKET_NAME_VALIDATION_PATTERN =
-      Pattern.compile("^[a-z0-9][-_.a-z0-9]{1,220}[a-z0-9]$");
-
-  /**
-   * Similar to REFERENCED_BUCKET_NAME_VALIDATION_PATTERN, except prohibits underscores. GCP
-   * recommends against underscores in bucket names because DNS hostnames can't have underscores. In
-   * particular, Nextflow fails if bucket name has underscore (because bucket name isn't valid DNS
-   * hostname.)
-   */
-  public static final Pattern CONTROLLED_BUCKET_NAME_VALIDATION_PATTERN =
-      Pattern.compile("^[a-z0-9][-.a-z0-9]{1,220}[a-z0-9]$");
-
-  private static final String REFERENCED_BUCKET_NAME_VALIDATION_FAILURE_ERROR =
-      "Invalid GCS bucket name specified. Names must be 3-222 lowercase letters, numbers, dashes, and underscores. See Google documentation for the full specification.";
-
-  private static final String CONTROLLED_BUCKET_NAME_VALIDATION_FAILURE_ERROR =
-      "Invalid GCS bucket name specified. Names must be 3-222 lowercase letters, numbers, and dashes. See Google documentation for the full specification.";
-
-  /**
-   * BigQuery datasets must be 1-1024 characters, using letters (upper or lowercase), numbers, and
-   * underscores.
-   */
-  public static final Pattern BQ_DATASET_NAME_VALIDATION_PATTERN =
-      Pattern.compile("^[_a-zA-Z0-9]{1,1024}$");
-
-  /**
-   * BigQuery data table name must be 1-1024 characters, contains Unicode characters in category L
-   * (letter), M (mark), N (number), Pc (connector, including underscore), Pd (dash), Zs (space).
-   */
-  public static final Pattern BQ_DATATABLE_NAME_VALIDATION_PATTERN =
-      Pattern.compile("^[\\p{L}\\p{N}\\p{Pc}\\p{Pd}\\p{Zs}\\p{M}]{1,1024}$");
-
-  /**
-   * AI Notebook instances must be 1-63 characters, using lower case letters, numbers, and dashes.
-   * The first character must be a lower case letter, and the last character must not be a dash.
-   */
-  public static final Pattern AI_NOTEBOOK_INSTANCE_NAME_VALIDATION_PATTERN =
-      Pattern.compile("(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)");
-
-  /**
-   * Resource names must be 1-1024 characters, using letters, numbers, dashes, and underscores and
-   * must not start with a dash or underscore.
-   */
-  public static final Pattern RESOURCE_NAME_VALIDATION_PATTERN =
-      Pattern.compile("^[a-zA-Z0-9][-_a-zA-Z0-9]{0,1023}$");
-
-  // An object named "." or ".." is nearly impossible for a user to delete.
-  private static final ImmutableList<String> DISALLOWED_OBJECT_NAMES = ImmutableList.of(".", "..");
-
-  // Pattern for Git SSH URL. It often but doesn't have to have the .git extension.
-  private static final Pattern GIT_SSH_URI_PATTERN = Pattern.compile("git@([.a-z]{0,17}):.*$");
-  /**
-   * Magic prefix for ACME HTTP challenge.
-   *
-   * <p>See https://tools.ietf.org/html/draft-ietf-acme-acme-09#section-8.3
-   */
-  public static final String ACME_CHALLENGE_PREFIX = ".well-known/acme-challenge/";
-
-  private static final String GOOG_PREFIX = "goog";
-  private static final ImmutableList<String> GOOGLE_NAMES = ImmutableList.of("google", "g00gle");
-  private static final int MAX_RESOURCE_DESCRIPTION_NAME = 2048;
-  private static final int MAX_FLEXIBLE_RESOURCE_DATA_BYTE_SIZE = 5000;
 
   private final GitRepoReferencedResourceConfiguration gitRepoReferencedResourceConfiguration;
 
@@ -124,58 +48,102 @@ public class ResourceValidationUtils {
     this.gitRepoReferencedResourceConfiguration = gitRepoReferencedResourceConfiguration;
   }
 
-  public static void validateBucketNameDisallowUnderscore(String name) {
-    validateBucketName(
-        name,
-        CONTROLLED_BUCKET_NAME_VALIDATION_PATTERN,
-        CONTROLLED_BUCKET_NAME_VALIDATION_FAILURE_ERROR);
+  // General validation functions
+
+  public static <T> void checkFieldNonNull(@Nullable T fieldValue, String fieldName) {
+    checkFieldNonNull(fieldValue, fieldName, "Resource");
   }
 
-  public static void validateBucketNameAllowsUnderscore(String name) {
-    validateBucketName(
-        name,
-        REFERENCED_BUCKET_NAME_VALIDATION_PATTERN,
-        REFERENCED_BUCKET_NAME_VALIDATION_FAILURE_ERROR);
+  public static <T> void checkFieldNonNull(
+      @Nullable T fieldValue, String fieldName, String resourceDescriptor) {
+    if (fieldValue == null) {
+      throw new MissingRequiredFieldException(
+          String.format("Missing required field '%s' for %s", fieldName, resourceDescriptor));
+    }
+  }
+
+  // Resource properties
+
+  /**
+   * Resource names must be 1-1024 characters, using letters, numbers, dashes, and underscores and
+   * must not start with a dash or underscore.
+   */
+  public static final Pattern RESOURCE_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[a-zA-Z0-9][-_a-zA-Z0-9]{0,1023}$");
+
+  private static final int MAX_RESOURCE_DESCRIPTION_NAME = 2048;
+
+  public static void validateResourceName(String name) {
+    if (StringUtils.isEmpty(name) || !RESOURCE_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
+      logger.warn("Invalid resource name {}", name);
+      throw new InvalidNameException(
+          "Invalid resource name specified. Name must be 1 to 1024 alphanumeric characters, underscores, and dashes and must not start with a dash or underscore.");
+    }
+  }
+
+  public static void validateOptionalResourceName(@Nullable String name) {
+    if (name != null && !RESOURCE_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
+      logger.warn("Invalid resource name {}", name);
+      throw new InvalidNameException(
+          "Invalid resource name specified. Name must be 1 to 1024 alphanumeric characters, underscores, and dashes and must not start with a dash or underscore.");
+    }
+  }
+
+  public static void validateResourceDescriptionName(@Nullable String name) {
+    if (name != null && name.length() > MAX_RESOURCE_DESCRIPTION_NAME) {
+      throw new InvalidNameException(
+          "Invalid description specified. Description must be under 2048 characters.");
+    }
   }
 
   /**
-   * Validates gcs-bucket name following Google documentation
-   * https://cloud.google.com/storage/docs/naming-buckets#requirements on a best-effort base.
+   * Validate the terra reserved properties has valid values.
    *
-   * <p>This method DOES NOT guarantee that the bucket name is valid.
-   *
-   * @param name gcs-bucket name
-   * @param validationFailureError validationFailureError
-   * @throws InvalidNameException throws exception when the bucket name fails to conform to the
-   *     Google naming convention for bucket name.
+   * @param properties of a resource.
    */
-  @VisibleForTesting
-  public static void validateBucketName(
-      String name, Pattern validationPattern, String validationFailureError) {
-    if (StringUtils.isEmpty(name) || !validationPattern.matcher(name).matches()) {
-      logger.warn("Invalid bucket name {}", name);
-      throw new InvalidNameException(validationFailureError);
-    }
-    for (String s : name.split("\\.")) {
-      if (s.length() > 63) {
-        logger.warn("Invalid bucket name {}", name);
-        throw new InvalidNameException(
-            "Invalid GCS bucket name specified. Names containing dots can contain up to 222 characters, but each dot-separated component can be no longer than 63 characters. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
-      }
-    }
-    if (name.startsWith(GOOG_PREFIX)) {
-      logger.warn("Invalid bucket name {}", name);
-      throw new InvalidNameException(
-          "Invalid GCS bucket name specified. Bucket names cannot have prefix goog. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
-    }
-    for (String google : GOOGLE_NAMES) {
-      if (name.contains(google)) {
-        logger.warn("Invalid bucket name {}", name);
-        throw new InvalidNameException(
-            "Invalid GCS bucket name specified. Bucket names cannot contains google or mis-spelled google. See Google documentation https://cloud.google.com/storage/docs/naming-buckets#requirements for the full specification.");
+  public static void validateProperties(Map<String, String> properties) {
+    if (properties.containsKey(FOLDER_ID_KEY)) {
+      try {
+        var unused = UUID.fromString(properties.get(FOLDER_ID_KEY));
+      } catch (IllegalArgumentException e) {
+        throw new BadRequestException(
+            String.format(
+                "Property %s contains an invalid non-UUID format folder id %s.",
+                FOLDER_ID_KEY, properties.get(FOLDER_ID_KEY)));
       }
     }
   }
+
+  // Resource operations
+
+  /**
+   * Assert that the cloning instructions specified for a controlled or referenced resource are a
+   * valid combination. Intended for use at the api controller level.
+   *
+   * @param stewardshipType - controlled or referenced
+   * @param cloningInstructions - supplied cloning instructions with the API request
+   * @throws ValidationException if the combination is not valid
+   */
+  public static void validateCloningInstructions(
+      StewardshipType stewardshipType, CloningInstructions cloningInstructions) {
+    switch (stewardshipType) {
+      case CONTROLLED:
+        if (cloningInstructions.isValidForControlledResource()) {
+          return;
+        }
+        break;
+      case REFERENCED:
+        if (cloningInstructions.isValidForReferencedResource()) {
+          return;
+        }
+    }
+    throw new ValidationException(
+        String.format(
+            "Cloning Instruction %s is not valid with Stewardship Type %s",
+            cloningInstructions.toString(), stewardshipType));
+  }
+
+  // Region
 
   public static void validateRegionAgainstPolicy(
       TpsApiDispatch tpsApiDispatch, UUID workspaceUuid, String region, CloudPlatform platform) {
@@ -213,6 +181,33 @@ public class ResourceValidationUtils {
                     .formatted(violation.getName(), violation.getRegion()))
         .toList();
   }
+
+  public static void validateRegion(
+      TpsApiDispatch tpsApiDispatch, UUID workspaceId, String region, CloudPlatform cloudPlatform) {
+    Rethrow.onInterrupted(
+        () ->
+            tpsApiDispatch.createPaoIfNotExist(
+                workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE),
+        "createPaoIfNotExist");
+
+    // Get the list of valid locations for this workspace from TPS. If there are no regional
+    // constraints applied to the workspace, TPS should return all available regions.
+    List<String> validLocations =
+        Rethrow.onInterrupted(
+            () -> tpsApiDispatch.listValidRegions(workspaceId, cloudPlatform), "listValidRegions");
+
+    if (validLocations.stream().noneMatch(region::equalsIgnoreCase)) {
+      throw new RegionNotAllowedException(
+          String.format(
+              "Specified region %s is not allowed by effective policy. Allowed regions are %s",
+              region, validLocations));
+    }
+  }
+
+  // Git
+
+  // Pattern for Git SSH URL. It often but doesn't have to have the .git extension.
+  private static final Pattern GIT_SSH_URI_PATTERN = Pattern.compile("git@([.a-z]{0,17}):.*$");
 
   /** Validate whether the input URI is a valid GitHub Repo https uri. */
   public void validateGitRepoUri(String gitUri) {
@@ -262,177 +257,9 @@ public class ResourceValidationUtils {
     return hostName.startsWith("git-codecommit.") && hostName.endsWith(".amazonaws.com");
   }
 
-  /**
-   * Validate GCS object name.
-   *
-   * @param objectName full path to the object in the bucket
-   * @throws InvalidNameException InvalidNameException
-   */
-  public static void validateGcsObjectName(String objectName) {
-    int nameLength = objectName.getBytes(StandardCharsets.UTF_8).length;
-    if (nameLength < 1 || nameLength > 1024) {
-      throw new InvalidNameException(
-          "bucket object names must contain any sequence of valid Unicode characters, of length 1-1024 bytes when UTF-8 encoded");
-    }
-    if (objectName.startsWith(ACME_CHALLENGE_PREFIX)) {
-      throw new InvalidNameException(
-          "bucket object name cannot start with .well-known/acme-challenge/");
-    }
-    for (String disallowedObjectName : DISALLOWED_OBJECT_NAMES) {
-      if (disallowedObjectName.equals(objectName)) {
-        throw new InvalidNameException("bucket object name cannot be . or ..");
-      }
-    }
-  }
+  // Flex resources
 
-  public static void validateBqDatasetName(String name) {
-    if (StringUtils.isEmpty(name) || !BQ_DATASET_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
-      logger.warn("Invalid BQ name {}", name);
-      throw new InvalidReferenceException(
-          "Invalid BQ dataset name specified. Name must be 1 to 1024 alphanumeric characters or underscores.");
-    }
-  }
-
-  public static void validateBqDataTableName(String name) {
-    if (StringUtils.isEmpty(name)
-        || !BQ_DATATABLE_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
-      logger.warn("Invalid data table name {}", name);
-      throw new InvalidNameException(
-          "Invalid BQ table name specified. Name must be 1-1024 characters, contains Unicode characters in category L"
-              + " (letter), M (mark), N (number), Pc (connector, including underscore), Pd (dash), Zs (space)");
-    }
-  }
-
-  public static void validateAiNotebookInstanceId(String name) {
-    if (!AI_NOTEBOOK_INSTANCE_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
-      logger.warn("Invalid AI Notebook instance ID {}", name);
-      throw new InvalidReferenceException(
-          "Invalid AI Notebook instance ID specified. ID must be 1 to 63 alphanumeric lower case characters or dashes, where the first character is a lower case letter.");
-    }
-  }
-
-  public static void validate(ApiGcpAiNotebookInstanceCreationParameters creationParameters) {
-    validateAiNotebookInstanceId(creationParameters.getInstanceId());
-    // OpenApi one-of fields aren't being generated correctly, so we do manual one-of fields.
-    if ((creationParameters.getVmImage() == null)
-        == (creationParameters.getContainerImage() == null)) {
-      throw new InconsistentFieldsException(
-          "Exactly one of vmImage or containerImage must be specified.");
-    }
-    validate(creationParameters.getVmImage());
-  }
-
-  private static void validate(ApiGcpAiNotebookInstanceVmImage vmImage) {
-    if (vmImage == null) {
-      return;
-    }
-    if ((vmImage.getImageName() == null) == (vmImage.getImageFamily() == null)) {
-      throw new InconsistentFieldsException(
-          "Exactly one of imageName or imageFamily must be specified for a valid vmImage.");
-    }
-  }
-
-  public static void validateResourceName(String name) {
-    if (StringUtils.isEmpty(name) || !RESOURCE_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
-      logger.warn("Invalid resource name {}", name);
-      throw new InvalidNameException(
-          "Invalid resource name specified. Name must be 1 to 1024 alphanumeric characters, underscores, and dashes and must not start with a dash or underscore.");
-    }
-  }
-
-  public static void validateOptionalResourceName(@Nullable String name) {
-    if (name != null && !RESOURCE_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
-      logger.warn("Invalid resource name {}", name);
-      throw new InvalidNameException(
-          "Invalid resource name specified. Name must be 1 to 1024 alphanumeric characters, underscores, and dashes and must not start with a dash or underscore.");
-    }
-  }
-
-  public static void validateResourceDescriptionName(@Nullable String name) {
-    if (name != null && name.length() > MAX_RESOURCE_DESCRIPTION_NAME) {
-      throw new InvalidNameException(
-          "Invalid description specified. Description must be under 2048 characters.");
-    }
-  }
-
-  public static void validateRegion(
-      TpsApiDispatch tpsApiDispatch, UUID workspaceId, String region, CloudPlatform cloudPlatform) {
-    Rethrow.onInterrupted(
-        () ->
-            tpsApiDispatch.createPaoIfNotExist(
-                workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE),
-        "createPaoIfNotExist");
-
-    // Get the list of valid locations for this workspace from TPS. If there are no regional
-    // constraints applied to the workspace, TPS should return all available regions.
-    List<String> validLocations =
-        Rethrow.onInterrupted(
-            () -> tpsApiDispatch.listValidRegions(workspaceId, cloudPlatform), "listValidRegions");
-
-    if (validLocations.stream().noneMatch(region::equalsIgnoreCase)) {
-      throw new RegionNotAllowedException(
-          String.format(
-              "Specified region %s is not allowed by effective policy. Allowed regions are %s",
-              region, validLocations));
-    }
-  }
-
-  public static <T> void checkFieldNonNull(@Nullable T fieldValue, String fieldName) {
-    checkFieldNonNull(fieldValue, fieldName, "Resource");
-  }
-
-  public static <T> void checkFieldNonNull(
-      @Nullable T fieldValue, String fieldName, String resourceDescriptor) {
-    if (fieldValue == null) {
-      throw new MissingRequiredFieldException(
-          String.format("Missing required field '%s' for %s", fieldName, resourceDescriptor));
-    }
-  }
-
-  /**
-   * Assert that the cloning instructions specified for a controlled or referenced resource are a
-   * valid combination. Intended for use at the api controller level.
-   *
-   * @param stewardshipType - controlled or referenced
-   * @param cloningInstructions - supplied cloning instructions with the API request
-   * @throws ValidationException if the combination is not valid
-   */
-  public static void validateCloningInstructions(
-      StewardshipType stewardshipType, CloningInstructions cloningInstructions) {
-    switch (stewardshipType) {
-      case CONTROLLED:
-        if (cloningInstructions.isValidForControlledResource()) {
-          return;
-        }
-        break;
-      case REFERENCED:
-        if (cloningInstructions.isValidForReferencedResource()) {
-          return;
-        }
-    }
-    throw new ValidationException(
-        String.format(
-            "Cloning Instruction %s is not valid with Stewardship Type %s",
-            cloningInstructions.toString(), stewardshipType));
-  }
-
-  /**
-   * Validate the terra reserved properties has valid values.
-   *
-   * @param properties of a resource.
-   */
-  public static void validateProperties(Map<String, String> properties) {
-    if (properties.containsKey(FOLDER_ID_KEY)) {
-      try {
-        var unused = UUID.fromString(properties.get(FOLDER_ID_KEY));
-      } catch (IllegalArgumentException e) {
-        throw new BadRequestException(
-            String.format(
-                "Property %s contains an invalid non-UUID format folder id %s.",
-                FOLDER_ID_KEY, properties.get(FOLDER_ID_KEY)));
-      }
-    }
-  }
+  private static final int MAX_FLEXIBLE_RESOURCE_DATA_BYTE_SIZE = 5000;
 
   public static void validateFlexResourceDataSize(@Nullable String decodedData) {
     if (decodedData != null) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -13,7 +13,6 @@ import bio.terra.workspace.common.utils.GcpUtils;
 import bio.terra.workspace.common.utils.Rethrow;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.exception.FieldSizeExceededException;
-import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
@@ -73,23 +72,6 @@ public class ResourceValidationUtils {
       "Invalid GCS bucket name specified. Names must be 3-222 lowercase letters, numbers, and dashes. See Google documentation for the full specification.";
 
   /**
-   * Azure Storage Account name validation valid. An storage account name must be between 3-24
-   * characters in length and may contain numbers and lowercase letters only.
-   */
-  public static final Pattern AZURE_STORAGE_ACCOUNT_NAME_VALIDATION_PATTERN =
-      Pattern.compile("^[a-z0-9]{3,24}$");
-
-  /**
-   * Azure Storage Container name validation. A storage container name must be between 3-63
-   * characters in length and may contain numbers, lowercase letters, and dash (-) characters only.
-   * It must start and end with a letter or number. Matching this pattern is necessary but not
-   * sufficient for a valid container name (in particular, the dash character must be immediately
-   * preceded and followed by a letter or number; consecutive dashes are not permitted).
-   */
-  public static final Pattern AZURE_STORAGE_CONTAINER_NAME_VALIDATION_PATTERN =
-      Pattern.compile("^[a-z0-9][-a-z0-9]{1,61}[a-z0-9]$");
-
-  /**
    * BigQuery datasets must be 1-1024 characters, using letters (upper or lowercase), numbers, and
    * underscores.
    */
@@ -117,13 +99,6 @@ public class ResourceValidationUtils {
   public static final Pattern RESOURCE_NAME_VALIDATION_PATTERN =
       Pattern.compile("^[a-zA-Z0-9][-_a-zA-Z0-9]{0,1023}$");
 
-  public static final Pattern AZURE_RELAY_NAMESPACE_PATTERN =
-      Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-]{0,78}[a-zA-Z0-9]$");
-
-  /** Batch Pool id must be -64 characters, using letters, numbers, dashes, and underscores */
-  public static final Pattern AZURE_BATCH_POOL_ID_VALIDATION_PATTERN =
-      Pattern.compile("^[-_a-zA-Z0-9]{0,63}$");
-
   // An object named "." or ".." is nearly impossible for a user to delete.
   private static final ImmutableList<String> DISALLOWED_OBJECT_NAMES = ImmutableList.of(".", "..");
 
@@ -139,7 +114,6 @@ public class ResourceValidationUtils {
   private static final String GOOG_PREFIX = "goog";
   private static final ImmutableList<String> GOOGLE_NAMES = ImmutableList.of("google", "g00gle");
   private static final int MAX_RESOURCE_DESCRIPTION_NAME = 2048;
-  private static final int MAX_BATCH_POOL_DISPLAY_NAME = 1024;
   private static final int MAX_FLEXIBLE_RESOURCE_DATA_BYTE_SIZE = 5000;
 
   private final GitRepoReferencedResourceConfiguration gitRepoReferencedResourceConfiguration;
@@ -311,76 +285,6 @@ public class ResourceValidationUtils {
     }
   }
 
-  /**
-   * See
-   * https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
-   * for azure resource rules
-   */
-  public static void validateAzureIPorSubnetName(String name) {
-    Pattern pattern = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-_.]{0,78}[a-zA-Z0-9_]$");
-
-    if (!pattern.matcher(name).matches()) {
-      logger.warn("Invalid Azure IP or Subnet name {}", name);
-      throw new InvalidReferenceException(
-          "Invalid Azure IP or Subnet name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
-    }
-  }
-
-  /**
-   * See
-   * https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
-   * for azure resource rules
-   */
-  public static void validateAzureNamespace(String name) {
-    if (!AZURE_RELAY_NAMESPACE_PATTERN.matcher(name).matches()
-        || name.length() > 50
-        || name.length() < 6) {
-      logger.warn("Invalid Azure Namespace {}", name);
-      throw new InvalidReferenceException(
-          "Invalid Azure Namespace specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
-    }
-  }
-
-  public static void validateAzureNetworkName(String name) {
-    Pattern pattern = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}[a-zA-Z0-9_]$");
-
-    if (!pattern.matcher(name).matches()) {
-      logger.warn("Invalid Azure network name {}", name);
-      throw new InvalidReferenceException(
-          "Invalid Azure network name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
-    }
-  }
-
-  public static void validateAzureDiskName(String name) {
-    Pattern pattern = Pattern.compile("^[a-zA-Z0-9-_]{0,80}$");
-
-    if (!pattern.matcher(name).matches()) {
-      logger.warn("Invalid Disk name {}", name);
-      throw new InvalidReferenceException(
-          "Invalid Azure Disk name specified. See documentation for full specification https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.");
-    }
-  }
-
-  public static void validateAzureBatchPoolId(String id) {
-    if (!AZURE_BATCH_POOL_ID_VALIDATION_PATTERN.matcher(id).matches()) {
-      logger.warn("Invalid Azure Batch Pool id {}", id);
-      throw new InvalidReferenceException(
-          "Invalid Azure Batch Pool id specified. Name must be 1 to 64 alphanumeric characters or underscores or dashes.");
-    }
-  }
-
-  public static void validateAzureCidrBlock(String range) {
-    Pattern pattern =
-        Pattern.compile(
-            "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(\\d|[1-2]\\d|3[0-2]))$");
-
-    if (!pattern.matcher(range).matches()) {
-      logger.warn("Invalid CIDR block {}", range);
-      throw new InvalidReferenceException(
-          "Invalid Azure CIDR block specified. See documentation for full specification https://stackoverflow.com/questions/18608165/cidr-notation-and-ip-range-validator-pattern/18611259.");
-    }
-  }
-
   public static void validateBqDatasetName(String name) {
     if (StringUtils.isEmpty(name) || !BQ_DATASET_NAME_VALIDATION_PATTERN.matcher(name).matches()) {
       logger.warn("Invalid BQ name {}", name);
@@ -451,31 +355,6 @@ public class ResourceValidationUtils {
     }
   }
 
-  public static void validateBatchPoolDisplayName(@Nullable String displayName) {
-    if (displayName != null && displayName.length() > MAX_BATCH_POOL_DISPLAY_NAME) {
-      throw new InvalidNameException(
-          "Invalid display name specified. Display name must be under 1024 characters.");
-    }
-  }
-
-  public static void validateStorageAccountName(String storageAccountName) {
-    if (!AZURE_STORAGE_ACCOUNT_NAME_VALIDATION_PATTERN.matcher(storageAccountName).matches()) {
-      logger.warn("Invalid Storage Account name: {}", storageAccountName);
-      throw new InvalidReferenceException(
-          "Invalid Azure Storage Account name. The name must be 3 to 24 alphanumeric lower case characters.");
-    }
-  }
-
-  public static void validateStorageContainerName(String storageContainerName) {
-    if (!AZURE_STORAGE_CONTAINER_NAME_VALIDATION_PATTERN.matcher(storageContainerName).matches()
-        || storageContainerName.contains("--")) {
-      logger.warn("Invalid Storage Container name: {}", storageContainerName);
-      throw new InvalidReferenceException(
-          "Invalid Azure Storage Container name. The name must be 3 to 63 alphanumeric lower case characters "
-              + "or dashes, must start and end with a letter or number, and cannot contain consecutive dashes.");
-    }
-  }
-
   public static void validateRegion(
       TpsApiDispatch tpsApiDispatch, UUID workspaceId, String region, CloudPlatform cloudPlatform) {
     Rethrow.onInterrupted(
@@ -507,34 +386,6 @@ public class ResourceValidationUtils {
     if (fieldValue == null) {
       throw new MissingRequiredFieldException(
           String.format("Missing required field '%s' for %s", fieldName, resourceDescriptor));
-    }
-  }
-
-  public static void validateApiAzureVmCreationParameters(
-      ApiAzureVmCreationParameters apiAzureVmCreationParameters) {
-    var vmImage = apiAzureVmCreationParameters.getVmImage();
-    if (StringUtils.isEmpty(vmImage.getUri())
-        && StringUtils.isEmpty(vmImage.getPublisher())
-        && StringUtils.isEmpty(vmImage.getOffer())
-        && StringUtils.isEmpty(vmImage.getSku())
-        && StringUtils.isEmpty(vmImage.getVersion())) {
-      throw new MissingRequiredFieldException(
-          "Missing required fields for vmImage. Either uri or publisher, offer, sku, version should be defined.");
-    }
-    if (StringUtils.isEmpty(vmImage.getUri())
-        && (StringUtils.isEmpty(vmImage.getPublisher())
-            || StringUtils.isEmpty(vmImage.getOffer())
-            || StringUtils.isEmpty(vmImage.getSku())
-            || StringUtils.isEmpty(vmImage.getVersion()))) {
-      throw new MissingRequiredFieldException(
-          "Missing required fields for vmImage. Publisher, offer, sku, version should be defined.");
-    }
-    if (StringUtils.isEmpty(vmImage.getUri())
-        && (!StringUtils.isEmpty(vmImage.getPublisher())
-            && !StringUtils.isEmpty(vmImage.getOffer())
-            && !StringUtils.isEmpty(vmImage.getSku())
-            && !StringUtils.isEmpty(vmImage.getVersion()))) {
-      checkFieldNonNull(apiAzureVmCreationParameters.getVmUser(), "vmUser");
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
@@ -185,9 +185,9 @@ public class ControlledAwsS3StorageFolderResource extends ControlledResource {
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected CONTROLLED_AWS_S3_STORAGE_FOLDER");
     }
-    ResourceValidationUtils.checkFieldNonNull(bucketName, "bucketName", RESOURCE_DESCRIPTOR);
-    ResourceValidationUtils.checkFieldNonNull(prefix, "prefix", RESOURCE_DESCRIPTOR);
-    ResourceValidationUtils.checkFieldNonNull(getRegion(), "region", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkStringNonEmpty(bucketName, "bucketName", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkStringNonEmpty(prefix, "prefix", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkStringNonEmpty(getRegion(), "region", RESOURCE_DESCRIPTOR);
     AwsResourceValidationUtils.validateAwsS3StorageFolderName(prefix);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
@@ -208,9 +208,9 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
       throw new BadRequestException(
           "Access scope must be private. Shared Sagemaker Notebook instances are not yet implemented.");
     }
-    ResourceValidationUtils.checkFieldNonNull(instanceName, "instanceName", RESOURCE_DESCRIPTOR);
-    ResourceValidationUtils.checkFieldNonNull(instanceType, "instanceType", RESOURCE_DESCRIPTOR);
-    ResourceValidationUtils.checkFieldNonNull(getRegion(), "region", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkStringNonEmpty(instanceName, "instanceName", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkStringNonEmpty(instanceType, "instanceType", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkStringNonEmpty(getRegion(), "region", RESOURCE_DESCRIPTOR);
     AwsResourceValidationUtils.validateAwsSageMakerNotebookName(instanceName);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
@@ -10,7 +10,7 @@ import bio.terra.workspace.generated.model.ApiAzureBatchPoolAttributes;
 import bio.terra.workspace.generated.model.ApiAzureBatchPoolResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.AzureResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool.model.BatchPoolUserAssignedManagedIdentity;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
@@ -250,8 +250,8 @@ public class ControlledAzureBatchPoolResource extends ControlledResource {
         || getStewardshipType() != StewardshipType.CONTROLLED) {
       throw new InconsistentFieldsException("Expected controlled AZURE_BATCH_POOL");
     }
-    ResourceValidationUtils.validateAzureBatchPoolId(getId());
-    ResourceValidationUtils.validateBatchPoolDisplayName(getDisplayName());
+    AzureResourceValidationUtils.validateAzureBatchPoolId(getId());
+    AzureResourceValidationUtils.validateAzureBatchPoolDisplayName(getDisplayName());
     if (deploymentConfiguration != null) {
       if (deploymentConfiguration.virtualMachineConfiguration() != null
           && deploymentConfiguration.cloudServiceConfiguration() != null) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiAzureDiskAttributes;
 import bio.terra.workspace.generated.model.ApiAzureDiskResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.AzureResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
@@ -181,7 +181,7 @@ public class ControlledAzureDiskResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureDisk.");
     }
-    ResourceValidationUtils.validateAzureDiskName(getDiskName());
+    AzureResourceValidationUtils.validateAzureDiskName(getDiskName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiAzureStorageContainerAttributes;
 import bio.terra.workspace.generated.model.ApiAzureStorageContainerResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.AzureResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
@@ -184,7 +184,7 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
           "Missing required storage container name field for ControlledAzureStorageContainer.");
     }
 
-    ResourceValidationUtils.validateStorageContainerName(getStorageContainerName());
+    AzureResourceValidationUtils.validateAzureStorageContainerName(getStorageContainerName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiAzureVmAttributes;
 import bio.terra.workspace.generated.model.ApiAzureVmResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.AzureResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
@@ -239,7 +239,7 @@ public class ControlledAzureVmResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required valid vmImage field for ControlledAzureVm.");
     }
-    ResourceValidationUtils.validateAzureIPorSubnetName(getVmName());
+    AzureResourceValidationUtils.validateAzureIPorSubnetName(getVmName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -16,6 +16,7 @@ import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceAttributes;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.resource.GcpResourceValidationUtils;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
@@ -323,7 +324,7 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
     ResourceValidationUtils.checkFieldNonNull(getInstanceId(), "instanceId", RESOURCE_DESCRIPTOR);
     ResourceValidationUtils.checkFieldNonNull(getLocation(), "location", RESOURCE_DESCRIPTOR);
     ResourceValidationUtils.checkFieldNonNull(getProjectId(), "projectId", RESOURCE_DESCRIPTOR);
-    ResourceValidationUtils.validateAiNotebookInstanceId(getInstanceId());
+    GcpResourceValidationUtils.validateAiNotebookInstanceId(getInstanceId());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -321,9 +321,9 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
       throw new BadRequestException(
           "Access scope must be private. Shared AI Notebook instances are not yet implemented.");
     }
-    ResourceValidationUtils.checkFieldNonNull(getInstanceId(), "instanceId", RESOURCE_DESCRIPTOR);
-    ResourceValidationUtils.checkFieldNonNull(getLocation(), "location", RESOURCE_DESCRIPTOR);
-    ResourceValidationUtils.checkFieldNonNull(getProjectId(), "projectId", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkStringNonEmpty(getInstanceId(), "instanceId", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkStringNonEmpty(getLocation(), "location", RESOURCE_DESCRIPTOR);
+    ResourceValidationUtils.checkStringNonEmpty(getProjectId(), "projectId", RESOURCE_DESCRIPTOR);
     GcpResourceValidationUtils.validateAiNotebookInstanceId(getInstanceId());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -13,7 +13,7 @@ import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetAttributes;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.GcpResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
@@ -239,7 +239,7 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required field projectId for BigQuery dataset");
     }
-    ResourceValidationUtils.validateBqDatasetName(getDatasetName());
+    GcpResourceValidationUtils.validateBqDatasetName(getDatasetName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -14,7 +14,7 @@ import bio.terra.workspace.generated.model.ApiGcpGcsBucketAttributes;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.GcpResourceValidationUtils;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
@@ -227,13 +227,13 @@ public class ControlledGcsBucketResource extends ControlledResource {
     }
     // Allow underscore bucket name to be backward compatible. The database contains bucket with
     // underscore bucketname.
-    ResourceValidationUtils.validateBucketNameAllowsUnderscore(bucketName);
+    GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore(bucketName);
   }
 
   public void validateForNewBucket() {
     validate();
     // Disallow underscore in new terra managed GCS bucket.
-    ResourceValidationUtils.validateBucketNameDisallowUnderscore(bucketName);
+    GcpResourceValidationUtils.validateGcsBucketNameDisallowUnderscore(bucketName);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/model/ControlledResourceFields.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
  * <p>See {@link ControlledResource} for details on the meaning of the fields
  */
 public class ControlledResourceFields extends WsmResourceFields {
+  private static final String RESOURCE_DESCRIPTIOR = "ControlledResourceFields";
   private final WsmControlledResourceFields wsmControlledResourceFields;
   // We hold the iamRole to simplify the controller flow. It is not retained in the
   // controlled object.
@@ -161,8 +162,8 @@ public class ControlledResourceFields extends WsmResourceFields {
     @Override
     public void validate() {
       super.validate();
-      ResourceValidationUtils.checkFieldNonNull(accessScope, "accessScope");
-      ResourceValidationUtils.checkFieldNonNull(managedBy, "managedBy");
+      ResourceValidationUtils.checkFieldNonNull(accessScope, "accessScope", RESOURCE_DESCRIPTIOR);
+      ResourceValidationUtils.checkFieldNonNull(managedBy, "managedBy", RESOURCE_DESCRIPTIOR);
     }
 
     public Builder assignedUser(@Nullable String assignedUser) {
@@ -208,7 +209,7 @@ public class ControlledResourceFields extends WsmResourceFields {
       if (privateResourceState != null) {
         return;
       }
-      ResourceValidationUtils.checkFieldNonNull(accessScope, "accessScope");
+      ResourceValidationUtils.checkFieldNonNull(accessScope, "accessScope", RESOURCE_DESCRIPTIOR);
       privateResourceState =
           (accessScope == AccessScopeType.ACCESS_SCOPE_PRIVATE
               ? PrivateResourceState.INITIALIZING

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResourceFields.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
  */
 @JsonDeserialize(builder = WsmResourceFields.Builder.class)
 public class WsmResourceFields {
+  private static final String RESOURCE_DESCRIPTIOR = "WsmResourceFields";
   private final UUID workspaceUuid;
   private final UUID resourceId;
   private final String name;
@@ -228,13 +229,15 @@ public class WsmResourceFields {
     public Builder() {}
 
     public void validate() {
-      ResourceValidationUtils.checkFieldNonNull(workspaceUuid, "workspaceId");
-      ResourceValidationUtils.checkFieldNonNull(resourceId, "resourceId");
-      ResourceValidationUtils.checkFieldNonNull(name, "name");
-      ResourceValidationUtils.checkFieldNonNull(cloningInstructions, "cloningInstructions");
-      ResourceValidationUtils.checkFieldNonNull(properties, "properties");
-      ResourceValidationUtils.checkFieldNonNull(createdByEmail, "createdByEmail");
-      ResourceValidationUtils.checkFieldNonNull(state, "state");
+      ResourceValidationUtils.checkFieldNonNull(workspaceUuid, "workspaceId", RESOURCE_DESCRIPTIOR);
+      ResourceValidationUtils.checkFieldNonNull(resourceId, "resourceId", RESOURCE_DESCRIPTIOR);
+      ResourceValidationUtils.checkStringNonEmpty(name, "name", RESOURCE_DESCRIPTIOR);
+      ResourceValidationUtils.checkFieldNonNull(
+          cloningInstructions, "cloningInstructions", RESOURCE_DESCRIPTIOR);
+      ResourceValidationUtils.checkFieldNonNull(properties, "properties", RESOURCE_DESCRIPTIOR);
+      ResourceValidationUtils.checkStringNonEmpty(
+          createdByEmail, "createdByEmail", RESOURCE_DESCRIPTIOR);
+      ResourceValidationUtils.checkFieldNonNull(state, "state", RESOURCE_DESCRIPTIOR);
     }
 
     public WsmResourceFields build() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
@@ -12,7 +12,7 @@ import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.GcpResourceValidationUtils;
 import bio.terra.workspace.service.resource.flight.UpdateResourceFlight;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
@@ -151,7 +151,7 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
       throw new MissingRequiredFieldException(
           "Missing required field for ReferenceBigQueryDatasetAttributes.");
     }
-    ResourceValidationUtils.validateBqDatasetName(getDatasetName());
+    GcpResourceValidationUtils.validateBqDatasetName(getDatasetName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
@@ -12,7 +12,7 @@ import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.GcpResourceValidationUtils;
 import bio.terra.workspace.service.resource.flight.UpdateResourceFlight;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
@@ -166,8 +166,8 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
       throw new MissingRequiredFieldException(
           "Missing required field for ReferenceBigQueryDataTableAttributes");
     }
-    ResourceValidationUtils.validateBqDatasetName(getDatasetId());
-    ResourceValidationUtils.validateBqDataTableName(getDataTableId());
+    GcpResourceValidationUtils.validateBqDatasetName(getDatasetId());
+    GcpResourceValidationUtils.validateBqDataTableName(getDataTableId());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
@@ -12,7 +12,7 @@ import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.GcpResourceValidationUtils;
 import bio.terra.workspace.service.resource.flight.UpdateResourceFlight;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
@@ -135,7 +135,7 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
     }
     // Validate in case there's a typo and user gave wrong name. This gives a slightly more usable
     // error message than "You do not have access to bucket".
-    ResourceValidationUtils.validateBucketNameAllowsUnderscore(getBucketName());
+    GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore(getBucketName());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
@@ -12,7 +12,7 @@ import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.petserviceaccount.PetSaService;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.GcpResourceValidationUtils;
 import bio.terra.workspace.service.resource.flight.UpdateResourceFlight;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
@@ -141,8 +141,8 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
       throw new MissingRequiredFieldException(
           "Missing required field for ReferenceGcsObjectResource.");
     }
-    ResourceValidationUtils.validateBucketNameAllowsUnderscore(getBucketName());
-    ResourceValidationUtils.validateGcsObjectName(getObjectName());
+    GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore(getBucketName());
+    GcpResourceValidationUtils.validateGcsObjectName(getObjectName());
   }
 
   @Override

--- a/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
@@ -388,7 +388,8 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         MissingRequiredFieldException.class,
         () ->
-            ResourceValidationUtils.validateApiAzureVmCreationParameters(apiVmCreationParameters));
+            AzureResourceValidationUtils.validateApiAzureVmCreationParameters(
+                apiVmCreationParameters));
   }
 
   @Test
@@ -401,7 +402,8 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         MissingRequiredFieldException.class,
         () ->
-            ResourceValidationUtils.validateApiAzureVmCreationParameters(apiVmCreationParameters));
+            AzureResourceValidationUtils.validateApiAzureVmCreationParameters(
+                apiVmCreationParameters));
   }
 
   @Test
@@ -418,7 +420,8 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         MissingRequiredFieldException.class,
         () ->
-            ResourceValidationUtils.validateApiAzureVmCreationParameters(apiVmCreationParameters));
+            AzureResourceValidationUtils.validateApiAzureVmCreationParameters(
+                apiVmCreationParameters));
   }
 
   @Test
@@ -435,7 +438,8 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         MissingRequiredFieldException.class,
         () ->
-            ResourceValidationUtils.validateApiAzureVmCreationParameters(apiVmCreationParameters));
+            AzureResourceValidationUtils.validateApiAzureVmCreationParameters(
+                apiVmCreationParameters));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
@@ -67,43 +67,43 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
 
   @Test
   public void aiNotebookInstanceName() {
-    ResourceValidationUtils.validateAiNotebookInstanceId("valid-instance-id-0");
+    GcpResourceValidationUtils.validateAiNotebookInstanceId("valid-instance-id-0");
     assertThrows(
         InvalidReferenceException.class,
-        () -> ResourceValidationUtils.validateAiNotebookInstanceId("1number-first"));
+        () -> GcpResourceValidationUtils.validateAiNotebookInstanceId("1number-first"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ResourceValidationUtils.validateAiNotebookInstanceId("-dash-first"));
+        () -> GcpResourceValidationUtils.validateAiNotebookInstanceId("-dash-first"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ResourceValidationUtils.validateAiNotebookInstanceId("dash-last-"));
+        () -> GcpResourceValidationUtils.validateAiNotebookInstanceId("dash-last-"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ResourceValidationUtils.validateAiNotebookInstanceId("white space"));
+        () -> GcpResourceValidationUtils.validateAiNotebookInstanceId("white space"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ResourceValidationUtils.validateAiNotebookInstanceId("other-symbols^&)"));
+        () -> GcpResourceValidationUtils.validateAiNotebookInstanceId("other-symbols^&)"));
     assertThrows(
         InvalidReferenceException.class,
-        () -> ResourceValidationUtils.validateAiNotebookInstanceId("unicode-\\u00C6"));
+        () -> GcpResourceValidationUtils.validateAiNotebookInstanceId("unicode-\\u00C6"));
     assertThrows(
         InvalidReferenceException.class,
         () ->
-            ResourceValidationUtils.validateAiNotebookInstanceId(
+            GcpResourceValidationUtils.validateAiNotebookInstanceId(
                 "more-than-63-chars111111111111111111111111111111111111111111111111111"));
   }
 
   @Test
   public void notebookCreationParametersExactlyOneOfVmImageOrContainerImage() {
     // Nothing throws on successful validation.
-    ResourceValidationUtils.validate(
+    GcpResourceValidationUtils.validate(
         ControlledGcpResourceFixtures.defaultNotebookCreationParameters());
 
     // Neither vmImage nor containerImage.
     assertThrows(
         InconsistentFieldsException.class,
         () ->
-            ResourceValidationUtils.validate(
+            GcpResourceValidationUtils.validate(
                 ControlledGcpResourceFixtures.defaultNotebookCreationParameters()
                     .containerImage(null)
                     .vmImage(null)));
@@ -111,22 +111,22 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InconsistentFieldsException.class,
         () ->
-            ResourceValidationUtils.validate(
+            GcpResourceValidationUtils.validate(
                 ControlledGcpResourceFixtures.defaultNotebookCreationParameters()
                     .containerImage(new ApiGcpAiNotebookInstanceContainerImage())
                     .vmImage(new ApiGcpAiNotebookInstanceVmImage())));
     // Valid containerImage.
-    ResourceValidationUtils.validate(
+    GcpResourceValidationUtils.validate(
         ControlledGcpResourceFixtures.defaultNotebookCreationParameters()
             .vmImage(null)
             .containerImage(
                 new ApiGcpAiNotebookInstanceContainerImage().repository("my-repository")));
     // Valid vmImage.
-    ResourceValidationUtils.validate(
+    GcpResourceValidationUtils.validate(
         ControlledGcpResourceFixtures.defaultNotebookCreationParameters()
             .vmImage(new ApiGcpAiNotebookInstanceVmImage().imageName("image-name"))
             .containerImage(null));
-    ResourceValidationUtils.validate(
+    GcpResourceValidationUtils.validate(
         ControlledGcpResourceFixtures.defaultNotebookCreationParameters()
             .vmImage(new ApiGcpAiNotebookInstanceVmImage().imageFamily("image-family"))
             .containerImage(null));
@@ -134,7 +134,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InconsistentFieldsException.class,
         () ->
-            ResourceValidationUtils.validate(
+            GcpResourceValidationUtils.validate(
                 ControlledGcpResourceFixtures.defaultNotebookCreationParameters()
                     .vmImage(new ApiGcpAiNotebookInstanceVmImage())
                     .containerImage(null)));
@@ -142,7 +142,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InconsistentFieldsException.class,
         () ->
-            ResourceValidationUtils.validate(
+            GcpResourceValidationUtils.validate(
                 ControlledGcpResourceFixtures.defaultNotebookCreationParameters()
                     .vmImage(
                         new ApiGcpAiNotebookInstanceVmImage()
@@ -155,29 +155,29 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
   public void validateReferencedBucketName_nameHas64Character_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore(INVALID_STRING));
+        () -> GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore(INVALID_STRING));
   }
 
   @Test
   public void validateReferencedBucketName_nameHas63Character_OK() {
-    ResourceValidationUtils.validateBucketNameAllowsUnderscore(MAX_VALID_STRING);
+    GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore(MAX_VALID_STRING);
   }
 
   @Test
   public void validateReferencedBucketName_nameHas2Character_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("aa"));
+        () -> GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore("aa"));
   }
 
   @Test
   public void validateReferencedBucketName_nameHas3Character_OK() {
-    ResourceValidationUtils.validateBucketNameAllowsUnderscore("123");
+    GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore("123");
   }
 
   @Test
   public void validateReferencedBucketName_nameHas222CharacterWithDotSeparator_OK() {
-    ResourceValidationUtils.validateBucketNameAllowsUnderscore(MAX_VALID_STRING_WITH_DOTS);
+    GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore(MAX_VALID_STRING_WITH_DOTS);
   }
 
   @Test
@@ -186,53 +186,56 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InvalidNameException.class,
         () ->
-            ResourceValidationUtils.validateBucketNameAllowsUnderscore(
+            GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore(
                 INVALID_STRING + "." + MAX_VALID_STRING));
   }
 
   @Test
   public void validateReferencedBucketName_nameStartAndEndWithNumber_OK() {
-    ResourceValidationUtils.validateBucketNameAllowsUnderscore("1-bucket-1");
+    GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore("1-bucket-1");
   }
 
   @Test
   public void validateReferencedBucketName_nameStartAndEndWithDot_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore(".bucket-name."));
+        () -> GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore(".bucket-name."));
   }
 
   @Test
   public void validateReferencedBucketName_nameWithGoogPrefix_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("goog-bucket-name1"));
+        () ->
+            GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore("goog-bucket-name1"));
   }
 
   @Test
   public void validateReferencedBucketName_nameContainsGoogle_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("bucket-google-name"));
+        () ->
+            GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore("bucket-google-name"));
   }
 
   @Test
   public void validateReferencedBucketName_nameContainsG00gle_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("bucket-g00gle-name"));
+        () ->
+            GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore("bucket-g00gle-name"));
   }
 
   @Test
   public void validateReferencedBucketName_nameContainsUnderscore_OK() {
-    ResourceValidationUtils.validateBucketNameAllowsUnderscore("bucket_name");
+    GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore("bucket_name");
   }
 
   @Test
   public void validateControlledBucketName_nameContainsUnderscore_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateBucketNameDisallowUnderscore("bucket_name"));
+        () -> GcpResourceValidationUtils.validateGcsBucketNameDisallowUnderscore("bucket_name"));
   }
 
   @Test
@@ -250,13 +253,13 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
   @Test
   public void validateBucketFileName_disallowName_throwException() {
     assertThrows(
-        InvalidNameException.class, () -> ResourceValidationUtils.validateGcsObjectName("."));
+        InvalidNameException.class, () -> GcpResourceValidationUtils.validateGcsObjectName("."));
   }
 
   @Test
   public void validateBucketFileName_emptyOrNullString_throwsException() {
     assertThrows(
-        InvalidNameException.class, () -> ResourceValidationUtils.validateGcsObjectName(""));
+        InvalidNameException.class, () -> GcpResourceValidationUtils.validateGcsObjectName(""));
   }
 
   @Test
@@ -264,7 +267,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     String file = ".well-known/acme-challenge/hello.txt";
 
     assertThrows(
-        InvalidNameException.class, () -> ResourceValidationUtils.validateGcsObjectName(file));
+        InvalidNameException.class, () -> GcpResourceValidationUtils.validateGcsObjectName(file));
   }
 
   @Test
@@ -272,33 +275,33 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
     assertThrows(
         InvalidNameException.class,
         () ->
-            ResourceValidationUtils.validateGcsObjectName(
+            GcpResourceValidationUtils.validateGcsObjectName(
                 RandomStringUtils.random(1025, /*letters=*/ true, /*numbers=*/ true)));
   }
 
   @Test
   public void validateBucketFileName_legalFileName_validate() {
-    ResourceValidationUtils.validateGcsObjectName("hello.txt");
-    ResourceValidationUtils.validateGcsObjectName(
+    GcpResourceValidationUtils.validateGcsObjectName("hello.txt");
+    GcpResourceValidationUtils.validateGcsObjectName(
         RandomStringUtils.random(1024, /*letters=*/ true, /*numbers=*/ true));
-    ResourceValidationUtils.validateGcsObjectName("你好.png");
+    GcpResourceValidationUtils.validateGcsObjectName("你好.png");
   }
 
   @Test
   public void validateBqDataTableName() {
-    ResourceValidationUtils.validateBqDataTableName("00_お客様");
-    ResourceValidationUtils.validateBqDataTableName("table 01");
-    ResourceValidationUtils.validateBqDataTableName("ग्राहक");
-    ResourceValidationUtils.validateBqDataTableName("étudiant-01");
+    GcpResourceValidationUtils.validateBqDataTableName("00_お客様");
+    GcpResourceValidationUtils.validateBqDataTableName("table 01");
+    GcpResourceValidationUtils.validateBqDataTableName("ग्राहक");
+    GcpResourceValidationUtils.validateBqDataTableName("étudiant-01");
   }
 
   @Test
   public void validateBqDataTableName_invalidName_throwsException() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateBqDataTableName("00_お客様*"));
+        () -> GcpResourceValidationUtils.validateBqDataTableName("00_お客様*"));
     assertThrows(
-        InvalidNameException.class, () -> ResourceValidationUtils.validateBqDataTableName(""));
+        InvalidNameException.class, () -> GcpResourceValidationUtils.validateBqDataTableName(""));
   }
 
   @Test
@@ -387,9 +390,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
 
     assertThrows(
         MissingRequiredFieldException.class,
-        () ->
-            AzureResourceValidationUtils.validateApiAzureVmCreationParameters(
-                apiVmCreationParameters));
+        () -> AzureResourceValidationUtils.validate(apiVmCreationParameters));
   }
 
   @Test
@@ -401,9 +402,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
 
     assertThrows(
         MissingRequiredFieldException.class,
-        () ->
-            AzureResourceValidationUtils.validateApiAzureVmCreationParameters(
-                apiVmCreationParameters));
+        () -> AzureResourceValidationUtils.validate(apiVmCreationParameters));
   }
 
   @Test
@@ -419,9 +418,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
 
     assertThrows(
         MissingRequiredFieldException.class,
-        () ->
-            AzureResourceValidationUtils.validateApiAzureVmCreationParameters(
-                apiVmCreationParameters));
+        () -> AzureResourceValidationUtils.validate(apiVmCreationParameters));
   }
 
   @Test
@@ -437,9 +434,7 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
 
     assertThrows(
         MissingRequiredFieldException.class,
-        () ->
-            AzureResourceValidationUtils.validateApiAzureVmCreationParameters(
-                apiVmCreationParameters));
+        () -> AzureResourceValidationUtils.validate(apiVmCreationParameters));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferenceValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferenceValidationUtilsTest.java
@@ -3,7 +3,7 @@ package bio.terra.workspace.service.resource.referenced;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.workspace.common.BaseUnitTest;
-import bio.terra.workspace.service.resource.ResourceValidationUtils;
+import bio.terra.workspace.service.resource.GcpResourceValidationUtils;
 import bio.terra.workspace.service.resource.exception.InvalidNameException;
 import bio.terra.workspace.service.resource.referenced.exception.InvalidReferenceException;
 import org.junit.jupiter.api.Test;
@@ -14,23 +14,24 @@ public class ReferenceValidationUtilsTest extends BaseUnitTest {
   public void testInvalidCharInBucketName() {
     assertThrows(
         InvalidNameException.class,
-        () -> ResourceValidationUtils.validateBucketNameAllowsUnderscore("INVALIDBUCKETNAME"));
+        () ->
+            GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore("INVALIDBUCKETNAME"));
   }
 
   @Test
   public void validBucketNameOk() {
-    ResourceValidationUtils.validateBucketNameAllowsUnderscore("valid-bucket_name.1");
+    GcpResourceValidationUtils.validateGcsBucketNameAllowsUnderscore("valid-bucket_name.1");
   }
 
   @Test
   public void testInvalidCharInBqDatasetName() {
     assertThrows(
         InvalidReferenceException.class,
-        () -> ResourceValidationUtils.validateBqDatasetName("invalid-name-for-dataset"));
+        () -> GcpResourceValidationUtils.validateBqDatasetName("invalid-name-for-dataset"));
   }
 
   @Test
   public void validBqDatasetNameOk() {
-    ResourceValidationUtils.validateBqDatasetName("valid_bigquery_name_1");
+    GcpResourceValidationUtils.validateBqDatasetName("valid_bigquery_name_1");
   }
 }


### PR DESCRIPTION
Move Cloud specific functions to separate file ResourceValidationUtils
New files created - AzureResourceValidationUtils & GcpResourceValidationUtils
Add new validation util function - checkStringNonEmpty and use it where appropriate
Remove wrapper function checkFieldNonNull to add more meaningful error message

No other functional changes
