### PR TITLE
WOR-1093 Azure disk step should be resilient to OperationNotAllowed exceptions

### DIFF
--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/DeleteAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/DeleteAzureDiskStepTest.java
@@ -2,21 +2,51 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.disk;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.exception.ManagementError;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.compute.ComputeManager;
+import com.azure.resourcemanager.compute.models.Disks;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 
 class DeleteAzureDiskStepTest extends BaseAzureUnitTest {
+  private static final String resourceIdFormat =
+      "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s";
+  private static final String SUBSCRIPTION_ID = "subId";
+  private static final String RESOURCE_GROUP_ID = "resGroupId";
+  private static final String DISK_NAME = "vmDisk";
+
   @Mock private AzureConfiguration mockAzureConfig;
   @Mock private CrlService mockCrlService;
   @Mock private ControlledAzureDiskResource mockDiskResource;
   @Mock private FlightContext mockFlightContext;
+  @Mock private FlightMap mockWorkingMap;
+  @Mock private AzureCloudContext mockAzureCloudContext;
+  @Mock private ComputeManager mockComputeManager;
+  @Mock private Disks mockDisks;
+  @Mock private ManagementException mockManagementException;
+  @Mock private StepResult mockStepResult;
+  @Captor private ArgumentCaptor<String> diskResourceIdCaptor;
 
   private DeleteAzureDiskStep testStep;
 
@@ -26,18 +56,65 @@ class DeleteAzureDiskStepTest extends BaseAzureUnitTest {
   }
 
   @Test
-  void doStepWhenDiskSuccessfullyDeleted() throws InterruptedException {
+  void deleteDisk() throws InterruptedException {
+    setupBaseMocks();
+
     StepResult result = testStep.doStep(mockFlightContext);
+
     assertThat(result, equalTo(StepResult.getStepResultSuccess()));
+    verify(mockDisks, times(1)).deleteById(diskResourceIdCaptor.capture());
+    assertThat(
+        diskResourceIdCaptor.getValue(),
+        equalTo(String.format(resourceIdFormat, SUBSCRIPTION_ID, RESOURCE_GROUP_ID, DISK_NAME)));
   }
 
-  //    @Test
-  //    void doStepWhenDiskAttachedToVm() {
-  //
-  //    }
-  //
-  //    @Test
-  //    void undoStep() {
-  //
-  //    }
+  @Test
+  void deleteDisk_diskIsAttachedToExistingVm() throws InterruptedException {
+    setupBaseMocks();
+    setupExceptionMock();
+    doThrow(mockManagementException).when(mockDisks).deleteById(anyString());
+
+    StepResult result = testStep.doStep(mockFlightContext);
+
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    verify(mockDisks, times(1)).deleteById(diskResourceIdCaptor.capture());
+    assertThat(
+        diskResourceIdCaptor.getValue(),
+        equalTo(String.format(resourceIdFormat, SUBSCRIPTION_ID, RESOURCE_GROUP_ID, DISK_NAME)));
+  }
+
+  @Test
+  void undoStep_diskIsAttachedToExistingVm() throws InterruptedException {
+    setupExceptionMock();
+    when(mockStepResult.getStepStatus()).thenReturn(StepStatus.STEP_RESULT_FAILURE_FATAL);
+    when(mockStepResult.getException()).thenReturn(Optional.of(mockManagementException));
+    when(mockFlightContext.getResult()).thenReturn(mockStepResult);
+
+    StepResult result = testStep.undoStep(mockFlightContext);
+
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  private void setupExceptionMock() {
+    var mockManagementError = mock(ManagementError.class);
+    when(mockManagementError.getCode()).thenReturn("OperationNotAllowed");
+    when(mockManagementError.getMessage()).thenReturn("Disk is attached to VM");
+    when(mockManagementException.getValue()).thenReturn(mockManagementError);
+    when(mockManagementException.getSuppressed()).thenReturn(new Throwable[] {});
+    when(mockManagementException.getMessage()).thenReturn("Disk is attached to VM");
+  }
+
+  private void setupBaseMocks() {
+    when(mockAzureCloudContext.getAzureSubscriptionId()).thenReturn(SUBSCRIPTION_ID);
+    when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(RESOURCE_GROUP_ID);
+    when(mockDiskResource.getDiskName()).thenReturn(DISK_NAME);
+    when(mockWorkingMap.get(
+            WorkspaceFlightMapKeys.ControlledResourceKeys.AZURE_CLOUD_CONTEXT,
+            AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockComputeManager.disks()).thenReturn(mockDisks);
+    when(mockCrlService.getComputeManager(mockAzureCloudContext, mockAzureConfig))
+        .thenReturn(mockComputeManager);
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/DeleteAzureDiskStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/DeleteAzureDiskStepTest.java
@@ -1,0 +1,43 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.disk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.BaseAzureUnitTest;
+import bio.terra.workspace.service.crl.CrlService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class DeleteAzureDiskStepTest extends BaseAzureUnitTest {
+  @Mock private AzureConfiguration mockAzureConfig;
+  @Mock private CrlService mockCrlService;
+  @Mock private ControlledAzureDiskResource mockDiskResource;
+  @Mock private FlightContext mockFlightContext;
+
+  private DeleteAzureDiskStep testStep;
+
+  @BeforeEach
+  void setup() {
+    testStep = new DeleteAzureDiskStep(mockAzureConfig, mockCrlService, mockDiskResource);
+  }
+
+  @Test
+  void doStepWhenDiskSuccessfullyDeleted() throws InterruptedException {
+    StepResult result = testStep.doStep(mockFlightContext);
+    assertThat(result, equalTo(StepResult.getStepResultSuccess()));
+  }
+
+  //    @Test
+  //    void doStepWhenDiskAttachedToVm() {
+  //
+  //    }
+  //
+  //    @Test
+  //    void undoStep() {
+  //
+  //    }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1093. 

Main issue with this is that corresponding WSM resource stays in "DELETING" state and requires manual intervention since disk isn't deleted and still exists.

This PR improves resilience of disk deletion operation:
-returns fatal error instead of retrying in case disk is still attached to a virtual machine
-when undo step identify that do operation failed with "OperationNotAllowed" error (disk is attached to VM) it returns Success (disk is still working). Returning Success allows "DeleteMetadataStartStep" to successfully finish undo operation and move corresponding WSM resource into Ready state. 

The flight still completes with dismal failure. Dismal failure usually happens when undo operation failed. In the context of disk deletion step (in case of this specific issue when disk is attached to virtual machine) undo operation completes successfully, but since deletion flight contains multiple steps, some of them still return failure in "undo" operation.  In our case it is DeleteMetadataStartStep which has default implementation of returning any error which happened during "do" steps in any of the steps during the disk deletion flight. This step is used in many different flights, so changing this behavior might have big impact. The most important thing that WSM resource stays in correct state and flight still reports issue why disk couldn't be deleted.