### PR TITLE
[BENCH-714] Add CloudPlatform param to createCloudContext testUtil, spotbug warnings

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/CreateAwsSageMakerNotebookStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/CreateAwsSageMakerNotebookStep.java
@@ -12,7 +12,6 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.CliConfiguration;
 import bio.terra.workspace.common.utils.AwsUtils;
 import bio.terra.workspace.common.utils.FlightUtils;
-import bio.terra.workspace.generated.model.ApiAwsSageMakerNotebookCreationParameters;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
@@ -75,12 +74,6 @@ public class CreateAwsSageMakerNotebookStep implements Step {
     AwsUtils.appendUserTags(tags, samUser);
     AwsUtils.appendResourceTags(tags, cloudContext, resource);
     tags.add(Tag.builder().key("CliServerName").value(cliConfiguration.getServerName()).build());
-
-    // TODO(TERRA-550): creationParameters may be used later
-    ApiAwsSageMakerNotebookCreationParameters creationParameters =
-        inputParameters.get(
-            ControlledResourceKeys.CREATE_NOTEBOOK_PARAMETERS,
-            ApiAwsSageMakerNotebookCreationParameters.class);
 
     AwsUtils.createSageMakerNotebook(
         credentialsProvider,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/CreateAiNotebookInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/CreateAiNotebookInstanceStep.java
@@ -268,10 +268,6 @@ public class CreateAiNotebookInstanceStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    final GcpCloudContext gcpCloudContext =
-        flightContext
-            .getWorkingMap()
-            .get(ControlledResourceKeys.GCP_CLOUD_CONTEXT, GcpCloudContext.class);
     String requestedLocation =
         FlightUtils.getRequired(
             flightContext.getWorkingMap(), CREATE_NOTEBOOK_LOCATION, String.class);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/DeleteAiNotebookInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/DeleteAiNotebookInstanceStep.java
@@ -9,8 +9,6 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.GcpUtils;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
-import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.notebooks.v1.model.Operation;
 import java.io.IOException;
@@ -36,11 +34,6 @@ public class DeleteAiNotebookInstanceStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    final GcpCloudContext gcpCloudContext =
-        flightContext
-            .getWorkingMap()
-            .get(ControlledResourceKeys.GCP_CLOUD_CONTEXT, GcpCloudContext.class);
-
     InstanceName instanceName = resource.toInstanceName();
     AIPlatformNotebooksCow notebooks = crlService.getAIPlatformNotebooksCow();
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
@@ -114,7 +114,7 @@ public class CloneAllResourcesFlight extends Flight {
                     resourceCloneInputs.getFlightId()),
                 RetryRules.shortDatabase());
           }
