### PR TITLE
[BENCH-727] Ignore NotFound error in Delete functions

### DIFF
--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
@@ -577,7 +577,8 @@ public class AwsUtilsTest extends BaseAwsUnitTest {
     when(mockSageMakerClient.deleteNotebookInstance((DeleteNotebookInstanceRequest) any()))
         .thenReturn(ControlledAwsResourceFixtures.deleteNotebookResponse200)
         .thenReturn(ControlledAwsResourceFixtures.deleteNotebookResponse400)
-        .thenThrow(AWS_SERVICE_EXCEPTION_1);
+        .thenThrow(AWS_SERVICE_EXCEPTION_1)
+        .thenThrow(AWS_SERVICE_EXCEPTION_2);
 
     // success
     assertDoesNotThrow(
@@ -592,14 +593,20 @@ public class AwsUtilsTest extends BaseAwsUnitTest {
             AwsUtils.deleteSageMakerNotebook(
                 ControlledAwsResourceFixtures.AWS_CREDENTIALS_PROVIDER, notebookResource));
 
-    // exception from AWS
-    assertThrows(
-        NotFoundException.class,
+    // failure (notFound exception from AWS)
+    assertDoesNotThrow(
         () ->
             AwsUtils.deleteSageMakerNotebook(
                 ControlledAwsResourceFixtures.AWS_CREDENTIALS_PROVIDER, notebookResource));
 
-    verify(mockSageMakerClient, times(3))
+    // other exception from AWS
+    assertThrows(
+        UnauthorizedException.class,
+        () ->
+            AwsUtils.deleteSageMakerNotebook(
+                ControlledAwsResourceFixtures.AWS_CREDENTIALS_PROVIDER, notebookResource));
+
+    verify(mockSageMakerClient, times(4))
         .deleteNotebookInstance((DeleteNotebookInstanceRequest) any());
   }
 
@@ -666,23 +673,23 @@ public class AwsUtilsTest extends BaseAwsUnitTest {
             NotFoundException.class,
             () ->
                 AwsUtils.checkException(
-                    S3Exception.builder().message("a ResourceNotFoundException b").build()));
+                    S3Exception.builder().message("a ResourceNotFoundException b").build(), "err"));
     assertThat(ex.getMessage(), equalTo("Resource deleted or no longer accessible"));
 
     // defaults ignoreNotFound=false
     SdkException notFound = S3Exception.builder().message("a RecordNotFound b").build();
-    ex = assertThrows(NotFoundException.class, () -> AwsUtils.checkException(notFound));
+    ex = assertThrows(NotFoundException.class, () -> AwsUtils.checkException(notFound, "err"));
     assertThat(ex.getMessage(), equalTo("Resource deleted or no longer accessible"));
 
     // set ignoreNotFound=true
-    assertDoesNotThrow(() -> AwsUtils.checkException(notFound, /* ignoreNotFound= */ true));
+    assertDoesNotThrow(() -> AwsUtils.checkException(notFound, "err", /* ignoreNotFound= */ true));
 
     ex =
         assertThrows(
             UnauthorizedException.class,
             () ->
                 AwsUtils.checkException(
-                    S3Exception.builder().message("a not authorized to perform b").build()));
+                    S3Exception.builder().message("a not authorized to perform b").build(), "err"));
     assertThat(
         ex.getMessage(),
         equalTo("Error performing resource operation, check the name / permissions and retry"));
@@ -692,10 +699,14 @@ public class AwsUtilsTest extends BaseAwsUnitTest {
             BadRequestException.class,
             () ->
                 AwsUtils.checkException(
-                    S3Exception.builder().message("a Unable to transition to b").build()));
+                    S3Exception.builder().message("a Unable to transition to b").build(), "err"));
     assertThat(ex.getMessage(), equalTo("Unable to perform resource lifecycle operation"));
 
-    assertDoesNotThrow(
-        () -> AwsUtils.checkException(S3Exception.builder().message("text").build()));
+    // does not match expected errors
+    ex =
+        assertThrows(
+            ApiException.class,
+            () -> AwsUtils.checkException(S3Exception.builder().message("text").build(), "err"));
+    assertThat(ex.getMessage(), equalTo("err"));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
@@ -48,6 +48,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -668,13 +669,13 @@ public class AwsUtilsTest extends BaseAwsUnitTest {
                     S3Exception.builder().message("a ResourceNotFoundException b").build()));
     assertThat(ex.getMessage(), equalTo("Resource deleted or no longer accessible"));
 
