### PR TITLE
[BENCH-712] Force delete AWS Notebooks - stop & delete

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -169,6 +169,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
             jobControl.getId(),
             workspaceUuid,
             resourceUuid,
+            /* forceDelete= */ false,
             getAsyncResultEndpoint(jobControl.getId(), "delete-result"),
             userRequest);
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -375,7 +375,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
         workspaceUuid.toString());
 
     controlledResourceService.deleteControlledResourceSync(
-        workspaceUuid, resourceUuid, userRequest);
+        workspaceUuid, resourceUuid, /* forceDelete= */ false, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -477,6 +477,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             jobControl.getId(),
             workspaceUuid,
             resourceUuid,
+            /* forceDelete= */ false,
             getAsyncResultEndpoint(jobControl.getId(), "delete-result"),
             userRequest);
     return getJobDeleteResult(jobId);

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiController.java
@@ -183,7 +183,7 @@ public class ControlledFlexibleResourceApiController extends ControlledResourceC
         resourceUuid.toString(),
         workspaceUuid.toString());
     controlledResourceService.deleteControlledResourceSync(
-        workspaceUuid, resourceUuid, userRequest);
+        workspaceUuid, resourceUuid, /* forceDelete= */ false, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiController.java
@@ -183,6 +183,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
             jobControl.getId(),
             workspaceUuid,
             resourceUuid,
+            /* forceDelete= */ false,
             getAsyncResultEndpoint(jobControl.getId(), "delete-result"),
             userRequest);
     return getDeleteResult(jobId);
@@ -447,7 +448,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
         resourceUuid.toString(),
         workspaceUuid.toString());
     controlledResourceService.deleteControlledResourceSync(
-        workspaceUuid, resourceUuid, userRequest);
+        workspaceUuid, resourceUuid, /* forceDelete= */ false, userRequest);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
@@ -648,6 +649,7 @@ public class ControlledGcpResourceApiController extends ControlledResourceContro
             jobControl.getId(),
             workspaceUuid,
             resourceUuid,
+            /* forceDelete= */ false,
             getAsyncResultEndpoint(jobControl.getId(), "delete-result"),
             userRequest);
     ApiDeleteControlledGcpAiNotebookInstanceResult result =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/ControlledResourceService.java
