### PR TITLE
[PF-2710] list workspace performance

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -754,14 +754,14 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
     UUID sourceWorkspaceId = requestBody.getWorkspaceId();
     Rethrow.onInterrupted(
         () ->
-            tpsApiDispatch.createPaoIfNotExist(
+            tpsApiDispatch.getOrCreatePao(
                 sourceWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE),
-        "createPaoIfNotExist");
+        "getOrCreatePao");
     Rethrow.onInterrupted(
         () ->
-            tpsApiDispatch.createPaoIfNotExist(
+            tpsApiDispatch.getOrCreatePao(
                 targetWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE),
-        "createPaoIfNotExist");
+        "getOrCreatePao");
 
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     workspaceService.validateWorkspaceAndAction(

--- a/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/WorkspaceApiController.java
@@ -246,22 +246,19 @@ public class WorkspaceApiController extends ControllerBase implements WorkspaceA
       minimumHighestRole = ApiIamRole.READER;
     }
 
-    // Unlike other operations, there's no Sam permission required to list workspaces. As long as
+    // Unlike most other operations, there's no Sam permission required to list workspaces. As long
+    // as
     // a user is enabled, they can call this endpoint, though they may not have any workspaces they
     // can read.
-    List<WorkspaceDescription> workspacesAndHighestRoles =
+    List<WorkspaceDescription> workspaceDescriptions =
         workspaceService.getWorkspaceDescriptions(
             userRequest, offset, limit, WsmIamRole.fromApiModel(minimumHighestRole));
+
     var response =
         new ApiWorkspaceDescriptionList()
             .workspaces(
-                workspacesAndHighestRoles.stream()
-                    .map(
-                        workspaceAndHighestRole ->
-                            workspaceApiUtils.buildWorkspaceDescription(
-                                workspaceAndHighestRole.workspace(),
-                                workspaceAndHighestRole.highestRole(),
-                                workspaceAndHighestRole.missingAuthDomains()))
+                workspaceDescriptions.stream()
+                    .map(workspaceApiUtils::buildApiWorkspaceDescription)
                     .toList());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -2,21 +2,12 @@ package bio.terra.workspace.app.controller.shared;
 
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
 
-import bio.terra.policy.model.TpsComponent;
-import bio.terra.policy.model.TpsObjectType;
-import bio.terra.policy.model.TpsPaoGetResult;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.exception.FeatureNotSupportedException;
-import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
-import bio.terra.workspace.common.utils.Rethrow;
-import bio.terra.workspace.generated.model.ApiAwsContext;
-import bio.terra.workspace.generated.model.ApiAzureContext;
-import bio.terra.workspace.generated.model.ApiGcpContext;
 import bio.terra.workspace.generated.model.ApiProperties;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWorkspaceStageModel;
-import bio.terra.workspace.generated.model.ApiWsmPolicyInput;
 import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
@@ -36,10 +27,7 @@ import bio.terra.workspace.service.workspace.model.GcpCloudContext;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceDescription;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -126,81 +114,6 @@ public class WorkspaceApiUtils {
           "Cannot apply policies to a RAWLS_WORKSPACE stage workspace");
     }
     return TpsApiConversionUtils.tpsFromApiTpsPolicyInputs(policyInputs);
