### PR TITLE
[BENCH-826] Split GCP path formats / functions from MockMvcUtils (pr 1)

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAccessScope;
@@ -44,6 +45,7 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends BaseConnectedTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired JobService jobService;
 
@@ -84,7 +86,7 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
                 .value("asia-east1")));
 
     ApiGcpAiNotebookInstanceResource notebook =
-        mockMvcUtils
+        mockGcpApi
             .createAiNotebookInstance(userAccessUtils.defaultUserAuthRequest(), workspaceId, null)
             .getAiNotebookInstance();
 
@@ -98,7 +100,7 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
         userAccessUtils.getDefaultUserEmail());
 
     notebook =
-        mockMvcUtils
+        mockGcpApi
             .createAiNotebookInstance(
                 userAccessUtils.defaultUserAuthRequest(), workspaceId, "europe-west1-b")
             .getAiNotebookInstance();
@@ -120,13 +122,14 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
   @Test
   public void createAiNotebookInstance_duplicateInstanceId() throws Exception {
     var duplicateName = "not-unique-name";
-    mockMvcUtils
-        .createAiNotebookInstanceAndWait(
-            userAccessUtils.defaultUserAuthRequest(), workspaceId, duplicateName, null)
-        .getAiNotebookInstance();
+    ApiGcpAiNotebookInstanceResource unused =
+        mockGcpApi
+            .createAiNotebookInstanceAndWait(
+                userAccessUtils.defaultUserAuthRequest(), workspaceId, duplicateName, null)
+            .getAiNotebookInstance();
 
     ApiErrorReport errorReport =
-        mockMvcUtils
+        mockGcpApi
             .createAiNotebookInstanceAndExpect(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -47,6 +48,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
     extends BaseConnectedTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired JobService jobService;
 
@@ -121,7 +123,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
                 .value("asia-east1")));
 
     ApiGcpDataprocClusterResource cluster =
-        mockMvcUtils
+        mockGcpApi
             .createDataprocCluster(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspaceId,
@@ -146,18 +148,19 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
   @Test
   public void createDataprocCluster_duplicateInstanceId() throws Exception {
     var duplicateName = "not-unique-name";
-    mockMvcUtils
-        .createDataprocClusterAndWait(
-            userAccessUtils.defaultUserAuthRequest(),
-            workspaceId,
-            "asia-east1",
-            stagingBucketUuid,
-            tempBucketUuid,
-            duplicateName)
-        .getDataprocCluster();
+    ApiGcpDataprocClusterResource unused =
+        mockGcpApi
+            .createDataprocClusterAndWait(
+                userAccessUtils.defaultUserAuthRequest(),
+                workspaceId,
+                "asia-east1",
+                stagingBucketUuid,
+                tempBucketUuid,
+                duplicateName)
+            .getDataprocCluster();
 
     ApiErrorReport errorReport =
-        mockMvcUtils
+        mockGcpApi
             .createDataprocClusterAndExpect(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAccessScope;
@@ -44,6 +45,7 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends BaseConnectedTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired JobService jobService;
 
@@ -84,7 +86,7 @@ public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends 
                 .value("asia-east1")));
 
     ApiGcpGceInstanceResource instance =
-        mockMvcUtils
+        mockGcpApi
             .createGceInstance(userAccessUtils.defaultUserAuthRequest(), workspaceId, null)
             .getGceInstance();
 
@@ -98,7 +100,7 @@ public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends 
         userAccessUtils.getDefaultUserEmail());
 
     instance =
-        mockMvcUtils
+        mockGcpApi
             .createGceInstance(
                 userAccessUtils.defaultUserAuthRequest(), workspaceId, "europe-west1-b")
             .getGceInstance();
