### PR TITLE
[PF-2884] Deflake tests

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -999,13 +999,17 @@ public class SamService {
   public void deleteControlledResource(ControlledResource resource, String token)
       throws InterruptedException {
 
+    logger.info("Deleting controlled resource {}", resource.getResourceId());
     ResourcesApi resourceApi = samResourcesApi(token);
+    logger.info("Deleting controlled resource {} - got api", resource.getResourceId());
     try {
+      logger.info("Deleting controlled resource {} - launch retry", resource.getResourceId());
       SamRetry.retry(
-          () ->
-              resourceApi.deleteResourceV2(
-                  resource.getCategory().getSamResourceName(),
-                  resource.getResourceId().toString()));
+          () -> {
+            logger.info("Deleting controlled resource {} - call Sam API", resource.getResourceId());
+            resourceApi.deleteResourceV2(
+                resource.getCategory().getSamResourceName(), resource.getResourceId().toString());
+          });
       logger.info("Deleted Sam controlled resource {}", resource.getResourceId());
     } catch (ApiException apiException) {
       // Do nothing if the resource to delete is not found, this may not be the first time delete is
@@ -1019,6 +1023,8 @@ public class SamService {
         return;
       }
       throw SamExceptionFactory.create("Error deleting controlled resource in Sam", apiException);
+    } catch (Exception e) {
+      logger.error("Caught unexpected exception deleting controlled resource", e);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -999,14 +999,16 @@ public class SamService {
   public void deleteControlledResource(ControlledResource resource, String token)
       throws InterruptedException {
 
-    logger.info("Deleting controlled resource {}", resource.getResourceId());
+    // TODO: PF-2884 - remove this ridiculous level of logging
+    logger.info(">>Deleting controlled resource {}", resource.getResourceId());
     ResourcesApi resourceApi = samResourcesApi(token);
-    logger.info("Deleting controlled resource {} - got api", resource.getResourceId());
+    logger.info(">>Deleting controlled resource {} - got api", resource.getResourceId());
     try {
-      logger.info("Deleting controlled resource {} - launch retry", resource.getResourceId());
+      logger.info(">>Deleting controlled resource {} - launch retry", resource.getResourceId());
       SamRetry.retry(
           () -> {
-            logger.info("Deleting controlled resource {} - call Sam API", resource.getResourceId());
+            logger.info(
+                ">>Deleting controlled resource {} - call Sam API", resource.getResourceId());
             resourceApi.deleteResourceV2(
                 resource.getCategory().getSamResourceName(), resource.getResourceId().toString());
           });

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteSamResourceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteSamResourceStep.java
@@ -34,6 +34,7 @@ public class DeleteSamResourceStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     WsmResource wsmResource = resourceDao.getResource(workspaceUuid, resourceId);
+    // TODO: PF-2884 - remove this ridiculous level of logging
     logger.info(">>Retrieved wsmResource: {}", wsmResource);
     ControlledResource resource = wsmResource.castToControlledResource();
     logger.info(">>Try to delete Sam controlled resource: {}", resource);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteSamResourceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/delete/DeleteSamResourceStep.java
@@ -34,9 +34,16 @@ public class DeleteSamResourceStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     WsmResource wsmResource = resourceDao.getResource(workspaceUuid, resourceId);
+    logger.info(">>Retrieved wsmResource: {}", wsmResource);
     ControlledResource resource = wsmResource.castToControlledResource();
-    logger.info("Try to delete Sam controlled resource: {}", resource);
-    samService.deleteControlledResource(resource, samService.getWsmServiceAccountToken());
+    logger.info(">>Try to delete Sam controlled resource: {}", resource);
+    try {
+      samService.deleteControlledResource(resource, samService.getWsmServiceAccountToken());
+      logger.info(">>Success return from Sam delete controlled resource: {}", resource);
+    } catch (Exception e) {
+      logger.error(">>Caught exception from Sam delete controlled resource", e);
+      throw e;
+    }
     return StepResult.getStepResultSuccess();
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
@@ -105,8 +105,8 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
@@ -70,7 +70,7 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -200,8 +200,8 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
   public void cleanup() throws Exception {
     AuthenticatedUserRequest defaultUserRequest =
         userAccessUtils.defaultUser().getAuthenticatedRequest();
-    mockMvcUtils.deleteWorkspace(defaultUserRequest, workspaceId);
-    mockMvcUtils.deleteWorkspace(defaultUserRequest, workspaceId2);
+    mockMvcUtils.deleteWorkspaceV2AndWait(defaultUserRequest, workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(defaultUserRequest, workspaceId2);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
@@ -70,7 +70,7 @@ public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends 
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -261,8 +261,8 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
   public void cleanup() throws Exception {
     AuthenticatedUserRequest defaultUserRequest =
         userAccessUtils.defaultUser().getAuthenticatedRequest();
-    mockMvcUtils.deleteWorkspace(defaultUserRequest, workspaceId);
-    mockMvcUtils.deleteWorkspace(defaultUserRequest, workspaceId2);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -104,8 +104,8 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqTableConnectedTest.java
@@ -106,8 +106,8 @@ public class ReferencedGcpResourceControllerBqTableConnectedTest extends BaseCon
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -99,8 +99,8 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -93,8 +93,8 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -99,8 +99,8 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -96,8 +96,8 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
@@ -63,7 +63,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }
 
   @Nested

--- a/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
@@ -54,7 +54,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
 
   @After
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -101,7 +101,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   /** Clean up workspaces from Broad dev SAM. */
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.cleanupWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+    mockMvcUtils.deleteWorkspaceV2AndWait(
+        userAccessUtils.defaultUserAuthRequest(), workspace.getId());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -74,6 +74,7 @@ import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotAttributes;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
+import bio.terra.workspace.generated.model.ApiDeleteWorkspaceV2Request;
 import bio.terra.workspace.generated.model.ApiErrorReport;
 import bio.terra.workspace.generated.model.ApiFlexibleResource;
 import bio.terra.workspace.generated.model.ApiFlexibleResourceAttributes;
@@ -212,6 +213,9 @@ public class MockMvcUtils {
   public static final String CLONE_WORKSPACE_PATH_FORMAT = "/api/workspaces/v1/%s/clone";
   public static final String CLONE_WORKSPACE_RESULT_PATH_FORMAT =
       "/api/workspaces/v1/%s/clone-result/%s";
+  public static final String DELETE_WORKSPACE_V2_FORMAT = "/api/workspaces/v2/%s/delete";
+  public static final String GET_DELETE_WORKSPACE_V2_RESULT_FORMAT =
+      "/api/workspaces/v2/%s/delete-result/%s";
   public static final String UPDATE_WORKSPACES_V1_PROPERTIES_PATH_FORMAT =
       "/api/workspaces/v1/%s/properties";
   public static final String UPDATE_WORKSPACES_V1_POLICIES_PATH_FORMAT =
@@ -662,6 +666,43 @@ public class MockMvcUtils {
                     .content(objectMapper.writeValueAsString(apiPropertyKeys)),
                 userRequest))
         .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
+  }
+
+  public ApiJobResult deleteWorkspaceV2Async(AuthenticatedUserRequest userRequest, UUID workspaceId)
+      throws Exception {
+    ApiDeleteWorkspaceV2Request request =
+        new ApiDeleteWorkspaceV2Request()
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    String content =
+        getSerializedResponseForPost(
+            userRequest,
+            DELETE_WORKSPACE_V2_FORMAT,
+            workspaceId,
+            objectMapper.writeValueAsString(request));
+    return objectMapper.readValue(content, ApiJobResult.class);
+  }
+
+  public ApiJobResult getDeleteWorkspaceV2Result(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, String jobId) throws Exception {
+    String serializedResponse =
+        getSerializedResponseForGetJobResult(
+            userRequest, GET_DELETE_WORKSPACE_V2_RESULT_FORMAT, workspaceId, jobId);
+    return objectMapper.readValue(serializedResponse, ApiJobResult.class);
+  }
+
+  public void deleteWorkspaceV2AndWait(AuthenticatedUserRequest userRequest, UUID workspaceId)
+      throws Exception {
+    ApiJobResult result = deleteWorkspaceV2Async(userRequest, workspaceId);
+    String jobId = result.getJobReport().getId();
+    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
+      TimeUnit.SECONDS.sleep(15);
+      result = getDeleteWorkspaceV2Result(userRequest, workspaceId, jobId);
+    }
+    if (result.getJobReport().getStatus() != StatusEnum.SUCCEEDED) {
+      logger.error("Delete workspace failed: {}", result.getErrorReport());
+    } else {
+      logger.info("Deleted workspace {}", workspaceId);
+    }
   }
 
   public void deleteWorkspace(AuthenticatedUserRequest userRequest, UUID workspaceId)


### PR DESCRIPTION
New delete code is taking long enough in some cases that the synchronous delete request times out. Converting to the new async delete workspace call fixes the problem.

I have been unable to locally reproduce, debug, or analyze my way to a fix for the flake in RemoveUserFromWorkspaceFlightTest. This PR adds ridiculous logging to the code path in the hopes of catching the point of failure.