@@ -191,12 +191,6 @@ public class ControlledResourceService {
 
   /** Synchronously delete a controlled resource. */
   public void deleteControlledResourceSync(
-      UUID workspaceUuid, UUID resourceId, AuthenticatedUserRequest userRequest) {
-    deleteControlledResourceSync(workspaceUuid, resourceId, false, userRequest);
-  }
-
-  /** Synchronously delete a controlled resource. */
-  public void deleteControlledResourceSync(
       UUID workspaceUuid,
       UUID resourceId,
       boolean forceDelete,
@@ -218,20 +212,6 @@ public class ControlledResourceService {
    * job.
    */
   public String deleteControlledResourceAsync(
-      String jobId,
-      UUID workspaceUuid,
-      UUID resourceId,
-      String resultPath,
-      AuthenticatedUserRequest userRequest) {
-    return deleteControlledResourceAsync(
-        jobId, workspaceUuid, resourceId, false, resultPath, userRequest);
-  }
-
-  /**
-   * Asynchronously delete a controlled resource. Returns the ID of the flight running the delete
-   * job.
-   */
-  private String deleteControlledResourceAsync(
       String jobId,
       UUID workspaceUuid,
       UUID resourceId,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerDefinitionStep.java
@@ -162,7 +162,10 @@ public class CopyAzureStorageContainerDefinitionStep implements Step {
     try {
       if (clonedContainer != null) {
         controlledResourceService.deleteControlledResourceSync(
-            clonedContainer.getWorkspaceId(), clonedContainer.getResourceId(), userRequest);
+            clonedContainer.getWorkspaceId(),
+            clonedContainer.getResourceId(),
+            /* forceDelete= */ false,
+            userRequest);
       }
     } catch (ResourceNotFoundException e) {
       logger.info(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CopyGcsBucketDefinitionStep.java
@@ -161,7 +161,10 @@ public class CopyGcsBucketDefinitionStep implements Step {
                 ControlledGcsBucketResource.class);
     if (clonedBucket != null) {
       controlledResourceService.deleteControlledResourceSync(
-          clonedBucket.getWorkspaceId(), clonedBucket.getResourceId(), userRequest);
+          clonedBucket.getWorkspaceId(),
+          clonedBucket.getResourceId(),
+          /* forceDelete= */ false,
+          userRequest);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDefinitionStep.java
@@ -151,7 +151,10 @@ public class CopyBigQueryDatasetDefinitionStep implements Step {
                 ControlledBigQueryDatasetResource.class);
     if (clonedDataset != null) {
       controlledResourceService.deleteControlledResourceSync(
-          clonedDataset.getWorkspaceId(), clonedDataset.getResourceId(), userRequest);
+          clonedDataset.getWorkspaceId(),
+          clonedDataset.getResourceId(),
+          /* forceDelete= */ false,
+          userRequest);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/flexibleresource/CloneFlexibleResourceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/flexibleresource/CloneFlexibleResourceStep.java
@@ -127,7 +127,7 @@ public class CloneFlexibleResourceStep implements Step {
             WorkspaceFlightMapKeys.ControlledResourceKeys.DESTINATION_RESOURCE_ID, UUID.class);
 
     controlledResourceService.deleteControlledResourceSync(
-        destinationWorkspaceId, destinationResourceId, userRequest);
+        destinationWorkspaceId, destinationResourceId, /* forceDelete= */ false, userRequest);
     return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/AwsCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/AwsCloudContextService.java
@@ -111,7 +111,7 @@ public class AwsCloudContextService implements CloudContextService {
   }
 
   @Override
-  public void launchDeleteFlight( // TODO-Dex
+  public void launchDeleteFlight(
       ControlledResourceService controlledResourceService,
       UUID workspaceUuid,
       UUID resourceId,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/AwsCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/AwsCloudContextService.java
@@ -23,6 +23,7 @@ import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.exceptions.InvalidApplicationConfigException;
 import bio.terra.workspace.service.workspace.flight.cloud.aws.MakeAwsCloudContextStep;
+import bio.terra.workspace.service.workspace.flight.cloud.gcp.DeleteCloudContextResourceFlight;
 import bio.terra.workspace.service.workspace.flight.create.cloudcontext.CreateCloudContextFlight;
 import bio.terra.workspace.service.workspace.flight.delete.cloudcontext.DeleteCloudContextFlight;
 import bio.terra.workspace.service.workspace.model.AwsCloudContext;
@@ -110,14 +111,22 @@ public class AwsCloudContextService implements CloudContextService {
   }
 
   @Override
-  public void launchDeleteFlight(
+  public void launchDeleteFlight( // TODO-Dex
       ControlledResourceService controlledResourceService,
       UUID workspaceUuid,
       UUID resourceId,
       String flightId,
       AuthenticatedUserRequest userRequest) {
-    controlledResourceService.deleteControlledResourceAsync(
-        flightId, workspaceUuid, resourceId, null, userRequest);
+    controlledResourceService
+        .flexibleDeletionJobBuilder(
+            flightId,
+            workspaceUuid,
+            resourceId,
+            /* forceDelete= */ true,
+            /* resultPath= */ null,
+            userRequest,
+            DeleteCloudContextResourceFlight.class)
+        .submit();
   }
 
   /** Returns authentication from configuration */

--- a/service/src/main/java/bio/terra/workspace/service/workspace/AwsCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/AwsCloudContextService.java
@@ -23,7 +23,6 @@ import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredException;
 import bio.terra.workspace.service.workspace.exceptions.InvalidApplicationConfigException;
 import bio.terra.workspace.service.workspace.flight.cloud.aws.MakeAwsCloudContextStep;
-import bio.terra.workspace.service.workspace.flight.cloud.gcp.DeleteCloudContextResourceFlight;
 import bio.terra.workspace.service.workspace.flight.create.cloudcontext.CreateCloudContextFlight;
 import bio.terra.workspace.service.workspace.flight.delete.cloudcontext.DeleteCloudContextFlight;
 import bio.terra.workspace.service.workspace.model.AwsCloudContext;
@@ -111,22 +110,19 @@ public class AwsCloudContextService implements CloudContextService {
   }
 
   @Override
-  public void launchDeleteFlight(
+  public void launchDeleteResourceFlight(
       ControlledResourceService controlledResourceService,
       UUID workspaceUuid,
       UUID resourceId,
       String flightId,
       AuthenticatedUserRequest userRequest) {
-    controlledResourceService
-        .flexibleDeletionJobBuilder(
-            flightId,
-            workspaceUuid,
-            resourceId,
-            /* forceDelete= */ true,
-            /* resultPath= */ null,
-            userRequest,
-            DeleteCloudContextResourceFlight.class)
-        .submit();
+    controlledResourceService.deleteControlledResourceAsync(
+        flightId,
+        workspaceUuid,
+        resourceId,
+        /* forceDelete= */ true,
+        /* resultPath= */ null,
+        userRequest);
   }
 
   /** Returns authentication from configuration */

--- a/service/src/main/java/bio/terra/workspace/service/workspace/AzureCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/AzureCloudContextService.java
@@ -138,14 +138,19 @@ public class AzureCloudContextService implements CloudContextService {
   }
 
   @Override
-  public void launchDeleteFlight(
+  public void launchDeleteFlight( // TODO-Dex
       ControlledResourceService controlledResourceService,
       UUID workspaceUuid,
       UUID resourceId,
       String flightId,
       AuthenticatedUserRequest userRequest) {
     controlledResourceService.deleteControlledResourceAsync(
-        flightId, workspaceUuid, resourceId, null, userRequest);
+        flightId,
+        workspaceUuid,
+        resourceId,
+        /* forceDelete= */ true,
+        /* resultPath= */ null,
+        userRequest);
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/workspace/AzureCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/AzureCloudContextService.java
@@ -138,7 +138,7 @@ public class AzureCloudContextService implements CloudContextService {
   }
 
   @Override
-  public void launchDeleteFlight(
+  public void launchDeleteResourceFlight(
       ControlledResourceService controlledResourceService,
       UUID workspaceUuid,
       UUID resourceId,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/AzureCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/AzureCloudContextService.java
@@ -138,7 +138,7 @@ public class AzureCloudContextService implements CloudContextService {
   }
 
   @Override
-  public void launchDeleteFlight( // TODO-Dex
+  public void launchDeleteFlight(
       ControlledResourceService controlledResourceService,
       UUID workspaceUuid,
       UUID resourceId,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/CloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/CloudContextService.java
@@ -45,7 +45,7 @@ public interface CloudContextService {
    * <p>We cannot autowire the controlled resource service into the cloud context services, because
    * it makes an autowire loop in Spring.
    */
-  void launchDeleteFlight(
+  void launchDeleteResourceFlight(
       ControlledResourceService controlledResourceService,
       UUID workspaceUuid,
       UUID resourceId,

--- a/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudContextService.java
@@ -16,7 +16,6 @@ import bio.terra.workspace.service.workspace.exceptions.CloudContextRequiredExce
 import bio.terra.workspace.service.workspace.exceptions.InvalidCloudContextStateException;
 import bio.terra.workspace.service.workspace.flight.cloud.gcp.CreateCustomGcpRolesStep;
 import bio.terra.workspace.service.workspace.flight.cloud.gcp.CreatePetSaStep;
-import bio.terra.workspace.service.workspace.flight.cloud.gcp.DeleteCloudContextResourceFlight;
 import bio.terra.workspace.service.workspace.flight.cloud.gcp.DeleteGcpProjectStep;
 import bio.terra.workspace.service.workspace.flight.cloud.gcp.GcpCloudSyncStep;
 import bio.terra.workspace.service.workspace.flight.cloud.gcp.GenerateRbsRequestIdStep;
@@ -143,22 +142,19 @@ public class GcpCloudContextService implements CloudContextService {
   }
 
   @Override
-  public void launchDeleteFlight(
+  public void launchDeleteResourceFlight(
       ControlledResourceService controlledResourceService,
       UUID workspaceUuid,
       UUID resourceId,
       String flightId,
       AuthenticatedUserRequest userRequest) {
-    controlledResourceService
-        .flexibleDeletionJobBuilder(
-            flightId,
-            workspaceUuid,
-            resourceId,
-            /* forceDelete= */ true,
-            /* resultPath= */ null,
-            userRequest,
-            DeleteCloudContextResourceFlight.class)
-        .submit();
+    controlledResourceService.deleteControlledResourceAsync(
+        flightId,
+        workspaceUuid,
+        resourceId,
+        /* forceDelete= */ true,
+        /* resultPath= */ null,
+        userRequest);
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudContextService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/GcpCloudContextService.java
@@ -154,7 +154,7 @@ public class GcpCloudContextService implements CloudContextService {
             flightId,
             workspaceUuid,
             resourceId,
-            /* forceDelete= */ false,
+            /* forceDelete= */ true,
             /* resultPath= */ null,
             userRequest,
             DeleteCloudContextResourceFlight.class)

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/DeleteResourcesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/DeleteResourcesStep.java
@@ -117,7 +117,7 @@ public class DeleteResourcesStep implements Step {
 
   private void launchFlightAndWait(ResourceDeleteFlightPair pair, Stairway stairway)
       throws InterruptedException {
-    cloudContextService.launchDeleteFlight(
+    cloudContextService.launchDeleteResourceFlight(
         controlledResourceService, workspaceUuid, pair.resourceId(), pair.flightId(), userRequest);
     waitForFlight(pair, stairway);
   }

--- a/service/src/test/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/privateresource/PrivateResourceCleanupServiceTest.java
@@ -117,7 +117,7 @@ public class PrivateResourceCleanupServiceTest extends BaseConnectedTest {
     // workspace.
     if (appOwnedResource != null) {
       controlledResourceService.deleteControlledResourceSync(
-          workspace.workspaceId(), appOwnedResource.getResourceId(), testAppRequest);
+          workspace.workspaceId(), appOwnedResource.getResourceId(), false, testAppRequest);
     }
     workspaceService.deleteWorkspace(workspace, userAccessUtils.defaultUserAuthRequest());
     deleteGroup(groupName, ownerGroupApi);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBqTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBqTest.java
@@ -161,7 +161,7 @@ public class ControlledResourceServiceBqTest extends BaseConnectedTest {
         updatedDatasetFromCloud.getDefaultPartitionExpirationMs());
 
     controlledResourceService.deleteControlledResourceSync(
-        resource.getWorkspaceId(), resource.getResourceId(), user.getAuthenticatedRequest());
+        resource.getWorkspaceId(), resource.getResourceId(), false, user.getAuthenticatedRequest());
 
     assertThrows(
         ResourceNotFoundException.class,
@@ -293,7 +293,7 @@ public class ControlledResourceServiceBqTest extends BaseConnectedTest {
         FlightDebugInfo.newBuilder().doStepFailures(retrySteps).build());
 
     controlledResourceService.deleteControlledResourceSync(
-        resource.getWorkspaceId(), resource.getResourceId(), user.getAuthenticatedRequest());
+        resource.getWorkspaceId(), resource.getResourceId(), false, user.getAuthenticatedRequest());
 
     BigQueryCow bqCow = crlService.createWsmSaBigQueryCow();
     GoogleJsonResponseException getException =
@@ -340,6 +340,7 @@ public class ControlledResourceServiceBqTest extends BaseConnectedTest {
             controlledResourceService.deleteControlledResourceSync(
                 resource.getWorkspaceId(),
                 resource.getResourceId(),
+                false,
                 user.getAuthenticatedRequest()));
 
     BigQueryCow bqCow = crlService.createWsmSaBigQueryCow();
@@ -562,7 +563,7 @@ public class ControlledResourceServiceBqTest extends BaseConnectedTest {
     } finally {
       // Remove dataset to not conflict with other test that checks for empty lifetime
       controlledResourceService.deleteControlledResourceSync(
-          workspaceId, resource.getResourceId(), userAccessUtils.defaultUserAuthRequest());
+          workspaceId, resource.getResourceId(), false, userAccessUtils.defaultUserAuthRequest());
     }
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
@@ -259,6 +259,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
             UUID.randomUUID().toString(),
             workspaceId,
             createdBucket.getResourceId(),
+            /* forceDelete= */ false,
             "fake result path",
             user.getAuthenticatedRequest());
     jobService.waitForJob(jobId);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
@@ -259,7 +259,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
             UUID.randomUUID().toString(),
             workspaceId,
             createdBucket.getResourceId(),
-            /* forceDelete= */ false,
+            false,
             "fake result path",
             user.getAuthenticatedRequest());
     jobService.waitForJob(jobId);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceNotebookTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceNotebookTest.java
@@ -709,7 +709,7 @@ public class ControlledResourceServiceNotebookTest extends BaseConnectedTest {
         FlightDebugInfo.newBuilder().doStepFailures(retrySteps).build());
 
     controlledResourceService.deleteControlledResourceSync(
-        resource.getWorkspaceId(), resource.getResourceId(), user.getAuthenticatedRequest());
+        resource.getWorkspaceId(), resource.getResourceId(), false, user.getAuthenticatedRequest());
     assertNotFound(instanceName, notebooks);
     assertThrows(
         ResourceNotFoundException.class,
@@ -733,6 +733,7 @@ public class ControlledResourceServiceNotebookTest extends BaseConnectedTest {
             controlledResourceService.deleteControlledResourceSync(
                 resource.getWorkspaceId(),
                 resource.getResourceId(),
+                false,
                 user.getAuthenticatedRequest()));
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerDefinitionStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerDefinitionStepTest.java
@@ -182,6 +182,6 @@ public class CopyAzureStorageContainerDefinitionStepTest extends BaseAzureUnitTe
     var result = step.undoStep(flightContext);
 
     assertEquals(result.getStepStatus(), StepStatus.STEP_RESULT_SUCCESS);
-    verify(controlledResourceService).deleteControlledResourceSync(any(), any(), any());
+    verify(controlledResourceService).deleteControlledResourceSync(any(), any(), any(), any());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerDefinitionStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/container/CopyAzureStorageContainerDefinitionStepTest.java
@@ -182,6 +182,6 @@ public class CopyAzureStorageContainerDefinitionStepTest extends BaseAzureUnitTe
     var result = step.undoStep(flightContext);
 
     assertEquals(result.getStepStatus(), StepStatus.STEP_RESULT_SUCCESS);
-    verify(controlledResourceService).deleteControlledResourceSync(any(), any(), any(), any());
+    verify(controlledResourceService).deleteControlledResourceSync(any(), any(), eq(false), any());
   }
 }


### PR DESCRIPTION
Current implementation - during AWS cloud context deletion, resources are not force deleted. The wrong overloaded function is being called. Hence Workspace deletion fails if the notebook is not stopped prior to delete attempt

Fix - 
- call the correct overloaded deletion job submit function which forces notebook stop prior to delete attempt.
- To avoid future such errors (wrong function being called), the overloaded function is removed
- Individual resources are forceDeleted when cloud context is being deleted (i.e. deletion triggered from top)
-  Individual resources are NOT forceDeleted during stand alone deletion
- rename function launchDeleteFlight to launchDeleteResourceFlight to reflect that resource is being deleted (not cloud context)