@@ -120,13 +122,14 @@ public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends 
   @Test
   public void createGceInstance_duplicateInstanceId() throws Exception {
     var duplicateName = "not-unique-name";
-    mockMvcUtils
-        .createGceInstanceAndWait(
-            userAccessUtils.defaultUserAuthRequest(), workspaceId, duplicateName, null)
-        .getGceInstance();
+    ApiGcpGceInstanceResource unused =
+        mockGcpApi
+            .createGceInstanceAndWait(
+                userAccessUtils.defaultUserAuthRequest(), workspaceId, duplicateName, null)
+            .getGceInstance();
 
     ApiErrorReport errorReport =
-        mockMvcUtils
+        mockGcpApi
             .createGceInstanceAndExpect(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -6,9 +6,9 @@ import static bio.terra.workspace.common.GcsBucketUtils.addFileToBucket;
 import static bio.terra.workspace.common.GcsBucketUtils.buildSignedUrlListObject;
 import static bio.terra.workspace.common.GcsBucketUtils.waitForProjectAccess;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.LOAD_SIGNED_URL_LIST_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.LOAD_SIGNED_URL_LIST_RESULT_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.LOAD_SIGNED_URL_LIST_ALPHA_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.LOAD_SIGNED_URL_LIST_RESULT_ALPHA_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiGcsBucketEquals;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertControlledResourceMetadata;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
@@ -401,7 +401,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
 
     mockMvcUtils.updateResource(
         ApiGcpGcsBucketResource.class,
-        CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT,
+        CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT,
         workspaceId,
         sourceBucket.getMetadata().getResourceId(),
         objectMapper.writeValueAsString(
@@ -923,7 +923,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
     mockMvcUtils.postExpect(
         userRequest,
         objectMapper.writeValueAsString(requestBody),
-        String.format(LOAD_SIGNED_URL_LIST_PATH_FORMAT, workspaceId, bucketId),
+        String.format(LOAD_SIGNED_URL_LIST_ALPHA_PATH_FORMAT, workspaceId, bucketId),
         httpStatus);
   }
 
@@ -934,7 +934,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
     var serializedResponse =
         mockMvcUtils.getSerializedResponseForPost(
             userRequest,
-            String.format(LOAD_SIGNED_URL_LIST_PATH_FORMAT, workspaceId, bucketId),
+            String.format(LOAD_SIGNED_URL_LIST_ALPHA_PATH_FORMAT, workspaceId, bucketId),
             objectMapper.writeValueAsString(requestBody));
     var result = objectMapper.readValue(serializedResponse, ApiLoadUrlListResult.class);
     String jobId = result.getJobReport().getId();
@@ -954,7 +954,8 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
     String serializedResponse =
         mockMvcUtils.getSerializedResponseForGetJobResult(
             userRequest,
-            String.format(LOAD_SIGNED_URL_LIST_RESULT_PATH_FORMAT, workspaceId, resourceId, jobId));
+            String.format(
+                LOAD_SIGNED_URL_LIST_RESULT_ALPHA_PATH_FORMAT, workspaceId, resourceId, jobId));
     return objectMapper.readValue(serializedResponse, ApiLoadUrlListResult.class);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
@@ -1,9 +1,9 @@
 package bio.terra.workspace.app.controller;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_AI_NOTEBOOK_NAME_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_BQ_DATASET_NAME_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.GENERATE_GCP_GCS_BUCKET_NAME_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.GENERATE_NAME_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.GENERATE_NAME_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.GENERATE_NAME_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.service.workspace.model.WorkspaceConstants.ResourceProperties.FOLDER_ID_KEY;
@@ -83,7 +83,8 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
         mockMvc
             .perform(
                 addAuth(
-                    post(String.format(GENERATE_GCP_GCS_BUCKET_NAME_PATH_FORMAT, workspaceId))
+                    post(String.format(
+                            GENERATE_NAME_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT, workspaceId))
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
@@ -113,7 +114,8 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
         mockMvc
             .perform(
                 addAuth(
-                    post(String.format(GENERATE_GCP_BQ_DATASET_NAME_PATH_FORMAT, workspaceId))
+                    post(String.format(
+                            GENERATE_NAME_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT, workspaceId))
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
@@ -141,7 +143,8 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
         mockMvc
             .perform(
                 addAuth(
-                    post(String.format(GENERATE_GCP_AI_NOTEBOOK_NAME_PATH_FORMAT, workspaceId))
+                    post(String.format(
+                            GENERATE_NAME_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT, workspaceId))
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")
@@ -173,7 +176,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(datasetCreationRequest),
-        String.format(CONTROLLED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT, workspaceId),
+        String.format(CREATE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT, workspaceId),
         HttpStatus.SC_BAD_REQUEST);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_BUCKET_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiGcsBucketEquals;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -206,7 +206,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         objectMapper.writeValueAsString(
             new ApiUpdateBigQueryDatasetReferenceRequestBody().name(newName)),
         String.format(
-            REFERENCED_GCP_GCS_BUCKET_V1_PATH_FORMAT,
+            REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT,
             workspaceId,
             sourceResource.getMetadata().getResourceId()),
         HttpStatus.SC_CONFLICT);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_OBJECT_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -184,7 +184,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         objectMapper.writeValueAsString(
             new ApiUpdateBigQueryDatasetReferenceRequestBody().name(newName)),
         String.format(
-            REFERENCED_GCP_GCS_OBJECT_V1_PATH_FORMAT,
+            REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT,
             workspaceId,
             sourceResource.getMetadata().getResourceId()),
         HttpStatus.SC_CONFLICT);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.service.iam.model.SamConstants;
@@ -26,6 +27,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
 
   @BeforeEach
@@ -55,7 +57,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedDataRepoSnapshot_copyDefinition_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
     mockMvcUtils.cloneReferencedDataRepoSnapshot(
         USER_REQUEST,
         workspaceId,
@@ -69,7 +70,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedDataRepoSnapshot_copyResource_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
     mockMvcUtils.cloneReferencedDataRepoSnapshot(
         USER_REQUEST,
         workspaceId,
@@ -83,8 +83,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedBqDataset_copyDefinition_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
-    mockMvcUtils.cloneReferencedBqDataset(
+    mockGcpApi.cloneReferencedBqDatasetAndExpect(
         USER_REQUEST,
         workspaceId,
         /*sourceResourceId=*/ UUID.randomUUID(),
@@ -97,8 +96,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedBqDataset_copyResource_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
-    mockMvcUtils.cloneReferencedBqDataset(
+    mockGcpApi.cloneReferencedBqDatasetAndExpect(
         USER_REQUEST,
         workspaceId,
         /*sourceResourceId=*/ UUID.randomUUID(),
@@ -111,8 +109,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedBqTable_copyDefinition_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
-    mockMvcUtils.cloneReferencedBqTable(
+    mockGcpApi.cloneReferencedBqDataTableAndExpect(
         USER_REQUEST,
         workspaceId,
         /*sourceResourceId=*/ UUID.randomUUID(),
@@ -125,8 +122,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedBqTable_copyResource_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
-    mockMvcUtils.cloneReferencedBqTable(
+    mockGcpApi.cloneReferencedBqDataTableAndExpect(
         USER_REQUEST,
         workspaceId,
         /*sourceResourceId=*/ UUID.randomUUID(),
@@ -139,7 +135,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGcsBucket_copyDefinition_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
     mockMvcUtils.cloneReferencedGcsBucket(
         USER_REQUEST,
         workspaceId,
@@ -153,7 +148,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGcsBucket_copyResource_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
     mockMvcUtils.cloneReferencedGcsBucket(
         USER_REQUEST,
         workspaceId,
@@ -167,7 +161,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGcsObject_copyDefinition_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
     mockMvcUtils.cloneReferencedGcsObject(
         USER_REQUEST,
         workspaceId,
@@ -181,7 +174,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGcsObject_copyResource_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
     mockMvcUtils.cloneReferencedGcsObject(
         USER_REQUEST,
         workspaceId,
@@ -195,7 +187,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGitRepo_copyDefinition_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
     mockMvcUtils.cloneReferencedGitRepo(
         USER_REQUEST,
         workspaceId,
@@ -209,7 +200,6 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGitRepo_copyResource_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
     mockMvcUtils.cloneReferencedGitRepo(
         USER_REQUEST,
         workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
@@ -3,8 +3,8 @@ package bio.terra.workspace.app.controller;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.fixtures.PolicyFixtures.IOWA_REGION;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_NAME;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CLONE_WORKSPACE_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -373,7 +373,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
     String serializedResponse =
         mockMvcUtils.getSerializedResponseForPost(
             userAccessUtils.defaultUserAuthRequest(),
-            REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT,
+            CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT,
             sourceWorkspaceId,
             objectMapper.writeValueAsString(request));
     sourceResource = objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.workspace.common.BaseConnectedTest;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
@@ -46,8 +47,9 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;
-  @Autowired ObjectMapper objectMapper;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
+  @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired WorkspaceConnectedTestUtils connectedTestUtils;
 
@@ -72,7 +74,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
     public void updateResourceProperties_newPropertiesAdded() throws Exception {
       // Create resource with properties foo -> bar.
       ApiCreatedControlledGcpBigQueryDataset resource =
-          mockMvcUtils.createControlledBqDataset(
+          mockGcpApi.createControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId);
       UUID resourceId = resource.getResourceId();
       var folderIdKey = "terra_workspace_folder_id";
@@ -91,7 +93,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
       // Get the updated resource and assert that the new properties are added.
       ApiGcpBigQueryDatasetResource updatedResource =
-          mockMvcUtils.getControlledBqDataset(
+          mockGcpApi.getControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId, resourceId);
       assertEquals(
           expectedProperties,
@@ -107,7 +109,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
       // Get the updated resource and assert terra_workspace_folder_id has new UUID.
       ApiGcpBigQueryDatasetResource updatedResource2 =
-          mockMvcUtils.getControlledBqDataset(
+          mockGcpApi.getControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId, resourceId);
       assertEquals(
           newFolderId.toString(),
@@ -126,7 +128,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
     @Test
     public void updateResourceProperties_propertiesIsEmpty_throws400() throws Exception {
       ApiCreatedControlledGcpBigQueryDataset resource =
-          mockMvcUtils.createControlledBqDataset(
+          mockGcpApi.createControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId);
       UUID resourceId = resource.getResourceId();
 
@@ -137,7 +139,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
     @Test
     public void updateResourceProperties_folderIdNotUuid_throws400() throws Exception {
       ApiCreatedControlledGcpBigQueryDataset resource =
-          mockMvcUtils.createControlledBqDataset(
+          mockGcpApi.createControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId);
       UUID resourceId = resource.getResourceId();
 
@@ -148,7 +150,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
     @Test
     public void updateResourceProperties_readOnlyPermission_throws403() throws Exception {
       ApiCreatedControlledGcpBigQueryDataset resource =
-          mockMvcUtils.createControlledBqDataset(
+          mockGcpApi.createControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId);
       UUID resourceId = resource.getResourceId();
       mockMvcUtils.grantRole(
@@ -172,7 +174,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
     @Test
     public void deleteResourceProperties_propertiesDeleted() throws Exception {
       ApiCreatedControlledGcpBigQueryDataset resource =
-          mockMvcUtils.createControlledBqDataset(
+          mockGcpApi.createControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId);
       UUID resourceId = resource.getResourceId();
       updateResourcePropertiesExpectCode(
@@ -185,7 +187,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
           workspaceId, resourceId, List.of("foo", "sweet", "cute"), HttpStatus.SC_NO_CONTENT);
 
       ApiGcpBigQueryDatasetResource updatedResource =
-          mockMvcUtils.getControlledBqDataset(
+          mockGcpApi.getControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId, resourceId);
       assertTrue(convertApiPropertyToMap(updatedResource.getMetadata().getProperties()).isEmpty());
     }
@@ -199,7 +201,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
     @Test
     public void deleteResourceProperties_propertiesIsEmpty_throws400() throws Exception {
       ApiCreatedControlledGcpBigQueryDataset resource =
-          mockMvcUtils.createControlledBqDataset(
+          mockGcpApi.createControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId);
       UUID resourceId = resource.getResourceId();
 
@@ -210,7 +212,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
     @Test
     public void deleteResourceProperties_readOnlyPermission_throws403() throws Exception {
       ApiCreatedControlledGcpBigQueryDataset resource =
-          mockMvcUtils.createControlledBqDataset(
+          mockGcpApi.createControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId);
       UUID resourceId = resource.getResourceId();
       updateResourcePropertiesExpectCode(

--- a/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
@@ -5,10 +5,13 @@ import static bio.terra.workspace.common.GcsBucketUtils.addFileToBucket;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.GcpCloudUtils;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
+import bio.terra.workspace.generated.model.ApiGcpAiNotebookInstanceResource;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.SamService;
@@ -34,6 +37,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired JobService jobService;
@@ -72,16 +76,17 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
 
     String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
     String sourceBucketName = TestUtils.appendRandomNumber("source-bucket-name");
-    mockMvcUtils
-        .createControlledGcsBucket(
-            userAccessUtils.defaultUserAuthRequest(),
-            workspaceId,
-            sourceResourceName,
-            sourceBucketName,
-            null,
-            null,
-            null)
-        .getGcpBucket();
+    ApiGcpGcsBucketResource unused =
+        mockMvcUtils
+            .createControlledGcsBucket(
+                userAccessUtils.defaultUserAuthRequest(),
+                workspaceId,
+                sourceResourceName,
+                sourceBucketName,
+                null,
+                null,
+                null)
+            .getGcpBucket();
     addFileToBucket(
         userAccessUtils.defaultUser().getGoogleCredentials(), projectId, sourceBucketName);
 
@@ -104,9 +109,10 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
 
     logger.info("Created workspace {} with project {}", workspaceId, projectId);
 
-    mockMvcUtils
-        .createAiNotebookInstance(userAccessUtils.defaultUserAuthRequest(), workspaceId, null)
-        .getAiNotebookInstance();
+    ApiGcpAiNotebookInstanceResource unused =
+        mockGcpApi
+            .createAiNotebookInstance(userAccessUtils.defaultUserAuthRequest(), workspaceId, null)
+            .getAiNotebookInstance();
 
     // So I can end the test and run cleanup when I'm done debugging
     while (!timeToFinish) {
@@ -131,7 +137,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
     String sourceDatasetName = TestUtils.appendRandomNumber("sourcedatasetname");
 
     ApiGcpBigQueryDatasetResource resource =
-        mockMvcUtils
+        mockGcpApi
             .createControlledBqDataset(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspaceId,

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockGcpApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockGcpApi.java
@@ -1,0 +1,869 @@
+package bio.terra.workspace.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.stairway.FlightDebugInfo;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.fixtures.ControlledGcpResourceFixtures;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
+import bio.terra.workspace.generated.model.ApiCloneControlledGcpBigQueryDatasetRequest;
+import bio.terra.workspace.generated.model.ApiCloneControlledGcpBigQueryDatasetResult;
+import bio.terra.workspace.generated.model.ApiCloneReferencedGcpBigQueryDataTableResourceResult;
+import bio.terra.workspace.generated.model.ApiCloneReferencedGcpBigQueryDatasetResourceResult;
+import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
+import bio.terra.workspace.generated.model.ApiCreateControlledGcpAiNotebookInstanceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledGcpBigQueryDatasetRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledGcpDataprocClusterRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateControlledGcpGceInstanceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDataTableReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreateGcpBigQueryDatasetReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiCreatedControlledGcpAiNotebookInstanceResult;
+import bio.terra.workspace.generated.model.ApiCreatedControlledGcpBigQueryDataset;
+import bio.terra.workspace.generated.model.ApiCreatedControlledGcpDataprocClusterResult;
+import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGceInstanceResult;
+import bio.terra.workspace.generated.model.ApiErrorReport;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableAttributes;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDataTableResource;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetAttributes;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetCreationParameters;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetUpdateParameters;
+import bio.terra.workspace.generated.model.ApiJobControl;
+import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
+import bio.terra.workspace.generated.model.ApiUpdateBigQueryDataTableReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiUpdateBigQueryDatasetReferenceRequestBody;
+import bio.terra.workspace.generated.model.ApiUpdateControlledGcpBigQueryDatasetRequestBody;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.controlled.flight.clone.CheckControlledResourceAuthStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.dataset.CompleteTableCopyJobsStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.dataset.CreateTableCopyJobsStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.dataset.SetReferencedDestinationBigQueryDatasetInWorkingMapStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.dataset.SetReferencedDestinationBigQueryDatasetResponseStep;
+import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.referenced.flight.create.CreateReferenceMetadataStep;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.google.common.collect.ImmutableList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+
+@Component
+public class MockGcpApi {
+  private static final Logger logger = LoggerFactory.getLogger(MockGcpApi.class);
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private JobService jobService;
+
+  // GCS Bucket (Controlled)
+  public static final String CREATE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/buckets";
+  public static final String GENERATE_NAME_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT + "/generateName";
+  public static final String CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT + "/%s";
+  public static final String CLONE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT =
+      CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT + "/clone";
+  public static final String CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT + "/clone-result/%s";
+
+  // GCS Bucket (Referenced)
+  public static final String CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/gcp/buckets";
+  public static final String REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT =
+      CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT + "/%s";
+  public static final String CLONE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT =
+      REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT + "/clone";
+
+  // GCS Bucket (alpha1)
+  public static final String LOAD_SIGNED_URL_LIST_ALPHA_PATH_FORMAT =
+      "/api/workspaces/alpha1/%s/resources/controlled/gcp/buckets/%s/load";
+  public static final String LOAD_SIGNED_URL_LIST_RESULT_ALPHA_PATH_FORMAT =
+      LOAD_SIGNED_URL_LIST_ALPHA_PATH_FORMAT + "/result/%s";
+
+  // GCS Object
+  public static final String CREATE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/gcp/bucket/objects";
+  public static final String REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT =
+      CREATE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT + "/%s";
+  public static final String CLONE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT =
+      REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT + "/clone";
+
+  // BQ Dataset (Controlled)
+  public static final String CREATE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/bqdatasets";
+  public static final String GENERATE_NAME_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT + "/generateName";
+  public static final String CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT + "/%s";
+  public static final String CLONE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT =
+      CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT + "/clone";
+  public static final String CLONE_RESULT_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT + "/clone-result/%s";
+
+  public ApiCreatedControlledGcpBigQueryDataset createControlledBqDataset(
+      AuthenticatedUserRequest userRequest, UUID workspaceId) throws Exception {
+    return createControlledBqDataset(
+        userRequest,
+        workspaceId,
+        /*resourceName=*/ TestUtils.appendRandomNumber("resource-name"),
+        /*datasetName=*/ TestUtils.appendRandomNumber("dataset-name"),
+        /*location=*/ null,
+        /*defaultTableLifetime=*/ null,
+        /*defaultPartitionTableLifetime=*/ null);
+  }
+
+  public ApiCreatedControlledGcpBigQueryDataset createControlledBqDataset(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      String resourceName,
+      String datasetName,
+      @Nullable String location,
+      @Nullable Long defaultTableLifetime,
+      @Nullable Long defaultPartitionLifetime)
+      throws Exception {
+    ApiGcpBigQueryDatasetCreationParameters creationParameters =
+        new ApiGcpBigQueryDatasetCreationParameters().datasetId(datasetName);
+    if (location != null) {
+      creationParameters.setLocation(location);
+    }
+    if (defaultTableLifetime != null) {
+      creationParameters.setDefaultTableLifetime(defaultTableLifetime);
+    }
+    if (defaultPartitionLifetime != null) {
+      creationParameters.defaultPartitionLifetime(defaultPartitionLifetime);
+    }
+    ApiCreateControlledGcpBigQueryDatasetRequestBody request =
+        new ApiCreateControlledGcpBigQueryDatasetRequestBody()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi()
+                    .name(resourceName))
+            .dataset(creationParameters);
+
+    String serializedResponse =
+        mockMvcUtils.getSerializedResponseForPost(
+            userRequest,
+            CREATE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT,
+            workspaceId,
+            objectMapper.writeValueAsString(request));
+    return objectMapper.readValue(serializedResponse, ApiCreatedControlledGcpBigQueryDataset.class);
+  }
+
+  public void deleteBqDataset(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      UUID resourceId,
+      StewardshipType stewardshipType)
+      throws Exception {
+    mockMvcUtils.deleteResource(
+        userRequest,
+        workspaceId,
+        resourceId,
+        StewardshipType.CONTROLLED.equals(stewardshipType)
+            ? CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT
+            : REFERENCED_GCP_BQ_DATASET_PATH_FORMAT);
+  }
+
+  public ApiGcpBigQueryDatasetResource getControlledBqDataset(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
+    return getBqDataset(
+        userRequest, workspaceId, resourceId, CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT);
+  }
+
+  private ApiGcpBigQueryDatasetResource getBqDataset(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId, String path)
+      throws Exception {
+    String serializedResponse =
+        mockMvcUtils.getSerializedResponseForGet(userRequest, path, workspaceId, resourceId);
+    return objectMapper.readValue(serializedResponse, ApiGcpBigQueryDatasetResource.class);
+  }
+
+  public ApiGcpBigQueryDatasetResource updateControlledBqDataset(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      UUID resourceId,
+      String newName,
+      String newDescription,
+      ApiCloningInstructionsEnum newCloningInstruction)
+      throws Exception {
+    ApiUpdateControlledGcpBigQueryDatasetRequestBody requestBody =
+        new ApiUpdateControlledGcpBigQueryDatasetRequestBody()
+            .name(newName)
+            .description(newDescription)
+            .updateParameters(
+                new ApiGcpBigQueryDatasetUpdateParameters()
+                    .cloningInstructions(newCloningInstruction));
+    return mockMvcUtils.updateResource(
+        ApiGcpBigQueryDatasetResource.class,
+        CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT,
+        workspaceId,
+        resourceId,
+        objectMapper.writeValueAsString(requestBody),
+        userRequest,
+        HttpStatus.SC_OK);
+  }
+
+  public ApiGcpBigQueryDatasetResource cloneControlledBqDataset(
+      AuthenticatedUserRequest userRequest,
+      UUID sourceWorkspaceId,
+      UUID sourceResourceId,
+      UUID destWorkspaceId,
+      ApiCloningInstructionsEnum cloningInstructions,
+      @Nullable String destResourceName,
+      @Nullable String destDatasetName)
+      throws Exception {
+    return cloneControlledBqDatasetAndWait(
+        userRequest,
+        sourceWorkspaceId,
+        sourceResourceId,
+        destWorkspaceId,
+        cloningInstructions,
+        destResourceName,
+        destDatasetName,
+        /*location=*/ null,
+        /*defaultTableLifetime=*/ null,
+        /*defaultPartitionLifetime=*/ null);
+  }
+
+  public ApiGcpBigQueryDatasetResource cloneControlledBqDatasetAndWait(
+      AuthenticatedUserRequest userRequest,
+      UUID sourceWorkspaceId,
+      UUID sourceResourceId,
+      UUID destWorkspaceId,
+      ApiCloningInstructionsEnum cloningInstructions,
+      @Nullable String destResourceName,
+      @Nullable String destDatasetName,
+      @Nullable String destLocation,
+      @Nullable Long defaultTableLifetime,
+      @Nullable Long defaultPartitionLifetime)
+      throws Exception {
+    ApiCloneControlledGcpBigQueryDatasetResult result =
+        cloneControlledBqDatasetAsync(
+            userRequest,
+            sourceWorkspaceId,
+            sourceResourceId,
+            destWorkspaceId,
+            cloningInstructions,
+            destResourceName,
+            destDatasetName,
+            destLocation,
+            defaultTableLifetime,
+            defaultPartitionLifetime,
+            // clone_copyNothing sometimes returns SC_OK, even for the initial call. So accept both
+            // to avoid flakes.
+            MockMvcUtils.JOB_SUCCESS_CODES,
+            /*shouldUndo=*/ false);
+
+    String jobId = result.getJobReport().getId();
+    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
+      Thread.sleep(/*millis=*/ 5000);
+      result =
+          mockMvcUtils.getCreateResourceJobResult(
+              ApiCloneControlledGcpBigQueryDatasetResult.class,
+              userRequest,
+              CLONE_RESULT_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT,
+              sourceWorkspaceId,
+              jobId);
+    }
+    assertEquals(StatusEnum.SUCCEEDED, result.getJobReport().getStatus());
+    logger.info(
+        "Controlled BQ dataset clone of resource %s completed. ".formatted(sourceResourceId));
+    return result.getDataset().getDataset();
+  }
+
+  /** Call cloneBigQueryDataset() and return immediately; don't wait for flight to finish. */
+  public ApiCloneControlledGcpBigQueryDatasetResult cloneControlledBqDatasetAsync(
+      AuthenticatedUserRequest userRequest,
+      UUID sourceWorkspaceId,
+      UUID sourceResourceId,
+      UUID destWorkspaceId,
+      ApiCloningInstructionsEnum cloningInstructions,
+      @Nullable String destResourceName,
+      @Nullable String destDatasetName,
+      @Nullable String destLocation,
+      @Nullable Long defaultTableLifetime,
+      @Nullable Long defaultPartitionLifetime,
+      List<Integer> expectedCodes,
+      boolean shouldUndo)
+      throws Exception {
+    // Retry to ensure steps are idempotent
+    Map<String, StepStatus> retryableStepsMap = new HashMap<>();
+    List<Class<? extends Step>> retryableSteps =
+        ImmutableList.of(
+            CheckControlledResourceAuthStep.class,
+            SetReferencedDestinationBigQueryDatasetInWorkingMapStep.class,
+            CreateReferenceMetadataStep.class,
+            SetReferencedDestinationBigQueryDatasetResponseStep.class,
+            CreateTableCopyJobsStep.class,
+            CompleteTableCopyJobsStep.class);
+    retryableSteps.forEach(
+        step -> retryableStepsMap.put(step.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY));
+    jobService.setFlightDebugInfoForTest(
+        FlightDebugInfo.newBuilder()
+            .doStepFailures(retryableStepsMap)
+            .lastStepFailure(shouldUndo)
+            .build());
+
+    ApiCloneControlledGcpBigQueryDatasetRequest request =
+        new ApiCloneControlledGcpBigQueryDatasetRequest()
+            .destinationWorkspaceId(destWorkspaceId)
+            .cloningInstructions(cloningInstructions)
+            .location(destLocation)
+            .defaultTableLifetime(defaultTableLifetime)
+            .defaultPartitionLifetime(defaultPartitionLifetime)
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+    if (!StringUtils.isEmpty(destResourceName)) {
+      request.name(destResourceName);
+    }
+    if (!StringUtils.isEmpty(destDatasetName)) {
+      request.destinationDatasetName(destDatasetName);
+    }
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(
+                MockMvcUtils.addJsonContentType(
+                    MockMvcUtils.addAuth(
+                        post(CLONE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT.formatted(
+                                sourceWorkspaceId, sourceResourceId))
+                            .content(objectMapper.writeValueAsString(request)),
+                        userRequest)))
+            .andExpect(status().is(MockMvcUtils.getExpectedCodesMatcher(expectedCodes)))
+            .andReturn()
+            .getResponse();
+
+    // Disable the debug info post flight
+    jobService.setFlightDebugInfoForTest(null);
+    if (mockMvcUtils.isErrorResponse(response)) {
+      return null;
+    }
+
+    String serializedResponse = response.getContentAsString();
+    return objectMapper.readValue(
+        serializedResponse, ApiCloneControlledGcpBigQueryDatasetResult.class);
+  }
+
+  public ApiErrorReport cloneControlledBqDatasetAndExpectError(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, String jobId, int expectedCode)
+      throws Exception {
+    // While job is running, cloneBigQueryDataset returns ApiCloneControlledGcpBigQueryDatasetResult
+    // After job fails, cloneBigQueryDataset returns ApiCloneControlledGcpBigQueryDatasetResult OR
+    // ApiErrorReport.
+    ApiCloneControlledGcpBigQueryDatasetResult result =
+        mockMvcUtils.getCreateResourceJobResult(
+            ApiCloneControlledGcpBigQueryDatasetResult.class,
+            userRequest,
+            CLONE_RESULT_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT,
+            workspaceId,
+            jobId);
+
+    ApiErrorReport errorReport;
+    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
+      Thread.sleep(/*millis=*/ 3000);
+      String serializedResponse =
+          mockMvcUtils.getSerializedResponseForGetJobResult_error(
+              userRequest, CLONE_RESULT_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT, workspaceId, jobId);
+      try {
+        result =
+            objectMapper.readValue(
+                serializedResponse, ApiCloneControlledGcpBigQueryDatasetResult.class);
+      } catch (UnrecognizedPropertyException e) {
+        errorReport = objectMapper.readValue(serializedResponse, ApiErrorReport.class);
+        assertEquals(expectedCode, errorReport.getStatusCode());
+        return errorReport;
+      }
+    }
+    // Job failed and cloneBigQueryData returned ApiCloneControlledGcpBigQueryDatasetResult
+    assertEquals(StatusEnum.FAILED, result.getJobReport().getStatus());
+    return result.getErrorReport();
+  }
+
+  // BQ Dataset (Referenced)
+  public static final String CREATE_REFERENCED_GCP_BQ_DATASETS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/gcp/bigquerydatasets";
+  public static final String REFERENCED_GCP_BQ_DATASET_PATH_FORMAT =
+      CREATE_REFERENCED_GCP_BQ_DATASETS_PATH_FORMAT + "/%s";
+  public static final String CLONE_REFERENCED_GCP_BQ_DATASET_PATH_FORMAT =
+      REFERENCED_GCP_BQ_DATASET_PATH_FORMAT + "/clone";
+
+  public ApiGcpBigQueryDatasetResource createReferencedBqDataset(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      String resourceName,
+      String projectId,
+      String datasetName)
+      throws Exception {
+    ApiGcpBigQueryDatasetAttributes creationParameters =
+        new ApiGcpBigQueryDatasetAttributes().projectId(projectId).datasetId(datasetName);
+    ApiCreateGcpBigQueryDatasetReferenceRequestBody request =
+        new ApiCreateGcpBigQueryDatasetReferenceRequestBody()
+            .metadata(
+                ReferenceResourceFixtures.makeDefaultReferencedResourceFieldsApi()
+                    .name(resourceName))
+            .dataset(creationParameters);
+    String serializedResponse =
+        mockMvcUtils.getSerializedResponseForPost(
+            userRequest,
+            CREATE_REFERENCED_GCP_BQ_DATASETS_PATH_FORMAT,
+            workspaceId,
+            objectMapper.writeValueAsString(request));
+    return objectMapper.readValue(serializedResponse, ApiGcpBigQueryDatasetResource.class);
+  }
+
+  public ApiGcpBigQueryDatasetResource getReferencedBqDataset(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
+    return getBqDataset(
+        userRequest, workspaceId, resourceId, REFERENCED_GCP_BQ_DATASET_PATH_FORMAT);
+  }
+
+  public ApiGcpBigQueryDatasetResource updateReferencedBqDataset(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      UUID resourceId,
+      String newName,
+      String newDescription,
+      ApiCloningInstructionsEnum newCloningInstruction,
+      String newBqDataset)
+      throws Exception {
+    ApiUpdateBigQueryDatasetReferenceRequestBody requestBody =
+        new ApiUpdateBigQueryDatasetReferenceRequestBody()
+            .name(newName)
+            .description(newDescription)
+            .cloningInstructions(newCloningInstruction)
+            .datasetId(newBqDataset);
+    var serializedResponse =
+        mockMvcUtils.getSerializedResponseForPost(
+            userRequest,
+            String.format(REFERENCED_GCP_BQ_DATASET_PATH_FORMAT, workspaceId, resourceId),
+            objectMapper.writeValueAsString(requestBody));
+    return objectMapper.readValue(serializedResponse, ApiGcpBigQueryDatasetResource.class);
+  }
+
+  public ApiGcpBigQueryDatasetResource cloneReferencedBqDataset(
+      AuthenticatedUserRequest userRequest,
+      UUID sourceWorkspaceId,
+      UUID sourceResourceId,
+      UUID destWorkspaceId,
+      ApiCloningInstructionsEnum cloningInstructions,
+      @Nullable String destResourceName)
+      throws Exception {
+    return cloneReferencedBqDatasetAndExpect(
+        userRequest,
+        sourceWorkspaceId,
+        sourceResourceId,
+        destWorkspaceId,
+        cloningInstructions,
+        destResourceName,
+        HttpStatus.SC_OK);
+  }
+
+  public ApiGcpBigQueryDatasetResource cloneReferencedBqDatasetAndExpect(
+      AuthenticatedUserRequest userRequest,
+      UUID sourceWorkspaceId,
+      UUID sourceResourceId,
+      UUID destWorkspaceId,
+      ApiCloningInstructionsEnum cloningInstructions,
+      @Nullable String destResourceName,
+      int expectedCode)
+      throws Exception {
+    MockHttpServletResponse response =
+        mockMvcUtils.cloneReferencedResource(
+            userRequest,
+            CLONE_REFERENCED_GCP_BQ_DATASET_PATH_FORMAT,
+            sourceWorkspaceId,
+            sourceResourceId,
+            destWorkspaceId,
+            cloningInstructions,
+            destResourceName,
+            expectedCode);
+    if (mockMvcUtils.isErrorResponse(response)) {
+      return null;
+    }
+
+    String serializedResponse = response.getContentAsString();
+    return objectMapper
+        .readValue(serializedResponse, ApiCloneReferencedGcpBigQueryDatasetResourceResult.class)
+        .getResource();
+  }
+
+  // BQ Data Table
+  public static final String CREATE_REFERENCED_GCP_BQ_DATA_TABLES_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/referenced/gcp/bigquerydatatables";
+  public static final String REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT =
+      CREATE_REFERENCED_GCP_BQ_DATA_TABLES_PATH_FORMAT + "/%s";
+  public static final String CLONE_REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT =
+      REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT + "/clone";
+
+  public ApiGcpBigQueryDataTableResource createReferencedBqDataTable(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      String resourceName,
+      String projectId,
+      String datasetName,
+      String tableId)
+      throws Exception {
+    ApiGcpBigQueryDataTableAttributes creationParameters =
+        new ApiGcpBigQueryDataTableAttributes()
+            .projectId(projectId)
+            .datasetId(datasetName)
+            .dataTableId(tableId);
+    ApiCreateGcpBigQueryDataTableReferenceRequestBody request =
+        new ApiCreateGcpBigQueryDataTableReferenceRequestBody()
+            .metadata(
+                ReferenceResourceFixtures.makeDefaultReferencedResourceFieldsApi()
+                    .name(resourceName))
+            .dataTable(creationParameters);
+    String serializedResponse =
+        mockMvcUtils.getSerializedResponseForPost(
+            userRequest,
+            CREATE_REFERENCED_GCP_BQ_DATA_TABLES_PATH_FORMAT,
+            workspaceId,
+            objectMapper.writeValueAsString(request));
+    return objectMapper.readValue(serializedResponse, ApiGcpBigQueryDataTableResource.class);
+  }
+
+  public void deleteBqDataTable(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
+    mockMvcUtils.deleteResource(
+        userRequest, workspaceId, resourceId, REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT);
+  }
+
+  public ApiGcpBigQueryDataTableResource getReferencedBqDataTable(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
+    String serializedResponse =
+        mockMvcUtils.getSerializedResponseForGet(
+            userRequest, REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT, workspaceId, resourceId);
+    return objectMapper.readValue(serializedResponse, ApiGcpBigQueryDataTableResource.class);
+  }
+
+  public ApiGcpBigQueryDataTableResource updateReferencedBqDataTable(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      UUID resourceId,
+      String newName,
+      String newDescription,
+      ApiCloningInstructionsEnum newCloningInstruction,
+      String newProjectId,
+      String newDataset,
+      String newTable)
+      throws Exception {
+    ApiUpdateBigQueryDataTableReferenceRequestBody requestBody =
+        new ApiUpdateBigQueryDataTableReferenceRequestBody()
+            .name(newName)
+            .description(newDescription)
+            .cloningInstructions(newCloningInstruction)
+            .projectId(newProjectId)
+            .datasetId(newDataset)
+            .dataTableId(newTable);
+    var serializedResponse =
+        mockMvcUtils.getSerializedResponseForPost(
+            userRequest,
+            String.format(REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT, workspaceId, resourceId),
+            objectMapper.writeValueAsString(requestBody));
+    return objectMapper.readValue(serializedResponse, ApiGcpBigQueryDataTableResource.class);
+  }
+
+  public ApiGcpBigQueryDataTableResource cloneReferencedBqDataTable(
+      AuthenticatedUserRequest userRequest,
+      UUID sourceWorkspaceId,
+      UUID sourceResourceId,
+      UUID destWorkspaceId,
+      ApiCloningInstructionsEnum cloningInstructions,
+      @Nullable String destResourceName)
+      throws Exception {
+    return cloneReferencedBqDataTableAndExpect(
+        userRequest,
+        sourceWorkspaceId,
+        sourceResourceId,
+        destWorkspaceId,
+        cloningInstructions,
+        destResourceName,
+        HttpStatus.SC_OK);
+  }
+
+  public ApiGcpBigQueryDataTableResource cloneReferencedBqDataTableAndExpect(
+      AuthenticatedUserRequest userRequest,
+      UUID sourceWorkspaceId,
+      UUID sourceResourceId,
+      UUID destWorkspaceId,
+      ApiCloningInstructionsEnum cloningInstructions,
+      @Nullable String destResourceName,
+      int expectedCode)
+      throws Exception {
+    MockHttpServletResponse response =
+        mockMvcUtils.cloneReferencedResource(
+            userRequest,
+            CLONE_REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT,
+            sourceWorkspaceId,
+            sourceResourceId,
+            destWorkspaceId,
+            cloningInstructions,
+            destResourceName,
+            expectedCode);
+    if (mockMvcUtils.isErrorResponse(response)) {
+      return null;
+    }
+
+    String serializedResponse = response.getContentAsString();
+    return objectMapper
+        .readValue(serializedResponse, ApiCloneReferencedGcpBigQueryDataTableResourceResult.class)
+        .getResource();
+  }
+
+  // AI Notebook
+  public static final String CREATE_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/ai-notebook-instances";
+  public static final String GENERATE_NAME_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT + "/generateName";
+  public static final String CREATE_RESULT_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT + "/create-result/%s";
+  public static final String CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT + "/%s";
+
+  public ApiCreatedControlledGcpAiNotebookInstanceResult createAiNotebookInstance(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, @Nullable String location)
+      throws Exception {
+    return createAiNotebookInstanceAndWait(
+        userRequest, workspaceId, /*instanceId=*/ null, location);
+  }
+
+  public ApiCreatedControlledGcpAiNotebookInstanceResult createAiNotebookInstanceAndWait(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      @Nullable String instanceId,
+      @Nullable String location)
+      throws Exception {
+    return createAiNotebookInstanceAndExpect(
+        userRequest, workspaceId, instanceId, location, StatusEnum.SUCCEEDED);
+  }
+
+  public ApiCreatedControlledGcpAiNotebookInstanceResult createAiNotebookInstanceAndExpect(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      @Nullable String instanceId,
+      @Nullable String location,
+      StatusEnum jobStatus)
+      throws Exception {
+    ApiCreateControlledGcpAiNotebookInstanceRequestBody request =
+        new ApiCreateControlledGcpAiNotebookInstanceRequestBody()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi()
+                    .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE.toApiModel())
+                    .name(TestUtils.appendRandomNumber("ai-notebook")))
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()))
+            .aiNotebookInstance(
+                ControlledGcpResourceFixtures.defaultNotebookCreationParameters()
+                    .location(location)
+                    .instanceId(
+                        Optional.ofNullable(instanceId)
+                            .orElse(TestUtils.appendRandomNumber("instance-id"))));
+
+    String serializedResponse =
+        mockMvcUtils.getSerializedResponseForPost(
+            userRequest,
+            CREATE_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT,
+            workspaceId,
+            objectMapper.writeValueAsString(request));
+    ApiCreatedControlledGcpAiNotebookInstanceResult result =
+        objectMapper.readValue(
+            serializedResponse, ApiCreatedControlledGcpAiNotebookInstanceResult.class);
+
+    String jobId = result.getJobReport().getId();
+    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
+      TimeUnit.SECONDS.sleep(5);
+      result =
+          mockMvcUtils.getCreateResourceJobResult(
+              ApiCreatedControlledGcpAiNotebookInstanceResult.class,
+              userRequest,
+              CREATE_RESULT_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT,
+              workspaceId,
+              jobId);
+    }
+    assertEquals(jobStatus, result.getJobReport().getStatus());
+
+    return result;
+  }
+
+  // GCE Instance
+  public static final String CREATE_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/gce-instances";
+  public static final String GENERATE_NAME_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT + "/generateName";
+  public static final String CREATE_RESULT_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT + "/create-result/%s";
+  public static final String CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT + "/%s";
+
+  public ApiCreatedControlledGcpGceInstanceResult createGceInstance(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, @Nullable String zone)
+      throws Exception {
+    return createGceInstanceAndWait(userRequest, workspaceId, /*instanceId=*/ null, zone);
+  }
+
+  public ApiCreatedControlledGcpGceInstanceResult createGceInstanceAndWait(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      @Nullable String instanceId,
+      @Nullable String zone)
+      throws Exception {
+    return createGceInstanceAndExpect(
+        userRequest, workspaceId, instanceId, zone, StatusEnum.SUCCEEDED);
+  }
+
+  public ApiCreatedControlledGcpGceInstanceResult createGceInstanceAndExpect(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      @Nullable String instanceId,
+      @Nullable String zone,
+      StatusEnum jobStatus)
+      throws Exception {
+    ApiCreateControlledGcpGceInstanceRequestBody request =
+        new ApiCreateControlledGcpGceInstanceRequestBody()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi()
+                    .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE.toApiModel())
+                    .name(TestUtils.appendRandomNumber("gce-instance")))
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()))
+            .gceInstance(
+                ControlledGcpResourceFixtures.defaultGceInstanceCreationParameters()
+                    .zone(zone)
+                    .instanceId(
+                        Optional.ofNullable(instanceId)
+                            .orElse(TestUtils.appendRandomNumber("instance-id"))));
+
+    String serializedResponse =
+        mockMvcUtils.getSerializedResponseForPost(
+            userRequest,
+            CREATE_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT,
+            workspaceId,
+            objectMapper.writeValueAsString(request));
+    ApiCreatedControlledGcpGceInstanceResult result =
+        objectMapper.readValue(serializedResponse, ApiCreatedControlledGcpGceInstanceResult.class);
+
+    String jobId = result.getJobReport().getId();
+    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
+      Thread.sleep(/*millis=*/ 5000);
+      result =
+          mockMvcUtils.getCreateResourceJobResult(
+              ApiCreatedControlledGcpGceInstanceResult.class,
+              userRequest,
+              CREATE_RESULT_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT,
+              workspaceId,
+              jobId);
+    }
+    assertEquals(jobStatus, result.getJobReport().getStatus());
+
+    return result;
+  }
+
+  // DataProc Cluster
+  public static final String CREATE_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/gcp/dataproc-clusters";
+  public static final String GENERATE_NAME_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT + "/generateName";
+  public static final String CREATE_RESULT_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT + "/create-result/%s";
+  public static final String CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT =
+      CREATE_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT + "/%s";
+
+  public ApiCreatedControlledGcpDataprocClusterResult createDataprocCluster(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      String region,
+      UUID stagingBucketId,
+      UUID tempBucketId)
+      throws Exception {
+    return createDataprocClusterAndWait(
+        userRequest, workspaceId, region, stagingBucketId, tempBucketId, /*clusterId=*/ null);
+  }
+
+  public ApiCreatedControlledGcpDataprocClusterResult createDataprocClusterAndWait(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      String region,
+      UUID stagingBucketId,
+      UUID tempBucketId,
+      @Nullable String clusterId)
+      throws Exception {
+    return createDataprocClusterAndExpect(
+        userRequest,
+        workspaceId,
+        region,
+        stagingBucketId,
+        tempBucketId,
+        clusterId,
+        StatusEnum.SUCCEEDED);
+  }
+
+  public ApiCreatedControlledGcpDataprocClusterResult createDataprocClusterAndExpect(
+      AuthenticatedUserRequest userRequest,
+      UUID workspaceId,
+      String region,
+      UUID stagingBucketId,
+      UUID tempBucketId,
+      @Nullable String clusterId,
+      StatusEnum jobStatus)
+      throws Exception {
+    ApiCreateControlledGcpDataprocClusterRequestBody request =
+        new ApiCreateControlledGcpDataprocClusterRequestBody()
+            .common(
+                ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi()
+                    .accessScope(AccessScopeType.ACCESS_SCOPE_PRIVATE.toApiModel())
+                    .name(TestUtils.appendRandomNumber("dataproc-cluster")))
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()))
+            .dataprocCluster(
+                ControlledGcpResourceFixtures.defaultDataprocClusterCreationParameters()
+                    .region(region)
+                    .clusterId(
+                        Optional.ofNullable(clusterId)
+                            .orElse(TestUtils.appendRandomNumber("cluster-id")))
+                    .configBucket(stagingBucketId)
+                    .tempBucket(tempBucketId));
+
+    String serializedResponse =
+        mockMvcUtils.getSerializedResponseForPost(
+            userRequest,
+            CREATE_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT,
+            workspaceId,
+            objectMapper.writeValueAsString(request));
+    ApiCreatedControlledGcpDataprocClusterResult result =
+        objectMapper.readValue(
+            serializedResponse, ApiCreatedControlledGcpDataprocClusterResult.class);
+
+    String jobId = result.getJobReport().getId();
+    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
+      Thread.sleep(/*millis=*/ 5000);
+      result =
+          mockMvcUtils.getCreateResourceJobResult(
+              ApiCreatedControlledGcpDataprocClusterResult.class,
+              userRequest,
+              CREATE_RESULT_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT,
+              workspaceId,
+              jobId);
+    }
+    assertEquals(jobStatus, result.getJobReport().getStatus());
+
+    return result;
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AnyResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AnyResourceStateFailureTest.java
@@ -1,14 +1,14 @@
 package bio.terra.workspace.service.resource.statetests;
 
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_REFERENCED_GCP_BQ_DATASETS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_REFERENCED_GCP_BQ_DATA_TABLES_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.REFERENCED_GCP_BQ_DATASET_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_FLEXIBLE_RESOURCES_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_DATA_REPO_SNAPSHOTS_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_DATA_REPO_SNAPSHOT_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATA_TABLES_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GIT_REPOS_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.REFERENCED_GIT_REPO_V1_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
@@ -137,7 +137,7 @@ public class AnyResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(refBqDatasetRequest),
-        REFERENCED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        CREATE_REFERENCED_GCP_BQ_DATASETS_PATH_FORMAT.formatted(workspace.workspaceId()),
         HttpStatus.SC_CONFLICT);
 
     // GCP-Referenced BQ data table
@@ -152,7 +152,7 @@ public class AnyResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(refBqDataTableRequest),
-        REFERENCED_GCP_BIG_QUERY_DATA_TABLES_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        CREATE_REFERENCED_GCP_BQ_DATA_TABLES_PATH_FORMAT.formatted(workspace.workspaceId()),
         HttpStatus.SC_CONFLICT);
 
     // GCP-Referenced Bucket
@@ -163,7 +163,7 @@ public class AnyResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(refBucketRequest),
-        REFERENCED_GCP_GCS_BUCKETS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT.formatted(workspace.workspaceId()),
         HttpStatus.SC_CONFLICT);
 
     // GCP-Referenced Bucket Object
@@ -174,7 +174,7 @@ public class AnyResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(refBucketObjectRequest),
-        REFERENCED_GCP_GCS_OBJECTS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        CREATE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT.formatted(workspace.workspaceId()),
         HttpStatus.SC_CONFLICT);
   }
 
@@ -264,10 +264,10 @@ public class AnyResourceStateFailureTest extends BaseUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         bqResource.getResourceId(),
-        REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT,
+        REFERENCED_GCP_BQ_DATASET_PATH_FORMAT,
         objectMapper.writeValueAsString(bqUpdateRequest));
     stateTestUtils.deleteResourceExpectConflict(
-        workspaceUuid, bqResource.getResourceId(), REFERENCED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT);
+        workspaceUuid, bqResource.getResourceId(), REFERENCED_GCP_BQ_DATASET_PATH_FORMAT);
 
     // GCP-Referenced BQ data table
     var bqTableUpdateRequest =
@@ -275,20 +275,18 @@ public class AnyResourceStateFailureTest extends BaseUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         bqTable.getResourceId(),
-        REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT,
+        REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT,
         objectMapper.writeValueAsString(bqTableUpdateRequest));
     stateTestUtils.deleteResourceExpectConflict(
-        workspaceUuid, bqTable.getResourceId(), REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT);
+        workspaceUuid, bqTable.getResourceId(), REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT);
 
     // GCP-Referenced Bucket
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         bqResource.getResourceId(),
-        REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT,
+        REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT,
         objectMapper.writeValueAsString(bqTableUpdateRequest));
     stateTestUtils.deleteResourceExpectConflict(
-        workspaceUuid,
-        bqResource.getResourceId(),
-        REFERENCED_GCP_BIG_QUERY_DATA_TABLE_V1_PATH_FORMAT);
+        workspaceUuid, bqResource.getResourceId(), REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
@@ -1,14 +1,14 @@
 package bio.terra.workspace.service.resource.statetests;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_AI_NOTEBOOKS_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_AI_NOTEBOOK_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_GCE_INSTANCES_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_GCE_INSTANCE_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -18,6 +18,7 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledGcpResourceFixtures;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.common.utils.WorkspaceUnitTestUtils;
@@ -64,6 +65,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired ReferencedResourceService referencedResourceService;
   @Autowired ResourceDao resourceDao;
@@ -115,7 +117,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(instanceRequest),
-        CONTROLLED_GCP_GCE_INSTANCES_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        CREATE_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT.formatted(workspace.workspaceId()),
         HttpStatus.SC_CONFLICT);
 
     // GCP-Controlled Notebook
@@ -132,7 +134,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(notebookRequest),
-        CONTROLLED_GCP_AI_NOTEBOOKS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        CREATE_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT.formatted(workspace.workspaceId()),
         HttpStatus.SC_CONFLICT);
 
     // GCP-Controlled Dataproc cluster
@@ -151,7 +153,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(clusterRequest),
-        CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT.formatted(workspace.workspaceId()),
+        CREATE_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT.formatted(workspace.workspaceId()),
         HttpStatus.SC_CONFLICT);
 
     // GCP-Controlled BigQuery
@@ -165,7 +167,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(bqRequest),
-        CONTROLLED_GCP_BIG_QUERY_DATASETS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        CREATE_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT.formatted(workspace.workspaceId()),
         HttpStatus.SC_CONFLICT);
 
     // GCP-Controlled Bucket
@@ -178,7 +180,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
     mockMvcUtils.postExpect(
         USER_REQUEST,
         objectMapper.writeValueAsString(bucketRequest),
-        CONTROLLED_GCP_GCS_BUCKETS_V1_PATH_FORMAT.formatted(workspace.workspaceId()),
+        CREATE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT.formatted(workspace.workspaceId()),
         HttpStatus.SC_CONFLICT);
   }
 
@@ -218,7 +220,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
         ApiGcpGceInstanceResource.class,
         workspaceUuid,
         instanceResource.getResourceId(),
-        CONTROLLED_GCP_GCE_INSTANCE_V1_PATH_FORMAT,
+        CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT,
         objectMapper.writeValueAsString(instanceRequestBody));
     var instanceDeleteBody =
         new ApiDeleteControlledGcpGceInstanceRequest()
@@ -226,7 +228,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         instanceResource.getResourceId(),
-        CONTROLLED_GCP_GCE_INSTANCE_V1_PATH_FORMAT,
+        CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT,
         objectMapper.writeValueAsString(instanceDeleteBody));
 
     // GCP-Controlled Notebook
@@ -236,7 +238,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
         ApiGcpAiNotebookInstanceResource.class,
         workspaceUuid,
         notebookResource.getResourceId(),
-        CONTROLLED_GCP_AI_NOTEBOOK_V1_PATH_FORMAT,
+        CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT,
         objectMapper.writeValueAsString(notebookRequestBody));
     var notebookDeleteBody =
         new ApiDeleteControlledGcpAiNotebookInstanceRequest()
@@ -244,7 +246,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         notebookResource.getResourceId(),
-        CONTROLLED_GCP_AI_NOTEBOOK_V1_PATH_FORMAT,
+        CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT,
         objectMapper.writeValueAsString(notebookDeleteBody));
 
     // GCP-Controlled BigQuery