-          case CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE ->
+          default ->
           // Can't throw in a flight constructor
           logger.error(
               "Unsupported controlled resource type {}",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
@@ -61,6 +61,7 @@ public class CloneAllResourcesFlight extends Flight {
         break;
       case CONTROLLED:
         switch (resourceCloneInputs.getResource().getResourceType()) {
+            // GCP
           case CONTROLLED_GCP_GCS_BUCKET -> {
             addStep(
                 new LaunchCloneGcsBucketResourceFlightStep(
@@ -87,6 +88,9 @@ public class CloneAllResourcesFlight extends Flight {
                     resourceCloneInputs.getFlightId()),
                 RetryRules.cloudLongRunning());
           }
+            // CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE: not supported
+
+            // Azure
           case CONTROLLED_AZURE_STORAGE_CONTAINER -> {
             addStep(
                 new LaunchCloneControlledAzureStorageContainerResourceFlightStep(
@@ -100,6 +104,14 @@ public class CloneAllResourcesFlight extends Flight {
                     resourceCloneInputs.getFlightId()),
                 RetryRules.cloudLongRunning());
           }
+            // CONTROLLED_AZURE_MANAGED_IDENTITY, CONTROLLED_AZURE_DATABASE, CONTROLLED_AZURE_DISK
+            // CONTROLLED_AZURE_VM, CONTROLLED_AZURE_BATCH_POOL: not supported / implemented
+
+            // AWS
+            // TODO(BENCH-694): support clone CONTROLLED_AWS_S3_STORAGE_FOLDER
+            // CONTROLLED_AWS_SAGEMAKER_NOTEBOOK: not supported
+
+            // Flexible
           case CONTROLLED_FLEXIBLE_RESOURCE -> {
             addStep(
                 new LaunchCloneControlledFlexibleResourceFlightStep(
@@ -114,6 +126,7 @@ public class CloneAllResourcesFlight extends Flight {
                     resourceCloneInputs.getFlightId()),
                 RetryRules.shortDatabase());
           }
+
           default ->
           // Can't throw in a flight constructor
           logger.error(
@@ -121,6 +134,7 @@ public class CloneAllResourcesFlight extends Flight {
               resourceCloneInputs.getResource().getResourceType());
         }
         break;
+
       default:
         logger.error(
             "Unsupported stewardship type {}",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneWorkspaceFlight.java
@@ -14,7 +14,6 @@ import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import bio.terra.workspace.service.workspace.model.CloudContext;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
-import bio.terra.workspace.service.workspace.model.Workspace;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -51,8 +50,6 @@ public class CloneWorkspaceFlight extends Flight {
     var spendProfile =
         FlightUtils.getRequired(
             inputParameters, WorkspaceFlightMapKeys.SPEND_PROFILE, SpendProfile.class);
-
-    Workspace sourceWorkspace = flightBeanBag.getWorkspaceDao().getWorkspace(sourceWorkspaceId);
 
     addStep(
         new CloneAllFoldersStep(flightBeanBag.getSamService(), flightBeanBag.getFolderDao()),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GetGcpCloudContextStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/GetGcpCloudContextStep.java
@@ -7,9 +7,6 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
-import bio.terra.workspace.common.utils.FlightUtils;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import java.util.UUID;
@@ -33,11 +30,6 @@ public class GetGcpCloudContextStep implements Step {
       throws InterruptedException, RetryException {
     FlightMap workingMap = flightContext.getWorkingMap();
     if (workingMap.get(GCP_CLOUD_CONTEXT, GcpCloudContext.class) == null) {
-      AuthenticatedUserRequest userRequest =
-          FlightUtils.getRequired(
-              flightContext.getInputParameters(),
-              JobMapKeys.AUTH_USER_INFO.getKeyName(),
-              AuthenticatedUserRequest.class);
       workingMap.put(
           GCP_CLOUD_CONTEXT, gcpCloudContextService.getRequiredGcpCloudContext(workspaceUuid));
     }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
@@ -39,7 +39,7 @@ public class ControlledAzureResourceApiControllerAzureVmTest extends BaseAzureUn
   @Autowired ControlledAzureResourceApiController controller;
 
   @BeforeEach
-  void setUp() throws InterruptedException {
+  void setUp() {
     when(mockSamService()
             .getUserEmailFromSamAndRethrowOnInterrupt(any(AuthenticatedUserRequest.class)))
         .thenReturn(DEFAULT_USER_EMAIL);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerBatchPoolTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerBatchPoolTest.java
@@ -37,7 +37,7 @@ public class ControlledAzureResourceApiControllerBatchPoolTest extends BaseAzure
   @Autowired ControlledAzureResourceApiController controller;
 
   @BeforeEach
-  void setUp() throws InterruptedException {
+  void setUp() {
     when(mockSamService()
             .getUserEmailFromSamAndRethrowOnInterrupt(any(AuthenticatedUserRequest.class)))
         .thenReturn(DEFAULT_USER_EMAIL);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
@@ -53,7 +53,8 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
   public void setup() throws Exception {
     workspaceId =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithCloudContext(
+                userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -131,8 +131,8 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
         userAccessUtils.secondUser().getEmail());
 
     // Create the cloud contexts
-    mockMvcUtils.createGcpCloudContextAndWait(defaultUserRequest, workspaceId);
-    mockMvcUtils.createGcpCloudContextAndWait(defaultUserRequest, workspaceId2);
+    mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId, apiCloudPlatform);
+    mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId2, apiCloudPlatform);
 
     ApiWorkspaceDescription workspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
@@ -290,13 +290,12 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
     var oldName = sourceResource.getMetadata().getName();
     var newName = TestUtils.appendRandomNumber("newdatatableresourcename");
 
-    var unused =
-        mockMvcUtils.createReferencedBqDataset(
-            userAccessUtils.defaultUserAuthRequest(),
-            workspaceId,
-            newName,
-            projectId,
-            sourceDatasetName);
+    mockMvcUtils.createReferencedBqDataset(
+        userAccessUtils.defaultUserAuthRequest(),
+        workspaceId,
+        newName,
+        projectId,
+        sourceDatasetName);
 
     mockMvcUtils.updateResource(
         ApiGcpBigQueryDatasetResource.class,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -184,8 +184,8 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
         userAccessUtils.secondUser().getEmail());
 
     // Create the cloud contexts
-    mockMvcUtils.createGcpCloudContextAndWait(defaultUserRequest, workspaceId);
-    mockMvcUtils.createGcpCloudContextAndWait(defaultUserRequest, workspaceId2);
+    mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId, apiCloudPlatform);
+    mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId2, apiCloudPlatform);
 
     ApiWorkspaceDescription workspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
@@ -396,9 +396,8 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
   public void update_throws409() throws Exception {
     var oldName = sourceBucket.getMetadata().getName();
     var newName = TestUtils.appendRandomNumber("newbucketresourcename");
-    var unused =
-        mockMvcUtils.createReferencedGcsBucket(
-            userAccessUtils.defaultUserAuthRequest(), workspaceId, newName, sourceBucketName);
+    mockMvcUtils.createReferencedGcsBucket(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId, newName, sourceBucketName);
 
     mockMvcUtils.updateResource(
         ApiGcpGcsBucketResource.class,

--- a/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
@@ -32,11 +32,11 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
   private UUID workspaceId;
   private UUID storageContainerId;
 
-  ArgumentCaptor<SasTokenOptions> sasTokenOptionsCaptor =
+  final ArgumentCaptor<SasTokenOptions> sasTokenOptionsCaptor =
       ArgumentCaptor.forClass(SasTokenOptions.class);
 
   @BeforeEach
-  public void setup() throws Exception {
+  public void setup() {
     workspaceId = UUID.randomUUID();
     storageContainerId = UUID.randomUUID();
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -76,7 +76,8 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
   public void setup() throws Exception {
     workspaceId =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithCloudContext(
+                userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableConnectedTest.java
@@ -75,7 +75,8 @@ public class ReferencedGcpResourceControllerBqTableConnectedTest extends BaseCon
   public void setup() throws Exception {
     workspaceId =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithCloudContext(
+                userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -72,7 +72,8 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
   public void setup() throws Exception {
     workspaceId =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithCloudContext(
+                userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     workspaceId2 =
         mockMvcUtils

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 import org.springframework.test.web.servlet.MockMvc;
@@ -50,8 +48,6 @@ import org.springframework.test.web.servlet.MockMvc;
 @Tag("connectedPlus")
 @TestInstance(Lifecycle.PER_CLASS)
 public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseConnectedTest {
-  private static final Logger logger =
-      LoggerFactory.getLogger(ReferencedGcpResourceControllerGcsBucketConnectedTest.class);
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -71,7 +71,8 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
   public void setup() throws Exception {
     workspaceId =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithCloudContext(
+                userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     workspaceId2 =
         mockMvcUtils

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
@@ -66,7 +66,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
   private ApiGcpGcsBucketResource sourceResource;
 
   @BeforeEach
-  public void setup() throws Exception {
+  public void setup() {
     sourceWorkspaceId = null;
     destinationWorkspaceId = null;
   }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
@@ -54,7 +54,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
   private UUID workspaceId;
 
   @BeforeAll
-  public void setUp() throws Exception {
+  public void setUp() {
     workspaceId =
         connectedTestUtils
             .createWorkspaceWithGcpContext(userAccessUtils.defaultUserAuthRequest())

--- a/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
@@ -8,9 +8,7 @@ import bio.terra.workspace.common.GcpCloudUtils;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
-import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.SamService;
@@ -50,7 +48,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
   private boolean timeToFinish;
 
   @Before
-  public void startup() throws Exception {
+  public void startup() {
     timeToFinish = false;
   }
 
@@ -63,7 +61,8 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
   public void setupAndWaitBucket() throws Exception {
     workspaceId =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithCloudContext(
+                userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
@@ -73,17 +72,16 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
 
     String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
     String sourceBucketName = TestUtils.appendRandomNumber("source-bucket-name");
-    ApiGcpGcsBucketResource sourceBucket =
-        mockMvcUtils
-            .createControlledGcsBucket(
-                userAccessUtils.defaultUserAuthRequest(),
-                workspaceId,
-                sourceResourceName,
-                sourceBucketName,
-                null,
-                null,
-                null)
-            .getGcpBucket();
+    mockMvcUtils
+        .createControlledGcsBucket(
+            userAccessUtils.defaultUserAuthRequest(),
+            workspaceId,
+            sourceResourceName,
+            sourceBucketName,
+            null,
+            null,
+            null)
+        .getGcpBucket();
     addFileToBucket(
         userAccessUtils.defaultUser().getGoogleCredentials(), projectId, sourceBucketName);
 
@@ -97,7 +95,8 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
   public void setupAndWaitNotebook() throws Exception {
     workspaceId =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithCloudContext(
+                userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
@@ -105,10 +104,9 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
 
     logger.info("Created workspace {} with project {}", workspaceId, projectId);
 
-    ApiGcpAiNotebookInstanceResource notebook =
-        mockMvcUtils
-            .createAiNotebookInstance(userAccessUtils.defaultUserAuthRequest(), workspaceId, null)
-            .getAiNotebookInstance();
+    mockMvcUtils
+        .createAiNotebookInstance(userAccessUtils.defaultUserAuthRequest(), workspaceId, null)
+        .getAiNotebookInstance();
 
     // So I can end the test and run cleanup when I'm done debugging
     while (!timeToFinish) {
@@ -120,7 +118,8 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
   public void setupAndWaitBigQuery() throws Exception {
     workspaceId =
         mockMvcUtils
-            .createWorkspaceWithCloudContext(userAccessUtils.defaultUserAuthRequest())
+            .createWorkspaceWithCloudContext(
+                userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -397,7 +397,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       //  Create target workspace with US region constraint.
       targetWorkspaceId =
           mockMvcUtils.createWorkspaceWithRegionConstraintAndCloudContext(
-              userRequest, PolicyFixtures.US_REGION);
+              userRequest, apiCloudPlatform, PolicyFixtures.US_REGION);
 
       // Then add a resource with US east region to the target.
       mockMvcUtils.createControlledGcsBucket(
@@ -437,7 +437,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       //  Create target workspace with US region constraint.
       targetWorkspaceId =
           mockMvcUtils.createWorkspaceWithRegionConstraintAndCloudContext(
-              userRequest, PolicyFixtures.US_REGION);
+              userRequest, apiCloudPlatform, PolicyFixtures.US_REGION);
 
       // Then add a resource with US east region to the target.
       mockMvcUtils.createControlledGcsBucket(
@@ -470,7 +470,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       //  Create target workspace with US region constraint.
       targetWorkspaceId =
           mockMvcUtils.createWorkspaceWithRegionConstraintAndCloudContext(
-              userRequest, PolicyFixtures.US_REGION);
+              userRequest, apiCloudPlatform, PolicyFixtures.US_REGION);
 
       // Then add a resource with US east region to the target.
       mockMvcUtils.createControlledGcsBucket(

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -432,7 +432,6 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void mergeCheck_existingResourceNoPolicyOnSource() throws Exception {
     var userRequest = userAccessUtils.defaultUserAuthRequest();
     UUID targetWorkspaceId = null;
-    UUID sourceWorkspaceId = null;
     try {
       //  Create target workspace with US region constraint.
       targetWorkspaceId =

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
@@ -4,7 +4,6 @@ import bio.terra.landingzone.db.LandingZoneDao;
 import bio.terra.workspace.common.utils.AzureTestUtils;
 import bio.terra.workspace.connected.AzureConnectedTestUtils;
 import bio.terra.workspace.connected.LandingZoneTestUtils;
-import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.TestLandingZoneManager;
 import bio.terra.workspace.service.spendprofile.SpendProfile;
@@ -29,7 +28,6 @@ public class BaseAzureConnectedTest extends BaseTest {
   @Autowired protected AzureConnectedTestUtils azureUtils;
   @Autowired private LandingZoneTestUtils landingZoneTestUtils;
   @Autowired private LandingZoneDao landingZoneDao;
-  @Autowired private WorkspaceDao workspaceDao;
 
   protected TestLandingZoneManager testLandingZoneManager;
   protected UUID landingZoneId;
@@ -50,8 +48,7 @@ public class BaseAzureConnectedTest extends BaseTest {
 
     // create quasi landing zone with no resources, tests can add any they need
     landingZoneId = UUID.fromString(landingZoneTestUtils.getDefaultLandingZoneId());
-    testLandingZoneManager =
-        new TestLandingZoneManager(landingZoneDao, workspaceDao, azureTestUtils);
+    testLandingZoneManager = new TestLandingZoneManager(landingZoneDao, azureTestUtils);
     testLandingZoneManager.createLandingZoneDbRecord(landingZoneId);
 
     azureUtils.createCloudContext(workspace.getWorkspaceId(), userRequest);

--- a/service/src/test/java/bio/terra/workspace/common/BaseConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseConnectedTest.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.common;
 
+import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -12,4 +13,6 @@ import org.springframework.test.context.ActiveProfiles;
 public class BaseConnectedTest extends BaseTest {
 
   public static final String BUFFER_SERVICE_DISABLED_ENVS_REG_EX = "dev|alpha|staging|prod";
+
+  protected static final ApiCloudPlatform apiCloudPlatform = ApiCloudPlatform.GCP;
 }

--- a/service/src/test/java/bio/terra/workspace/common/GcsBucketUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/GcsBucketUtils.java
@@ -65,10 +65,7 @@ public class GcsBucketUtils {
     // Define resource
     BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, objectName)).build();
 
-    URL url =
-        storage.signUrl(blobInfo, 12, TimeUnit.HOURS, Storage.SignUrlOption.withV4Signature());
-
-    return url;
+    return storage.signUrl(blobInfo, 12, TimeUnit.HOURS, Storage.SignUrlOption.withV4Signature());
   }
 
   /**
@@ -158,7 +155,7 @@ public class GcsBucketUtils {
 
   /** Asserts table is populated as per populateBqTable(). */
   public void assertBucketHasNoFiles(
-      AuthenticatedUserRequest userRequest, String projectId, String bucketName) throws Exception {
+      AuthenticatedUserRequest userRequest, String projectId, String bucketName) {
     StorageCow storageCow = crlService.createStorageCow(projectId, userRequest);
     int numFiles = 0;
     for (BlobCow blob : storageCow.get(bucketName).list().iterateAll()) {

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledGcpResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledGcpResourceFixtures.java
@@ -44,7 +44,6 @@ import com.google.cloud.storage.StorageClass;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -184,7 +183,7 @@ public class ControlledGcpResourceFixtures {
                   .addMatchesStorageClassItem(ApiGcpGcsBucketDefaultStorageClass.STANDARD));
   // list must not be immutable if deserialization is to work
   public static final List<ApiGcpGcsBucketLifecycleRule> LIFECYCLE_RULES =
-      new ArrayList<>(List.of(LIFECYCLE_RULE_1, LIFECYCLE_RULE_2));
+      List.of(LIFECYCLE_RULE_1, LIFECYCLE_RULE_2);
 
   public static final ApiGcpGcsBucketUpdateParameters BUCKET_UPDATE_PARAMETERS_1 =
       new ApiGcpGcsBucketUpdateParameters()

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -27,20 +27,15 @@ public class ControlledResourceFixtures {
       OffsetDateTime.parse("2017-12-03T10:15:30+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
   public static final OffsetDateTime OFFSET_DATE_TIME_2 =
       OffsetDateTime.parse("2017-12-03T10:15:30-05:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-
   public static final DateTime DATE_TIME_1 = DateTime.parseRfc3339("1985-04-12T23:20:50.52Z");
   public static final DateTime DATE_TIME_2 = DateTime.parseRfc3339("1996-12-19T16:39:57-08:00");
-
   public static final UUID WORKSPACE_ID = UUID.fromString("00000000-fcf0-4981-bb96-6b8dd634e7c0");
-  public static final String OWNER_EMAIL = "jay@all-the-bits-thats-fit-to-blit.dev";
-
   public static final UUID RESOURCE_ID = UUID.fromString("11111111-fcf0-4981-bb96-6b8dd634e7c0");
   public static final String RESOURCE_NAME = "my_first_bucket";
   public static final String RESOURCE_DESCRIPTION =
       "A bucket that had beer in it, briefly. \uD83C\uDF7B";
   public static final Map<String, String> DEFAULT_RESOURCE_PROPERTIES = Map.of("foo", "bar");
   public static final String DEFAULT_RESOURCE_REGION = "us-central1";
-  public static final CloningInstructions CLONING_INSTRUCTIONS = CloningInstructions.COPY_RESOURCE;
 
   /** Returns a {@link ControlledResourceFields.Builder} with the fields filled in */
   public static ControlledResourceFields.Builder makeDefaultControlledResourceFieldsBuilder() {

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/PolicyFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/PolicyFixtures.java
@@ -42,7 +42,7 @@ public class PolicyFixtures {
           .name(REGION_CONSTRAINT)
           .addAdditionalDataItem(new ApiWsmPolicyPair().key(REGION).value(IOWA_REGION));
 
-  public static ApiWsmPolicyInput REGION_POLICY_NEVADA =
+  public static final ApiWsmPolicyInput REGION_POLICY_NEVADA =
       new ApiWsmPolicyInput()
           .namespace(NAMESPACE)
           .name(REGION_CONSTRAINT)

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -619,6 +619,6 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
     }
 
     @Override
-    public void setProgressMeter(String name, long v1, long v2) throws InterruptedException {}
+    public void setProgressMeter(String name, long v1, long v2) {}
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
@@ -7,8 +7,6 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.service.job.JobService;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -118,7 +116,6 @@ class MdcHookTest extends BaseUnitTest {
   }
   /** A step that asserts the MDC context is what's expected on do and undo. */
   public static class CheckMdc implements Step {
-    private final Logger logger = LoggerFactory.getLogger(CheckMdc.class);
     private final ImmutableMap<String, String> expectedContext;
 
     public CheckMdc(ImmutableMap<String, String> expectedContext) {

--- a/service/src/test/java/bio/terra/workspace/db/FolderDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/FolderDaoTest.java
@@ -435,9 +435,9 @@ public class FolderDaoTest extends BaseUnitTest {
     // second and third folders are under folder foo.
     var secondFolder = getFolder("bar", workspaceUuid, folder.id());
     var thirdFolder = getFolder("garrr", workspaceUuid, folder.id());
-    var createdFolder = folderDao.createFolder(folder);
-    var createdSecondFolder = folderDao.createFolder(secondFolder);
-    var createdThirdFolder = folderDao.createFolder(thirdFolder);
+    folderDao.createFolder(folder);
+    folderDao.createFolder(secondFolder);
+    folderDao.createFolder(thirdFolder);
 
     assertTrue(folderDao.deleteAllFolders(workspaceUuid));
 

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -450,9 +450,6 @@ public class ResourceDaoTest extends BaseUnitTest {
     WsmResource resourceBeforeUpdate =
         resourceDao.getResource(resource.getWorkspaceId(), resource.getResourceId());
 
-    Map<String, String> expectedUpdatedProperties = new HashMap<>();
-    expectedUpdatedProperties.putAll(DEFAULT_RESOURCE_PROPERTIES);
-    expectedUpdatedProperties.putAll(properties);
     resourceDao.updateResourceProperties(workspaceUuid, resource.getResourceId(), properties);
     String userEmail = "foo";
     activityLogDao.writeActivity(

--- a/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
@@ -45,7 +45,7 @@ public class PolicyValidatorTest extends BaseUnitTest {
   @MockBean private WorkspaceDao mockWorkspaceDao;
   @MockBean private AzureConfiguration mockAzureConfiguration;
 
-  private AuthenticatedUserRequest userRequest =
+  private final AuthenticatedUserRequest userRequest =
       new AuthenticatedUserRequest("email", "id", Optional.of("token"));
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/MakeApiResourceDescriptionTest.java
@@ -58,7 +58,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
   }
 
   @Test
-  public void mapReferencedBigQueryDatasetTest() throws Exception {
+  public void mapReferencedBigQueryDatasetTest() {
     String projectId = RandomStringUtils.randomAlphabetic(12);
     String datasetName = RandomStringUtils.randomAlphabetic(12);
 
@@ -86,7 +86,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
   }
 
   @Test
-  public void mapReferencedBigQueryDataTableTest() throws Exception {
+  public void mapReferencedBigQueryDataTableTest() {
     String projectId = RandomStringUtils.randomAlphabetic(12);
     String datasetName = RandomStringUtils.randomAlphabetic(12);
     String datatableName = RandomStringUtils.randomAlphabetic(12);
@@ -117,7 +117,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
   }
 
   @Test
-  public void mapReferencedDataRepoSnapshotTest() throws Exception {
+  public void mapReferencedDataRepoSnapshotTest() {
     String snapshotId = UUID.randomUUID().toString();
     String instanceName = RandomStringUtils.randomAlphabetic(5);
 
@@ -145,7 +145,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
   }
 
   @Test
-  public void mapReferencedGcsBucketTest() throws Exception {
+  public void mapReferencedGcsBucketTest() {
     String bucketName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
 
     var resource =
@@ -193,7 +193,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
     }
 
     @Test
-    public void mapControlledGcsBucketTest() throws Exception {
+    public void mapControlledGcsBucketTest() {
       String bucketName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
 
       var resource =
@@ -223,7 +223,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
     }
 
     @Test
-    public void mapControlledBigQueryDatasetTest() throws Exception {
+    public void mapControlledBigQueryDatasetTest() {
       String datasetName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
       String projectId = "my-project-id";
 
@@ -256,7 +256,7 @@ public class MakeApiResourceDescriptionTest extends BaseUnitTest {
     }
 
     @Test
-    public void mapControlledAiNotebookInstanceTest() throws Exception {
+    public void mapControlledAiNotebookInstanceTest() {
       String instanceId = RandomStringUtils.randomAlphabetic(5).toLowerCase();
 
       var resource =

--- a/service/src/test/java/bio/terra/workspace/service/resource/ResourceLineageUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ResourceLineageUtilsTest.java
@@ -26,9 +26,6 @@ public class ResourceLineageUtilsTest extends BaseUnitTest {
   @Test
   public void constructResourceNullLineage_resourceLineageEmptyArray() {
     UUID randomId = UUID.randomUUID();
-    String resourceName = "testdatarepo-" + randomId;
-    Map<String, String> propertyMap = new HashMap<>();
-
     var resource =
         ReferencedDataRepoSnapshotResource.builder()
             .wsmResourceFields(
@@ -74,8 +71,6 @@ public class ResourceLineageUtilsTest extends BaseUnitTest {
   @Test
   public void constructResourceWithLineage_matchingLineageArray() {
     UUID randomId = UUID.randomUUID();
-    String resourceName = "testdatarepo-" + randomId;
-    Map<String, String> propertyMap = new HashMap<>();
     var lineageEntry = new ResourceLineageEntry(randomId, randomId);
     var lineage = new ArrayList<ResourceLineageEntry>();
     lineage.add(lineageEntry);

--- a/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
-import bio.terra.policy.model.TpsPaoGetResult;
 import bio.terra.workspace.app.configuration.external.GitRepoReferencedResourceConfiguration;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledGcpResourceFixtures;
@@ -513,7 +512,6 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
   @Test
   public void validateRegion_invalid_throws() throws Exception {
     UUID workspaceId = UUID.randomUUID();
-    TpsPaoGetResult pao = new TpsPaoGetResult().objectId(workspaceId);
     when(mockTpsApiDispatch().listValidRegions(workspaceId, CloudPlatform.GCP))
         .thenReturn(List.of("us-central1", "us-east1"));
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBqTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBqTest.java
@@ -219,7 +219,7 @@ public class ControlledResourceServiceBqTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void createBqDatasetUndo() throws Exception {
+  void createBqDatasetUndo() {
     String datasetId = ControlledGcpResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
 
@@ -265,7 +265,7 @@ public class ControlledResourceServiceBqTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void deleteBqDatasetDo() throws Exception {
+  void deleteBqDatasetDo() {
     String datasetId = ControlledGcpResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
 
@@ -310,7 +310,7 @@ public class ControlledResourceServiceBqTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void deleteBqDatasetUndo() throws Exception {
+  void deleteBqDatasetUndo() {
     String datasetId = ControlledGcpResourceFixtures.uniqueDatasetId();
     String location = "us-central1";
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
@@ -113,7 +113,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void createGcsBucketDo_invalidBucketName_throwsBadRequestException() throws Exception {
+  void createGcsBucketDo_invalidBucketName_throwsBadRequestException() {
     ControlledGcsBucketResource resource =
         ControlledGcpResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceId)
             .bucketName("192.168.5.4")
@@ -131,7 +131,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void createGcsBucketUndo() throws Exception {
+  void createGcsBucketUndo() {
     ControlledGcsBucketResource resource =
         ControlledGcpResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceId).build();
 
@@ -279,8 +279,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void updateGcsBucketDo() throws Exception {
-    Workspace workspace = workspaceService.getWorkspace(workspaceId);
+  void updateGcsBucketDo() {
     ControlledGcsBucketResource createdBucket = createDefaultSharedGcsBucket(user);
 
     Map<String, StepStatus> retrySteps = new HashMap<>();
@@ -314,7 +313,7 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void updateGcsBucketUndo() throws Exception {
+  void updateGcsBucketUndo() {
     ControlledGcsBucketResource createdBucket = createDefaultSharedGcsBucket(user);
 
     Map<String, StepStatus> doErrorStep = new HashMap<>();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceFlexTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceFlexTest.java
@@ -83,7 +83,7 @@ public class ControlledResourceServiceFlexTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void updateFlexResourceUndo() throws Exception {
+  void updateFlexResourceUndo() {
     ControlledFlexibleResource originalFlex =
         ControlledResourceFixtures.makeDefaultFlexResourceBuilder(workspaceId).build();
     ControlledFlexibleResource createdFlex =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceNotebookTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceNotebookTest.java
@@ -228,11 +228,6 @@ public class ControlledResourceServiceNotebookTest extends BaseConnectedTest {
     assertThat(instance.getMetadata(), Matchers.hasEntry("terra-cli-server", serverName));
     assertThat(
         instance.getMetadata(), Matchers.hasEntry("terra-workspace-id", workspaceUserFacingId));
-    ServiceAccountName serviceAccountName =
-        ServiceAccountName.builder()
-            .projectId(instanceName.projectId())
-            .email(instance.getServiceAccount())
-            .build();
 
     // Creating a controlled resource with a duplicate underlying notebook instance is not allowed.
     ControlledAiNotebookInstanceResource duplicateResource =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceNotebookTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceNotebookTest.java
@@ -457,13 +457,11 @@ public class ControlledResourceServiceNotebookTest extends BaseConnectedTest {
             .getControlledResource(workspaceId, resource.getResourceId())
             .castByEnum(WsmResourceType.CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE);
 
-    var instanceFromCloud =
-        crlService
-            .getAIPlatformNotebooksCow()
-            .instances()
-            .get(fetchedInstance.toInstanceName())
-            .execute();
-    var metadata = instanceFromCloud.getMetadata();
+    crlService
+        .getAIPlatformNotebooksCow()
+        .instances()
+        .get(fetchedInstance.toInstanceName())
+        .execute();
 
     Map<String, StepStatus> retrySteps = new HashMap<>();
     retrySteps.put(
@@ -663,7 +661,7 @@ public class ControlledResourceServiceNotebookTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void createAiNotebookInstanceNoWriterRoleThrowsBadRequest() throws Exception {
+  void createAiNotebookInstanceNoWriterRoleThrowsBadRequest() {
     String instanceId = "create-ai-notebook-instance-shared";
 
     ApiGcpAiNotebookInstanceCreationParameters creationParameters =
@@ -694,7 +692,7 @@ public class ControlledResourceServiceNotebookTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void deleteAiNotebookInstanceDo() throws Exception {
+  void deleteAiNotebookInstanceDo() {
     ControlledAiNotebookInstanceResource resource =
         createDefaultPrivateAiNotebookInstance("delete-ai-notebook-instance-do", user);
     InstanceName instanceName = resource.toInstanceName();
@@ -720,7 +718,7 @@ public class ControlledResourceServiceNotebookTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void deleteAiNotebookInstanceUndoIsDismalFailure() throws Exception {
+  void deleteAiNotebookInstanceUndoIsDismalFailure() {
     ControlledAiNotebookInstanceResource resource =
         createDefaultPrivateAiNotebookInstance("delete-ai-notebook-instance-undo", user);
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceStateTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceStateTest.java
@@ -40,7 +40,7 @@ public class ControlledResourceStateTest extends BaseUnitTestMockGcpCloudContext
   private static final String FAKE_PROJECT_ID = "fakeprojectid";
 
   @BeforeEach
-  public void setup() throws IOException {
+  public void setup() {
     when(mockGcpCloudContextService().getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
   }
 
@@ -59,7 +59,7 @@ public class ControlledResourceStateTest extends BaseUnitTestMockGcpCloudContext
     assertNull(dbResource);
   }
 
-  private WsmResource testCreateBucketFailedState(WsmResourceStateRule rule) throws Exception {
+  private WsmResource testCreateBucketFailedState(WsmResourceStateRule rule) {
     when(mockFeatureConfiguration().getStateRule()).thenReturn(rule);
 
     UUID workspaceId = WorkspaceUnitTestUtils.createWorkspaceWithGcpContext(workspaceDao);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceStateTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceStateTest.java
@@ -24,7 +24,6 @@ import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.resource.model.WsmResourceStateRule;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -45,7 +44,7 @@ public class ControlledResourceStateTest extends BaseUnitTestMockGcpCloudContext
   }
 
   @Test
-  public void testCreateBucketFailBroken() throws Exception {
+  public void testCreateBucketFailBroken() {
     // Get the resource from database and check state
     WsmResource dbResource = testCreateBucketFailedState(WsmResourceStateRule.BROKEN_ON_FAILURE);
     assertNotNull(dbResource);
@@ -53,7 +52,7 @@ public class ControlledResourceStateTest extends BaseUnitTestMockGcpCloudContext
   }
 
   @Test
-  public void testCreateBucketFailDeleted() throws Exception {
+  public void testCreateBucketFailDeleted() {
     // Get the resource from database and check state
     WsmResource dbResource = testCreateBucketFailedState(WsmResourceStateRule.DELETE_ON_FAILURE);
     assertNull(dbResource);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ValidCommonEnumTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ValidCommonEnumTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class ValidCommonEnumTest extends BaseUnitTest {
 
   @Test
-  public void accessScopeValidityTest() throws Exception {
+  public void accessScopeValidityTest() {
     assertThat(
         AccessScopeType.fromApi(ApiAccessScope.PRIVATE_ACCESS),
         equalTo(AccessScopeType.ACCESS_SCOPE_PRIVATE));
@@ -42,7 +42,7 @@ public class ValidCommonEnumTest extends BaseUnitTest {
   }
 
   @Test
-  public void managedByValidityTest() throws Exception {
+  public void managedByValidityTest() {
     assertThat(
         ManagedByType.fromApi(ApiManagedBy.APPLICATION),
         equalTo(ManagedByType.MANAGED_BY_APPLICATION));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureControlledVmResourceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureControlledVmResourceFlightTest.java
@@ -62,7 +62,6 @@ public class AzureControlledVmResourceFlightTest extends BaseAzureConnectedTest 
   private Workspace sharedWorkspace;
   private UUID workspaceUuid;
   private ControlledAzureDiskResource diskResource;
-  private String networkName;
 
   @BeforeAll
   public void setup() throws InterruptedException {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDatabaseConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDatabaseConnectedTest.java
@@ -123,7 +123,7 @@ public class AzureDatabaseConnectedTest extends BaseAzureConnectedTest {
                   return parts[parts.length - 1];
                 })
             .orElseThrow();
-    final BiFunction<String, String, Database> getDatabaseFunction =
+    BiFunction<String, String, Database> getDatabaseFunction =
         (resourceGroup, resourceName) ->
             azureTestUtils
                 .getPostgreSqlManager()

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -64,7 +64,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
   private AzureStorageAccessService azureStorageAccessService;
 
   @BeforeEach
-  public void setup() throws InterruptedException {
+  public void setup() {
     var keyProvider = mock(StorageAccountKeyProvider.class);
     var cred = new StorageSharedKeyCredential("fake", "fake");
     when(keyProvider.getStorageAccountKey(any(), any())).thenReturn(cred);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopierConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/BlobCopierConnectedTest.java
@@ -188,12 +188,7 @@ public class BlobCopierConnectedTest extends BaseAzureConnectedTest {
 
   private static String[] generateFilenames(int numberOfFiles) {
     return Stream.range(0, numberOfFiles)
-        .map(
-            idx -> {
-              var fileId = UUID.randomUUID();
-              var blobName = idx + "/it-blob-" + fileId;
-              return blobName;
-            })
+        .map(idx -> idx + "/it-blob-" + UUID.randomUUID())
         .collect(Collectors.toList())
         .toArray(new String[0]);
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/TestLandingZoneManager.java
@@ -4,7 +4,6 @@ import bio.terra.landingzone.db.LandingZoneDao;
 import bio.terra.landingzone.db.exception.DuplicateLandingZoneException;
 import bio.terra.landingzone.db.model.LandingZoneRecord;
 import bio.terra.workspace.common.utils.AzureTestUtils;
-import bio.terra.workspace.db.WorkspaceDao;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
@@ -18,13 +17,10 @@ import java.util.UUID;
  */
 public class TestLandingZoneManager {
   private final LandingZoneDao landingZoneDao;
-  private final WorkspaceDao workspaceDao;
   private final AzureTestUtils azureTestUtils;
 
-  public TestLandingZoneManager(
-      LandingZoneDao landingZoneDao, WorkspaceDao workspaceDao, AzureTestUtils azureTestUtils) {
+  public TestLandingZoneManager(LandingZoneDao landingZoneDao, AzureTestUtils azureTestUtils) {
     this.landingZoneDao = landingZoneDao;
-    this.workspaceDao = workspaceDao;
     this.azureTestUtils = azureTestUtils;
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStepTest.java
@@ -180,18 +180,16 @@ public class CreateAzureDatabaseStepTest {
 
     when(mockSamService.getWsmServiceAccountToken()).thenReturn(UUID.randomUUID().toString());
 
-    var step =
-        new CreateAzureDatabaseStep(
-            mockAzureConfig,
-            mockCrlService,
-            databaseResource,
-            mockLandingZoneApiDispatch,
-            mockSamService,
-            mockWorkspaceService,
-            workspaceId,
-            mockKubernetesClient,
-            mockResourceDao);
-    return step;
+    return new CreateAzureDatabaseStep(
+        mockAzureConfig,
+        mockCrlService,
+        databaseResource,
+        mockLandingZoneApiDispatch,
+        mockSamService,
+        mockWorkspaceService,
+        workspaceId,
+        mockKubernetesClient,
+        mockResourceDao);
   }
 
   @NotNull
@@ -243,18 +241,16 @@ public class CreateAzureDatabaseStepTest {
             any()))
         .thenReturn(new V1Pod());
 
-    var step =
-        new CreateAzureDatabaseStep(
-            mockAzureConfig,
-            mockCrlService,
-            databaseResource,
-            mockLandingZoneApiDispatch,
-            mockSamService,
-            mockWorkspaceService,
-            workspaceId,
-            mockKubernetesClient,
-            mockResourceDao);
-    return step;
+    return new CreateAzureDatabaseStep(
+        mockAzureConfig,
+        mockCrlService,
+        databaseResource,
+        mockLandingZoneApiDispatch,
+        mockSamService,
+        mockWorkspaceService,
+        workspaceId,
+        mockKubernetesClient,
+        mockResourceDao);
   }
 
   private FlightContext createMockFlightContext() {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
@@ -46,14 +46,14 @@ import org.springframework.http.HttpStatus;
 @Tag("azure-unit")
 public class CreateFederatedIdentityStepTest {
   private MockitoSession mockito;
-  private String k8sNamespace = UUID.randomUUID().toString();
+  private final String k8sNamespace = UUID.randomUUID().toString();
   @Mock private AzureConfiguration mockAzureConfig;
   @Mock private CrlService mockCrlService;
   @Mock private KubernetesClientProvider mockKubernetesClientProvider;
   @Mock private LandingZoneApiDispatch mockLandingZoneApiDispatch;
   @Mock private SamService mockSamService;
   @Mock private WorkspaceService mockWorkspaceService;
-  private UUID workspaceId = UUID.randomUUID();
+  private final UUID workspaceId = UUID.randomUUID();
   @Mock private ResourceDao mockResourceDao;
   @Mock private AzureCloudContext mockAzureCloudContext;
   private final ControlledAzureManagedIdentityResource identityResource =
@@ -63,8 +63,8 @@ public class CreateFederatedIdentityStepTest {
           .build();
   @Mock private MsiManager mockMsiManager;
   @Mock private CoreV1Api mockCoreV1Api;
-  private String oidcIssuer = UUID.randomUUID().toString();
-  private String uamiClientId = UUID.randomUUID().toString();
+  private final String oidcIssuer = UUID.randomUUID().toString();
+  private final String uamiClientId = UUID.randomUUID().toString();
   @Mock private Identities mockIdentities;
   @Mock private MsiManager mockManager;
   @Mock private ManagedServiceIdentityClient mockServiceClient;
@@ -192,15 +192,13 @@ public class CreateFederatedIdentityStepTest {
             mockWorkspaceService,
             workspaceId,
             mockResourceDao);
-    var result =
-        step.createFederatedIdentityAndK8sServiceAccount(
-            identityResource.getManagedIdentityName(),
-            mockAzureCloudContext,
-            mockMsiManager,
-            mockCoreV1Api,
-            oidcIssuer,
-            uamiClientId);
-    return result;
+    return step.createFederatedIdentityAndK8sServiceAccount(
+        identityResource.getManagedIdentityName(),
+        mockAzureCloudContext,
+        mockMsiManager,
+        mockCoreV1Api,
+        oidcIssuer,
+        uamiClientId);
   }
 
   private void setupMocks() {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storage/BaseStorageStepTest.java
@@ -22,7 +22,7 @@ import org.mockito.Mock;
 /** Base class for storage account and storage container tests. */
 public class BaseStorageStepTest extends BaseAzureUnitTest {
 
-  protected final String STUB_STRING_RETURN = "stubbed-return";
+  protected static final String STUB_STRING_RETURN = "stubbed-return";
 
   @Mock protected FlightContext mockFlightContext;
   @Mock protected CrlService mockCrlService;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureNetworkInterfaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureNetworkInterfaceStepTest.java
@@ -55,9 +55,9 @@ public class CreateAzureNetworkInterfaceStepTest extends BaseAzureUnitTest {
 
   @Mock private AzureCloudContext azureCloudContext;
 
-  private final String STUB_MRG = "RG";
+  private static final String STUB_MRG = "RG";
 
-  private final String STUB_SUBNET = "SUBNET";
+  private static final String STUB_SUBNET = "SUBNET";
 
   private CreateAzureNetworkInterfaceStep networkInterfaceStep;
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureNetworkInterfaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureNetworkInterfaceStepTest.java
@@ -18,17 +18,14 @@ import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneResourcesList;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneResourcesPurposeGroup;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
-import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.resourcemanager.network.NetworkManager;
 import com.azure.resourcemanager.network.models.Network;
 import com.azure.resourcemanager.network.models.Networks;
 import com.azure.resourcemanager.network.models.Subnet;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,27 +43,15 @@ public class CreateAzureNetworkInterfaceStepTest extends BaseAzureUnitTest {
   @Mock private ControlledAzureVmResource resource;
   @Mock private SamService samService;
   @Mock private WorkspaceService mockWorkspaceService;
-
   @Mock private ResourceDao resourceDao;
-
   @Mock private LandingZoneApiDispatch landingZoneApiDispatch;
-
   @Mock private Networks networks;
-
-  @Mock private AzureCloudContext azureCloudContext;
-
-  private static final String STUB_MRG = "RG";
-
-  private static final String STUB_SUBNET = "SUBNET";
-
-  private CreateAzureNetworkInterfaceStep networkInterfaceStep;
-
   @Mock private Network armNetwork;
-
   @Mock private Subnet armSubnet;
 
-  private final AuthenticatedUserRequest USER_REQUEST =
-      new AuthenticatedUserRequest().token(Optional.of("some-token"));
+  private static final String STUB_MRG = "RG";
+  private static final String STUB_SUBNET = "SUBNET";
+  private CreateAzureNetworkInterfaceStep networkInterfaceStep;
 
   @BeforeEach
   void setUp() {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/UpdateBigQueryDatasetStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/UpdateBigQueryDatasetStepTest.java
@@ -46,12 +46,12 @@ public class UpdateBigQueryDatasetStepTest extends BaseUnitTest {
   @Mock private GcpCloudContextService mockGcpCloudContextService;
 
   UpdateBigQueryDatasetStep updateBigQueryDatasetStep;
-  Dataset mockExistingDataset = new Dataset();
-  ControlledBigQueryDatasetResource baseDatasetResource =
+  final Dataset mockExistingDataset = new Dataset();
+  final ControlledBigQueryDatasetResource baseDatasetResource =
       ControlledGcpResourceFixtures.makeDefaultControlledBqDatasetBuilder(null)
           .projectId(PROJECT_ID)
           .build();
-  FlightMap workingMap = new FlightMap();
+  final FlightMap workingMap = new FlightMap();
   DbUpdater dbUpdater;
 
   @Captor private ArgumentCaptor<Dataset> datasetCaptor;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketHandlerTest.java
@@ -9,7 +9,6 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFOR
 
 import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.ControlledAiNotebookHandler;
-import java.io.IOException;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +25,7 @@ public class ControlledGcsBucketHandlerTest extends BaseUnitTestMockGcpCloudCont
   private static final String FAKE_PROJECT_ID = "fakeprojectid";
 
   @BeforeEach
-  public void setup() throws IOException {
+  public void setup() {
     when(mockGcpCloudContextService().getRequiredGcpProject(any())).thenReturn(FAKE_PROJECT_ID);
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/UpdateGcsBucketStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/UpdateGcsBucketStepTest.java
@@ -90,7 +90,6 @@ public class UpdateGcsBucketStepTest extends BaseUnitTest {
     doReturn(PROJECT_ID)
         .when(mockGcpCloudContextService)
         .getRequiredReadyGcpProject(bucketResource.getWorkspaceId());
-    FlightMap workkingMap = new FlightMap();
     workingMap.put(WorkspaceFlightMapKeys.GCP_PROJECT_ID, PROJECT_ID);
     doReturn(workingMap).when(mockFlightContext).getWorkingMap();
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/GcsBucketCloneTestFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/GcsBucketCloneTestFixtures.java
@@ -26,7 +26,6 @@ public class GcsBucketCloneTestFixtures {
   public static final String SOURCE_PROJECT_ID = "popular-strawberry-1234";
   public static final String DESTINATION_PROJECT_ID = "hairless-kiwi-5678";
   public static final String SOURCE_BUCKET_NAME = "source-bucket";
-  public static final String SOURCE_BUCKET_DESCRIPTION = "A bucket with a hole in it.";
   public static final String DESTINATION_BUCKET_NAME = "destination-bucket";
   public static final String SOURCE_RESOURCE_NAME = "source_bucket";
   public static final ApiGcpGcsBucketCreationParameters SOURCE_BUCKET_CREATION_PARAMETERS =
@@ -86,5 +85,4 @@ public class GcsBucketCloneTestFixtures {
               Role.of(DESTINATION_ROLE_NAMES.get(0)),
               Identity.serviceAccount(STORAGE_TRANSFER_SERVICE_SA_EMAIL))
           .build();
-  public static final String CONTROL_PLANE_PROJECT_ID = "terra-control-plane-2468";
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllFoldersStepTest.java
@@ -48,7 +48,7 @@ public class CloneAllFoldersStepTest extends BaseUnitTest {
   private static final String DEFAULT_USER_EMAIL = "foo@gmail.com";
 
   @BeforeEach
-  public void setup() throws InterruptedException {
+  public void setup() {
 
     SOURCE_WORKSPACE_ID = WorkspaceUnitTestUtils.createWorkspaceWithGcpContext(workspaceDao);
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -152,10 +152,6 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
     referenceResourceService.createReferenceResource(referencedResource, USER_REQUEST);
 
     UUID resourceId = referencedResource.getResourceId();
-    ReferencedDataRepoSnapshotResource originalResource =
-        referenceResourceService
-            .getReferenceResource(workspaceUuid, resourceId)
-            .castByEnum(WsmResourceType.REFERENCED_ANY_DATA_REPO_SNAPSHOT);
     String originalName = referencedResource.getName();
     String originalDescription = referencedResource.getDescription();
 
@@ -446,7 +442,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
   class GcpBucketReference {
 
     @BeforeEach
-    void setup() throws Exception {
+    void setup() {
       // Make the Verify step always succeed
       doReturn(true).when(mockCrlService()).canReadGcsBucket(any(), any());
       doReturn(true).when(mockCrlService()).canReadGcsObject(any(), any(), any());
@@ -633,7 +629,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
     private static final String DATA_TABLE_NAME = "testbq datatablename";
 
     @BeforeEach
-    void setup() throws Exception {
+    void setup() {
       // Make the Verify step always succeed
       doReturn(true).when(mockCrlService()).canReadBigQueryDataset(any(), any(), any());
       doReturn(true).when(mockCrlService()).canReadBigQueryDataTable(any(), any(), any(), any());
@@ -884,9 +880,6 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
 
     @Test
     void createReferencedBigQueryDataTableResource_missesDataTableName_throwsException() {
-      UUID resourceId = UUID.randomUUID();
-      String resourceName = "testdatarepo-" + resourceId;
-
       assertThrows(
           MissingRequiredFieldException.class,
           () ->
@@ -952,7 +945,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
 
   @Nested
   class TerraWorkspaceReference {
-    UUID referencedWorkspaceId = UUID.randomUUID();
+    final UUID referencedWorkspaceId = UUID.randomUUID();
 
     @BeforeEach
     void setup() throws Exception {
@@ -960,9 +953,6 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
     }
 
     private ReferencedTerraWorkspaceResource makeTerraWorkspaceReference() {
-      UUID resourceId = UUID.randomUUID();
-      String resourceName = "terra-workspace-" + resourceId;
-
       return ReferencedTerraWorkspaceResource.builder()
           .wsmResourceFields(ReferenceResourceFixtures.makeDefaultWsmResourceFields(workspaceUuid))
           .referencedWorkspaceId(referencedWorkspaceId)

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AnyResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AnyResourceStateFailureTest.java
@@ -38,7 +38,6 @@ import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiUpdateBigQueryDataTableReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiUpdateBigQueryDatasetReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiUpdateDataRepoSnapshotReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiUpdateGcsBucketReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiUpdateGitRepoReferenceRequestBody;
 import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
@@ -282,7 +281,6 @@ public class AnyResourceStateFailureTest extends BaseUnitTest {
         workspaceUuid, bqTable.getResourceId(), REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT);
 
     // GCP-Referenced Bucket
-    var bucketUpdateRequest = new ApiUpdateGcsBucketReferenceRequestBody().bucketName("foo");
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         bqResource.getResourceId(),

--- a/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/ApplicationServiceTest.java
@@ -94,9 +94,7 @@ public class ApplicationServiceTest extends BaseUnitTest {
   @Autowired ResourceDao resourceDao;
   @Autowired WorkspaceDao workspaceDao;
 
-  private UUID workspaceId1;
   private Workspace workspace;
-  private UUID workspaceId2;
   private Workspace workspace2;
 
   @BeforeEach

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -220,8 +220,8 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
             .createWorkspaceWithoutCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), ApiWorkspaceStageModel.MC_WORKSPACE)
             .getId();
-    mockMvcUtils.createGcpCloudContextAndWait(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.createCloudContextAndWait(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId2, apiCloudPlatform);
 
     assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceId2).isPresent());
     ActivityLogChangeDetails changeDetails =

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -121,7 +121,8 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
     jobService.setFlightDebugInfoForTest(null);
     doReturn(true).when(mockDataRepoService).snapshotReadable(any(), any(), any());
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();
-    workspaceId = mockMvcUtils.createWorkspaceWithCloudContext(userRequest).getId();
+    workspaceId =
+        mockMvcUtils.createWorkspaceWithCloudContext(userRequest, apiCloudPlatform).getId();
     projectId = gcpCloudContextService.getRequiredGcpProject(workspaceId);
     workspaceId2 = null;
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/CreateGcpContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/CreateGcpContextFlightTest.java
@@ -145,8 +145,7 @@ class CreateGcpContextFlightTest extends BaseConnectedTest {
 
   @Test
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
-  void createsProjectAndContext_emptySpendProfile_flightFailsAndGcpProjectNotCreated()
-      throws Exception {
+  void createsProjectAndContext_emptySpendProfile_flightFailsAndGcpProjectNotCreated() {
     UUID workspaceUuid = createWorkspace(null);
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceUuid).isEmpty());


### PR DESCRIPTION
NOTE -- rebase after https://github.com/DataBiosphere/terra-workspace-manager/pull/1335

- Address some of the spotbug warnings (unused variables, static & final declarations)
- remove exceptions that are not thrown in tests
- Add ApiCloudPlatform as a param to test util function for cloud context creation. This enables its use across all cloud platforms (specifically in AWS tests)