### PR TITLE
[PF-2782] Use new RBS pool for testing and local deployment

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -109,7 +109,7 @@ workspace:
     enabled: true
     client-credential-file-path: ../config/buffer-client-sa.json
     instanceUrl: https://buffer.tools.integ.envs.broadinstitute.org
-    poolId: workspace_manager_v10
+    poolId: workspace_manager_v11
 
   policy:
     client-credential-file-path: ../config/policy-client-sa.json


### PR DESCRIPTION
This moves WSM's connected and local integration tests to use the newest RBS pool without the deprecated genomics API enabled. Live deployments are handled separately in https://github.com/broadinstitute/terra-helmfile/pull/4317