### PR TITLE
[PF-2882] Fixes to instance GPU configs

### DIFF
--- a/service/src/main/java/bio/terra/workspace/common/utils/GcpUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/GcpUtils.java
@@ -276,4 +276,14 @@ public class GcpUtils {
     return String.format(
         "projects/%s/regions/%s/subnetworks/%s", projectId, region, subnetworkName);
   }
+
+  public static String toMachineTypeString(String zone, String machineType) {
+    return String.format("zones/%s/machineTypes/%s", zone, machineType);
+  }
+
+  public static String toAcceleratorTypeString(
+      String projectId, String zone, String acceleratorType) {
+    return String.format(
+        "projects/%s/zones/%s/acceleratorTypes/%s", projectId, zone, acceleratorType);
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
@@ -68,7 +68,7 @@ public class CreateGceInstanceStep implements Step {
 
   private static final String EXTERNAL_IP_TYPE = "ONE_TO_ONE_NAT";
   private static final String EXTERNAL_IP_NAME = "External IP";
-  private static final String GPU_HOST_MAINTENANCE_BEHAVIOUR = "TERMINATE";
+  private static final String HOST_MAINTENANCE_BEHAVIOUR = "TERMINATE";
 
   public CreateGceInstanceStep(
       ControlledGceInstanceResource resource,
@@ -215,9 +215,9 @@ public class CreateGceInstanceStep implements Step {
                                   projectId, zone, accelerator.getType()))
                           .setAcceleratorCount(accelerator.getCardCount()))
               .collect(Collectors.toList()));
-      // Instances with guest accelerators do not support live migration
-      instance.setScheduling(new Scheduling().setOnHostMaintenance(GPU_HOST_MAINTENANCE_BEHAVIOUR));
     }
+    // Instances with guest accelerators do not support live migration
+    instance.setScheduling(new Scheduling().setOnHostMaintenance(HOST_MAINTENANCE_BEHAVIOUR));
     // Set metadata
     Map<String, String> metadata = new HashMap<>();
     Optional.ofNullable(creationParameters.getMetadata()).ifPresent(metadata::putAll);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
@@ -37,6 +37,7 @@ import com.google.api.services.compute.model.Metadata;
 import com.google.api.services.compute.model.Metadata.Items;
 import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Scheduling;
 import com.google.api.services.compute.model.ServiceAccount;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
@@ -67,6 +68,7 @@ public class CreateGceInstanceStep implements Step {
 
   private static final String EXTERNAL_IP_TYPE = "ONE_TO_ONE_NAT";
   private static final String EXTERNAL_IP_NAME = "External IP";
+  private static final String GPU_HOST_MAINTENANCE_BEHAVIOUR = "TERMINATE";
 
   public CreateGceInstanceStep(
       ControlledGceInstanceResource resource,
@@ -213,6 +215,8 @@ public class CreateGceInstanceStep implements Step {
                                   projectId, zone, accelerator.getType()))
                           .setAcceleratorCount(accelerator.getCardCount()))
               .collect(Collectors.toList()));
+      // Instances with guest accelerators do not support live migration
+      instance.setScheduling(new Scheduling().setOnHostMaintenance(GPU_HOST_MAINTENANCE_BEHAVIOUR));
     }
     // Set metadata
     Map<String, String> metadata = new HashMap<>();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
