### PR TITLE
[BENCH-826] Split Azure path formats from MockMvcUtils

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
-import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
@@ -51,7 +51,7 @@ public class ControlledAzureResourceApiControllerAzureVmTest extends BaseAzureUn
     mockMvc
         .perform(
             addAuth(
-                post(String.format(CREATE_AZURE_VM_PATH_FORMAT, workspaceId))
+                post(String.format(CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT, workspaceId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -97,7 +97,7 @@ public class ControlledAzureResourceApiControllerAzureVmTest extends BaseAzureUn
         .perform(
             addJsonContentType(
                 addAuth(
-                    post(String.format(CREATE_AZURE_VM_PATH_FORMAT, workspaceId))
+                    post(String.format(CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT, workspaceId))
                         .content(objectMapper.writeValueAsString(vmRequest)),
                     USER_REQUEST)))
         .andExpect(status().is(HttpStatus.SC_OK));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureVmTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_VM_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerBatchPoolTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerBatchPoolTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
-import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_BATCH_POOL_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -49,7 +49,7 @@ public class ControlledAzureResourceApiControllerBatchPoolTest extends BaseAzure
     mockMvc
         .perform(
             MockMvcUtils.addAuth(
-                post(String.format(CREATE_AZURE_BATCH_POOL_PATH_FORMAT, workspaceId))
+                post(String.format(CREATE_CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT, workspaceId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -95,7 +95,7 @@ public class ControlledAzureResourceApiControllerBatchPoolTest extends BaseAzure
     mockMvc
         .perform(
             MockMvcUtils.addAuth(
-                post(String.format(CREATE_AZURE_BATCH_POOL_PATH_FORMAT, workspaceId))
+                post(String.format(CREATE_CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT, workspaceId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -137,7 +137,7 @@ public class ControlledAzureResourceApiControllerBatchPoolTest extends BaseAzure
     mockMvc
         .perform(
             MockMvcUtils.addAuth(
-                post(String.format(CREATE_AZURE_BATCH_POOL_PATH_FORMAT, workspaceId))
+                post(String.format(CREATE_CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT, workspaceId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerBatchPoolTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerBatchPoolTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_BATCH_POOL_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_BATCH_POOL_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.app.controller;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_SAS_TOKEN_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_SAS_TOKEN_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.app.controller;
 
-import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_SAS_TOKEN_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,7 +56,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -69,7 +71,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -90,7 +94,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -103,7 +109,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8"),
@@ -133,7 +141,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -149,7 +159,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -171,7 +183,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -191,7 +205,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -207,7 +223,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
@@ -228,7 +246,9 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
         .perform(
             addAuth(
                 post(String.format(
-                        CREATE_AZURE_SAS_TOKEN_PATH_FORMAT, workspaceId, storageContainerId))
+                        CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT,
+                        workspaceId,
+                        storageContainerId))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockAwsApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockAwsApi.java
@@ -13,11 +13,10 @@ import org.springframework.stereotype.Component;
 public class MockAwsApi extends MockMvcUtils {
 
   // S3 folder
-
-  public static final String CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT =
+  public static final String CREATE_CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/aws/storageFolder";
-  public static final String CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT =
-      CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT + "/%s";
+  public static final String CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT =
+      CREATE_CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT + "/%s";
 
   public ApiCreatedControlledAwsS3StorageFolder createControlledAwsS3StorageFolder(
       AuthenticatedUserRequest userRequest,
@@ -34,7 +33,7 @@ public class MockAwsApi extends MockMvcUtils {
     String serializedResponse =
         getSerializedResponseForPost(
             userRequest,
-            CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT,
+            CREATE_CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT,
             workspaceId,
             objectMapper.writeValueAsString(requestBody));
     return objectMapper.readValue(serializedResponse, ApiCreatedControlledAwsS3StorageFolder.class);
@@ -44,14 +43,13 @@ public class MockAwsApi extends MockMvcUtils {
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
     String serializedResponse =
         getSerializedResponseForGet(
-            userRequest, CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT, workspaceId, resourceId);
+            userRequest, CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT, workspaceId, resourceId);
     return objectMapper.readValue(serializedResponse, ApiAwsS3StorageFolderResource.class);
   }
 
   // SageMaker Notebook
-
-  public static final String CREATE_CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT =
+  public static final String CREATE_CONTROLLED_AWS_NOTEBOOK_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/aws/notebook";
-  public static final String CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT =
-      CREATE_CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT + "/%s";
+  public static final String CONTROLLED_AWS_NOTEBOOK_PATH_FORMAT =
+      CREATE_CONTROLLED_AWS_NOTEBOOK_PATH_FORMAT + "/%s";
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockAwsApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockAwsApi.java
@@ -10,10 +10,14 @@ import java.util.UUID;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MvcAwsApi extends MockMvcUtils {
+public class MockAwsApi extends MockMvcUtils {
 
-  public static final String CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT =
+  // S3 folder
+
+  public static final String CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/aws/storageFolder";
+  public static final String CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT =
+      CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT + "/%s";
 
   public ApiCreatedControlledAwsS3StorageFolder createControlledAwsS3StorageFolder(
       AuthenticatedUserRequest userRequest,
@@ -30,7 +34,7 @@ public class MvcAwsApi extends MockMvcUtils {
     String serializedResponse =
         getSerializedResponseForPost(
             userRequest,
-            CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT,
+            CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT,
             workspaceId,
             objectMapper.writeValueAsString(requestBody));
     return objectMapper.readValue(serializedResponse, ApiCreatedControlledAwsS3StorageFolder.class);
@@ -40,10 +44,14 @@ public class MvcAwsApi extends MockMvcUtils {
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
     String serializedResponse =
         getSerializedResponseForGet(
-            userRequest,
-            CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT + "/%s",
-            workspaceId,
-            resourceId);
+            userRequest, CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT, workspaceId, resourceId);
     return objectMapper.readValue(serializedResponse, ApiAwsS3StorageFolderResource.class);
   }
+
+  // SageMaker Notebook
+
+  public static final String CREATE_CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/aws/notebook";
+  public static final String CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT =
+      CREATE_CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT + "/%s";
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockAwsApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockAwsApi.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class MockAwsApi {
 
   @Autowired private MockMvcUtils mockMvcUtils;
-  @Autowired protected ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
   // S3 folder
   public static final String CREATE_CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT =

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockAwsApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockAwsApi.java
@@ -6,11 +6,16 @@ import bio.terra.workspace.generated.model.ApiAwsS3StorageFolderResource;
 import bio.terra.workspace.generated.model.ApiCreateControlledAwsS3StorageFolderRequestBody;
 import bio.terra.workspace.generated.model.ApiCreatedControlledAwsS3StorageFolder;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MockAwsApi extends MockMvcUtils {
+public class MockAwsApi {
+
+  @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired protected ObjectMapper objectMapper;
 
   // S3 folder
   public static final String CREATE_CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT =
@@ -31,7 +36,7 @@ public class MockAwsApi extends MockMvcUtils {
             .awsS3StorageFolder(creationParameters);
 
     String serializedResponse =
-        getSerializedResponseForPost(
+        mockMvcUtils.getSerializedResponseForPost(
             userRequest,
             CREATE_CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT,
             workspaceId,
@@ -42,7 +47,7 @@ public class MockAwsApi extends MockMvcUtils {
   public ApiAwsS3StorageFolderResource getControlledAwsS3StorageFolder(
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
     String serializedResponse =
-        getSerializedResponseForGet(
+        mockMvcUtils.getSerializedResponseForGet(
             userRequest, CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT, workspaceId, resourceId);
     return objectMapper.readValue(serializedResponse, ApiAwsS3StorageFolderResource.class);
   }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockAzureApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockAzureApi.java
@@ -4,24 +4,31 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MockAzureApi extends MockMvcUtils {
-  public static final String CREATE_AZURE_DISK_PATH_FORMAT =
+  // Disks
+  public static final String CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/disks";
-  public static final String CREATE_AZURE_VM_PATH_FORMAT =
+  public static final String CONTROLLED_AZURE_DISK_PATH_FORMAT =
+      CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT + "/%s";
+
+  // VM
+  public static final String CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/vm";
-  public static final String CREATE_AZURE_SAS_TOKEN_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/getSasToken";
-  public static final String CREATE_AZURE_BATCH_POOL_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/batchpool";
-  public static final String CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT =
+  public static final String CONTROLLED_AZURE_VM_PATH_FORMAT =
+      CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT + "/%s";
+
+  // Storage Container
+  public static final String CREATE_CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer";
-  public static final String AZURE_BATCH_POOL_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/batchpool/%s";
-  public static final String AZURE_DISK_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/disks/%s";
-  public static final String AZURE_STORAGE_CONTAINER_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s";
-  public static final String AZURE_VM_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/vm/%s";
-  public static final String CLONE_AZURE_STORAGE_CONTAINER_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/clone";
+  public static final String CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT =
+      CREATE_CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT + "/%s";
+  public static final String CLONE_CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT =
+      CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT + "/clone";
+  public static final String CONTROLLED_AZURE_STORAGE_CONTAINER_SAS_TOKEN_PATH_FORMAT =
+      CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT + "/getSasToken";
+
+  // Batch Pool
+  public static final String CREATE_CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/batchpool";
+  public static final String CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT =
+      CREATE_CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT + "/%s";
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockAzureApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockAzureApi.java
@@ -3,7 +3,8 @@ package bio.terra.workspace.common.utils;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MockAzureApi extends MockMvcUtils {
+public class MockAzureApi {
+
   // Disks
   public static final String CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/disks";

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockAzureApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockAzureApi.java
@@ -1,0 +1,27 @@
+package bio.terra.workspace.common.utils;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MockAzureApi extends MockMvcUtils {
+  public static final String CREATE_AZURE_DISK_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/disks";
+  public static final String CREATE_AZURE_VM_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/vm";
+  public static final String CREATE_AZURE_SAS_TOKEN_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/getSasToken";
+  public static final String CREATE_AZURE_BATCH_POOL_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/batchpool";
+  public static final String CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer";
+  public static final String AZURE_BATCH_POOL_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/batchpool/%s";
+  public static final String AZURE_DISK_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/disks/%s";
+  public static final String AZURE_STORAGE_CONTAINER_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s";
+  public static final String AZURE_VM_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/vm/%s";
+  public static final String CLONE_AZURE_STORAGE_CONTAINER_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/clone";
+}

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -241,26 +241,6 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/cloudcontexts/GCP";
   public static final String GET_CLOUD_CONTEXT_PATH_FORMAT =
       "/api/workspaces/v1/%s/cloudcontexts/result/%s";
-  public static final String CREATE_AZURE_DISK_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/disks";
-  public static final String CREATE_AZURE_VM_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/vm";
-  public static final String CREATE_AZURE_SAS_TOKEN_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/getSasToken";
-  public static final String CREATE_AZURE_BATCH_POOL_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/batchpool";
-  public static final String CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer";
-  public static final String AZURE_BATCH_POOL_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/batchpool/%s";
-  public static final String AZURE_DISK_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/disks/%s";
-  public static final String AZURE_STORAGE_CONTAINER_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s";
-  public static final String AZURE_VM_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/vm/%s";
-  public static final String CLONE_AZURE_STORAGE_CONTAINER_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/azure/storageContainer/%s/clone";
   public static final String CREATE_AWS_STORAGE_FOLDERS_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/aws/storageFolder";
   public static final String AWS_STORAGE_FOLDERS_PATH_FORMAT =

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -356,11 +356,11 @@ public class MockMvcUtils {
 
   // Do not Autowire UserAccessUtils. UserAccessUtils are for connected tests and not unit tests
   // (since unit tests don't use real SAM). Instead, each method must take in userRequest.
-  @Autowired protected MockMvc mockMvc;
-  @Autowired protected ObjectMapper objectMapper;
-  @Autowired protected JobService jobService;
-  @Autowired protected NamedParameterJdbcTemplate jdbcTemplate;
-  @Autowired protected SamService samService;
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private JobService jobService;
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+  @Autowired private SamService samService;
 
   public static MockHttpServletRequestBuilder addAuth(
       MockHttpServletRequestBuilder request, AuthenticatedUserRequest userRequest) {

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -241,14 +241,6 @@ public class MockMvcUtils {
       "/api/workspaces/v1/%s/cloudcontexts/GCP";
   public static final String GET_CLOUD_CONTEXT_PATH_FORMAT =
       "/api/workspaces/v1/%s/cloudcontexts/result/%s";
-  public static final String CREATE_AWS_STORAGE_FOLDERS_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/aws/storageFolder";
-  public static final String AWS_STORAGE_FOLDERS_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/aws/storageFolder/%s";
-  public static final String CREATE_AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/aws/notebook";
-  public static final String AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT =
-      "/api/workspaces/v1/%s/resources/controlled/aws/notebook/%s";
   public static final String GET_REFERENCED_GCP_GCS_BUCKET_FORMAT =
       "/api/workspaces/v1/%s/resources/referenced/gcp/buckets/%s";
   public static final String CLONE_CONTROLLED_GCP_GCS_BUCKET_FORMAT =

--- a/service/src/test/java/bio/terra/workspace/common/utils/WorkspaceUnitTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/WorkspaceUnitTestUtils.java
@@ -47,6 +47,13 @@ public class WorkspaceUnitTestUtils {
         .error(null);
   }
 
+  public static void deleteCloudContextInDatabase(
+      WorkspaceDao workspaceDao, UUID workspaceUuid, CloudPlatform cloudPlatform) {
+    String flightId = UUID.randomUUID().toString();
+    workspaceDao.deleteCloudContextStart(workspaceUuid, cloudPlatform, flightId);
+    workspaceDao.deleteCloudContextSuccess(workspaceUuid, cloudPlatform, flightId);
+  }
+
   // GCP cloud context
 
   public static final String GCP_PROJECT_ID = "my-project-id";
@@ -82,13 +89,6 @@ public class WorkspaceUnitTestUtils {
         flightId);
   }
 
-  public static void deleteGcpCloudContextInDatabase(
-      WorkspaceDao workspaceDao, UUID workspaceUuid) {
-    String flightId = UUID.randomUUID().toString();
-    workspaceDao.deleteCloudContextStart(workspaceUuid, CloudPlatform.GCP, flightId);
-    workspaceDao.deleteCloudContextSuccess(workspaceUuid, CloudPlatform.GCP, flightId);
-  }
-
   // Azure cloud context
 
   public static void createAzureCloudContextInDatabase(
@@ -119,11 +119,11 @@ public class WorkspaceUnitTestUtils {
         CloudPlatform.AWS,
         new AwsCloudContext(
                 new AwsCloudContextFields(
-                    "majorversion",
-                    "fake-org-id",
-                    "fake-account-id",
-                    "fake-env-alias",
-                    "fake-env-alias"),
+                    AwsTestUtils.MAJOR_VERSION,
+                    AwsTestUtils.ORGANIZATION_ID,
+                    AwsTestUtils.ACCOUNT_ID,
+                    AwsTestUtils.TENANT_ALIAS,
+                    AwsTestUtils.ENVIRONMENT_ALIAS),
                 new CloudContextCommonFields(
                     billingProfileId, WsmResourceState.CREATING, flightId, null))
             .serialize(),

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -69,7 +69,8 @@ public class ResourceDaoTest extends BaseUnitTest {
 
   @AfterAll
   public void cleanUp() {
-    WorkspaceUnitTestUtils.deleteGcpCloudContextInDatabase(workspaceDao, workspaceUuid);
+    WorkspaceUnitTestUtils.deleteCloudContextInDatabase(
+        workspaceDao, workspaceUuid, CloudPlatform.GCP);
     WorkspaceFixtures.deleteWorkspaceFromDb(workspaceUuid, workspaceDao);
   }
 
@@ -266,7 +267,8 @@ public class ResourceDaoTest extends BaseUnitTest {
     List<ControlledResource> listAfterDeletion =
         resourceDao.listControlledResources(workspaceUuid, CloudPlatform.GCP);
     assertTrue(listAfterDeletion.isEmpty());
-    WorkspaceUnitTestUtils.deleteGcpCloudContextInDatabase(workspaceDao, workspaceUuid);
+    WorkspaceUnitTestUtils.deleteCloudContextInDatabase(
+        workspaceDao, workspaceUuid, CloudPlatform.GCP);
   }
 
   private void assertPartialEqualList(

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -316,7 +316,8 @@ class WorkspaceDaoTest extends BaseUnitTest {
       // Run the normal case
       WorkspaceUnitTestUtils.createGcpCloudContextInDatabase(
           workspaceDao, workspaceUuid, PROJECT_ID);
-      WorkspaceUnitTestUtils.deleteGcpCloudContextInDatabase(workspaceDao, workspaceUuid);
+      WorkspaceUnitTestUtils.deleteCloudContextInDatabase(
+          workspaceDao, workspaceUuid, CloudPlatform.GCP);
 
       // Mismatched flight id
       String flightId = UUID.randomUUID().toString();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
-import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_DISK_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GET_CLOUD_CONTEXT_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
@@ -96,7 +96,7 @@ public class AzureDisabledTest extends BaseConnectedTest {
         .perform(
             addJsonContentType(
                 addAuth(
-                    post(String.format(CREATE_AZURE_DISK_PATH_FORMAT, workspaceUuid))
+                    post(String.format(CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT, workspaceUuid))
                         .content(objectMapper.writeValueAsString(diskRequest)),
                     userRequest)))
         .andExpect(status().is(HttpStatus.SC_NOT_IMPLEMENTED));
@@ -110,7 +110,7 @@ public class AzureDisabledTest extends BaseConnectedTest {
         .perform(
             addJsonContentType(
                 addAuth(
-                    post(String.format(CREATE_AZURE_VM_PATH_FORMAT, workspaceUuid))
+                    post(String.format(CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT, workspaceUuid))
                         .content(objectMapper.writeValueAsString(vmRequest)),
                     userRequest)))
         .andExpect(status().is(HttpStatus.SC_NOT_IMPLEMENTED));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_DISK_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_DISK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_VM_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.GET_CLOUD_CONTEXT_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AwsResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AwsResourceStateFailureTest.java
@@ -1,9 +1,9 @@
 package bio.terra.workspace.service.resource.statetests;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.AWS_STORAGE_FOLDERS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AWS_STORAGE_FOLDERS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAwsApi.CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAwsApi.CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAwsApi.CREATE_CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAwsApi.CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -82,7 +82,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(storageRequest),
-        CREATE_AWS_STORAGE_FOLDERS_PATH_FORMAT.formatted(workspaceUuid),
+        CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT.formatted(workspaceUuid),
         HttpStatus.SC_CONFLICT);
 
     // AWS-notebook
@@ -97,7 +97,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(vmRequest),
-        CREATE_AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT.formatted(workspaceUuid),
+        CREATE_CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT.formatted(workspaceUuid),
         HttpStatus.SC_CONFLICT);
   }
 
@@ -132,7 +132,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         storageResource.getResourceId(),
-        AWS_STORAGE_FOLDERS_PATH_FORMAT,
+        CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT,
         objectMapper.writeValueAsString(storageDeleteBody));
 
     // AWS-Notebook
@@ -142,7 +142,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         notebookResource.getResourceId(),
-        AWS_SAGEMAKER_NOTEBOOKS_PATH_FORMAT,
+        CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT,
         objectMapper.writeValueAsString(notebookDeleteBody));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AwsResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AwsResourceStateFailureTest.java
@@ -1,9 +1,9 @@
 package bio.terra.workspace.service.resource.statetests;
 
-import static bio.terra.workspace.common.utils.MockAwsApi.CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAwsApi.CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAwsApi.CREATE_CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAwsApi.CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAwsApi.CONTROLLED_AWS_NOTEBOOK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAwsApi.CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAwsApi.CREATE_CONTROLLED_AWS_NOTEBOOK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAwsApi.CREATE_CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -82,7 +82,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(storageRequest),
-        CREATE_CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT.formatted(workspaceUuid),
+        CREATE_CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT.formatted(workspaceUuid),
         HttpStatus.SC_CONFLICT);
 
     // AWS-notebook
@@ -97,7 +97,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(vmRequest),
-        CREATE_CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT.formatted(workspaceUuid),
+        CREATE_CONTROLLED_AWS_NOTEBOOK_PATH_FORMAT.formatted(workspaceUuid),
         HttpStatus.SC_CONFLICT);
   }
 
@@ -132,7 +132,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         storageResource.getResourceId(),
-        CONTROLLED_AWS_STORAGE_FOLDER_V1_PATH_FORMAT,
+        CONTROLLED_AWS_STORAGE_FOLDER_PATH_FORMAT,
         objectMapper.writeValueAsString(storageDeleteBody));
 
     // AWS-Notebook
@@ -142,7 +142,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         notebookResource.getResourceId(),
-        CONTROLLED_AWS_NOTEBOOK_V1_PATH_FORMAT,
+        CONTROLLED_AWS_NOTEBOOK_PATH_FORMAT,
         objectMapper.writeValueAsString(notebookDeleteBody));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AzureResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AzureResourceStateFailureTest.java
@@ -1,14 +1,14 @@
 package bio.terra.workspace.service.resource.statetests;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.AZURE_BATCH_POOL_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.AZURE_DISK_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.AZURE_STORAGE_CONTAINER_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.AZURE_VM_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CLONE_AZURE_STORAGE_CONTAINER_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_BATCH_POOL_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_DISK_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.AZURE_BATCH_POOL_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.AZURE_DISK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.AZURE_STORAGE_CONTAINER_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CLONE_AZURE_STORAGE_CONTAINER_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_BATCH_POOL_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_DISK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_VM_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AzureResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AzureResourceStateFailureTest.java
@@ -1,14 +1,14 @@
 package bio.terra.workspace.service.resource.statetests;
 
-import static bio.terra.workspace.common.utils.MockAzureApi.AZURE_BATCH_POOL_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAzureApi.AZURE_DISK_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAzureApi.AZURE_STORAGE_CONTAINER_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAzureApi.AZURE_VM_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAzureApi.CLONE_AZURE_STORAGE_CONTAINER_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_BATCH_POOL_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_DISK_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CLONE_CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CONTROLLED_AZURE_DISK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CONTROLLED_AZURE_VM_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockAzureApi.CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -111,7 +111,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(batchRequest),
-        CREATE_AZURE_BATCH_POOL_PATH_FORMAT.formatted(workspaceUuid),
+        CREATE_CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT.formatted(workspaceUuid),
         HttpStatus.SC_CONFLICT);
 
     // AZURE-Controlled Disk
@@ -122,7 +122,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(diskRequest),
-        CREATE_AZURE_DISK_PATH_FORMAT.formatted(workspaceUuid),
+        CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT.formatted(workspaceUuid),
         HttpStatus.SC_CONFLICT);
 
     // AZURE-Storage Container
@@ -134,7 +134,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(storageRequest),
-        CREATE_AZURE_STORAGE_CONTAINERS_PATH_FORMAT.formatted(workspaceUuid),
+        CREATE_CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT.formatted(workspaceUuid),
         HttpStatus.SC_CONFLICT);
 
     // AZURE-VM
@@ -146,7 +146,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(vmRequest),
-        CREATE_AZURE_VM_PATH_FORMAT.formatted(workspaceUuid),
+        CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT.formatted(workspaceUuid),
         HttpStatus.SC_CONFLICT);
   }
 
@@ -189,7 +189,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
 
     // AZURE-Controlled Batch
     stateTestUtils.deleteResourceExpectConflict(
-        workspaceUuid, batchResource.getResourceId(), AZURE_BATCH_POOL_PATH_FORMAT);
+        workspaceUuid, batchResource.getResourceId(), CONTROLLED_AZURE_BATCH_POOL_PATH_FORMAT);
 
     // AZURE-Controlled Disk
     var diskDeleteBody =
@@ -198,7 +198,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         diskResource.getResourceId(),
-        AZURE_DISK_PATH_FORMAT,
+        CONTROLLED_AZURE_DISK_PATH_FORMAT,
         objectMapper.writeValueAsString(diskDeleteBody));
 
     // AZURE-Storage Container
@@ -208,7 +208,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         storageResource.getResourceId(),
-        AZURE_STORAGE_CONTAINER_PATH_FORMAT,
+        CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT,
         objectMapper.writeValueAsString(storageDeleteBody));
 
     // AZURE-VM
@@ -218,7 +218,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         vmResource.getResourceId(),
-        AZURE_VM_PATH_FORMAT,
+        CONTROLLED_AZURE_VM_PATH_FORMAT,
         objectMapper.writeValueAsString(vmDeleteBody));
   }
 
@@ -257,7 +257,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         storageResource.getResourceId(),
-        CLONE_AZURE_STORAGE_CONTAINER_PATH_FORMAT,
+        CLONE_CONTROLLED_AZURE_STORAGE_CONTAINER_PATH_FORMAT,
         objectMapper.writeValueAsString(storageCloneBody));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2ConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2ConnectedTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.workspace.common.BaseAwsConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures;
 import bio.terra.workspace.common.utils.AwsTestUtils;
-import bio.terra.workspace.common.utils.MvcAwsApi;
+import bio.terra.workspace.common.utils.MockAwsApi;
 import bio.terra.workspace.common.utils.MvcWorkspaceApi;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAwsS3StorageFolderCreationParameters;
@@ -31,7 +31,7 @@ import software.amazon.awssdk.regions.Region;
 public class AwsWorkspaceV2ConnectedTest extends BaseAwsConnectedTest {
   @Autowired private ControlledResourceService controlledResourceService;
   @Autowired MvcWorkspaceApi mvcWorkspaceApi;
-  @Autowired MvcAwsApi mvcAwsApi;
+  @Autowired MockAwsApi mockAwsApi;
   @Autowired UserAccessUtils userAccessUtils;
 
   @Test
@@ -62,14 +62,14 @@ public class AwsWorkspaceV2ConnectedTest extends BaseAwsConnectedTest {
         ControlledAwsResourceFixtures.makeAwsS3StorageFolderCreationParameters(
             ControlledAwsResourceFixtures.uniqueStorageName());
     UUID resourceUuid =
-        mvcAwsApi
+        mockAwsApi
             .createControlledAwsS3StorageFolder(userRequest, workspaceUuid, creationParameters)
             .getAwsS3StorageFolder()
             .getMetadata()
             .getResourceId();
 
     ApiAwsS3StorageFolderResource fetchedResource =
-        mvcAwsApi.getControlledAwsS3StorageFolder(userRequest, workspaceUuid, resourceUuid);
+        mockAwsApi.getControlledAwsS3StorageFolder(userRequest, workspaceUuid, resourceUuid);
     String expectedBucketName =
         awsConnectedTestUtils
             .getEnvironment()


### PR DESCRIPTION
- Part 1 of: Split MockMvcUtils to platform based components -> MockAzureApi (new) with Azure path formats
- Rename Path formats in MockAzureApi to keep them consistent.
- Renamed MvcAwsApi to MockAwsApi
- Add cloudPlatform param to deleteGcpCloudContextInDatabase (renamed to deleteCloudContextInDatabase)


Part 2 will contain GCP changes (MockGcpApi) in next PR