@@ -257,10 +259,10 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
         ApiGcpBigQueryDatasetResource.class,
         workspaceUuid,
         bqResource.getResourceId(),
-        CONTROLLED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT,
+        CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT,
         objectMapper.writeValueAsString(bqRequestBody));
     stateTestUtils.deleteResourceExpectConflict(
-        workspaceUuid, bqResource.getResourceId(), CONTROLLED_GCP_BIG_QUERY_DATASET_V1_PATH_FORMAT);
+        workspaceUuid, bqResource.getResourceId(), CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT);
 
     // GCP-Controlled bucket
     var bucketRequestBody =
@@ -272,7 +274,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
         ApiGcpGcsBucketResource.class,
         workspaceUuid,
         bucketResource.getResourceId(),
-        CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT,
+        CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT,
         objectMapper.writeValueAsString(bucketRequestBody));
     var bucketDeleteBody =
         new ApiDeleteControlledGcpGcsBucketRequest()
@@ -280,7 +282,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
     stateTestUtils.postResourceExpectConflict(
         workspaceUuid,
         notebookResource.getResourceId(),
-        CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT,
+        CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT,
         objectMapper.writeValueAsString(bucketDeleteBody));
   }
 
@@ -310,7 +312,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
         WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID,
         createContextFlightId);
 
-    mockMvcUtils.cloneControlledBqDatasetAsync(
+    mockGcpApi.cloneControlledBqDatasetAsync(
         USER_REQUEST,
         workspaceUuid,
         bqResource.getResourceId(),

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.utils.MockGcpApi.CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
@@ -180,7 +180,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
             .perform(
                 MockMvcUtils.addAuth(
                     get(
-                        CONTROLLED_GCP_GCS_BUCKET_V1_PATH_FORMAT.formatted(
+                        CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT.formatted(
                             workspaceId, bucketResource.getMetadata().getResourceId())),
                     userRequest))
             .andExpect(status().isNotFound())


### PR DESCRIPTION
- Part 2 of: Split MockMvcUtils to platform based components -> MockGcpApi (new) with Gcp path formats 
- moves functions of AiNotebooks, GCE Instance, DataProc cluster, BQ tables and BQ datasets
- Rename Path formats in MockGcpApi to keep them consistent
- Move few util functions to specific test files

Part 3 will move functions of objects and buckets in next PR