### PR TITLE
[PF-2902] Fix BigQuery cross-region COPY_RESOURCE clone

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDifferentRegionStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CopyBigQueryDatasetDifferentRegionStep.java
@@ -65,7 +65,9 @@ public class CopyBigQueryDatasetDifferentRegionStep implements Step {
 
     String destinationDatasetId =
         FlightUtils.getRequired(
-            inputParameters, ControlledResourceKeys.DESTINATION_DATASET_NAME, String.class);
+            flightContext.getWorkingMap(),
+            ControlledResourceKeys.DESTINATION_DATASET_NAME,
+            String.class);
 
     Map<String, Value> params = new HashMap<>();
     String sourceDatasetId = sourceDataset.getDatasetName();


### PR DESCRIPTION
The `ControlledResourceKeys.DESTINATION_DATASET_NAME` key is placed in the working map in a previous step, where the value gets pulled from the source resource if it isn't explicitly provided. As-is, cross-region COPY_RESOURCE clones will fail with a 500 error if this isn't explicitly set.