### PR TITLE
[PF-2918] - Ignore boot service child command exit codes and log its stdout, stderr

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -94,6 +94,7 @@ readonly USER_BASHRC="${USER_HOME_DIR}/.bashrc"
 readonly USER_BASH_PROFILE="${USER_HOME_DIR}/.bash_profile"
 
 readonly POST_STARTUP_OUTPUT_FILE="${USER_TERRA_CONFIG_DIR}/post-startup-output.txt"
+readonly TERRA_BOOT_SERVICE_OUTPUT_FILE="${USER_TERRA_CONFIG_DIR}/boot-output.txt"
 
 # When JupyterLab is provided by a Docker container, the default Deep Learning images
 # pick up jupyter_notebook_config.py provided by the host VM.
@@ -629,11 +630,17 @@ cat << EOF >"${TERRA_BOOT_SCRIPT}"
 #!/bin/bash
 # This script is run on instance boot to configure the instance for terra.
 
+# Send stdout and stderr from this script to a file for debugging.
+exec >> "${TERRA_BOOT_SERVICE_OUTPUT_FILE}"
+exec 2>&1
+
 # Pick up environment from the ~/.bashrc
 source "${USER_BASHRC}"
 
 # Mount terra workspace resources
 "${USER_HOME_LOCAL_BIN}/terra" resource mount
+
+exit 0
 EOF
 chmod +x "${TERRA_BOOT_SCRIPT}"
 chown ${JUPYTER_USER}:${JUPYTER_USER} "${TERRA_BOOT_SCRIPT}"
@@ -645,7 +652,7 @@ Description=Configure environment for terra
 After=jupyter.service
 
 [Service]
-ExecStart=-${TERRA_BOOT_SCRIPT}
+ExecStart=${TERRA_BOOT_SCRIPT}
 User=${JUPYTER_USER}
 RemainAfterExit=yes
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -645,7 +645,7 @@ Description=Configure environment for terra
 After=jupyter.service
 
 [Service]
-ExecStart=${TERRA_BOOT_SCRIPT}
+ExecStart=-${TERRA_BOOT_SCRIPT}
 User=${JUPYTER_USER}
 RemainAfterExit=yes
 


### PR DESCRIPTION
As reported in [PF-2918](https://broadworkbench.atlassian.net/browse/PF-2918), bucket mounting in workspaces with referenced resources that the mounting user does not have access to causes the `terra-instance-boot.service` to fail. This results the gcsfuse mount points for already mounted resources to die and result in `Transport endpoint is not connected` errors.

The startup script internal runs `terra resource mount`, which returns an exit code of 1 even if any of the resources do not mount due to permissions errors or 404 bucket errrors. This behavior is intentional and useful when the command is used in scripting. ~Instead of modifying the behavior of the CLI, we address the issue by adding a `-` to the terra startup service systemd unit, which tells systemd to ignore nonzero return codes and keep the service running.~ This change updates boot script so that child command exit codes are ignored and logged in the terra config folder.

[PF-2918]: https://broadworkbench.atlassian.net/browse/PF-2918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