### PR TITLE
[BENCH-471] Move test values to appropriate fixtures classes

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.app.controller;
 
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerBatchPoolTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerBatchPoolTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.app.controller;
 
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_BATCH_POOL_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAwsResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAwsResourceFixtures.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.common.fixtures;
 
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.WORKSPACE_ID;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_ID;
 import static software.amazon.awssdk.services.sagemaker.model.InstanceType.ML_T2_MEDIUM;
 
 import bio.terra.workspace.service.resource.controlled.cloud.aws.s3StorageFolder.ControlledAwsS3StorageFolderResource;

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAzureResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAzureResourceFixtures.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.common.fixtures;
 
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.WORKSPACE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_ID;
 import static bio.terra.workspace.connected.AzureConnectedTestUtils.getAzureName;
 
 import bio.terra.workspace.common.utils.AzureUtils;

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledGcpResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledGcpResourceFixtures.java
@@ -8,10 +8,10 @@ import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.OFF
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_ID;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_NAME;
-import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.WORKSPACE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_ID;
 
 import bio.terra.stairway.ShortUUID;
-import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceVmImage;
@@ -67,7 +67,7 @@ public class ControlledGcpResourceFixtures {
           .cloningInstructions(CloningInstructions.COPY_RESOURCE)
           .resourceLineage(null)
           .properties(Map.of())
-          .createdByEmail(MockMvcUtils.DEFAULT_USER_EMAIL)
+          .createdByEmail(DEFAULT_USER_EMAIL)
           .createdDate(null)
           .lastUpdatedByEmail(null)
           .lastUpdatedDate(null)
@@ -330,7 +330,7 @@ public class ControlledGcpResourceFixtures {
         .assignedUser("myusername@mydomain.mine")
         .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
         .managedBy(ManagedByType.MANAGED_BY_USER)
-        .createdByEmail(MockMvcUtils.DEFAULT_USER_EMAIL)
+        .createdByEmail(DEFAULT_USER_EMAIL)
         .region(DEFAULT_RESOURCE_REGION);
   }
 
@@ -385,7 +385,7 @@ public class ControlledGcpResourceFixtures {
         .assignedUser("myusername@mydomain.mine")
         .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
         .managedBy(ManagedByType.MANAGED_BY_USER)
-        .createdByEmail(MockMvcUtils.DEFAULT_USER_EMAIL)
+        .createdByEmail(DEFAULT_USER_EMAIL)
         .region(DEFAULT_RESOURCE_REGION);
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -1,8 +1,8 @@
 package bio.terra.workspace.common.fixtures;
 
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 
-import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.generated.model.*;
 import bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource.ControlledFlexibleResource;
@@ -29,7 +29,6 @@ public class ControlledResourceFixtures {
       OffsetDateTime.parse("2017-12-03T10:15:30-05:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
   public static final DateTime DATE_TIME_1 = DateTime.parseRfc3339("1985-04-12T23:20:50.52Z");
   public static final DateTime DATE_TIME_2 = DateTime.parseRfc3339("1996-12-19T16:39:57-08:00");
-  public static final UUID WORKSPACE_ID = UUID.fromString("00000000-fcf0-4981-bb96-6b8dd634e7c0");
   public static final UUID RESOURCE_ID = UUID.fromString("11111111-fcf0-4981-bb96-6b8dd634e7c0");
   public static final String RESOURCE_NAME = "my_first_bucket";
   public static final String RESOURCE_DESCRIPTION =
@@ -51,7 +50,7 @@ public class ControlledResourceFixtures {
         .managedBy(ManagedByType.MANAGED_BY_USER)
         .privateResourceState(PrivateResourceState.NOT_APPLICABLE)
         .properties(DEFAULT_RESOURCE_PROPERTIES)
-        .createdByEmail(MockMvcUtils.DEFAULT_USER_EMAIL)
+        .createdByEmail(DEFAULT_USER_EMAIL)
         .region(DEFAULT_RESOURCE_REGION);
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ReferenceResourceFixtures.java
@@ -1,8 +1,9 @@
 package bio.terra.workspace.common.fixtures;
 
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
+import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEFAULT_RESOURCE_PROPERTIES;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.TestUtils.appendRandomNumber;
 
 import bio.terra.workspace.common.utils.TestUtils;
@@ -16,11 +17,9 @@ import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.Refer
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable.ReferencedBigQueryDataTableResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket.ReferencedGcsBucketResource;
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject.ReferencedGcsObjectResource;
-import java.util.Map;
 import java.util.UUID;
 
 public class ReferenceResourceFixtures {
-  private static final Map<String, String> DEFAULT_RESOURCE_PROPERTIES = Map.of("foo", "bar");
 
   public static WsmResourceFields.Builder<?> makeDefaultWsmResourceFieldBuilder(UUID workspaceId) {
     return WsmResourceFields.builder()

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -1,7 +1,5 @@
 package bio.terra.workspace.common.fixtures;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
-
 import bio.terra.common.exception.ApiException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.UnauthorizedException;
@@ -32,6 +30,7 @@ import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 public class WorkspaceFixtures {
 
+  public static final UUID WORKSPACE_ID = UUID.fromString("00000000-fcf0-4981-bb96-6b8dd634e7c0");
   public static final String WORKSPACE_NAME = "TestWorkspace";
   public static final ApiProperty TYPE_PROPERTY =
       new ApiProperty().key(Properties.TYPE).value("type");
@@ -44,6 +43,8 @@ public class WorkspaceFixtures {
   public static final String DEFAULT_SPEND_PROFILE = "wm-default-spend-profile";
   public static final SpendProfileId DEFAULT_SPEND_PROFILE_ID =
       new SpendProfileId(DEFAULT_SPEND_PROFILE);
+  public static final String DEFAULT_USER_EMAIL = "fake@gmail.com";
+  public static final String DEFAULT_USER_SUBJECT_ID = "subjectId123456";
   public static final SamUser SAM_USER =
       new SamUser("example@example.com", "123ABC", new BearerToken("token"));
   public static final ApiException API_EXCEPTION = new ApiException("error");

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -46,7 +46,7 @@ public class WorkspaceFixtures {
   public static final String DEFAULT_USER_EMAIL = "fake@gmail.com";
   public static final String DEFAULT_USER_SUBJECT_ID = "subjectId123456";
   public static final SamUser SAM_USER =
-      new SamUser("example@example.com", "123ABC", new BearerToken("token"));
+      new SamUser(DEFAULT_USER_EMAIL, DEFAULT_USER_SUBJECT_ID, new BearerToken("token"));
   public static final ApiException API_EXCEPTION = new ApiException("error");
   public static final NotFoundException NOT_FOUND_EXCEPTION = new NotFoundException("not found");
   public static final UnauthorizedException UNAUTHORIZED_EXCEPTION =

--- a/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/WorkspaceActivityLogHookTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.common.logging;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys.CONTROLLED_RESOURCES_TO_DELETE;
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.FOLDER_ID;

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -1,6 +1,8 @@
 package bio.terra.workspace.common.utils;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEFAULT_RESOURCE_PROPERTIES;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_SUBJECT_ID;
 import static bio.terra.workspace.db.WorkspaceActivityLogDao.ACTIVITY_LOG_CHANGE_DETAILS_ROW_MAPPER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
@@ -355,8 +357,6 @@ public class MockMvcUtils {
 
   public static final String LOAD_SIGNED_URL_LIST_RESULT_PATH_FORMAT =
       "/api/workspaces/alpha1/%s/resources/controlled/gcp/buckets/%s/load/result/%s";
-  public static final String DEFAULT_USER_EMAIL = "fake@gmail.com";
-  public static final String DEFAULT_USER_SUBJECT_ID = "subjectId123456";
   // Only use this if you are mocking SAM. If you're using real SAM,
   // use userAccessUtils.defaultUserAuthRequest() instead.
   public static final AuthenticatedUserRequest USER_REQUEST =

--- a/service/src/test/java/bio/terra/workspace/db/FolderDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/FolderDaoTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.db;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.WorkspaceUnitTestUtils.createWorkspaceWithoutCloudContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -1,8 +1,8 @@
 package bio.terra.workspace.db;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEFAULT_RESOURCE_PROPERTIES;
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_SUBJECT_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_SUBJECT_ID;
 import static bio.terra.workspace.common.utils.WorkspaceUnitTestUtils.createWorkspaceWithGcpContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.db;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.WorkspaceUnitTestUtils.POLICY_APPLICATION;
 import static bio.terra.workspace.common.utils.WorkspaceUnitTestUtils.POLICY_OWNER;
 import static bio.terra.workspace.common.utils.WorkspaceUnitTestUtils.POLICY_READER;

--- a/service/src/test/java/bio/terra/workspace/service/folder/FolderServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/folder/FolderServiceTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.folder;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/service/src/test/java/bio/terra/workspace/service/resource/ResourceLineageUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ResourceLineageUtilsTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.resource;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.workspace.common.BaseUnitTest;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/AwsS3StorageFolderStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/AwsS3StorageFolderStepTest.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.aws.s3StorageFolde
 import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.AWS_CREDENTIALS_PROVIDER;
 import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.SDK_HTTP_RESPONSE_200;
 import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.SDK_HTTP_RESPONSE_400;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_ID;
 import static bio.terra.workspace.common.utils.TestUtils.assertStepResultFatal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -21,7 +22,6 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.BaseAwsUnitTest;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures;
-import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.utils.AwsUtils;
 import bio.terra.workspace.common.utils.MockMvcUtils;
@@ -67,8 +67,7 @@ public class AwsS3StorageFolderStepTest extends BaseAwsUnitTest {
   public void init() {
     mockAwsUtils = Mockito.mockStatic(AwsUtils.class);
     s3FolderResource =
-        ControlledAwsResourceFixtures.makeDefaultAwsS3StorageFolderResource(
-            ControlledResourceFixtures.WORKSPACE_ID);
+        ControlledAwsResourceFixtures.makeDefaultAwsS3StorageFolderResource(WORKSPACE_ID);
   }
 
   @AfterAll

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtilsTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.workspace;
 
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_GCP_RESOURCE_REGION;
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.service.resource.controlled.flight.clone.workspace.WorkspaceCloneUtils.buildDestinationControlledBigQueryDataset;
 import static bio.terra.workspace.service.resource.controlled.flight.clone.workspace.WorkspaceCloneUtils.buildDestinationControlledGcsBucket;
 import static bio.terra.workspace.service.workspace.model.WorkspaceConstants.ResourceProperties.FOLDER_ID_KEY;

--- a/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/referenced/ReferencedResourceServiceTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.resource.referenced;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
Move workspaceId, userEmail, user subjectId to workspaceFixtures so that they can be used in other tests
Remove duplicate declaration of referenceResourceFixtures.default_Resource_Properties