### PR TITLE
[PF-2883] Fix error deserialization from DbWorkspaceDescription

### DIFF
--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.db;
 
 import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
-import bio.terra.common.exception.ErrorReportException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
@@ -201,8 +200,7 @@ public class WorkspaceDao {
                   .flightId(rs.getString("cflightid"))
                   .error(
                       Optional.ofNullable(rs.getString("cerror"))
-                          .map(
-                              errorJson -> DbSerDes.fromJson(errorJson, ErrorReportException.class))
+                          .map(StateDao::deserializeException)
                           .orElse(null));
         }
         return new DbWorkspaceContextPair(dbWorkspace, dbCloudContext);

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -8,6 +8,7 @@ import static bio.terra.workspace.common.utils.WorkspaceUnitTestUtils.POLICY_WRI
 import static bio.terra.workspace.common.utils.WorkspaceUnitTestUtils.SPEND_PROFILE_ID;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,11 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.utils.WorkspaceUnitTestUtils;
+import bio.terra.workspace.db.exception.FieldSizeExceededException;
 import bio.terra.workspace.db.exception.ResourceStateConflictException;
 import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
 import bio.terra.workspace.db.model.DbCloudContext;
+import bio.terra.workspace.db.model.DbWorkspace;
 import bio.terra.workspace.db.model.DbWorkspaceDescription;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
+import bio.terra.workspace.service.resource.model.WsmResourceStateRule;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.exceptions.DuplicateWorkspaceException;
@@ -40,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
@@ -280,6 +285,24 @@ class WorkspaceDaoTest extends BaseUnitTest {
     assertEquals(updatedProperty, workspaceDao.getWorkspace(workspaceUuid).getProperties());
   }
 
+  @Test
+  void workspaceCreateErrorDeserializes() {
+    Workspace workspace =
+        WorkspaceFixtures.defaultWorkspaceBuilder(workspaceUuid)
+            .spendProfileId(spendProfileId)
+            .build();
+    var flightId = UUID.randomUUID().toString();
+    workspaceDao.createWorkspaceStart(workspace, /* applicationIds */ null, flightId);
+    var exception = new FieldSizeExceededException("This is a random ErrorReportException");
+    workspaceDao.createWorkspaceFailure(
+        workspaceUuid, flightId, exception, WsmResourceStateRule.BROKEN_ON_FAILURE);
+    DbWorkspace errorWorkspace = workspaceDao.getDbWorkspace(workspaceUuid);
+    // The deserialized exception will also include the original exception class name, so this
+    // isn't an exact match.
+    assertThat(errorWorkspace.getError().getMessage(), containsString(exception.getMessage()));
+    assertEquals(exception.getStatusCode(), errorWorkspace.getError().getStatusCode());
+  }
+
   @Nested
   class TestGcpCloudContext {
 
@@ -358,6 +381,48 @@ class WorkspaceDaoTest extends BaseUnitTest {
           WorkspaceNotFoundException.class, () -> workspaceDao.getWorkspace(workspaceUuid));
 
       assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceUuid).isEmpty());
+    }
+
+    @Test
+    void workspaceCreateErrorDeserializes() {
+      var flightId = UUID.randomUUID().toString();
+      workspaceDao.createCloudContextStart(
+          workspaceUuid, CloudPlatform.GCP, SPEND_PROFILE_ID, flightId);
+      var exception = new FieldSizeExceededException("This is a random ErrorReportException");
+      workspaceDao.createCloudContextFailure(
+          workspaceUuid,
+          CloudPlatform.GCP,
+          flightId,
+          exception,
+          WsmResourceStateRule.BROKEN_ON_FAILURE);
+      // Error deserializes from getCloudContext
+      DbCloudContext errorDbContext =
+          workspaceDao.getCloudContext(workspaceUuid, CloudPlatform.GCP).get();
+      // The deserialized exception will also include the original exception class name, so this
+      // isn't an exact match.
+      assertThat(errorDbContext.getError().getMessage(), containsString(exception.getMessage()));
+      assertEquals(exception.getStatusCode(), errorDbContext.getError().getStatusCode());
+      // Error deserializes from getWorkspaceDescription
+      GcpCloudContext brokenGcpContext =
+          workspaceDao.getWorkspaceDescription(workspaceUuid).getGcpCloudContext();
+      assertThat(
+          brokenGcpContext.getCommonFields().error().getMessage(),
+          containsString(exception.getMessage()));
+      assertEquals(
+          exception.getStatusCode(), brokenGcpContext.getCommonFields().error().getStatusCode());
+      // Error deserializes from getWorkspaceDescriptionMapFromIdList
+      Map<UUID, DbWorkspaceDescription> descriptionMap =
+          workspaceDao.getWorkspaceDescriptionMapFromIdList(
+              Set.of(workspaceUuid), /*offset=*/ 0, /*limit=*/ 100);
+      assertEquals(1, descriptionMap.size());
+      GcpCloudContext secondBrokenGcpContext =
+          descriptionMap.get(workspaceUuid).getGcpCloudContext();
+      assertThat(
+          secondBrokenGcpContext.getCommonFields().error().getMessage(),
+          containsString(exception.getMessage()));
+      assertEquals(
+          exception.getStatusCode(),
+          secondBrokenGcpContext.getCommonFields().error().getStatusCode());
     }
   }
 


### PR DESCRIPTION
The `WORKSPACE_CONTEXT_ROW_MAPPER` attempts to deserialize exceptions directly to the abstract class `ErrorReportException`, which does not work with the object mapper used in `DbSerDes.fromJson`. This moves it to the deserialization utility that other row mappers use instead.