### PR TITLE
WOR-1108 private azure db

### DIFF
--- a/openapi/src/parts/controlled_azure_database.yaml
+++ b/openapi/src/parts/controlled_azure_database.yaml
@@ -81,14 +81,14 @@ components:
         Database-specific properties to be set on creation. These are a subset of the values
         accepted by the azure resource API
       type: object
-      required: [ name, owner ]
+      required: [ name ]
       properties:
         name:
           description: A valid database name
           type: string
           pattern: ^[a-zA-Z][a-zA-Z0-9_]{0,31}$
         owner:
-          description: Resource id of an azure managed identity in this workspace to be the owner of the database
+          description: Resource id of an azure managed identity in this workspace to be the owner of the database, required for shared databases. For private databases, the owner will be determined from privateResourceUser.
           type: string
           format: uuid
         k8sNamespace:

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStep.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.database;
 import static bio.terra.workspace.service.resource.controlled.cloud.azure.AzureUtils.getResourceName;
 
 import bio.terra.common.iam.BearerToken;
+import bio.terra.landingzone.stairway.flight.utils.FlightUtils;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
@@ -11,16 +12,15 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.utils.RetryUtils;
-import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.KubernetesClientProvider;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.ControlledAzureManagedIdentityResource;
-import bio.terra.workspace.service.resource.model.WsmResourceType;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.ManagedIdentityStep;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.msi.models.Identity;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -53,7 +53,6 @@ public class CreateAzureDatabaseStep implements Step {
   private final WorkspaceService workspaceService;
   private final UUID workspaceId;
   private final KubernetesClientProvider kubernetesClientProvider;
-  private final ResourceDao resourceDao;
 
   // namespace where we create the pod to create the database
   private final String aksNamespace = "default";
@@ -66,8 +65,7 @@ public class CreateAzureDatabaseStep implements Step {
       SamService samService,
       WorkspaceService workspaceService,
       UUID workspaceId,
-      KubernetesClientProvider kubernetesClientProvider,
-      ResourceDao resourceDao) {
+      KubernetesClientProvider kubernetesClientProvider) {
     this.azureConfig = azureConfig;
     this.crlService = crlService;
     this.resource = resource;
@@ -76,7 +74,6 @@ public class CreateAzureDatabaseStep implements Step {
     this.workspaceService = workspaceService;
     this.workspaceId = workspaceId;
     this.kubernetesClientProvider = kubernetesClientProvider;
-    this.resourceDao = resourceDao;
   }
 
   private String getPodName(String newDbUserName) {
@@ -90,21 +87,12 @@ public class CreateAzureDatabaseStep implements Step {
             .getWorkingMap()
             .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
 
-    ControlledAzureManagedIdentityResource managedIdentityResource =
-        resourceDao
-            .getResource(workspaceId, resource.getDatabaseOwner())
-            .castByEnum(WsmResourceType.CONTROLLED_AZURE_MANAGED_IDENTITY);
+    var managedIdentity =
+        FlightUtils.getRequired(
+            context.getWorkingMap(), ManagedIdentityStep.MANAGED_IDENTITY, Identity.class);
 
     var containerServiceManager =
         crlService.getContainerServiceManager(azureCloudContext, azureConfig);
-    var msiManager = crlService.getMsiManager(azureCloudContext, azureConfig);
-
-    var managedIdentity =
-        msiManager
-            .identities()
-            .getByResourceGroup(
-                azureCloudContext.getAzureResourceGroupId(),
-                managedIdentityResource.getManagedIdentityName());
 
     var bearerToken = new BearerToken(samService.getWsmServiceAccountToken());
     UUID landingZoneId =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/AzureManagedIdentityGuardStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/AzureManagedIdentityGuardStep.java
@@ -19,12 +19,12 @@ import org.springframework.http.HttpStatus;
  * immediately before {@link CreateAzureManagedIdentityStep} to ensure idempotency of the create
  * operation.
  */
-public class GetAzureManagedIdentityStep implements Step {
+public class AzureManagedIdentityGuardStep implements Step {
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureManagedIdentityResource resource;
 
-  public GetAzureManagedIdentityStep(
+  public AzureManagedIdentityGuardStep(
       AzureConfiguration azureConfig,
       CrlService crlService,
       ControlledAzureManagedIdentityResource resource) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ControlledAzureManagedIdentityResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ControlledAzureManagedIdentityResource.java
@@ -115,7 +115,7 @@ public class ControlledAzureManagedIdentityResource extends ControlledResource {
       FlightBeanBag flightBeanBag) {
     RetryRule cloudRetry = RetryRules.cloud();
     flight.addStep(
-        new GetAzureManagedIdentityStep(
+        new AzureManagedIdentityGuardStep(
             flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
         cloudRetry);
     flight.addStep(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateAzureManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateAzureManagedIdentityStep.java
@@ -19,7 +19,7 @@ import org.springframework.http.HttpStatus;
 
 /**
  * Creates an Azure Managed Identity. Designed to run directly after {@link
- * GetAzureManagedIdentityStep}.
+ * AzureManagedIdentityGuardStep}.
  */
 public class CreateAzureManagedIdentityStep implements Step {
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetManagedIdentityStep.java
@@ -1,0 +1,31 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.workspace.common.utils.FlightUtils;
+import com.azure.resourcemanager.msi.models.Identity;
+
+public interface GetManagedIdentityStep {
+  String MANAGED_IDENTITY_PRINCIPAL_ID = "MANAGED_IDENTITY_PRINCIPAL_ID";
+  String MANAGED_IDENTITY_CLIENT_ID = "MANAGED_IDENTITY_CLIENT_ID";
+  String MANAGED_IDENTITY_NAME = "MANAGED_IDENTITY_NAME";
+
+  static String getManagedIdentityPrincipalId(FlightContext context) {
+    return FlightUtils.getRequired(
+        context.getWorkingMap(), MANAGED_IDENTITY_PRINCIPAL_ID, String.class);
+  }
+
+  static String getManagedIdentityClientId(FlightContext context) {
+    return FlightUtils.getRequired(
+        context.getWorkingMap(), MANAGED_IDENTITY_CLIENT_ID, String.class);
+  }
+
+  static String getManagedIdentityName(FlightContext context) {
+    return FlightUtils.getRequired(context.getWorkingMap(), MANAGED_IDENTITY_NAME, String.class);
+  }
+
+  default void putManagedIdentityInContext(FlightContext context, Identity identity) {
+    context.getWorkingMap().put(MANAGED_IDENTITY_PRINCIPAL_ID, identity.principalId());
+    context.getWorkingMap().put(MANAGED_IDENTITY_CLIENT_ID, identity.clientId());
+    context.getWorkingMap().put(MANAGED_IDENTITY_NAME, identity.name());
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetPetManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetPetManagedIdentityStep.java
@@ -1,0 +1,58 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+
+/** Gets an Azure Managed Identity for a user's pet. */
+public class GetPetManagedIdentityStep implements Step, ManagedIdentityStep {
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final SamService samService;
+  private final String userEmail;
+
+  public GetPetManagedIdentityStep(
+      AzureConfiguration azureConfig,
+      CrlService crlService,
+      SamService samService,
+      String userEmail) {
+    this.azureConfig = azureConfig;
+    this.crlService = crlService;
+    this.samService = samService;
+    this.userEmail = userEmail;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+    var msiManager = crlService.getMsiManager(azureCloudContext, azureConfig);
+
+    var objectId =
+        samService.getOrCreateUserManagedIdentityForUser(
+            userEmail,
+            azureCloudContext.getAzureSubscriptionId(),
+            azureCloudContext.getAzureTenantId(),
+            azureCloudContext.getAzureResourceGroupId());
+
+    var uami = msiManager.identities().getById(objectId);
+
+    context.getWorkingMap().put(MANAGED_IDENTITY, uami);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Nothing to undo
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
@@ -1,0 +1,74 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+import bio.terra.common.exception.BadRequestException;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import java.util.UUID;
+
+/** Gets an Azure Managed Identity that exists in a workspace. */
+public class GetWorkspaceManagedIdentityStep implements Step, ManagedIdentityStep {
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final UUID workspaceId;
+  private final ResourceDao resourceDao;
+  private final UUID managedIdentityId;
+
+  public GetWorkspaceManagedIdentityStep(
+      AzureConfiguration azureConfig,
+      CrlService crlService,
+      UUID workspaceId,
+      ResourceDao resourceDao,
+      UUID managedIdentityId) {
+    this.azureConfig = azureConfig;
+    this.crlService = crlService;
+    this.workspaceId = workspaceId;
+    this.resourceDao = resourceDao;
+    this.managedIdentityId = managedIdentityId;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    final AzureCloudContext azureCloudContext =
+        context
+            .getWorkingMap()
+            .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
+    var msiManager = crlService.getMsiManager(azureCloudContext, azureConfig);
+    ControlledAzureManagedIdentityResource managedIdentityResource =
+        resourceDao
+            .getResource(workspaceId, managedIdentityId)
+            .castByEnum(WsmResourceType.CONTROLLED_AZURE_MANAGED_IDENTITY);
+    if (managedIdentityResource == null) {
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new BadRequestException(
+              String.format(
+                  "An Azure Managed Identity with id %s does not exist in workspace %s",
+                  managedIdentityId, workspaceId)));
+    }
+    var uamiName = managedIdentityResource.getManagedIdentityName();
+
+    var uami =
+        msiManager
+            .identities()
+            .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), uamiName);
+
+    context.getWorkingMap().put(MANAGED_IDENTITY, uami);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Nothing to undo
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityStep.java
@@ -1,5 +1,0 @@
-package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
-
-public interface ManagedIdentityStep {
-  public static final String MANAGED_IDENTITY = "MANAGED_IDENTITY";
-}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityStep.java
@@ -1,0 +1,5 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+public interface ManagedIdentityStep {
+  public static final String MANAGED_IDENTITY = "MANAGED_IDENTITY";
+}

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAzureResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAzureResourceFixtures.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.generated.model.ApiAzureVmCustomScriptExtensionTag;
 import bio.terra.workspace.generated.model.ApiAzureVmImage;
 import bio.terra.workspace.generated.model.ApiAzureVmUser;
 import bio.terra.workspace.generated.model.ApiManagedBy;
+import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool.ControlledAzureBatchPoolResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.database.ControlledAzureDatabaseResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
@@ -411,7 +412,7 @@ public class ControlledAzureResourceFixtures {
   }
 
   public static ControlledAzureDatabaseResource.Builder
-      makeDefaultControlledAzureDatabaseResourceBuilder(
+      makeSharedControlledAzureDatabaseResourceBuilder(
           ApiAzureDatabaseCreationParameters creationParameters, UUID workspaceId) {
     return ControlledAzureDatabaseResource.builder()
         .common(
@@ -425,6 +426,27 @@ public class ControlledAzureResourceFixtures {
                 .build())
         .databaseName(creationParameters.getName())
         .databaseOwner(creationParameters.getOwner())
+        .k8sNamespace(creationParameters.getK8sNamespace());
+  }
+
+  public static ControlledAzureDatabaseResource.Builder
+      makePrivateControlledAzureDatabaseResourceBuilder(
+          ApiAzureDatabaseCreationParameters creationParameters,
+          UUID workspaceId,
+          String assignedUser) {
+    return ControlledAzureDatabaseResource.builder()
+        .common(
+            ControlledResourceFixtures.makeDefaultControlledResourceFieldsBuilder()
+                .workspaceUuid(workspaceId)
+                .name(getAzureName("db"))
+                .cloningInstructions(CloningInstructions.COPY_NOTHING)
+                .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE)
+                .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
+                .assignedUser(assignedUser)
+                .iamRole(ControlledResourceIamRole.EDITOR)
+                .region(DEFAULT_AZURE_RESOURCE_REGION)
+                .build())
+        .databaseName(creationParameters.getName())
         .k8sNamespace(creationParameters.getK8sNamespace());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
@@ -9,7 +9,9 @@ import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.model.ControlledResourceIamRole;
 import bio.terra.workspace.service.job.JobMapKeys;
+import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
@@ -18,6 +20,7 @@ import bio.terra.workspace.service.spendprofile.SpendProfile;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import bio.terra.workspace.service.workspace.model.AzureCloudContextFields;
@@ -108,6 +111,10 @@ public class AzureTestUtils {
     if (creationParameters != null) {
       inputs.put(
           WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
+    }
+    if (resource.getAccessScope() == AccessScopeType.ACCESS_SCOPE_PRIVATE) {
+      inputs.put(
+          ControlledResourceKeys.PRIVATE_RESOURCE_IAM_ROLE, ControlledResourceIamRole.EDITOR);
     }
     return inputs;
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDatabaseConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDatabaseConnectedTest.java
@@ -157,7 +157,7 @@ public class AzureDatabaseConnectedTest extends BaseAzureConnectedTest {
             uamiResource.getResourceId());
 
     var dbResource =
-        ControlledAzureResourceFixtures.makeDefaultControlledAzureDatabaseResourceBuilder(
+        ControlledAzureResourceFixtures.makeSharedControlledAzureDatabaseResourceBuilder(
                 dbCreationParameters, workspaceUuid)
             .build();
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/ControlledAzureDatabaseResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/ControlledAzureDatabaseResourceTest.java
@@ -1,0 +1,82 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.database;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
+import bio.terra.workspace.common.utils.FlightBeanBag;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.CreateFederatedIdentityStep;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetFederatedIdentityStep;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetPetManagedIdentityStep;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetWorkspaceManagedIdentityStep;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoSession;
+import org.mockito.quality.Strictness;
+
+@Tag("azure-unit")
+public class ControlledAzureDatabaseResourceTest {
+  private MockitoSession mockito;
+
+  private final UUID workspaceId = UUID.randomUUID();
+  @Mock private FlightBeanBag mockFlightBeanBag;
+
+  @BeforeEach
+  public void setup() {
+    // initialize session to start mocking
+    mockito =
+        Mockito.mockitoSession().initMocks(this).strictness(Strictness.STRICT_STUBS).startMocking();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    mockito.finishMocking();
+  }
+
+  @Test
+  void testCorrectPrivateDatabaseSteps() {
+    var creationParameters =
+        ControlledAzureResourceFixtures.getAzureDatabaseCreationParameters(null);
+
+    var databaseResource =
+        ControlledAzureResourceFixtures.makePrivateControlledAzureDatabaseResourceBuilder(
+                creationParameters, workspaceId, UUID.randomUUID().toString())
+            .build();
+
+    var steps = databaseResource.getAddSteps(mockFlightBeanBag);
+    assertThat(
+        steps.stream().map(Object::getClass).toList(),
+        contains(
+            GetAzureDatabaseStep.class,
+            GetPetManagedIdentityStep.class,
+            GetFederatedIdentityStep.class,
+            CreateFederatedIdentityStep.class,
+            CreateAzureDatabaseStep.class));
+  }
+
+  @Test
+  void testCorrectSharedDatabaseSteps() {
+    var creationParameters =
+        ControlledAzureResourceFixtures.getAzureDatabaseCreationParameters(UUID.randomUUID());
+
+    var databaseResource =
+        ControlledAzureResourceFixtures.makeSharedControlledAzureDatabaseResourceBuilder(
+                creationParameters, workspaceId)
+            .build();
+
+    var steps = databaseResource.getAddSteps(mockFlightBeanBag);
+    assertThat(
+        steps.stream().map(Object::getClass).toList(),
+        contains(
+            GetAzureDatabaseStep.class,
+            GetWorkspaceManagedIdentityStep.class,
+            GetFederatedIdentityStep.class,
+            CreateFederatedIdentityStep.class,
+            CreateAzureDatabaseStep.class));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStepTest.java
@@ -15,22 +15,17 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
-import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.generated.model.ApiAzureDatabaseCreationParameters;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.KubernetesClientProvider;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.ControlledAzureManagedIdentityResource;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.ManagedIdentityStep;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetManagedIdentityStep;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.management.exception.ManagementException;
-import com.azure.resourcemanager.msi.MsiManager;
-import com.azure.resourcemanager.msi.models.Identities;
-import com.azure.resourcemanager.msi.models.Identity;
 import com.azure.resourcemanager.postgresqlflexibleserver.PostgreSqlManager;
 import com.azure.resourcemanager.postgresqlflexibleserver.models.Databases;
 import io.kubernetes.client.openapi.ApiException;
@@ -67,9 +62,6 @@ public class CreateAzureDatabaseStepTest {
   @Mock private FlightContext mockFlightContext;
   @Mock private AzureCloudContext mockAzureCloudContext;
   @Mock private FlightMap mockWorkingMap;
-  @Mock private MsiManager mockMsiManager;
-  @Mock private Identities mockIdentities;
-  @Mock private Identity mockIdentity;
   @Mock private ApiAzureLandingZoneDeployedResource mockCluster;
   @Mock private CoreV1Api mockCoreV1Api;
   @Captor private ArgumentCaptor<V1Pod> podCaptor;
@@ -81,11 +73,12 @@ public class CreateAzureDatabaseStepTest {
 
   private final UUID workspaceId = UUID.randomUUID();
   private final String uamiName = UUID.randomUUID().toString();
+  private final String uamiPrincipalId = UUID.randomUUID().toString();
   private final ApiAzureDatabaseCreationParameters creationParameters =
       ControlledAzureResourceFixtures.getAzureDatabaseCreationParameters(null);
   private final ControlledAzureDatabaseResource databaseResource =
-      ControlledAzureResourceFixtures.makeDefaultControlledAzureDatabaseResourceBuilder(
-              creationParameters, workspaceId)
+      ControlledAzureResourceFixtures.makePrivateControlledAzureDatabaseResourceBuilder(
+              creationParameters, workspaceId, null)
           .build();
 
   @BeforeEach
@@ -111,8 +104,8 @@ public class CreateAzureDatabaseStepTest {
 
     assertThat(env.get("DB_SERVER_NAME"), equalTo(mockDatabase.getResourceId()));
     assertThat(env.get("ADMIN_DB_USER_NAME"), equalTo(mockAdminIdentity.getResourceId()));
-    assertThat(env.get("NEW_DB_USER_NAME"), equalTo(mockIdentity.name()));
-    assertThat(env.get("NEW_DB_USER_OID"), equalTo(mockIdentity.principalId()));
+    assertThat(env.get("NEW_DB_USER_NAME"), equalTo(uamiName));
+    assertThat(env.get("NEW_DB_USER_OID"), equalTo(uamiPrincipalId));
     assertThat(env.get("NEW_DB_NAME"), equalTo(databaseResource.getDatabaseName()));
 
     assertThat(
@@ -182,19 +175,16 @@ public class CreateAzureDatabaseStepTest {
         mockSamService,
         mockWorkspaceService,
         workspaceId,
-        mockKubernetesClient
-    );
+        mockKubernetesClient);
   }
 
   @NotNull
   private CreateAzureDatabaseStep setupStepTest(String podPhase) throws ApiException {
     createMockFlightContext();
-
-    when(mockCrlService.getMsiManager(mockAzureCloudContext, mockAzureConfig))
-        .thenReturn(mockMsiManager);
-    when(mockMsiManager.identities()).thenReturn(mockIdentities);
-    when(mockIdentity.name()).thenReturn(uamiName);
-    when(mockIdentity.principalId()).thenReturn(UUID.randomUUID().toString());
+    when(mockWorkingMap.get(GetManagedIdentityStep.MANAGED_IDENTITY_NAME, String.class))
+        .thenReturn(uamiName);
+    when(mockWorkingMap.get(GetManagedIdentityStep.MANAGED_IDENTITY_PRINCIPAL_ID, String.class))
+        .thenReturn(uamiPrincipalId);
 
     when(mockSamService.getWsmServiceAccountToken()).thenReturn(UUID.randomUUID().toString());
 
@@ -236,15 +226,13 @@ public class CreateAzureDatabaseStepTest {
         mockSamService,
         mockWorkspaceService,
         workspaceId,
-        mockKubernetesClient
-    );
+        mockKubernetesClient);
   }
 
   private FlightContext createMockFlightContext() {
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
     when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
         .thenReturn(mockAzureCloudContext);
-    when(mockWorkingMap.get(ManagedIdentityStep.MANAGED_IDENTITY, Identity.class)).thenReturn(mockIdentity);
 
     when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(UUID.randomUUID().toString());
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/AzureManagedIdentityGuardStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/AzureManagedIdentityGuardStepTest.java
@@ -1,4 +1,4 @@
-package bio.terra.workspace.service.resource.controlled.cloud.azure.database;
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -9,20 +9,15 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
-import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.iam.SamService;
-import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.management.exception.ManagementException;
-import com.azure.resourcemanager.postgresqlflexibleserver.PostgreSqlManager;
-import com.azure.resourcemanager.postgresqlflexibleserver.models.Databases;
-import java.util.Optional;
+import com.azure.resourcemanager.msi.MsiManager;
+import com.azure.resourcemanager.msi.models.Identities;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,20 +30,16 @@ import org.mockito.quality.Strictness;
 import org.springframework.http.HttpStatus;
 
 @Tag("azure-unit")
-public class GetAzureDatabaseStepTest {
+public class AzureManagedIdentityGuardStepTest {
   private MockitoSession mockito;
   @Mock private FlightContext mockFlightContext;
   @Mock private FlightMap mockWorkingMap;
   @Mock private AzureCloudContext mockAzureCloudContext;
   @Mock private CrlService mockCrlService;
+  @Mock private MsiManager mockMsiManager;
+  @Mock private Identities mockIdentities;
   @Mock private AzureConfiguration mockAzureConfig;
   @Mock private HttpResponse mockHttpResponse;
-  @Mock private PostgreSqlManager mockPostgreSqlManager;
-  @Mock private Databases mockDatabases;
-  @Mock private SamService mockSamService;
-  @Mock private LandingZoneApiDispatch mockLandingZoneApiDispatch;
-  @Mock private ApiAzureLandingZoneDeployedResource mockDatabase;
-  @Mock private WorkspaceService mockWorkspaceService;
 
   @BeforeEach
   public void setup() {
@@ -84,30 +75,23 @@ public class GetAzureDatabaseStepTest {
   void testAlreadyExists() throws InterruptedException {
     var workspaceId = UUID.randomUUID();
     var creationParameters =
-        ControlledAzureResourceFixtures.getAzureDatabaseCreationParameters(UUID.randomUUID());
-    var databaseResource =
-        ControlledAzureResourceFixtures.makeSharedControlledAzureDatabaseResourceBuilder(
+        ControlledAzureResourceFixtures.getAzureManagedIdentityCreationParameters();
+    var identityResource =
+        ControlledAzureResourceFixtures.makeDefaultControlledAzureManagedIdentityResourceBuilder(
                 creationParameters, workspaceId)
             .build();
 
     createMockFlightContext();
 
-    setupMocksUntilGetCall();
-    when(mockDatabases.get(
+    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
+    when(mockMsiManager.identities()).thenReturn(mockIdentities);
+    when(mockIdentities.getByResourceGroup(
             mockAzureCloudContext.getAzureResourceGroupId(),
-            mockDatabase.getResourceId(),
-            databaseResource.getDatabaseName()))
+            identityResource.getManagedIdentityName()))
         .thenReturn(null);
 
-    var step =
-        new GetAzureDatabaseStep(
-            mockAzureConfig,
-            mockCrlService,
-            databaseResource,
-            mockSamService,
-            mockLandingZoneApiDispatch,
-            mockWorkspaceService,
-            workspaceId);
+    AzureManagedIdentityGuardStep step =
+        new AzureManagedIdentityGuardStep(mockAzureConfig, mockCrlService, identityResource);
     assertThat(
         step.doStep(mockFlightContext).getStepStatus(),
         equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
@@ -116,42 +100,25 @@ public class GetAzureDatabaseStepTest {
   private StepResult testWithError(HttpStatus httpStatus) throws InterruptedException {
     var workspaceId = UUID.randomUUID();
     var creationParameters =
-        ControlledAzureResourceFixtures.getAzureDatabaseCreationParameters(UUID.randomUUID());
-    var databaseResource =
-        ControlledAzureResourceFixtures.makeSharedControlledAzureDatabaseResourceBuilder(
+        ControlledAzureResourceFixtures.getAzureManagedIdentityCreationParameters();
+    var identityResource =
+        ControlledAzureResourceFixtures.makeDefaultControlledAzureManagedIdentityResourceBuilder(
                 creationParameters, workspaceId)
             .build();
 
     createMockFlightContext();
 
-    setupMocksUntilGetCall();
-    when(mockDatabases.get(
+    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
+    when(mockMsiManager.identities()).thenReturn(mockIdentities);
+    when(mockIdentities.getByResourceGroup(
             mockAzureCloudContext.getAzureResourceGroupId(),
-            mockDatabase.getResourceId(),
-            databaseResource.getDatabaseName()))
+            identityResource.getManagedIdentityName()))
         .thenThrow(new ManagementException(httpStatus.name(), mockHttpResponse));
     when(mockHttpResponse.getStatusCode()).thenReturn(httpStatus.value());
 
-    var step =
-        new GetAzureDatabaseStep(
-            mockAzureConfig,
-            mockCrlService,
-            databaseResource,
-            mockSamService,
-            mockLandingZoneApiDispatch,
-            mockWorkspaceService,
-            workspaceId);
+    AzureManagedIdentityGuardStep step =
+        new AzureManagedIdentityGuardStep(mockAzureConfig, mockCrlService, identityResource);
     return step.doStep(mockFlightContext);
-  }
-
-  private void setupMocksUntilGetCall() {
-    when(mockSamService.getWsmServiceAccountToken()).thenReturn(UUID.randomUUID().toString());
-    when(mockLandingZoneApiDispatch.getLandingZoneId(any(), any())).thenReturn(UUID.randomUUID());
-    when(mockLandingZoneApiDispatch.getSharedDatabase(any(), any()))
-        .thenReturn(Optional.of(mockDatabase));
-    when(mockDatabase.getResourceId()).thenReturn(UUID.randomUUID().toString());
-    when(mockCrlService.getPostgreSqlManager(any(), any())).thenReturn(mockPostgreSqlManager);
-    when(mockPostgreSqlManager.databases()).thenReturn(mockDatabases);
   }
 
   private FlightContext createMockFlightContext() {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
@@ -14,7 +14,6 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
-import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.KubernetesClientProvider;
@@ -54,7 +53,6 @@ public class CreateFederatedIdentityStepTest {
   @Mock private SamService mockSamService;
   @Mock private WorkspaceService mockWorkspaceService;
   private final UUID workspaceId = UUID.randomUUID();
-  @Mock private ResourceDao mockResourceDao;
   @Mock private AzureCloudContext mockAzureCloudContext;
   private final ControlledAzureManagedIdentityResource identityResource =
       ControlledAzureResourceFixtures.makeDefaultControlledAzureManagedIdentityResourceBuilder(
@@ -103,8 +101,7 @@ public class CreateFederatedIdentityStepTest {
             mockLandingZoneApiDispatch,
             mockSamService,
             mockWorkspaceService,
-            workspaceId
-        );
+            workspaceId);
     var result =
         step.createFederatedIdentityAndK8sServiceAccount(
             identityResource.getManagedIdentityName(),
@@ -166,8 +163,7 @@ public class CreateFederatedIdentityStepTest {
             mockLandingZoneApiDispatch,
             mockSamService,
             mockWorkspaceService,
-            workspaceId
-        );
+            workspaceId);
     assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
   }
 
@@ -187,8 +183,7 @@ public class CreateFederatedIdentityStepTest {
             mockLandingZoneApiDispatch,
             mockSamService,
             mockWorkspaceService,
-            workspaceId
-        );
+            workspaceId);
     return step.createFederatedIdentityAndK8sServiceAccount(
         identityResource.getManagedIdentityName(),
         mockAzureCloudContext,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
@@ -99,13 +99,12 @@ public class CreateFederatedIdentityStepTest {
             k8sNamespace,
             mockAzureConfig,
             mockCrlService,
-            identityResource.getResourceId(),
             mockKubernetesClientProvider,
             mockLandingZoneApiDispatch,
             mockSamService,
             mockWorkspaceService,
-            workspaceId,
-            mockResourceDao);
+            workspaceId
+        );
     var result =
         step.createFederatedIdentityAndK8sServiceAccount(
             identityResource.getManagedIdentityName(),
@@ -163,13 +162,12 @@ public class CreateFederatedIdentityStepTest {
             k8sNamespace,
             mockAzureConfig,
             mockCrlService,
-            identityResource.getResourceId(),
             mockKubernetesClientProvider,
             mockLandingZoneApiDispatch,
             mockSamService,
             mockWorkspaceService,
-            workspaceId,
-            mockResourceDao);
+            workspaceId
+        );
     assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
   }
 
@@ -185,13 +183,12 @@ public class CreateFederatedIdentityStepTest {
             k8sNamespace,
             mockAzureConfig,
             mockCrlService,
-            identityResource.getResourceId(),
             mockKubernetesClientProvider,
             mockLandingZoneApiDispatch,
             mockSamService,
             mockWorkspaceService,
-            workspaceId,
-            mockResourceDao);
+            workspaceId
+        );
     return step.createFederatedIdentityAndK8sServiceAccount(
         identityResource.getManagedIdentityName(),
         mockAzureCloudContext,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetPetManagedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetPetManagedIdentityStepTest.java
@@ -1,0 +1,124 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.msi.MsiManager;
+import com.azure.resourcemanager.msi.models.Identities;
+import com.azure.resourcemanager.msi.models.Identity;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoSession;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+
+@Tag("azure-unit")
+public class GetPetManagedIdentityStepTest {
+  private MockitoSession mockito;
+  @Mock private FlightContext mockFlightContext;
+  @Mock private FlightMap mockWorkingMap;
+  @Mock private AzureCloudContext mockAzureCloudContext;
+  @Mock private CrlService mockCrlService;
+  @Mock private MsiManager mockMsiManager;
+  @Mock private Identities mockIdentities;
+  @Mock private AzureConfiguration mockAzureConfig;
+  @Mock private HttpResponse mockHttpResponse;
+  @Mock private SamService mockSamService;
+  private final String testEmail = UUID.randomUUID() + "@example.com";
+  @Mock private Identity mockIdentity;
+
+  @BeforeEach
+  public void setup() {
+    // initialize session to start mocking
+    mockito =
+        Mockito.mockitoSession().initMocks(this).strictness(Strictness.STRICT_STUBS).startMocking();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    mockito.finishMocking();
+  }
+
+  @Test
+  void testSuccess() throws InterruptedException {
+    createMockFlightContext();
+    var identityId = UUID.randomUUID().toString();
+    when(mockSamService.getOrCreateUserManagedIdentityForUser(
+            testEmail,
+            mockAzureCloudContext.getAzureSubscriptionId(),
+            mockAzureCloudContext.getAzureTenantId(),
+            mockAzureCloudContext.getAzureResourceGroupId()))
+        .thenReturn(identityId);
+    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
+    when(mockMsiManager.identities()).thenReturn(mockIdentities);
+    when(mockIdentities.getById(identityId)).thenReturn(mockIdentity);
+    when(mockIdentity.name()).thenReturn(UUID.randomUUID().toString());
+    when(mockIdentity.principalId()).thenReturn(UUID.randomUUID().toString());
+    when(mockIdentity.clientId()).thenReturn(UUID.randomUUID().toString());
+
+    var step =
+        new GetPetManagedIdentityStep(mockAzureConfig, mockCrlService, mockSamService, testEmail);
+    assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
+  }
+
+  @Test
+  void testFatal() throws InterruptedException {
+    StepResult stepResult = testWithError(HttpStatus.NOT_FOUND);
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void testRetry() throws InterruptedException {
+    StepResult stepResult = testWithError(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+
+  private StepResult testWithError(HttpStatus httpStatus) throws InterruptedException {
+    createMockFlightContext();
+
+    var identityId = UUID.randomUUID().toString();
+    when(mockSamService.getOrCreateUserManagedIdentityForUser(
+            testEmail,
+            mockAzureCloudContext.getAzureSubscriptionId(),
+            mockAzureCloudContext.getAzureTenantId(),
+            mockAzureCloudContext.getAzureResourceGroupId()))
+        .thenReturn(identityId);
+    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
+    when(mockMsiManager.identities()).thenReturn(mockIdentities);
+    when(mockIdentities.getById(identityId))
+        .thenThrow(new ManagementException(httpStatus.name(), mockHttpResponse));
+    when(mockHttpResponse.getStatusCode()).thenReturn(httpStatus.value());
+
+    var step =
+        new GetPetManagedIdentityStep(mockAzureConfig, mockCrlService, mockSamService, testEmail);
+    return step.doStep(mockFlightContext);
+  }
+
+  private FlightContext createMockFlightContext() {
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
+
+    when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(UUID.randomUUID().toString());
+
+    return mockFlightContext;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
@@ -11,6 +11,7 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
+import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
@@ -18,6 +19,7 @@ import com.azure.core.http.HttpResponse;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.msi.MsiManager;
 import com.azure.resourcemanager.msi.models.Identities;
+import com.azure.resourcemanager.msi.models.Identity;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +32,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.http.HttpStatus;
 
 @Tag("azure-unit")
-public class GetAzureManagedIdentityStepTest {
+public class GetWorkspaceManagedIdentityStepTest {
   private MockitoSession mockito;
   @Mock private FlightContext mockFlightContext;
   @Mock private FlightMap mockWorkingMap;
@@ -40,6 +42,8 @@ public class GetAzureManagedIdentityStepTest {
   @Mock private Identities mockIdentities;
   @Mock private AzureConfiguration mockAzureConfig;
   @Mock private HttpResponse mockHttpResponse;
+  @Mock private ResourceDao mockResourceDao;
+  @Mock private Identity mockIdentity;
 
   @BeforeEach
   public void setup() {
@@ -55,24 +59,6 @@ public class GetAzureManagedIdentityStepTest {
 
   @Test
   void testSuccess() throws InterruptedException {
-    StepResult stepResult = testWithError(HttpStatus.NOT_FOUND);
-    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
-  }
-
-  @Test
-  void testFatal() throws InterruptedException {
-    StepResult stepResult = testWithError(HttpStatus.BAD_REQUEST);
-    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
-  }
-
-  @Test
-  void testRetry() throws InterruptedException {
-    StepResult stepResult = testWithError(HttpStatus.SERVICE_UNAVAILABLE);
-    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
-  }
-
-  @Test
-  void testAlreadyExists() throws InterruptedException {
     var workspaceId = UUID.randomUUID();
     var creationParameters =
         ControlledAzureResourceFixtures.getAzureManagedIdentityCreationParameters();
@@ -88,13 +74,33 @@ public class GetAzureManagedIdentityStepTest {
     when(mockIdentities.getByResourceGroup(
             mockAzureCloudContext.getAzureResourceGroupId(),
             identityResource.getManagedIdentityName()))
-        .thenReturn(null);
+        .thenReturn(mockIdentity);
+    when(mockResourceDao.getResource(workspaceId, identityResource.getResourceId()))
+        .thenReturn(identityResource);
+    when(mockIdentity.name()).thenReturn(UUID.randomUUID().toString());
+    when(mockIdentity.principalId()).thenReturn(UUID.randomUUID().toString());
+    when(mockIdentity.clientId()).thenReturn(UUID.randomUUID().toString());
 
-    GetAzureManagedIdentityStep step =
-        new GetAzureManagedIdentityStep(mockAzureConfig, mockCrlService, identityResource);
-    assertThat(
-        step.doStep(mockFlightContext).getStepStatus(),
-        equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    var step =
+        new GetWorkspaceManagedIdentityStep(
+            mockAzureConfig,
+            mockCrlService,
+            workspaceId,
+            mockResourceDao,
+            identityResource.getResourceId());
+    assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
+  }
+
+  @Test
+  void testFatal() throws InterruptedException {
+    StepResult stepResult = testWithError(HttpStatus.NOT_FOUND);
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void testRetry() throws InterruptedException {
+    StepResult stepResult = testWithError(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
   }
 
   private StepResult testWithError(HttpStatus httpStatus) throws InterruptedException {
@@ -115,9 +121,16 @@ public class GetAzureManagedIdentityStepTest {
             identityResource.getManagedIdentityName()))
         .thenThrow(new ManagementException(httpStatus.name(), mockHttpResponse));
     when(mockHttpResponse.getStatusCode()).thenReturn(httpStatus.value());
+    when(mockResourceDao.getResource(workspaceId, identityResource.getResourceId()))
+        .thenReturn(identityResource);
 
-    GetAzureManagedIdentityStep step =
-        new GetAzureManagedIdentityStep(mockAzureConfig, mockCrlService, identityResource);
+    var step =
+        new GetWorkspaceManagedIdentityStep(
+            mockAzureConfig,
+            mockCrlService,
+            workspaceId,
+            mockResourceDao,
+            identityResource.getResourceId());
     return step.doStep(mockFlightContext);
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1108

The gist of the change is that the lookup of the managed identity was removed from within the created federated identity and database steps and performed in its own step ahead of time. There are now 2 different ways to lookup the managed identity which is reflected by 2 different step implementations. For shared databases, a step is used that looks up a workspace managed identity. For private databases, a step is used that looks up the assigned user's pet managed identity.