### PR TITLE
[PF-2833] Support revoking temporary grants for GCE instances

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneAllResourcesFlight.java
@@ -89,6 +89,7 @@ public class CloneAllResourcesFlight extends Flight {
                 RetryRules.cloudLongRunning());
           }
             // CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE: not supported
+            // CONTROLLED_GCP_GCE_INSTANCE: not supported
 
             // Azure
           case CONTROLLED_AZURE_STORAGE_CONTAINER -> {


### PR DESCRIPTION
A handful of grant revoke flights are failing in devel as WSM was missing the logic for cleaning up GCE instance temporary grants. These are the only two places I found that switch on `WsmResourceType`, so hopefully we won't hit other cases like this.