### PR TITLE
[PF-2875] Fixes for connectedPlus test

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.iam;
 
 import bio.terra.cloudres.google.iam.ServiceAccountName;
+import bio.terra.common.exception.ErrorReportException;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.iam.BearerToken;
@@ -413,10 +414,13 @@ public class SamService {
       }
 
       // Diagnostic: if the error was "Cannot delete a resource with children" then fetch and
-      // dump the remaining children.
+      // dump the remaining children. Make the Sam exception first, so we get the error message
+      // text from inside the Sam response.
+      ErrorReportException samException =
+          SamExceptionFactory.create("Error deleting a workspace in Sam", apiException);
       if (apiException.getCode() == HttpStatus.BAD_REQUEST.value()
           && StringUtils.contains(
-              apiException.getMessage(), "Cannot delete a resource with children")) {
+              samException.getMessage(), "Cannot delete a resource with children")) {
         try {
           List<FullyQualifiedResourceId> children =
               resourceApi.listResourceChildren(SamConstants.SamResource.WORKSPACE, uuid.toString());
@@ -433,7 +437,7 @@ public class SamService {
           logger.error("Failed to retrieve the list of workspace children", innerApiException);
         }
       }
-      throw SamExceptionFactory.create("Error deleting a workspace in Sam", apiException);
+      throw samException;
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteSamResourceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteSamResourceStep.java
@@ -35,7 +35,7 @@ public class DeleteSamResourceStep implements Step {
   public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     WsmResource wsmResource = resourceDao.getResource(workspaceUuid, resourceId);
     ControlledResource resource = wsmResource.castToControlledResource();
-
+    logger.info("Try to delete Sam controlled resource: {}", resource);
     samService.deleteControlledResource(resource, samService.getWsmServiceAccountToken());
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -65,9 +65,8 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
   private UUID workspaceId;
   private String projectId;
   private UUID workspaceId2;
-
-  private final String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
-  private final String sourceDatasetName = TestUtils.appendRandomNumber("source-dataset-name");
+  private String sourceResourceName;
+  private String sourceDatasetName;
   private ApiGcpBigQueryDatasetResource sourceResource;
 
   // See here for how to skip workspace creation for local runs:
@@ -92,6 +91,8 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
   @BeforeEach
   void setUpPerTest() throws Exception {
+    sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
+    sourceDatasetName = TestUtils.appendRandomNumber("source-dataset-name");
     sourceResource =
         mockMvcUtils.createReferencedBqDataset(
             userAccessUtils.defaultUserAuthRequest(),

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableConnectedTest.java
@@ -64,10 +64,9 @@ public class ReferencedGcpResourceControllerBqTableConnectedTest extends BaseCon
   private UUID workspaceId;
   private String projectId;
   private UUID workspaceId2;
-
-  private final String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
-  private final String sourceDatasetName = TestUtils.appendRandomNumber("source-dataset-name");
-  private final String sourceTableId = TestUtils.appendRandomNumber("source-table-id");
+  private String sourceResourceName;
+  private String sourceDatasetName;
+  private String sourceTableId;
   private ApiGcpBigQueryDataTableResource sourceResource;
 
   // See here for how to skip workspace creation for local runs:
@@ -92,6 +91,9 @@ public class ReferencedGcpResourceControllerBqTableConnectedTest extends BaseCon
 
   @BeforeEach
   void setUpPerTest() throws Exception {
+    sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
+    sourceDatasetName = TestUtils.appendRandomNumber("source-dataset-name");
+    sourceTableId = TestUtils.appendRandomNumber("source-table-id");
     sourceResource =
         mockMvcUtils.createReferencedBqTable(
             userAccessUtils.defaultUserAuthRequest(),

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -61,10 +61,9 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   private UUID workspaceId;
   private UUID workspaceId2;
-
-  private final String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
-  private final String sourceInstanceName = TestUtils.appendRandomNumber("source-instance-name");
-  private final String sourceSnapshot = UUID.randomUUID().toString();
+  private String sourceResourceName;
+  private String sourceInstanceName;
+  private String sourceSnapshot;
   private ApiDataRepoSnapshotResource sourceResource;
 
   // See here for how to skip workspace creation for local runs:
@@ -85,6 +84,9 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   @BeforeEach
   void setUpPerTest() throws Exception {
+    sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
+    sourceInstanceName = TestUtils.appendRandomNumber("source-instance-name");
+    sourceSnapshot = UUID.randomUUID().toString();
     sourceResource =
         mockMvcUtils.createReferencedDataRepoSnapshot(
             userAccessUtils.defaultUserAuthRequest(),

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -58,9 +58,8 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   private UUID workspaceId;
   private UUID workspaceId2;
-
-  private final String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
-  private final String sourceBucketName = TestUtils.appendRandomNumber("source-bucket-name");
+  private String sourceResourceName;
+  private String sourceBucketName;
   private ApiGcpGcsBucketResource sourceResource;
 
   // See here for how to skip workspace creation for local runs:
@@ -82,6 +81,8 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   @BeforeEach
   public void setUpPerTest() throws Exception {
+    sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
+    sourceBucketName = TestUtils.appendRandomNumber("source-bucket-name");
     sourceResource =
         mockMvcUtils.createReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -61,9 +61,9 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
   private UUID workspaceId;
   private UUID workspaceId2;
 
-  private final String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
-  private final String sourceBucketName = TestUtils.appendRandomNumber("source-bucket-name");
-  private final String sourceFileName = TestUtils.appendRandomNumber("source-file-name");
+  private String sourceResourceName;
+  private String sourceBucketName;
+  private String sourceFileName;
   private ApiGcpGcsObjectResource sourceResource;
 
   // See here for how to skip workspace creation for local runs:
@@ -85,6 +85,9 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
   @BeforeEach
   void setUpPerTest() throws Exception {
+    sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
+    sourceBucketName = TestUtils.appendRandomNumber("source-bucket-name");
+    sourceFileName = TestUtils.appendRandomNumber("source-file-name");
     sourceResource =
         mockMvcUtils.createReferencedGcsObject(
             userAccessUtils.defaultUserAuthRequest(),

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -59,11 +59,8 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   private UUID workspaceId;
   private UUID workspaceId2;
-
-  private final String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
-  private final String sourceGitRepoUrl =
-      "git@github.com:DataBiosphere/%s.git"
-          .formatted(TestUtils.appendRandomNumber("terra-workspace-manager"));
+  private String sourceResourceName;
+  private String sourceGitRepoUrl;
   private ApiGitRepoResource sourceResource;
 
   // See here for how to skip workspace creation for local runs:
@@ -84,6 +81,11 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @BeforeEach
   void setUpPerTest() throws Exception {
+    sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
+    sourceGitRepoUrl =
+        "git@github.com:DataBiosphere/%s.git"
+            .formatted(TestUtils.appendRandomNumber("terra-workspace-manager"));
+
     sourceResource =
         mockMvcUtils.createReferencedGitRepo(
             userAccessUtils.defaultUserAuthRequest(),

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -125,6 +125,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     when(mockSamService.getUserEmailFromSamAndRethrowOnInterrupt(
             any(AuthenticatedUserRequest.class)))
         .thenReturn(USER_REQUEST.getEmail());
+    when(mockSamService.listRequesterRoles(any(), eq(SamResource.WORKSPACE), any()))
+        .thenReturn(List.of(WsmIamRole.OWNER));
   }
 
   /**


### PR DESCRIPTION
In the `ReferencedGcpResourceController*` tests, variables like resource name had been made class-final. That immediately hit duplicate resource name errors. I moved the dynamic strings back to the `@BeforeEach` per-test method.

The re-arranged delete workspace code needed one more SamService mock in a WorkspaceServiceTest.

I saw a weird case where it looked like we ran a step, but it didn't do what it was supposed to. Then we got a Sam error for "workspace still has children". I fixed the diagnostic I had added (that didn't work), and added a little more logging. Very puzzling.