### PR TITLE
[PF-2843] Stop deleting GCP resources as part of cloud context delete

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/service/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.app.configuration.external.JobConfiguration;
 import bio.terra.workspace.app.configuration.external.StairwayDatabaseConfiguration;
 import bio.terra.workspace.common.logging.WorkspaceActivityLogHook;
 import bio.terra.workspace.common.utils.FlightBeanBag;
+import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.common.utils.MdcHook;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.SamConstants.SamWorkspaceAction;
@@ -143,11 +144,9 @@ public class JobService {
 
   public void waitForJob(String jobId) {
     try {
-      int pollSeconds = jobConfig.getPollingIntervalSeconds();
-      int pollCycles = jobConfig.getTimeoutSeconds() / jobConfig.getPollingIntervalSeconds();
-      stairwayComponent.get().waitForFlight(jobId, pollSeconds, pollCycles);
-    } catch (InterruptedException | StairwayException stairwayEx) {
-      throw new InternalStairwayException(stairwayEx);
+      FlightUtils.waitForJobFlightCompletion(stairwayComponent.get(), jobId);
+    } catch (Exception ex) {
+      throw new InternalStairwayException(ex);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCreateCloudContextFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCreateCloudContextFlightStep.java
@@ -45,9 +45,15 @@ public class AwaitCreateCloudContextFlightStep implements Step {
                                 "Subflight had unexpected status %s. No exception for subflight found.",
                                 subflightState.getFlightStatus()))));
       }
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw ie;
     } catch (DatabaseOperationException | FlightWaitTimedOutException e) {
       // Retry for database issues or expired wait loop
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    } catch (Exception e) {
+      // Error for any other exception
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
     }
 
     return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/DeleteResourcesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/DeleteResourcesStep.java
