### PR TITLE
Remove bad initialization script config in cluster creation

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -192,10 +192,6 @@ public class CreateDataprocClusterStep implements Step {
             new ClusterConfig()
                 .setConfigBucket(stagingBucketName)
                 .setTempBucket(tempBucketName)
-                .setInitializationActions(
-                    List.of(
-                        new NodeInitializationAction()
-                            .setExecutableFile(creationParameters.getInitializationScript())))
                 .setMasterConfig(
                     getInstanceGroupConfig(creationParameters.getManagerNodeConfig(), false))
                 .setWorkerConfig(


### PR DESCRIPTION
Made a last minute change in the dataproc cluster PR that causes cluster creation to fail. The presubmit checks did not catch it since they only run in nightlies. This change removes duplicate code that tries to set the user provided initialization script that is already being done safely below in L227.