-  }
-
-  public ApiWorkspaceDescription buildWorkspaceDescription(
-      Workspace workspace, WsmIamRole highestRole) {
-    return buildWorkspaceDescription(
-        workspace, highestRole, /*missingAuthDomains=*/ Collections.emptyList());
-  }
-
-  public ApiWorkspaceDescription buildWorkspaceDescription(
-      Workspace workspace, WsmIamRole highestRole, List<String> missingAuthDomains) {
-    UUID workspaceUuid = workspace.getWorkspaceId();
-    ApiGcpContext gcpContext =
-        gcpCloudContextService
-            .getGcpCloudContext(workspaceUuid)
-            .map(GcpCloudContext::toApi)
-            .orElse(null);
-
-    ApiAzureContext azureContext =
-        azureCloudContextService
-            .getAzureCloudContext(workspaceUuid)
-            .map(AzureCloudContext::toApi)
-            .orElse(null);
-
-    ApiAwsContext awsContext =
-        awsCloudContextService
-            .getAwsCloudContext(workspaceUuid)
-            .map(AwsCloudContext::toApi)
-            .orElse(null);
-
-    List<ApiWsmPolicyInput> workspacePolicies = null;
-    if (features.isTpsEnabled()) {
-      TpsPaoGetResult workspacePao =
-          Rethrow.onInterrupted(
-              () ->
-                  tpsApiDispatch.getOrCreatePao(
-                      workspaceUuid, TpsComponent.WSM, TpsObjectType.WORKSPACE),
-              "getOrCreatePao");
-      workspacePolicies = TpsApiConversionUtils.apiEffectivePolicyListFromTpsPao(workspacePao);
-    }
-
-    // When we have another cloud context, we will need to do a similar retrieval for it.
-    var lastChangeDetailsOptional =
-        workspaceActivityLogService.getLastUpdatedDetails(workspaceUuid);
-
-    if (highestRole == WsmIamRole.DISCOVERER) {
-      workspace = Workspace.stripWorkspaceForRequesterWithOnlyDiscovererRole(workspace);
-    }
-
-    // Convert the property map to API format
-    ApiProperties apiProperties = convertMapToApiProperties(workspace.getProperties());
-
-    return new ApiWorkspaceDescription()
-        .id(workspaceUuid)
-        .userFacingId(workspace.getUserFacingId())
-        .displayName(workspace.getDisplayName().orElse(null))
-        .description(workspace.getDescription().orElse(null))
-        .highestRole(highestRole.toApiModel())
-        .properties(apiProperties)
-        .spendProfile(workspace.getSpendProfileId().map(SpendProfileId::getId).orElse(null))
-        .stage(workspace.getWorkspaceStage().toApiModel())
-        .gcpContext(gcpContext)
-        .azureContext(azureContext)
-        .awsContext(awsContext)
-        .createdDate(workspace.createdDate())
-        .createdBy(workspace.createdByEmail())
-        .lastUpdatedDate(
-            lastChangeDetailsOptional
-                .map(ActivityLogChangeDetails::changeDate)
-                .orElse(workspace.createdDate()))
-        .lastUpdatedBy(
-            lastChangeDetailsOptional
-                .map(ActivityLogChangeDetails::actorEmail)
-                .orElse(workspace.createdByEmail()))
-        .policies(workspacePolicies)
-        .missingAuthDomains(missingAuthDomains);
   }
 
   public ApiWorkspaceDescription buildApiWorkspaceDescription(

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -155,13 +155,12 @@ public class WorkspaceApiUtils {
 
     List<ApiWsmPolicyInput> workspacePolicies = null;
     if (features.isTpsEnabled()) {
-      Rethrow.onInterrupted(
-          () ->
-              tpsApiDispatch.createPaoIfNotExist(
-                  workspaceUuid, TpsComponent.WSM, TpsObjectType.WORKSPACE),
-          "createPaoIfNotExist");
       TpsPaoGetResult workspacePao =
-          Rethrow.onInterrupted(() -> tpsApiDispatch.getPao(workspaceUuid), "getPao");
+        Rethrow.onInterrupted(
+          () ->
+            tpsApiDispatch.getOrCreatePao(
+              workspaceUuid, TpsComponent.WSM, TpsObjectType.WORKSPACE),
+          "getOrCreatePao");
       workspacePolicies = TpsApiConversionUtils.apiEffectivePolicyListFromTpsPao(workspacePao);
     }
 

--- a/service/src/main/java/bio/terra/workspace/common/logging/model/ActivityLogChangeDetails.java
+++ b/service/src/main/java/bio/terra/workspace/common/logging/model/ActivityLogChangeDetails.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.common.logging.model;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 import javax.annotation.Nullable;
 
 /**
@@ -10,6 +11,7 @@ import javax.annotation.Nullable;
  * `when` of an activity log change.
  */
 public record ActivityLogChangeDetails(
+    UUID workspaceId,
     OffsetDateTime changeDate,
     String actorEmail,
     String actorSubjectId,
@@ -20,6 +22,7 @@ public record ActivityLogChangeDetails(
   @VisibleForTesting
   public ActivityLogChangeDetails withChangeDate(@Nullable OffsetDateTime changeDate) {
     return new ActivityLogChangeDetails(
+        workspaceId(),
         changeDate,
         actorEmail(),
         actorSubjectId(),

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -48,6 +49,7 @@ public class WorkspaceActivityLogDao {
                 ? OperationType.UNKNOWN
                 : OperationType.valueOf(changeTypeString);
         return new ActivityLogChangeDetails(
+            UUID.fromString(rs.getString("workspace_id")),
             OffsetDateTime.ofInstant(rs.getTimestamp("change_date").toInstant(), ZoneId.of("UTC")),
             rs.getString("actor_email"),
             rs.getString("actor_subject_id"),
@@ -116,7 +118,7 @@ public class WorkspaceActivityLogDao {
   public Optional<ActivityLogChangeDetails> getLastUpdatedDetails(UUID workspaceId) {
     final String sql =
         """
-            SELECT change_date, actor_email, actor_subject_id, change_subject_id, change_subject_type, change_type
+            SELECT workspace_id, change_date, actor_email, actor_subject_id, change_subject_id, change_subject_type, change_type
             FROM workspace_activity_log
             WHERE workspace_id = :workspace_id AND change_type NOT IN (:change_type)
             ORDER BY change_date DESC
@@ -139,7 +141,7 @@ public class WorkspaceActivityLogDao {
       UUID workspaceId, String changeSubjectId) {
     final String sql =
         """
-            SELECT change_date, actor_email, actor_subject_id, change_subject_id, change_subject_type, change_type
+            SELECT workspace_id, change_date, actor_email, actor_subject_id, change_subject_id, change_subject_type, change_type
             FROM workspace_activity_log
             WHERE workspace_id = :workspace_id AND change_subject_id = :change_subject_id
             ORDER BY change_date DESC
@@ -153,5 +155,47 @@ public class WorkspaceActivityLogDao {
     return Optional.ofNullable(
         DataAccessUtils.singleResult(
             jdbcTemplate.query(sql, params, ACTIVITY_LOG_CHANGE_DETAILS_ROW_MAPPER)));
+  }
+
+  /**
+   * Given a list of workspace ids, return a list of last update activity log details
+   *
+   * @param workspaceIdList list of workspace ids
+   * @return list of last update activity log details
+   */
+  @Traced
+  @ReadTransaction
+  public List<ActivityLogChangeDetails> getLastUpdatedDetailsForList(Set<UUID> workspaceIdList) {
+    // This is a query that uses group by/max to build a result table of
+    // (workspace_id, max(date)) that we self-join to the activity log table
+    // to do a bulk retrieval of last-updated information.
+    final String sql =
+        """
+      SELECT
+        A.workspace_id,
+        A.change_date,
+        A.actor_email,
+        A.actor_subject_id,
+        A.change_subject_id,
+        A.change_subject_type,
+        A.change_type
+      FROM
+        (SELECT workspace_id, max(change_date) AS mxdate
+         FROM workspace_activity_log
+         WHERE workspace_id IN (:workspace_ids)
+           AND change_type NOT IN (:change_type)
+         GROUP BY workspace_id) X
+      JOIN
+        workspace_activity_log A
+      ON X.workspace_id = A.workspace_id AND X.mxdate = A.change_date
+      """;
+
+    List<String> textIdList = workspaceIdList.stream().map(UUID::toString).toList();
+    final var params =
+        new MapSqlParameterSource()
+            .addValue("workspace_ids", textIdList)
+            .addValue("change_type", NON_UPDATE_TYPE_OPERATION);
+
+    return jdbcTemplate.query(sql, params, ACTIVITY_LOG_CHANGE_DETAILS_ROW_MAPPER);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
@@ -170,7 +170,7 @@ public class WorkspaceActivityLogDao {
     if (workspaceIdList.isEmpty()) {
       return Collections.emptyList();
     }
-    
+
     // This is a query that uses group by/max to build a result table of
     // (workspace_id, max(date)) that we self-join to the activity log table
     // to do a bulk retrieval of last-updated information.

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceActivityLogDao.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -166,6 +167,10 @@ public class WorkspaceActivityLogDao {
   @Traced
   @ReadTransaction
   public List<ActivityLogChangeDetails> getLastUpdatedDetailsForList(Set<UUID> workspaceIdList) {
+    if (workspaceIdList.isEmpty()) {
+      return Collections.emptyList();
+    }
+    
     // This is a query that uses group by/max to build a result table of
     // (workspace_id, max(date)) that we self-join to the activity log table
     // to do a bulk retrieval of last-updated information.

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -487,7 +487,7 @@ public class WorkspaceDao {
   }
 
   /** Retrieves a workspace description by userFacingId. */
-  public DbWorkspaceDescription getWorkspaceByUserFacingId(String userFacingId) {
+  public DbWorkspaceDescription getWorkspaceDescriptionByUserFacingId(String userFacingId) {
     if (userFacingId == null || userFacingId.isEmpty()) {
       throw new MissingRequiredFieldException("userFacingId is required");
     }
@@ -666,7 +666,7 @@ public class WorkspaceDao {
    */
   @Traced
   @ReadTransaction
-  public Map<UUID, DbWorkspaceDescription> getWorkspacesMatchingList(
+  public Map<UUID, DbWorkspaceDescription> getWorkspaceDescriptionMapFromIdList(
       Set<UUID> idList, int offset, int limit) {
     // If the incoming list is empty, the caller does not have permission to see any
     // workspaces, so we return an empty list.

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.db;
 
 import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
+import bio.terra.common.exception.ErrorReportException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -4,11 +4,14 @@ import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.exception.InternalLogicException;
+import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
 import bio.terra.workspace.common.utils.ControllerValidationUtils;
 import bio.terra.workspace.db.exception.CloudContextNotFoundException;
 import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.db.model.DbCloudContext;
 import bio.terra.workspace.db.model.DbWorkspace;
+import bio.terra.workspace.db.model.DbWorkspaceContextPair;
+import bio.terra.workspace.db.model.DbWorkspaceDescription;
 import bio.terra.workspace.service.resource.controlled.model.PrivateResourceState;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.resource.model.WsmResourceStateRule;
@@ -16,6 +19,7 @@ import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateCloudContextException;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateUserFacingIdException;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateWorkspaceException;
+import bio.terra.workspace.service.workspace.model.CloudContext;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
@@ -114,16 +118,68 @@ public class WorkspaceDao {
               .flightId(rs.getString("flight_id"))
               .error(StateDao.deserializeException(rs.getString("error")));
 
+  /** Row mapper for the combo workspace+cloud context query */
+  private static final RowMapper<DbWorkspaceContextPair> WORKSPACE_CONTEXT_ROW_MAPPER =
+      (rs, rowNum) -> {
+        DbWorkspace dbWorkspace =
+            new DbWorkspace()
+                .workspaceId(UUID.fromString(rs.getString("workspace_id")))
+                .userFacingId(rs.getString("user_facing_id"))
+                .displayName(rs.getString("display_name"))
+                .description(rs.getString("description"))
+                .spendProfileId(
+                    Optional.ofNullable(rs.getString("spend_profile"))
+                        .map(SpendProfileId::new)
+                        .orElse(null))
+                .properties(
+                    Optional.ofNullable(rs.getString("properties"))
+                        .map(DbSerDes::jsonToProperties)
+                        .orElse(Collections.emptyMap()))
+                .workspaceStage(WorkspaceStage.valueOf(rs.getString("workspace_stage")))
+                .createdByEmail(rs.getString("created_by_email"))
+                .createdDate(
+                    OffsetDateTime.ofInstant(
+                        rs.getTimestamp("created_date").toInstant(), ZoneId.of("UTC")))
+                .state(WsmResourceState.fromDb(rs.getString("wstate")))
+                .flightId(rs.getString("wflightid"))
+                .error(StateDao.deserializeException(rs.getString("werror")));
+        DbCloudContext dbCloudContext = null;
+        if (rs.getString("cloud_platform") != null) {
+          dbCloudContext =
+              new DbCloudContext()
+                  .workspaceUuid(UUID.fromString(rs.getString("workspace_id")))
+                  .cloudPlatform(CloudPlatform.fromSql(rs.getString("cloud_platform")))
+                  .spendProfile(
+                      Optional.ofNullable(rs.getString("spend_profile"))
+                          .map(SpendProfileId::new)
+                          .orElse(null))
+                  .contextJson(rs.getString("context"))
+                  .state(WsmResourceState.fromDb(rs.getString("cstate")))
+                  .flightId(rs.getString("cflightid"))
+                  .error(
+                      Optional.ofNullable(rs.getString("cerror"))
+                          .map(
+                              errorJson -> DbSerDes.fromJson(errorJson, ErrorReportException.class))
+                          .orElse(null));
+        }
+        return new DbWorkspaceContextPair(dbWorkspace, dbCloudContext);
+      };
+
   private final NamedParameterJdbcTemplate jdbcTemplate;
   private final ApplicationDao applicationDao;
   private final StateDao stateDao;
+  private final WorkspaceActivityLogDao workspaceActivityLogDao;
 
   @Autowired
   public WorkspaceDao(
-      ApplicationDao applicationDao, NamedParameterJdbcTemplate jdbcTemplate, StateDao stateDao) {
+      ApplicationDao applicationDao,
+      NamedParameterJdbcTemplate jdbcTemplate,
+      StateDao stateDao,
+      WorkspaceActivityLogDao workspaceActivityLogDao) {
     this.applicationDao = applicationDao;
     this.jdbcTemplate = jdbcTemplate;
     this.stateDao = stateDao;
+    this.workspaceActivityLogDao = workspaceActivityLogDao;
   }
 
   /**
@@ -520,27 +576,93 @@ public class WorkspaceDao {
    * @param idList List of workspaceIds to query for
    * @param offset The number of items to skip before starting to collect the result set.
    * @param limit The maximum number of items to return.
-   * @return list of Workspaces corresponding to input IDs.
+   * @return map of Workspaces descriptions indexed by workspace id
    */
   @Traced
   @ReadTransaction
-  public List<Workspace> getWorkspacesMatchingList(Set<UUID> idList, int offset, int limit) {
+  public Map<UUID, DbWorkspaceDescription> getWorkspacesMatchingList(
+      Set<UUID> idList, int offset, int limit) {
     // If the incoming list is empty, the caller does not have permission to see any
     // workspaces, so we return an empty list.
     if (idList.isEmpty()) {
-      return Collections.emptyList();
+      return Collections.emptyMap();
     }
     String sql =
-        WORKSPACE_SELECT_SQL
-            + " WHERE workspace_id IN (:workspace_ids) ORDER BY workspace_id OFFSET :offset LIMIT :limit";
+        """
+        SELECT
+          W.workspace_id,
+          W.user_facing_id,
+          W.display_name,
+          W.description,
+          W.spend_profile,
+          W.properties,
+          W.workspace_stage,
+          W.created_by_email,
+          W.created_date,
+          W.state AS wstate,
+          W.flight_id AS wflightid,
+          W.error AS werror,
+          C.cloud_platform,
+          C.context,
+          C.spend_profile,
+          C.state AS cstate,
+          C.flight_id AS cflightid,
+          C.error AS cerror
+        FROM workspace W LEFT OUTER JOIN cloud_context C ON W.workspace_id = C.workspace_id
+        WHERE W.workspace_id IN (:workspace_ids)
+        ORDER BY W.workspace_id
+        OFFSET :offset
+        LIMIT :limit
+        """;
+
     var params =
         new MapSqlParameterSource()
             .addValue(
                 "workspace_ids", idList.stream().map(UUID::toString).collect(Collectors.toList()))
             .addValue("offset", offset)
             .addValue("limit", limit);
-    List<DbWorkspace> dbWorkspaces = jdbcTemplate.query(sql, params, WORKSPACE_ROW_MAPPER);
-    return dbWorkspaces.stream().map(Workspace::makeFromDb).toList();
+    List<DbWorkspaceContextPair> dbWorkspaceContextPairs =
+        jdbcTemplate.query(sql, params, WORKSPACE_CONTEXT_ROW_MAPPER);
+
+    // Build a map indexed by workspaceId that holds a workspace description.
+    // If the cloud context is present, add it to the workspace description
+    // It can be null for workspaces without any cloud context. We can see the
+    // same workspace more than once if it has more than one cloud context.
+    Map<UUID, DbWorkspaceDescription> workspaceContextMap = new HashMap<>();
+    for (DbWorkspaceContextPair pair : dbWorkspaceContextPairs) {
+      DbWorkspaceDescription dbWorkspaceDescription =
+          workspaceContextMap.get(pair.dbWorkspace().getWorkspaceId());
+      // If we don't have a workspace description for this workspace id, then make one
+      if (dbWorkspaceDescription == null) {
+        dbWorkspaceDescription =
+            new DbWorkspaceDescription(Workspace.makeFromDb(pair.dbWorkspace()));
+        workspaceContextMap.put(pair.dbWorkspace().getWorkspaceId(), dbWorkspaceDescription);
+      }
+      // If we have a cloud context, add it to the description
+      if (pair.dbCloudContext() != null) {
+        CloudContext cloudContext =
+            pair.dbCloudContext()
+                .getCloudPlatform()
+                .getCloudContextService()
+                .makeCloudContextFromDb(pair.dbCloudContext());
+        dbWorkspaceDescription.setCloudContext(cloudContext);
+      }
+    }
+
+    // Get the last update details for all of the workspaces and merge them
+    // into the workspace descriptions
+    List<ActivityLogChangeDetails> activityLogChangeDetails =
+        workspaceActivityLogDao.getLastUpdatedDetailsForList(workspaceContextMap.keySet());
+
+    for (ActivityLogChangeDetails details : activityLogChangeDetails) {
+      DbWorkspaceDescription dbWorkspaceDescription =
+          workspaceContextMap.get(details.workspaceId());
+      dbWorkspaceDescription
+          .setLastUpdatedByDate(details.changeDate())
+          .setLastUpdatedByEmail(details.actorEmail());
+    }
+
+    return workspaceContextMap;
   }
 
   /** List cloud platforms of all cloud contexts in a workspace. */
@@ -917,10 +1039,10 @@ public class WorkspaceDao {
   public void backfillCloudContextSpendProfile() {
     String sql =
         """
-      UPDATE cloud_context SET spend_profile =
-       (SELECT spend_profile FROM workspace WHERE workspace_id = cloud_context.workspace_id)
-      WHERE cloud_context.spend_profile IS NULL
-      """;
+        UPDATE cloud_context SET spend_profile =
+         (SELECT spend_profile FROM workspace WHERE workspace_id = cloud_context.workspace_id)
+        WHERE cloud_context.spend_profile IS NULL
+        """;
     jdbcTemplate.update(sql, new MapSqlParameterSource());
   }
 
@@ -933,8 +1055,8 @@ public class WorkspaceDao {
   public void backfillWorkspaceState() {
     String sql =
         """
-    UPDATE workspace SET state = 'READY' WHERE state IS NULL AND flight_id IS NULL
-    """;
+        UPDATE workspace SET state = 'READY' WHERE state IS NULL AND flight_id IS NULL
+        """;
     jdbcTemplate.update(sql, new MapSqlParameterSource());
   }
 }

--- a/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceContextPair.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceContextPair.java
@@ -1,0 +1,13 @@
+package bio.terra.workspace.db.model;
+
+import javax.annotation.Nullable;
+
+/**
+ * This record is used in the bulk retrieval query that gets a workspace and any associated cloud
+ * contexts in one query.
+ *
+ * @param dbWorkspace
+ * @param dbCloudContext
+ */
+public record DbWorkspaceContextPair(
+    DbWorkspace dbWorkspace, @Nullable DbCloudContext dbCloudContext) {}

--- a/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceDescription.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceDescription.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.db.model;
 
+import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.service.workspace.model.AwsCloudContext;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import bio.terra.workspace.service.workspace.model.CloudContext;
@@ -88,6 +89,7 @@ public class DbWorkspaceDescription {
       case AWS -> awsCloudContext = cloudContext.castByEnum(CloudPlatform.AWS);
       case AZURE -> azureCloudContext = cloudContext.castByEnum(CloudPlatform.AZURE);
       case GCP -> gcpCloudContext = cloudContext.castByEnum(CloudPlatform.GCP);
+      default -> throw new InternalLogicException("Unknown cloud platform");
     }
     return this;
   }

--- a/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceDescription.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceDescription.java
@@ -1,0 +1,94 @@
+package bio.terra.workspace.db.model;
+
+import bio.terra.workspace.service.workspace.model.AwsCloudContext;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import bio.terra.workspace.service.workspace.model.CloudContext;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.GcpCloudContext;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import java.time.OffsetDateTime;
+
+/**
+ * The DbWorkspaceDescription contains the full set of information about a workspace that WSM holds
+ * in its metadata. It is used for retrieving a single workspace or getting the list of all
+ * workspaces.
+ *
+ * <p>I made this a class instead of a record so that it could be filled in incrementally as we
+ * process the data. Otherwise, we need more intermediate forms that don't have a lot of value.
+ */
+public class DbWorkspaceDescription {
+  private Workspace workspace;
+  private String lastUpdatedByEmail;
+  private OffsetDateTime LastUpdatedByDate;
+  private AwsCloudContext awsCloudContext;
+  private AzureCloudContext azureCloudContext;
+  private GcpCloudContext gcpCloudContext;
+
+  public DbWorkspaceDescription(Workspace workspace) {
+    this.workspace = workspace;
+  }
+
+  public Workspace getWorkspace() {
+    return workspace;
+  }
+
+  public DbWorkspaceDescription setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
+    return this;
+  }
+
+  public String getLastUpdatedByEmail() {
+    return lastUpdatedByEmail;
+  }
+
+  public DbWorkspaceDescription setLastUpdatedByEmail(String lastUpdatedByEmail) {
+    this.lastUpdatedByEmail = lastUpdatedByEmail;
+    return this;
+  }
+
+  public OffsetDateTime getLastUpdatedByDate() {
+    return LastUpdatedByDate;
+  }
+
+  public DbWorkspaceDescription setLastUpdatedByDate(OffsetDateTime lastUpdatedByDate) {
+    LastUpdatedByDate = lastUpdatedByDate;
+    return this;
+  }
+
+  public AwsCloudContext getAwsCloudContext() {
+    return awsCloudContext;
+  }
+
+  public DbWorkspaceDescription setAwsCloudContext(AwsCloudContext awsCloudContext) {
+    this.awsCloudContext = awsCloudContext;
+    return this;
+  }
+
+  public AzureCloudContext getAzureCloudContext() {
+    return azureCloudContext;
+  }
+
+  public DbWorkspaceDescription setAzureCloudContext(AzureCloudContext azureCloudContext) {
+    this.azureCloudContext = azureCloudContext;
+    return this;
+  }
+
+  public GcpCloudContext getGcpCloudContext() {
+    return gcpCloudContext;
+  }
+
+  public DbWorkspaceDescription setGcpCloudContext(GcpCloudContext gcpCloudContext) {
+    this.gcpCloudContext = gcpCloudContext;
+    return this;
+  }
+
+  // Generic setter for any of the cloud contexts
+  public DbWorkspaceDescription setCloudContext(CloudContext cloudContext) {
+    switch (cloudContext.getCloudPlatform()) {
+      case AWS -> awsCloudContext = cloudContext.castByEnum(CloudPlatform.AWS);
+      case AZURE -> azureCloudContext = cloudContext.castByEnum(CloudPlatform.AZURE);
+      case GCP -> gcpCloudContext = cloudContext.castByEnum(CloudPlatform.GCP);
+    }
+    return this;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceDescription.java
+++ b/service/src/main/java/bio/terra/workspace/db/model/DbWorkspaceDescription.java
@@ -19,7 +19,7 @@ import java.time.OffsetDateTime;
 public class DbWorkspaceDescription {
   private Workspace workspace;
   private String lastUpdatedByEmail;
-  private OffsetDateTime LastUpdatedByDate;
+  private OffsetDateTime lastUpdatedByDate;
   private AwsCloudContext awsCloudContext;
   private AzureCloudContext azureCloudContext;
   private GcpCloudContext gcpCloudContext;
@@ -47,11 +47,11 @@ public class DbWorkspaceDescription {
   }
 
   public OffsetDateTime getLastUpdatedByDate() {
-    return LastUpdatedByDate;
+    return lastUpdatedByDate;
   }
 
   public DbWorkspaceDescription setLastUpdatedByDate(OffsetDateTime lastUpdatedByDate) {
-    LastUpdatedByDate = lastUpdatedByDate;
+    this.lastUpdatedByDate = lastUpdatedByDate;
     return this;
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -13,7 +13,6 @@ import bio.terra.workspace.app.configuration.external.SamConfiguration;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.GcpUtils;
 import bio.terra.workspace.common.utils.Rethrow;
-import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.iam.model.AccessibleWorkspace;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.iam.model.RoleBinding;
@@ -52,7 +51,6 @@ import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEn
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.FullyQualifiedResourceId;
 import org.broadinstitute.dsde.workbench.client.sam.model.GetOrCreatePetManagedIdentityRequest;
-import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserIdInfo;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
@@ -369,14 +367,18 @@ public class SamService {
           // Skip workspaces with no roles. (That means there's a role this WSM doesn't know
           // about.)
           WsmIamRole.getHighestRole(workspaceId, roles)
-            .ifPresent(
-              highestRole -> {
-                if (minimumHighestRoleFromRequest.roleAtLeastAsHighAs(highestRole)) {
-                  result.put(workspaceId,
-                    new AccessibleWorkspace(workspaceId, highestRole, ImmutableList.copyOf(
-                      userResourcesResponse.getMissingAuthDomainGroups())));
-                }
-              });
+              .ifPresent(
+                  highestRole -> {
+                    if (minimumHighestRoleFromRequest.roleAtLeastAsHighAs(highestRole)) {
+                      result.put(
+                          workspaceId,
+                          new AccessibleWorkspace(
+                              workspaceId,
+                              highestRole,
+                              ImmutableList.copyOf(
+                                  userResourcesResponse.getMissingAuthDomainGroups())));
+                    }
+                  });
         } catch (IllegalArgumentException e) {
           // WSM always uses UUIDs for workspace IDs, but this is not enforced in Sam and there are
           // old workspaces that don't use UUIDs. Any workspace with a non-UUID workspace ID is

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/AccessibleWorkspace.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/AccessibleWorkspace.java
@@ -3,5 +3,14 @@ package bio.terra.workspace.service.iam.model;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * This record is used to return the data for one workspace that the caller has some access to,
+ * according to Sam.
+ *
+ * @param workspaceUuid workspaceUuid of the workspace
+ * @param highestRole the highest IAM role the user has on the workspace
+ * @param missingAuthDomainGroups any auth domain groups the user is missing in order to access the
+ *     workspace
+ */
 public record AccessibleWorkspace(
     UUID workspaceUuid, WsmIamRole highestRole, List<String> missingAuthDomainGroups) {}

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/AccessibleWorkspace.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/AccessibleWorkspace.java
@@ -1,0 +1,6 @@
+package bio.terra.workspace.service.iam.model;
+
+import java.util.List;
+import java.util.UUID;
+
+public record AccessibleWorkspace(UUID workspaceUuid, WsmIamRole highestRole, List<String> missingAuthDomainGroups) {}

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/AccessibleWorkspace.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/AccessibleWorkspace.java
@@ -3,4 +3,5 @@ package bio.terra.workspace.service.iam.model;
 import java.util.List;
 import java.util.UUID;
 
-public record AccessibleWorkspace(UUID workspaceUuid, WsmIamRole highestRole, List<String> missingAuthDomainGroups) {}
+public record AccessibleWorkspace(
+    UUID workspaceUuid, WsmIamRole highestRole, List<String> missingAuthDomainGroups) {}

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
@@ -98,9 +98,10 @@ public class TpsApiDispatch {
 
   /**
    * Get a PAO. Create an empty PAO if it does not exist.
-   * <p>Since policy attributes were added later in development, not all existing
-   * workspaces have an associated policy attribute object. This function creates
-   * an empty one if it does not exist.
+   *
+   * <p>Since policy attributes were added later in development, not all existing workspaces have an
+   * associated policy attribute object. This function creates an empty one if it does not exist.
+   *
    * @param objectId TPS object to get
    * @param component component name
    * @param objectType object type
@@ -108,8 +109,8 @@ public class TpsApiDispatch {
    * @throws InterruptedException on timer interrupt
    */
   @Traced
-  public TpsPaoGetResult getOrCreatePao(UUID objectId, TpsComponent component, TpsObjectType objectType)
-      throws InterruptedException {
+  public TpsPaoGetResult getOrCreatePao(
+      UUID objectId, TpsComponent component, TpsObjectType objectType) throws InterruptedException {
     Optional<TpsPaoGetResult> pao = getPaoIfExists(objectId);
     if (pao.isPresent()) {
       return pao.get();

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
@@ -96,18 +96,27 @@ public class TpsApiDispatch {
     }
   }
 
-  // Since policy attributes were added later in development, not all existing
-  // workspaces have an associated policy attribute object. This function creates
-  // an empty one if it does not exist.
+  /**
+   * Get a PAO. Create an empty PAO if it does not exist.
+   * <p>Since policy attributes were added later in development, not all existing
+   * workspaces have an associated policy attribute object. This function creates
+   * an empty one if it does not exist.
+   * @param objectId TPS object to get
+   * @param component component name
+   * @param objectType object type
+   * @return PAO
+   * @throws InterruptedException on timer interrupt
+   */
   @Traced
-  public void createPaoIfNotExist(UUID objectId, TpsComponent component, TpsObjectType objectType)
+  public TpsPaoGetResult getOrCreatePao(UUID objectId, TpsComponent component, TpsObjectType objectType)
       throws InterruptedException {
     Optional<TpsPaoGetResult> pao = getPaoIfExists(objectId);
     if (pao.isPresent()) {
-      return;
+      return pao.get();
     }
     // Workspace doesn't have a PAO, so create an empty one for it.
     createPao(objectId, null, component, objectType);
+    return getPao(objectId);
   }
 
   @Traced

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/MergePolicyAttributesDryRunStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/MergePolicyAttributesDryRunStep.java
@@ -42,8 +42,7 @@ public class MergePolicyAttributesDryRunStep implements Step {
       throws InterruptedException, RetryException {
     // Create PAOs if they don't exist; catch TPS exceptions and retry
     try {
-      tpsApiDispatch.getOrCreatePao(
-          sourceWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
+      tpsApiDispatch.getOrCreatePao(sourceWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
       tpsApiDispatch.getOrCreatePao(
           destinationWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
     } catch (Exception ex) {

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/MergePolicyAttributesDryRunStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/MergePolicyAttributesDryRunStep.java
@@ -42,9 +42,9 @@ public class MergePolicyAttributesDryRunStep implements Step {
       throws InterruptedException, RetryException {
     // Create PAOs if they don't exist; catch TPS exceptions and retry
     try {
-      tpsApiDispatch.createPaoIfNotExist(
+      tpsApiDispatch.getOrCreatePao(
           sourceWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
-      tpsApiDispatch.createPaoIfNotExist(
+      tpsApiDispatch.getOrCreatePao(
           destinationWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
     } catch (Exception ex) {
       logger.info("Attempt to create a PAO for workspace failed", ex);

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/MergePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/MergePolicyAttributesStep.java
@@ -44,10 +44,12 @@ public class MergePolicyAttributesStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     // Create PAOs if they don't exist; catch TPS exceptions and retry
+    TpsPaoGetResult destinationPao;
     try {
-      tpsApiDispatch.createPaoIfNotExist(
+      tpsApiDispatch.getOrCreatePao(
           sourceWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
-      tpsApiDispatch.createPaoIfNotExist(
+      destinationPao =
+        tpsApiDispatch.getOrCreatePao(
           destinationWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
     } catch (Exception ex) {
       logger.info("Attempt to create a PAO for workspace failed", ex);
@@ -55,7 +57,6 @@ public class MergePolicyAttributesStep implements Step {
     }
 
     // Save the destination attributes so we can restore them if the flight fails
-    TpsPaoGetResult destinationPao = tpsApiDispatch.getPao(destinationWorkspaceId);
     TpsPolicyInputs destinationAttributes = destinationPao.getAttributes();
     context.getWorkingMap().put(WorkspaceFlightMapKeys.POLICIES, destinationAttributes);
 

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/MergePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/MergePolicyAttributesStep.java
@@ -46,11 +46,10 @@ public class MergePolicyAttributesStep implements Step {
     // Create PAOs if they don't exist; catch TPS exceptions and retry
     TpsPaoGetResult destinationPao;
     try {
-      tpsApiDispatch.getOrCreatePao(
-          sourceWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
+      tpsApiDispatch.getOrCreatePao(sourceWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
       destinationPao =
-        tpsApiDispatch.getOrCreatePao(
-          destinationWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
+          tpsApiDispatch.getOrCreatePao(
+              destinationWorkspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
     } catch (Exception ex) {
       logger.info("Attempt to create a PAO for workspace failed", ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);

--- a/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java
@@ -189,9 +189,7 @@ public class ResourceValidationUtils {
   public static void validateRegion(
       TpsApiDispatch tpsApiDispatch, UUID workspaceId, String region, CloudPlatform cloudPlatform) {
     Rethrow.onInterrupted(
-        () ->
-            tpsApiDispatch.createPaoIfNotExist(
-                workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE),
+        () -> tpsApiDispatch.getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE),
         "createPaoIfNotExist");
 
     // Get the list of valid locations for this workspace from TPS. If there are no regional

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -266,7 +266,7 @@ public class WorkspaceService {
   @Traced
   public Workspace validateWorkspaceAndAction(
       AuthenticatedUserRequest userRequest, UUID workspaceUuid, String action) {
-    logWorkspaceAction(userRequest, workspaceUuid, action);
+    logWorkspaceAction(userRequest, workspaceUuid.toString(), action);
     Workspace workspace = workspaceDao.getWorkspace(workspaceUuid);
     checkWorkspaceAuthz(userRequest, workspaceUuid, action);
     return workspace;
@@ -283,7 +283,7 @@ public class WorkspaceService {
   @Traced
   public WorkspaceDescription validateWorkspaceAndActionReturningDescription(
       AuthenticatedUserRequest userRequest, UUID workspaceUuid, String action) {
-    logWorkspaceAction(userRequest, workspaceUuid, action);
+    logWorkspaceAction(userRequest, workspaceUuid.toString(), action);
     DbWorkspaceDescription dbWorkspaceDescription =
         workspaceDao.getWorkspaceDescription(workspaceUuid);
     checkWorkspaceAuthz(userRequest, workspaceUuid, action);
@@ -301,9 +301,9 @@ public class WorkspaceService {
   @Traced
   public WorkspaceDescription validateWorkspaceAndActionReturningDescription(
       AuthenticatedUserRequest userRequest, String userFacingId, String action) {
+    logWorkspaceAction(userRequest, userFacingId, action);
     DbWorkspaceDescription dbWorkspaceDescription =
-        workspaceDao.getWorkspaceByUserFacingId(userFacingId);
-    logWorkspaceAction(userRequest, dbWorkspaceDescription.getWorkspace().workspaceId(), action);
+        workspaceDao.getWorkspaceDescriptionByUserFacingId(userFacingId);
     checkWorkspaceAuthz(userRequest, dbWorkspaceDescription.getWorkspace().workspaceId(), action);
     return makeWorkspaceDescription(userRequest, dbWorkspaceDescription);
   }
@@ -323,11 +323,11 @@ public class WorkspaceService {
 
   // -- private methods supporting validateWorkspaceAndAction methods --
   private void logWorkspaceAction(
-      AuthenticatedUserRequest userRequest, UUID workspaceUuid, String action) {
+      AuthenticatedUserRequest userRequest, String idString, String action) {
     logger.info(
-        "validateWorkspaceAndAction - userRequest: {}\nworkspaceUuid: {}\naction: {}",
+        "validateWorkspaceAndAction - userRequest: {}\nworkspace UUID/UFID: {}\naction: {}",
         userRequest,
-        workspaceUuid,
+        idString,
         action);
   }
 
@@ -502,7 +502,8 @@ public class WorkspaceService {
 
     // From DAO, retrieve the workspace metadata
     Map<UUID, DbWorkspaceDescription> dbWorkspaceDescriptions =
-        workspaceDao.getWorkspacesMatchingList(accessibleWorkspaces.keySet(), offset, limit);
+        workspaceDao.getWorkspaceDescriptionMapFromIdList(
+            accessibleWorkspaces.keySet(), offset, limit);
 
     // TODO: PF-2710(part 2): make a batch getOrCreatePao in TPS and use it here
     Map<UUID, TpsPaoGetResult> paoMap = new HashMap<>();

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceDescription.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/WorkspaceDescription.java
@@ -1,8 +1,32 @@
 package bio.terra.workspace.service.workspace.model;
 
+import bio.terra.policy.model.TpsPaoGetResult;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
+import java.time.OffsetDateTime;
 import java.util.List;
 import javax.annotation.Nullable;
 
+/**
+ * The WorkspaceDescription contains the full set of information about a workspace that WSM holds in
+ * its metadata. It is used for retrieving a single workspace or getting the list of all workspaces.
+ *
+ * @param workspace
+ * @param highestRole
+ * @param missingAuthDomains
+ * @param lastUpdatedByEmail
+ * @param lastUpdatedByDate
+ * @param awsCloudContext
+ * @param azureCloudContext
+ * @param gcpCloudContext
+ * @param workspacePolicies
+ */
 public record WorkspaceDescription(
-    Workspace workspace, WsmIamRole highestRole, @Nullable List<String> missingAuthDomains) {}
+    Workspace workspace,
+    WsmIamRole highestRole,
+    @Nullable List<String> missingAuthDomains,
+    String lastUpdatedByEmail,
+    OffsetDateTime lastUpdatedByDate,
+    @Nullable AwsCloudContext awsCloudContext,
+    @Nullable AzureCloudContext azureCloudContext,
+    @Nullable GcpCloudContext gcpCloudContext,
+    @Nullable TpsPaoGetResult workspacePolicies) {}

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -420,7 +420,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
 
     ApiWorkspaceDescription gotWorkspace =
         mockMvcUtils.getWorkspace(USER_REQUEST, workspace.getId());
-    assertNull(gotWorkspace.getPolicies());
+    assertEquals(0, gotWorkspace.getPolicies().size());
   }
 
   @Test
@@ -501,7 +501,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
 
     ApiWorkspaceDescription gotWorkspace =
         mockMvcUtils.getWorkspace(USER_REQUEST, workspace.getId());
-    assertNull(gotWorkspace.getPolicies());
+    assertEquals(0, gotWorkspace.getPolicies().size());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -51,6 +51,7 @@ import bio.terra.workspace.generated.model.ApiWsmPolicyInput;
 import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.generated.model.ApiWsmPolicyPair;
 import bio.terra.workspace.generated.model.ApiWsmPolicyUpdateResult;
+import bio.terra.workspace.service.iam.model.AccessibleWorkspace;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.iam.model.SamConstants.SamResource;
 import bio.terra.workspace.service.iam.model.SamConstants.SamSpendProfileAction;
@@ -60,7 +61,6 @@ import bio.terra.workspace.service.logging.WorkspaceActivityLogService;
 import bio.terra.workspace.service.policy.TpsApiConversionUtils;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import bio.terra.workspace.service.workspace.model.WorkspaceConstants.Properties;
-import bio.terra.workspace.service.workspace.model.WorkspaceDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import java.time.OffsetDateTime;
@@ -400,6 +400,8 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
             .attributes(new TpsPolicyInputs().addInputsItem(TPS_GROUP_POLICY))
             .effectiveAttributes(new TpsPolicyInputs().addInputsItem(TPS_GROUP_POLICY));
     when(mockTpsApiDispatch().getPao(eq(workspace.getId()))).thenReturn(getPolicyResult);
+    when(mockTpsApiDispatch().getOrCreatePao(eq(workspace.getId()), any(), any()))
+        .thenReturn(getPolicyResult);
 
     ApiWorkspaceDescription gotWorkspace =
         mockMvcUtils.getWorkspace(USER_REQUEST, workspace.getId());
@@ -433,15 +435,10 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         .thenReturn(
             ImmutableMap.of(
                 workspace.getId(),
-                new WorkspaceDescription(
-                    workspaceDao.getWorkspace(workspace.getId()),
-                    WsmIamRole.OWNER,
-                    missingAuthDomains),
+                new AccessibleWorkspace(workspace.getId(), WsmIamRole.OWNER, missingAuthDomains),
                 noPolicyWorkspace.getId(),
-                new WorkspaceDescription(
-                    workspaceDao.getWorkspace(noPolicyWorkspace.getId()),
-                    WsmIamRole.OWNER,
-                    Collections.emptyList())));
+                new AccessibleWorkspace(
+                    noPolicyWorkspace.getId(), WsmIamRole.OWNER, Collections.emptyList())));
     TpsPaoGetResult getPolicyResult =
         new TpsPaoGetResult()
             .attributes(new TpsPolicyInputs().addInputsItem(TPS_GROUP_POLICY))
@@ -452,6 +449,8 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
             .sourcesObjectIds(Collections.emptyList());
     // Return a policy object for the first workspace
     when(mockTpsApiDispatch().getPao(eq(workspace.getId()))).thenReturn(getPolicyResult);
+    when(mockTpsApiDispatch().getOrCreatePao(eq(workspace.getId()), any(), any()))
+        .thenReturn(getPolicyResult);
     // Treat the second workspace like it was created before policy existed. It should receive an
     // empty Pao.
     TpsPaoGetResult emptyPao =
@@ -497,10 +496,8 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         .thenReturn(
             ImmutableMap.of(
                 workspace.getId(),
-                new WorkspaceDescription(
-                    workspaceDao.getWorkspace(workspace.getId()),
-                    WsmIamRole.OWNER,
-                    Collections.emptyList())));
+                new AccessibleWorkspace(
+                    workspace.getId(), WsmIamRole.OWNER, Collections.emptyList())));
 
     ApiWorkspaceDescription gotWorkspace =
         mockMvcUtils.getWorkspace(USER_REQUEST, workspace.getId());

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -45,11 +45,14 @@ import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.Clone
 import bio.terra.workspace.service.resource.controlled.flight.clone.workspace.CloneWorkspaceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourcesFlight;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.flight.create.workspace.WorkspaceCreateFlight;
+import bio.terra.workspace.service.workspace.flight.delete.cloudcontext.DeleteCloudContextFlight;
 import bio.terra.workspace.service.workspace.flight.delete.workspace.WorkspaceDeleteFlight;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import java.util.ArrayList;
 import java.util.List;
@@ -280,18 +283,8 @@ public class WorkspaceActivityLogHookTest extends BaseUnitTest {
             DeleteCloudContextFlight.class.getName(), inputParams, FlightStatus.ERROR));
 
     assertTrue(workspaceDao.getCloudContext(workspaceUuid, CloudPlatform.GCP).isEmpty());
-    ActivityLogChangeDetails changeDetailsAfterFailedFlight =
-        activityLogDao.getLastUpdatedDetails(workspaceUuid).get();
-    assertEquals(
-        changeDetailsAfterFailedFlight,
-        new ActivityLogChangeDetails(
-            workspaceUuid,
-            changeDetailsAfterFailedFlight.changeDate(),
-            USER_REQUEST.getEmail(),
-            USER_REQUEST.getSubjectId(),
-            DELETE,
-            workspaceUuid.toString(),
-            ActivityLogChangedTarget.WORKSPACE));
+    var changeDetailsAfterFailedFlight = activityLogDao.getLastUpdatedDetails(workspaceUuid);
+    assertTrue(changeDetailsAfterFailedFlight.isEmpty());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -2572,6 +2572,7 @@ public class MockMvcUtils {
         getLastChangeDetails(workspaceId, expectedChangeSubjectId);
     assertEquals(
         new ActivityLogChangeDetails(
+            workspaceId,
             actualChangedDetails.changeDate(),
             expectedActorEmail,
             expectedActorSubjectId,

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -138,7 +138,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
     WorkspaceFixtures.createWorkspaceInDb(realWorkspace, workspaceDao);
     UUID fakeWorkspaceId = UUID.randomUUID();
     Map<UUID, DbWorkspaceDescription> workspaceList =
-        workspaceDao.getWorkspacesMatchingList(
+        workspaceDao.getWorkspaceDescriptionMapFromIdList(
             ImmutableSet.of(realWorkspace.getWorkspaceId(), fakeWorkspaceId), 0, 1);
     // The DAO should return all workspaces this user has access to, including realWorkspace but
     // not including the fake workspace id.
@@ -192,7 +192,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
         WorkspaceFixtures.buildWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
     WorkspaceFixtures.createWorkspaceInDb(secondWorkspace, workspaceDao);
     Map<UUID, DbWorkspaceDescription> workspaceMap =
-        workspaceDao.getWorkspacesMatchingList(
+        workspaceDao.getWorkspaceDescriptionMapFromIdList(
             ImmutableSet.of(firstWorkspace.getWorkspaceId(), secondWorkspace.getWorkspaceId()),
             1,
             10);
@@ -210,7 +210,7 @@ class WorkspaceDaoTest extends BaseUnitTest {
         WorkspaceFixtures.buildWorkspace(null, WorkspaceStage.RAWLS_WORKSPACE);
     WorkspaceFixtures.createWorkspaceInDb(secondWorkspace, workspaceDao);
     Map<UUID, DbWorkspaceDescription> workspaceMap =
-        workspaceDao.getWorkspacesMatchingList(
+        workspaceDao.getWorkspaceDescriptionMapFromIdList(
             ImmutableSet.of(firstWorkspace.getWorkspaceId(), secondWorkspace.getWorkspaceId()),
             0,
             1);

--- a/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/iam/SamServiceTest.java
@@ -28,6 +28,7 @@ import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
 import bio.terra.workspace.generated.model.ApiGrantRoleRequestBody;
 import bio.terra.workspace.generated.model.ApiReferenceResourceCommonFields;
 import bio.terra.workspace.service.datarepo.DataRepoService;
+import bio.terra.workspace.service.iam.model.AccessibleWorkspace;
 import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.iam.model.RoleBinding;
 import bio.terra.workspace.service.iam.model.SamConstants;
@@ -45,7 +46,6 @@ import bio.terra.workspace.service.resource.referenced.cloud.any.datareposnapsho
 import bio.terra.workspace.service.resource.referenced.model.ReferencedResource;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.Workspace;
-import bio.terra.workspace.service.workspace.model.WorkspaceDescription;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
@@ -331,13 +331,13 @@ class SamServiceTest extends BaseConnectedTest {
 
   @Test
   void listWorkspaceIdsAndHighestRoles() throws Exception {
-    Map<UUID, WorkspaceDescription> actual =
+    Map<UUID, AccessibleWorkspace> actual =
         samService.listWorkspaceIdsAndHighestRoles(
             userAccessUtils.defaultUserAuthRequest(), WsmIamRole.READER);
 
-    WorkspaceDescription match = actual.get(workspaceUuid);
+    AccessibleWorkspace match = actual.get(workspaceUuid);
     assertEquals(WsmIamRole.OWNER, match.highestRole());
-    assertTrue(match.missingAuthDomains().isEmpty());
+    assertTrue(match.missingAuthDomainGroups().isEmpty());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -133,6 +133,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
             .isBefore(lastUpdateDetailsAfterResourceUpdate.get().changeDate()));
     assertEquals(
         new ActivityLogChangeDetails(
+            workspaceUuid,
             lastUpdateDetailsAfterResourceUpdate.get().changeDate(),
             USER_REQUEST.getEmail(),
             USER_REQUEST.getSubjectId(),
@@ -223,6 +224,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
             .isBefore(lastUpdateDetailsAfterResourceUpdate.get().changeDate()));
     assertEquals(
         new ActivityLogChangeDetails(
+            workspaceUuid,
             lastUpdateDetailsAfterResourceUpdate.get().changeDate(),
             USER_REQUEST.getEmail(),
             USER_REQUEST.getSubjectId(),
@@ -355,6 +357,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterCreate.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterCreate.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),
@@ -395,6 +398,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterDelete.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterDelete.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),
@@ -483,6 +487,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterCreate.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterCreate.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),
@@ -524,6 +529,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterDelete.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterDelete.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),
@@ -692,6 +698,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterCreate.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterCreate.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),
@@ -734,6 +741,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterDelete.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterDelete.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),
@@ -768,6 +776,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterCreate.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterCreate.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),
@@ -807,6 +816,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterDelete.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterDelete.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),
@@ -991,6 +1001,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterCreate.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterCreate.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),
@@ -1032,6 +1043,7 @@ class ReferencedResourceServiceTest extends BaseUnitTestMockDataRepoService {
               .isBefore(lastUpdateDetailsAfterDelete.get().changeDate()));
       assertEquals(
           new ActivityLogChangeDetails(
+              workspaceUuid,
               lastUpdateDetailsAfterDelete.get().changeDate(),
               USER_REQUEST.getEmail(),
               USER_REQUEST.getSubjectId(),


### PR DESCRIPTION
This PR should improve workspace performance. At a high level, there are two changes:
1. Change the TPS method for creating a PAO if it doesn't exist. This reduces the calls to TPS by half.
2. Move all of the code to gather workspace, cloud context, and activity log information into the WorkspaceDao. This reduces the number of Postgres transactions to 1 from (5 * N) + 1 transactions, where N is the number of workspaces.

In order to put the work into the DAO, I added DbWorkspaceContextPair as an intermediate structure to hold the result of an outer join of workspace and cloud_context tables. I added DbWorkspaceDescription to hold the combined data from workspace, cloud_context, and workspace_activity_log (last update by and last update date).

I added a batch retrieval to the activity log DAO that gets a list of the last change detail for a list of workspaces in a single self-join. I'm very proud of that query :)  In order to be able to connect the activity with the list of workspaces, I added the workspaceUuid into ActivityLogChangeDetails. That had a ripple effect through a lot of tests.

I updated the WorkspaceDescription class to have all of the data needed for the ApiWorkspaceDescription result. That helped move work out of the controller and into services.

I made variations on validateWorkspaceAndAction that would return the WorkspaceDescription for the single-workspace retrieval cases.