@@ -51,7 +51,7 @@ public class DeleteResourcesStep implements Step {
   @Override
   //  @SuppressWarnings("unchecked")
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    // Jackson does not deserialize the list properly with a TypeReference. The unchecked for works.
+    // Jackson does not deserialize the list properly with a TypeReference. The array form works.
     ResourceDeleteFlightPair[] resourcePairs =
         FlightUtils.getRequired(
             context.getWorkingMap(),

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/RunDeleteCloudContextFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/workspace/RunDeleteCloudContextFlightStep.java
@@ -15,7 +15,6 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.delete.cloudcontext.DeleteCloudContextFlight;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import com.fasterxml.jackson.core.type.TypeReference;
-import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -24,11 +23,6 @@ import org.slf4j.LoggerFactory;
 public class RunDeleteCloudContextFlightStep implements Step {
   private static final Logger logger =
       LoggerFactory.getLogger(RunDeleteCloudContextFlightStep.class);
-  private static final Duration TOTAL_DURATION = Duration.ofHours(1);
-  private static final Duration INITIAL_SLEEP = Duration.ofSeconds(10);
-  private static final double FACTOR_INCREASE = 0.7;
-  private static final Duration MAX_SLEEP = Duration.ofMinutes(2);
-
   private final UUID workspaceUuid;
   private final CloudPlatform cloudPlatform;
   private final AuthenticatedUserRequest userRequest;

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceStateUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceStateUnitTest.java
@@ -1,0 +1,46 @@
+package bio.terra.workspace.service.workspace;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.db.exception.ResourceStateConflictException;
+import bio.terra.workspace.service.logging.WorkspaceActivityLogService;
+import bio.terra.workspace.service.policy.PolicyValidator;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+public class WorkspaceStateUnitTest extends BaseUnitTest {
+  @MockBean private PolicyValidator mockPolicyValidator;
+  @MockBean private WorkspaceActivityLogService mockWorkspaceActivityLogService;
+
+  @Autowired private WorkspaceService workspaceService;
+  @Autowired private WorkspaceDao workspaceDao;
+
+  @Test
+  void createDeleteStateTest() throws Exception {
+    Workspace workspace1 = WorkspaceFixtures.buildMcWorkspace();
+    var flightId1 = UUID.randomUUID().toString();
+    final var flightId2 = UUID.randomUUID().toString();
+    workspaceDao.createWorkspaceStart(workspace1, /* applicationIds */ null, flightId1);
+    assertThrows(
+        ResourceStateConflictException.class,
+        () -> workspaceDao.createWorkspaceSuccess(workspace1.workspaceId(), flightId2));
+
+    workspaceDao.createWorkspaceSuccess(workspace1.workspaceId(), flightId1);
+
+    var deleteFlightId1 = UUID.randomUUID().toString();
+    final var deleteFlightId2 = UUID.randomUUID().toString();
+
+    workspaceDao.deleteWorkspaceStart(workspace1.workspaceId(), deleteFlightId1);
+    assertThrows(
+        ResourceStateConflictException.class,
+        () -> workspaceDao.deleteWorkspaceStart(workspace1.workspaceId(), deleteFlightId2));
+
+    workspaceDao.deleteWorkspaceSuccess(workspace1.workspaceId(), deleteFlightId1);
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceStateUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceStateUnitTest.java
@@ -22,25 +22,33 @@ public class WorkspaceStateUnitTest extends BaseUnitTest {
   @Autowired private WorkspaceDao workspaceDao;
 
   @Test
-  void createDeleteStateTest() throws Exception {
-    Workspace workspace1 = WorkspaceFixtures.buildMcWorkspace();
-    var flightId1 = UUID.randomUUID().toString();
-    final var flightId2 = UUID.randomUUID().toString();
-    workspaceDao.createWorkspaceStart(workspace1, /* applicationIds */ null, flightId1);
+  void create_modifyStateWithDifferentFlightId_throwResourceStateConflict() throws Exception {
+    Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
+    String flightId1 = UUID.randomUUID().toString();
+    final String flightId2 = UUID.randomUUID().toString();
+    workspaceDao.createWorkspaceStart(workspace, /* applicationIds */ null, flightId1);
     assertThrows(
         ResourceStateConflictException.class,
-        () -> workspaceDao.createWorkspaceSuccess(workspace1.workspaceId(), flightId2));
+        () -> workspaceDao.createWorkspaceSuccess(workspace.workspaceId(), flightId2));
 
-    workspaceDao.createWorkspaceSuccess(workspace1.workspaceId(), flightId1);
+    workspaceDao.createWorkspaceSuccess(workspace.workspaceId(), flightId1);
+  }
 
-    var deleteFlightId1 = UUID.randomUUID().toString();
-    final var deleteFlightId2 = UUID.randomUUID().toString();
+  @Test
+  void delete_modifyStateWithDifferentFlightId_throwResourceStateConflict() throws Exception {
+    Workspace workspace = WorkspaceFixtures.buildMcWorkspace();
+    String flightId1 = UUID.randomUUID().toString();
+    workspaceDao.createWorkspaceStart(workspace, /* applicationIds */ null, flightId1);
+    workspaceDao.createWorkspaceSuccess(workspace.workspaceId(), flightId1);
 
-    workspaceDao.deleteWorkspaceStart(workspace1.workspaceId(), deleteFlightId1);
+    String deleteFlightId1 = UUID.randomUUID().toString();
+    final String deleteFlightId2 = UUID.randomUUID().toString();
+
+    workspaceDao.deleteWorkspaceStart(workspace.workspaceId(), deleteFlightId1);
     assertThrows(
         ResourceStateConflictException.class,
-        () -> workspaceDao.deleteWorkspaceStart(workspace1.workspaceId(), deleteFlightId2));
+        () -> workspaceDao.deleteWorkspaceStart(workspace.workspaceId(), deleteFlightId2));
 
-    workspaceDao.deleteWorkspaceSuccess(workspace1.workspaceId(), deleteFlightId1);
+    workspaceDao.deleteWorkspaceSuccess(workspace.workspaceId(), deleteFlightId1);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceUnitTest.java
@@ -46,6 +46,7 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   @MockBean private WorkspaceActivityLogService mockWorkspaceActivityLogService;
 
   @Autowired private WorkspaceService workspaceService;
+  @Autowired private WorkspaceDao workspaceDao;
 
   @Test
   void testErrorSerdes_errorReportExceptionWorks() {

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceUnitTest.java
@@ -46,7 +46,6 @@ public class WorkspaceUnitTest extends BaseUnitTest {
   @MockBean private WorkspaceActivityLogService mockWorkspaceActivityLogService;
 
   @Autowired private WorkspaceService workspaceService;
-  @Autowired private WorkspaceDao workspaceDao;
 
   @Test
   void testErrorSerdes_errorReportExceptionWorks() {


### PR DESCRIPTION
I missed a step in the new workspace/cloud-context delete and it was deleting the GCP resources.
I had written the flight, but didn't use it...

Anyway, there a few independent changes here:
1. Use the DeleteCloudContextResourceFlight for the GCP cloud context delete.
2. Centralize and share code for waiting for flights and put it in FlightUtils
3. Small code cleanup in DeleteGcsBucketStep