@@ -159,6 +159,7 @@ public class CreateGceInstanceStep implements Step {
     setFields(
         creationParameters,
         instanceId,
+        projectId,
         zone,
         serviceAccountEmail,
         workspaceUserFacingId,
@@ -173,14 +174,14 @@ public class CreateGceInstanceStep implements Step {
   static Instance setFields(
       ApiGcpGceInstanceCreationParameters creationParameters,
       String instanceId,
+      String projectId,
       String zone,
       String serviceAccountEmail,
       String workspaceUserFacingId,
       String cliServer,
       Instance instance,
       String gitHash) {
-    String machineType =
-        String.format("zones/%s/machineTypes/%s", zone, creationParameters.getMachineType());
+    String machineType = GcpUtils.toMachineTypeString(zone, creationParameters.getMachineType());
     instance.setName(instanceId).setMachineType(machineType);
 
     instance.setDisks(
@@ -207,7 +208,9 @@ public class CreateGceInstanceStep implements Step {
               .map(
                   accelerator ->
                       new AcceleratorConfig()
-                          .setAcceleratorType(accelerator.getType())
+                          .setAcceleratorType(
+                              GcpUtils.toAcceleratorTypeString(
+                                  projectId, zone, accelerator.getType()))
                           .setAcceleratorCount(accelerator.getCardCount()))
               .collect(Collectors.toList()));
     }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceGceInstanceConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceGceInstanceConnectedTest.java
@@ -25,6 +25,7 @@ import bio.terra.workspace.common.fixtures.ControlledGcpResourceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
 import bio.terra.workspace.generated.model.ApiGcpGceInstanceCreationParameters;
+import bio.terra.workspace.generated.model.ApiGcpGceInstanceGuestAccelerator;
 import bio.terra.workspace.generated.model.ApiGcpGceUpdateParameters;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.service.crl.CrlService;
@@ -182,7 +183,9 @@ public class ControlledResourceServiceGceInstanceConnectedTest extends BaseConne
     ApiGcpGceInstanceCreationParameters creationParameters =
         ControlledGcpResourceFixtures.defaultGceInstanceCreationParameters()
             .instanceId(instanceId)
-            .zone(DEFAULT_INSTANCE_ZONE);
+            .zone(DEFAULT_INSTANCE_ZONE)
+            .addGuestAcceleratorsItem(
+                new ApiGcpGceInstanceGuestAccelerator().cardCount(1).type("nvidia-tesla-p100"));
 
     ControlledGceInstanceResource resource =
         makeInstanceTestResource(workspaceId, "initial-instance-name", instanceId);

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStepTest.java
@@ -40,6 +40,7 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
         CreateGceInstanceStep.setFields(
             creationParameters,
             "instance-name",
+            "project-id",
             "zone",
             "foo@bar.com",
             WORKSPACE_ID,
@@ -68,6 +69,7 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
         CreateGceInstanceStep.setFields(
             new ApiGcpGceInstanceCreationParameters(),
             "instance-name",
+            "project-id",
             "zone",
             "foo@bar.com",
             WORKSPACE_ID,
@@ -101,6 +103,7 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
                     // "terra-workspace-id" is a reserved metadata key.
                     .metadata(Map.of("terra-workspace-id", "fakeworkspaceid")),
                 "instance-name",
+                "project-id",
                 "zone",
                 "foo@bar.com",
                 "workspaceId",
@@ -115,6 +118,7 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
                     // "terra-cli-server" is a reserved metadata key.
                     .metadata(Map.of("terra-cli-server", "fakeserver")),
                 "isntance-name",
+                "project-id",
                 "zone",
                 "foo@bar.com",
                 "workspaceId",

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStepTest.java
@@ -56,7 +56,9 @@ public class CreateGceInstanceStepTest extends BaseUnitTest {
     assertEquals("foo@bar.com", instance.getServiceAccounts().get(0).getEmail());
     assertEquals(SA_SCOPES, instance.getServiceAccounts().get(0).getScopes());
     assertEquals(1, instance.getGuestAccelerators().size());
-    assertEquals("accelerator-type", instance.getGuestAccelerators().get(0).getAcceleratorType());
+    assertEquals(
+        "projects/project-id/zones/zone/acceleratorTypes/accelerator-type",
+        instance.getGuestAccelerators().get(0).getAcceleratorType());
     assertEquals(
         "project-id/image-family/image-name",
         instance.getDisks().get(0).getInitializeParams().getSourceImage());


### PR DESCRIPTION
Similar to machine types, guest accelerators (gpus) take a url which we should build ourselves. Also, instances with a GPU attached need their maintenance behavior set to TERMINATE