-    ex =
-        assertThrows(
-            NotFoundException.class,
-            () ->
-                AwsUtils.checkException(
-                    S3Exception.builder().message("a RecordNotFound b").build()));
+    // defaults ignoreNotFound=false
+    SdkException notFound = S3Exception.builder().message("a RecordNotFound b").build();
+    ex = assertThrows(NotFoundException.class, () -> AwsUtils.checkException(notFound));
     assertThat(ex.getMessage(), equalTo("Resource deleted or no longer accessible"));
+
+    // set ignoreNotFound=true
+    assertDoesNotThrow(() -> AwsUtils.checkException(notFound, /* ignoreNotFound= */ true));
 
     ex =
         assertThrows(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/BaseAwsSageMakerNotebookStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/BaseAwsSageMakerNotebookStepTest.java
@@ -1,0 +1,72 @@
+package bio.terra.workspace.service.resource.controlled.cloud.aws.sageMakerNotebook;
+
+import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.AWS_CREDENTIALS_PROVIDER;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.app.configuration.external.CliConfiguration;
+import bio.terra.workspace.common.BaseAwsUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures;
+import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.AwsUtils;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.workspace.AwsCloudContextService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import software.amazon.awssdk.services.sagemaker.SageMakerClient;
+import software.amazon.awssdk.services.sagemaker.waiters.SageMakerWaiter;
+
+public class BaseAwsSageMakerNotebookStepTest extends BaseAwsUnitTest {
+
+  @MockBean protected FlightContext mockFlightContext;
+  @MockBean protected AwsCloudContextService mockAwsCloudContextService;
+  @MockBean protected CliConfiguration mockCliConfiguration;
+  @Mock protected SageMakerClient mockSageMakerClient;
+  @Mock protected SageMakerWaiter mockSageMakerWaiter;
+  protected static MockedStatic<AwsUtils> mockAwsUtils;
+
+  protected final ControlledAwsSageMakerNotebookResource notebookResource =
+      ControlledAwsResourceFixtures.makeDefaultAwsSagemakerNotebookResource(WORKSPACE_ID);
+
+  @BeforeAll
+  public static void init() {
+    mockAwsUtils = mockStatic(AwsUtils.class, Mockito.CALLS_REAL_METHODS);
+  }
+
+  @AfterAll
+  public static void terminate() {
+    mockAwsUtils.close();
+  }
+
+  @BeforeEach
+  public void setup() {
+    when(mockFlightContext.getResult())
+        .thenReturn(new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL));
+
+    when(mockSamService().getSamUser((AuthenticatedUserRequest) any()))
+        .thenReturn(WorkspaceFixtures.SAM_USER);
+
+    when(mockCliConfiguration.getServerName()).thenReturn("serverName");
+
+    when(mockAwsCloudContextService.getRequiredAwsCloudContext(any()))
+        .thenReturn(ControlledAwsResourceFixtures.makeAwsCloudContext());
+
+    mockAwsUtils
+        .when(() -> AwsUtils.createWsmCredentialProvider(any(), any()))
+        .thenReturn(AWS_CREDENTIALS_PROVIDER);
+    mockAwsUtils
+        .when(() -> AwsUtils.getSageMakerClient(any(), any()))
+        .thenReturn(mockSageMakerClient);
+    mockAwsUtils.when(() -> AwsUtils.getSageMakerWaiter(any())).thenReturn(mockSageMakerWaiter);
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/StopAwsSageMakerNotebookStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/StopAwsSageMakerNotebookStepTest.java
@@ -15,12 +15,9 @@ import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.utils.AwsUtils;
 import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import software.amazon.awssdk.services.sagemaker.model.NotebookInstanceStatus;
 
-@TestInstance(Lifecycle.PER_CLASS)
-public class StopAwsSageMakerNotebookStepTest extends AwsSageMakerNotebookStepTest {
+public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookStepTest {
 
   @Test
   void executeStopAwsSageMakerNotebook_InService_Test() {


### PR DESCRIPTION
- Delete flight and steps are already idempotent
- Adding option in the implementation function to not error out with NotFound during delete
- Refactored AWS notebook UT class to a abstract base class + 2 concrete test classes. This prevents base class tests from executing twice