### PR TITLE
[PF-2876] Build GCE machineType string in flight

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
@@ -101,6 +101,7 @@ public class CreateGceInstanceStep implements Step {
             flightContext,
             resource.getInstanceId(),
             projectId,
+            zone,
             petEmail,
             workspaceUserFacingId,
             cliConfiguration.getServerName(),
@@ -145,6 +146,7 @@ public class CreateGceInstanceStep implements Step {
       FlightContext flightContext,
       String instanceId,
       String projectId,
+      String zone,
       String serviceAccountEmail,
       String workspaceUserFacingId,
       String cliServer,
@@ -157,6 +159,7 @@ public class CreateGceInstanceStep implements Step {
     setFields(
         creationParameters,
         instanceId,
+        zone,
         serviceAccountEmail,
         workspaceUserFacingId,
         cliServer,
@@ -170,12 +173,15 @@ public class CreateGceInstanceStep implements Step {
   static Instance setFields(
       ApiGcpGceInstanceCreationParameters creationParameters,
       String instanceId,
+      String zone,
       String serviceAccountEmail,
       String workspaceUserFacingId,
       String cliServer,
       Instance instance,
       String gitHash) {
-    instance.setName(instanceId).setMachineType(creationParameters.getMachineType());
+    String machineType =
+        String.format("zones/%s/machineTypes/%s", zone, creationParameters.getMachineType());
+    instance.setName(instanceId).setMachineType(machineType);
 
     instance.setDisks(
         List.of(

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledGcpResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledGcpResourceFixtures.java
@@ -365,7 +365,7 @@ public class ControlledGcpResourceFixtures {
     return new ApiGcpGceInstanceCreationParameters()
         .instanceId(TestUtils.appendRandomNumber("default-instance-id"))
         .zone(DEFAULT_RESOURCE_ZONE)
-        .machineType(String.format("zones/%s/machineTypes/n1-standard-1", DEFAULT_RESOURCE_ZONE))
+        .machineType("n1-standard-1")
         .vmImage("projects/debian-cloud/global/images/family/debian-11");
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStepTest.java
@@ -31,7 +31,7 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
   public void setFields() {
     var creationParameters =
         new ApiGcpGceInstanceCreationParameters()
-            .machineType("zones/zone/machineTypes/machine-type")
+            .machineType("machine-type")
             .metadata(Map.of("metadata-key", "metadata-value"))
             .addGuestAcceleratorsItem(
                 new ApiGcpGceInstanceGuestAccelerator().cardCount(1).type("accelerator-type"))
@@ -40,6 +40,7 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
         CreateGceInstanceStep.setFields(
             creationParameters,
             "instance-name",
+            "zone",
             "foo@bar.com",
             WORKSPACE_ID,
             SERVER_ID,
@@ -67,6 +68,7 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
         CreateGceInstanceStep.setFields(
             new ApiGcpGceInstanceCreationParameters(),
             "instance-name",
+            "zone",
             "foo@bar.com",
             WORKSPACE_ID,
             SERVER_ID,
@@ -99,6 +101,7 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
                     // "terra-workspace-id" is a reserved metadata key.
                     .metadata(Map.of("terra-workspace-id", "fakeworkspaceid")),
                 "instance-name",
+                "zone",
                 "foo@bar.com",
                 "workspaceId",
                 "server-id",
@@ -112,6 +115,7 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
                     // "terra-cli-server" is a reserved metadata key.
                     .metadata(Map.of("terra-cli-server", "fakeserver")),
                 "isntance-name",
+                "zone",
                 "foo@bar.com",
                 "workspaceId",
                 "server-id",


### PR DESCRIPTION
The machine type requires a zone, but the final zone is not computed until during the create flight, so we should build it there. It also makes it more consistent with the ai notebooks api. This is technically a breaking api change but nobody is using this yet.