### PR TITLE
PF-2911: Cloning reference shouldn't fail with region constraint violation

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateWorkspaceAgainstPolicyStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateWorkspaceAgainstPolicyStep.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
 import bio.terra.workspace.service.resource.ResourceValidationUtils;
 import bio.terra.workspace.service.resource.exception.PolicyConflictException;
+import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import java.util.ArrayList;
@@ -23,11 +24,13 @@ public class ValidateWorkspaceAgainstPolicyStep implements Step {
   private final AuthenticatedUserRequest userRequest;
   private final ResourceDao resourceDao;
   private final TpsApiDispatch tpsApiDispatch;
+  private final CloningInstructions cloningInstructions;
 
   public ValidateWorkspaceAgainstPolicyStep(
       UUID workspaceId,
       CloudPlatform cloudPlatform,
       String destinationLocation,
+      CloningInstructions cloningInstructions,
       AuthenticatedUserRequest userRequest,
       ResourceDao resourceDao,
       TpsApiDispatch tpsApiDispatch) {
@@ -37,6 +40,7 @@ public class ValidateWorkspaceAgainstPolicyStep implements Step {
     this.tpsApiDispatch = tpsApiDispatch;
     this.resourceDao = resourceDao;
     this.destinationLocation = destinationLocation;
+    this.cloningInstructions = cloningInstructions;
   }
 
   @Override
@@ -61,7 +65,9 @@ public class ValidateWorkspaceAgainstPolicyStep implements Step {
             ResourceValidationUtils.validateExistingResourceRegions(
                 workspaceId, validRegions, cloudPlatform, resourceDao));
 
-    if (destinationLocation != null && !validRegions.contains(destinationLocation.toLowerCase())) {
+    if (!cloningInstructions.isReferenceClone()
+        && destinationLocation != null
+        && !validRegions.contains(destinationLocation.toLowerCase())) {
       validationErrors.add(
           String.format(
               "The specified destination location '%s' violates region policies",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/bucket/CloneControlledGcsBucketResourceFlight.java
@@ -98,6 +98,7 @@ public class CloneControlledGcsBucketResourceFlight extends Flight {
               destinationWorkspaceId,
               sourceResource.getResourceType().getCloudPlatform(),
               location,
+              resolvedCloningInstructions,
               userRequest,
               flightBeanBag.getResourceDao(),
               flightBeanBag.getTpsApiDispatch()));

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
@@ -84,6 +84,7 @@ public class CloneControlledGcpBigQueryDatasetResourceFlight extends Flight {
               destinationWorkspaceId,
               sourceResource.getResourceType().getCloudPlatform(),
               destLocation,
+              resolvedCloningInstructions,
               userRequest,
               flightBeanBag.getResourceDao(),
               flightBeanBag.getTpsApiDispatch()));

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/flexibleresource/CloneControlledFlexibleResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/flexibleresource/CloneControlledFlexibleResourceFlight.java
@@ -104,6 +104,7 @@ public class CloneControlledFlexibleResourceFlight extends Flight {
               destinationWorkspaceId,
               sourceFlexResource.getResourceType().getCloudPlatform(),
               /*destinationLocation=*/ null,
+              resolvedCloningInstructions,
               userRequest,
               flightBeanBag.getResourceDao(),
               flightBeanBag.getTpsApiDispatch()));

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/clone/CloneReferencedResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/flight/clone/CloneReferencedResourceFlight.java
@@ -89,6 +89,7 @@ public class CloneReferencedResourceFlight extends Flight {
               destinationWorkspaceId,
               sourceResource.getResourceType().getCloudPlatform(),
               null, // referenced resources don't have a location.
+              cloningInstructions,
               userRequest,
               appContext.getResourceDao(),
               appContext.getTpsApiDispatch()));


### PR DESCRIPTION
References are just pointers, so they don't really have a location. The clone instruction can pass the location of the source through, but policy validation shouldn't note a region violation if we're cloning a reference.