### PR TITLE
[BENCH-826] Split GCP path formats / functions from MockMvcUtils (pr 2)

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -421,7 +421,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
             List.of(HttpStatus.SC_ACCEPTED),
             /*shouldUndo=*/ false);
     ApiErrorReport errorReport =
-        mockGcpApi.cloneControlledBqDatasetAndExpectError(
+        mockGcpApi.getCloneControlledBqDatasetResultAndExpectError(
             userRequest, workspaceId, result.getJobReport().getId(), HttpStatus.SC_CONFLICT);
     assertThat(
         errorReport.getMessage(), equalTo("A resource with matching attributes already exists"));
@@ -735,7 +735,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
             /*defaultPartitionLifetime=*/ null,
             List.of(HttpStatus.SC_ACCEPTED),
             /*shouldUndo=*/ true);
-    mockGcpApi.cloneControlledBqDatasetAndExpectError(
+    mockGcpApi.getCloneControlledBqDatasetResultAndExpectError(
         userRequest,
         sourceWorkspaceId,
         result.getJobReport().getId(),
@@ -762,7 +762,6 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
   void clone_copyReference_undo() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-
     cloneControlledBqDataset_undo(
         userRequest,
         /*sourceWorkspaceId=*/ workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
@@ -68,7 +68,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
     String stagingBucketResourceName = TestUtils.appendRandomNumber("dataproc-staging-bucket");
     String stagingBucketCloudName = TestUtils.appendRandomNumber("dataproc-staging-bucket");
     ApiGcpGcsBucketResource stagingBucketResource =
-        mockMvcUtils
+        mockGcpApi
             .createControlledGcsBucket(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspaceId,
@@ -82,7 +82,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
     String tempBucketResourceName = TestUtils.appendRandomNumber("dataproc-temp-bucket");
     String tempBucketCloudName = TestUtils.appendRandomNumber("dataproc-temp-bucket");
     ApiGcpGcsBucketResource tempBucketResource =
-        mockMvcUtils
+        mockGcpApi
             .createControlledGcsBucket(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -52,6 +53,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired FeatureConfiguration features;
@@ -84,7 +86,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
     sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
     sourceBucketName = TestUtils.appendRandomNumber("source-bucket-name");
     sourceResource =
-        mockMvcUtils.createReferencedGcsBucket(
+        mockGcpApi.createReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,
             sourceResourceName,
@@ -114,7 +116,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
     // Assert resource returned by get
     ApiGcpGcsBucketResource gotResource =
-        mockMvcUtils.getReferencedGcsBucket(
+        mockGcpApi.getReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,
             sourceResource.getMetadata().getResourceId());
@@ -135,7 +137,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
     var newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
 
     ApiGcpGcsBucketResource updatedResource =
-        mockMvcUtils.updateReferencedGcsBucket(
+        mockGcpApi.updateReferencedGcsBucket(
             userAccessUtils.secondUserAuthRequest(),
             workspaceId,
             sourceResource.getMetadata().getResourceId(),
@@ -173,7 +175,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
     var newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
 
     ApiGcpGcsBucketResource updatedResource =
-        mockMvcUtils.updateReferencedGcsBucket(
+        mockGcpApi.updateReferencedGcsBucket(
             userAccessUtils.secondUserAuthRequest(),
             workspaceId,
             sourceResource.getMetadata().getResourceId(),
@@ -198,7 +200,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
   @Test
   public void update_throws409() throws Exception {
     var newName = TestUtils.appendRandomNumber("newgcsbucketresourcename");
-    mockMvcUtils.createReferencedGcsBucket(
+    mockGcpApi.createReferencedGcsBucket(
         userAccessUtils.defaultUserAuthRequest(), workspaceId, newName, sourceBucketName);
 
     mockMvcUtils.postExpect(
@@ -212,7 +214,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         HttpStatus.SC_CONFLICT);
 
     ApiGcpGcsBucketResource gotResource =
-        mockMvcUtils.getReferencedGcsBucket(
+        mockGcpApi.getReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,
             sourceResource.getMetadata().getResourceId());
@@ -221,7 +223,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   @Test
   public void clone_requesterNoReadAccessOnSourceWorkspace_throws403() throws Exception {
-    mockMvcUtils.cloneReferencedGcsBucket(
+    mockGcpApi.cloneReferencedGcsBucketAndExpect(
         userAccessUtils.secondUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
@@ -244,7 +246,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
 
-    mockMvcUtils.cloneReferencedGcsBucket(
+    mockGcpApi.cloneReferencedGcsBucketAndExpect(
         userAccessUtils.secondUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
@@ -279,7 +281,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         userAccessUtils.getSecondUserEmail());
 
     ApiGcpGcsBucketResource clonedResource =
-        mockMvcUtils.cloneReferencedGcsBucket(
+        mockGcpApi.cloneReferencedGcsBucket(
             userAccessUtils.secondUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
             /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
@@ -305,7 +307,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         workspaceId2,
         WsmIamRole.WRITER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.deleteReferencedGcsBucket(
+    mockGcpApi.deleteReferencedGcsBucket(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         clonedResource.getMetadata().getResourceId());
@@ -315,7 +317,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
   void clone_copyNothing() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
     ApiGcpGcsBucketResource clonedResource =
-        mockMvcUtils.cloneReferencedGcsBucket(
+        mockGcpApi.cloneReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
@@ -336,7 +338,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
     // Clone resource
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
     ApiGcpGcsBucketResource clonedResource =
-        mockMvcUtils.cloneReferencedGcsBucket(
+        mockGcpApi.cloneReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
@@ -355,8 +357,8 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
-    final ApiGcpGcsBucketResource gotResource =
-        mockMvcUtils.getReferencedGcsBucket(
+    ApiGcpGcsBucketResource gotResource =
+        mockGcpApi.getReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,
             clonedResource.getMetadata().getResourceId());
@@ -368,7 +370,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
     // Clone resource
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
     ApiGcpGcsBucketResource clonedResource =
-        mockMvcUtils.cloneReferencedGcsBucket(
+        mockGcpApi.cloneReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
@@ -387,8 +389,8 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         userAccessUtils.defaultUserAuthRequest());
 
     // Assert resource returned by get
-    final ApiGcpGcsBucketResource gotResource =
-        mockMvcUtils.getReferencedGcsBucket(
+    ApiGcpGcsBucketResource gotResource =
+        mockGcpApi.getReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId2,
             clonedResource.getMetadata().getResourceId());
@@ -418,7 +420,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
     // Clone resource
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
-    mockMvcUtils.cloneReferencedGcsBucket(
+    mockGcpApi.cloneReferencedGcsBucket(
         userAccessUtils.defaultUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         sourceResource.getMetadata().getResourceId(),

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -54,6 +55,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired FeatureConfiguration features;
@@ -70,15 +72,14 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
   // https://github.com/DataBiosphere/terra-workspace-manager/blob/main/DEVELOPMENT.md#for-local-runs-skip-workspacecontext-creation
   @BeforeAll
   public void setup() throws Exception {
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+
     workspaceId =
-        mockMvcUtils
-            .createWorkspaceWithCloudContext(
-                userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
-            .getId();
+        mockMvcUtils.createWorkspaceWithCloudContext(userRequest, apiCloudPlatform).getId();
     workspaceId2 =
         mockMvcUtils
             .createWorkspaceWithPolicy(
-                userAccessUtils.defaultUserAuthRequest(),
+                userRequest,
                 new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
             .getId();
   }
@@ -89,7 +90,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
     sourceBucketName = TestUtils.appendRandomNumber("source-bucket-name");
     sourceFileName = TestUtils.appendRandomNumber("source-file-name");
     sourceResource =
-        mockMvcUtils.createReferencedGcsObject(
+        mockGcpApi.createReferencedGcsObject(
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,
             sourceResourceName,
@@ -99,8 +100,9 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    mockMvcUtils.deleteWorkspaceV2AndWait(userRequest, workspaceId);
+    mockMvcUtils.deleteWorkspaceV2AndWait(userRequest, workspaceId2);
   }
 
   @Test
@@ -121,7 +123,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
     // Assert resource returned by get
     ApiGcpGcsObjectResource gotResource =
-        mockMvcUtils.getReferencedGcsObject(
+        mockGcpApi.getReferencedGcsObject(
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,
             sourceResource.getMetadata().getResourceId());
@@ -130,11 +132,9 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
   @Test
   public void update() throws Exception {
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     mockMvcUtils.grantRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId,
-        WsmIamRole.WRITER,
-        userAccessUtils.getSecondUserEmail());
+        userRequest, workspaceId, WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
 
     var newName = TestUtils.appendRandomNumber("newgcsobjectname");
     var newBucketName = TestUtils.appendRandomNumber("newgcsbucketname");
@@ -142,7 +142,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
     var newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
     String newDescription = "This is an updated description";
     ApiGcpGcsObjectResource updatedResource =
-        mockMvcUtils.updateReferencedGcsObject(
+        mockGcpApi.updateReferencedGcsObject(
             workspaceId,
             sourceResource.getMetadata().getResourceId(),
             newName,
@@ -163,24 +163,19 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
         /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
     mockMvcUtils.removeRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId,
-        WsmIamRole.WRITER,
-        userAccessUtils.getSecondUserEmail());
+        userRequest, workspaceId, WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
   }
 
   @Test
   public void update_throws409() throws Exception {
     var newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
-    mockMvcUtils.createReferencedGcsObject(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId,
-        newName,
-        sourceBucketName,
-        sourceFileName);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+
+    mockGcpApi.createReferencedGcsObject(
+        userRequest, workspaceId, newName, sourceBucketName, sourceFileName);
 
     mockMvcUtils.postExpect(
-        userAccessUtils.defaultUserAuthRequest(),
+        userRequest,
         objectMapper.writeValueAsString(
             new ApiUpdateBigQueryDatasetReferenceRequestBody().name(newName)),
         String.format(
@@ -190,16 +185,14 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         HttpStatus.SC_CONFLICT);
 
     ApiGcpGcsObjectResource gotResource =
-        mockMvcUtils.getReferencedGcsObject(
-            userAccessUtils.defaultUserAuthRequest(),
-            workspaceId,
-            sourceResource.getMetadata().getResourceId());
+        mockGcpApi.getReferencedGcsObject(
+            userRequest, workspaceId, sourceResource.getMetadata().getResourceId());
     assertEquals(sourceResourceName, gotResource.getMetadata().getName());
   }
 
   @Test
   public void clone_requesterNoReadAccessOnSourceWorkspace_throws403() throws Exception {
-    mockMvcUtils.cloneReferencedGcsObject(
+    mockGcpApi.cloneReferencedGcsObjectAndExpect(
         userAccessUtils.secondUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
@@ -211,18 +204,13 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     mockMvcUtils.grantRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId,
-        WsmIamRole.READER,
-        userAccessUtils.getSecondUserEmail());
+        userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
     mockMvcUtils.grantRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId2,
-        WsmIamRole.READER,
-        userAccessUtils.getSecondUserEmail());
+        userRequest, workspaceId2, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
 
-    mockMvcUtils.cloneReferencedGcsObject(
+    mockGcpApi.cloneReferencedGcsObjectAndExpect(
         userAccessUtils.secondUserAuthRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
@@ -232,32 +220,21 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         HttpStatus.SC_FORBIDDEN);
 
     mockMvcUtils.removeRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId,
-        WsmIamRole.READER,
-        userAccessUtils.getSecondUserEmail());
+        userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
     mockMvcUtils.removeRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId2,
-        WsmIamRole.READER,
-        userAccessUtils.getSecondUserEmail());
+        userRequest, workspaceId2, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
   }
 
   @Test
   public void clone_secondUserHasWriteAccessOnDestWorkspace_succeeds() throws Exception {
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     mockMvcUtils.grantRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId,
-        WsmIamRole.READER,
-        userAccessUtils.getSecondUserEmail());
+        userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
     mockMvcUtils.grantRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId2,
-        WsmIamRole.WRITER,
-        userAccessUtils.getSecondUserEmail());
+        userRequest, workspaceId2, WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
 
     ApiGcpGcsObjectResource clonedResource =
-        mockMvcUtils.cloneReferencedGcsObject(
+        mockGcpApi.cloneReferencedGcsObject(
             userAccessUtils.secondUserAuthRequest(),
             /*sourceWorkspaceId=*/ workspaceId,
             /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
@@ -276,27 +253,21 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
         userAccessUtils.secondUserAuthRequest());
     mockMvcUtils.removeRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId,
-        WsmIamRole.READER,
-        userAccessUtils.getSecondUserEmail());
+        userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
     mockMvcUtils.removeRole(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId2,
-        WsmIamRole.WRITER,
-        userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.deleteGcsObject(
-        userAccessUtils.defaultUserAuthRequest(),
-        workspaceId2,
-        clonedResource.getMetadata().getResourceId());
+        userRequest, workspaceId2, WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
+    mockGcpApi.deleteGcsObject(
+        userRequest, workspaceId2, clonedResource.getMetadata().getResourceId());
   }
 
   @Test
   void clone_copyNothing() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+
     ApiGcpGcsObjectResource clonedResource =
-        mockMvcUtils.cloneReferencedGcsObject(
-            userAccessUtils.defaultUserAuthRequest(),
+        mockGcpApi.cloneReferencedGcsObject(
+            userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
@@ -307,17 +278,18 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
     assertNull(clonedResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId, destResourceName);
+    mockMvcUtils.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   @Test
   void clone_copyReference_sameWorkspace() throws Exception {
     // Clone resource
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+
     ApiGcpGcsObjectResource clonedResource =
-        mockMvcUtils.cloneReferencedGcsObject(
-            userAccessUtils.defaultUserAuthRequest(),
+        mockGcpApi.cloneReferencedGcsObject(
+            userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
@@ -334,14 +306,12 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         sourceBucketName,
         sourceFileName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        userAccessUtils.defaultUserAuthRequest());
+        userRequest);
 
     // Assert resource returned by get
-    final ApiGcpGcsObjectResource gotResource =
-        mockMvcUtils.getReferencedGcsObject(
-            userAccessUtils.defaultUserAuthRequest(),
-            workspaceId,
-            clonedResource.getMetadata().getResourceId());
+    ApiGcpGcsObjectResource gotResource =
+        mockGcpApi.getReferencedGcsObject(
+            userRequest, workspaceId, clonedResource.getMetadata().getResourceId());
     assertEquals(clonedResource, gotResource);
   }
 
@@ -349,9 +319,11 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
   void clone_copyReference_differentWorkspace() throws Exception {
     // Clone resource
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+
     ApiGcpGcsObjectResource clonedResource =
-        mockMvcUtils.cloneReferencedGcsObject(
-            userAccessUtils.defaultUserAuthRequest(),
+        mockGcpApi.cloneReferencedGcsObject(
+            userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId2,
@@ -368,14 +340,12 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         sourceBucketName,
         sourceFileName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
-        userAccessUtils.defaultUserAuthRequest());
+        userRequest);
 
     // Assert resource returned by get
-    final ApiGcpGcsObjectResource gotResource =
-        mockMvcUtils.getReferencedGcsObject(
-            userAccessUtils.defaultUserAuthRequest(),
-            workspaceId2,
-            clonedResource.getMetadata().getResourceId());
+    ApiGcpGcsObjectResource gotResource =
+        mockGcpApi.getReferencedGcsObject(
+            userRequest, workspaceId2, clonedResource.getMetadata().getResourceId());
     assertEquals(clonedResource, gotResource);
   }
 
@@ -389,26 +359,28 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
       return;
     }
 
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.deletePolicies(userRequest, workspaceId);
+    mockMvcUtils.deletePolicies(userRequest, workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
     mockMvcUtils.updatePolicies(
-        userAccessUtils.defaultUserAuthRequest(),
+        userRequest,
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
     mockMvcUtils.updatePolicies(
-        userAccessUtils.defaultUserAuthRequest(),
+        userRequest,
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
         /*policiesToRemove=*/ null);
 
     // Clone resource
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
-    mockMvcUtils.cloneReferencedGcsObject(
-        userAccessUtils.defaultUserAuthRequest(),
+    mockGcpApi.cloneReferencedGcsObject(
+        userRequest,
         /*sourceWorkspaceId=*/ workspaceId,
         sourceResource.getMetadata().getResourceId(),
         /*destWorkspaceId=*/ workspaceId2,
@@ -416,16 +388,15 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         destResourceName);
 
     // Assert dest workspace policy is reduced to the narrower region.
-    ApiWorkspaceDescription destWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    ApiWorkspaceDescription destWorkspace = mockMvcUtils.getWorkspace(userRequest, workspaceId2);
     assertThat(
         destWorkspace.getPolicies(),
         containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockMvcUtils.deletePolicies(userRequest, workspaceId);
+    mockMvcUtils.deletePolicies(userRequest, workspaceId2);
   }
 
   private void assertGcsObject(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -53,6 +54,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired FeatureConfiguration features;
@@ -275,7 +277,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
         workspaceId2,
         WsmIamRole.WRITER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.deleteReferencedGcsBucket(
+    mockGcpApi.deleteReferencedGcsBucket(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         clonedResource.getMetadata().getResourceId());

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerTest.java
@@ -135,7 +135,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGcsBucket_copyDefinition_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    mockMvcUtils.cloneReferencedGcsBucket(
+    mockGcpApi.cloneReferencedGcsBucketAndExpect(
         USER_REQUEST,
         workspaceId,
         /*sourceResourceId=*/ UUID.randomUUID(),
@@ -148,7 +148,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGcsBucket_copyResource_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    mockMvcUtils.cloneReferencedGcsBucket(
+    mockGcpApi.cloneReferencedGcsBucketAndExpect(
         USER_REQUEST,
         workspaceId,
         /*sourceResourceId=*/ UUID.randomUUID(),
@@ -161,7 +161,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGcsObject_copyDefinition_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    mockMvcUtils.cloneReferencedGcsObject(
+    mockGcpApi.cloneReferencedGcsObjectAndExpect(
         USER_REQUEST,
         workspaceId,
         /*sourceResourceId=*/ UUID.randomUUID(),
@@ -174,7 +174,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
   @Test
   public void cloneReferencedGcsObject_copyResource_throws400() throws Exception {
     UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    mockMvcUtils.cloneReferencedGcsObject(
+    mockGcpApi.cloneReferencedGcsObjectAndExpect(
         USER_REQUEST,
         workspaceId,
         /*sourceResourceId=*/ UUID.randomUUID(),

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -54,6 +55,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired FeatureConfiguration features;
@@ -207,7 +209,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
 
     logger.info("Test workspaceId {}  workspaceId2 {}", sourceWorkspaceId, destinationWorkspaceId);
 
-    mockMvcUtils.cloneReferencedGcsBucket(
+    mockGcpApi.cloneReferencedGcsBucket(
         userAccessUtils.defaultUserAuthRequest(),
         sourceWorkspaceId,
         sourceResource.getMetadata().getResourceId(),
@@ -259,7 +261,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
     List<String> actualGroups =
         groupPolicy.getAdditionalData().stream()
             .filter(data -> data.getKey().equals(PolicyFixtures.GROUP))
-            .map(group -> group.getValue())
+            .map(ApiWsmPolicyPair::getValue)
             .toList();
     assertEquals(expectedGroups, actualGroups);
   }
@@ -306,7 +308,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
         userAccessUtils.defaultUserAuthRequest(), workspace2Request);
 
     sourceResource =
-        mockMvcUtils.createReferencedGcsBucket(
+        mockGcpApi.createReferencedGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             sourceWorkspaceId,
             sourceResourceName,

--- a/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
@@ -77,7 +77,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
     String sourceResourceName = TestUtils.appendRandomNumber("source-resource-name");
     String sourceBucketName = TestUtils.appendRandomNumber("source-bucket-name");
     ApiGcpGcsBucketResource unused =
-        mockMvcUtils
+        mockGcpApi
             .createControlledGcsBucket(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.logging.model.ActivityLogChangedTarget;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
@@ -84,6 +85,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockGcpApi mockGcpApi;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserAccessUtils userAccessUtils;
   @Autowired private SamService samService;
@@ -401,7 +403,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
               userRequest, apiCloudPlatform, PolicyFixtures.US_REGION);
 
       // Then add a resource with US east region to the target.
-      mockMvcUtils.createControlledGcsBucket(
+      mockGcpApi.createControlledGcsBucket(
           userRequest,
           targetWorkspaceId,
           "resource-name",
@@ -440,7 +442,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
               userRequest, apiCloudPlatform, PolicyFixtures.US_REGION);
 
       // Then add a resource with US east region to the target.
-      mockMvcUtils.createControlledGcsBucket(
+      mockGcpApi.createControlledGcsBucket(
           userRequest,
           targetWorkspaceId,
           "resource-name",
@@ -473,7 +475,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
               userRequest, apiCloudPlatform, PolicyFixtures.US_REGION);
 
       // Then add a resource with US east region to the target.
-      mockMvcUtils.createControlledGcsBucket(
+      mockGcpApi.createControlledGcsBucket(
           userRequest,
           targetWorkspaceId,
           "resource-name",

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockGcpApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockGcpApi.java
@@ -280,7 +280,7 @@ public class MockGcpApi {
                                 sourceWorkspaceId, sourceResourceId))
                             .content(objectMapper.writeValueAsString(request)),
                         userRequest)))
-            .andExpect(status().is(mockMvcUtils.getExpectedCodesMatcher(expectedCodes)))
+            .andExpect(status().is(MockMvcUtils.getExpectedCodesMatcher(expectedCodes)))
             .andReturn()
             .getResponse();
 

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -3,16 +3,6 @@ package bio.terra.workspace.common.utils;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEFAULT_RESOURCE_PROPERTIES;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_SUBJECT_ID;
-import static bio.terra.workspace.common.utils.MockGcpApi.CLONE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockGcpApi.CLONE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockGcpApi.CLONE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockGcpApi.CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockGcpApi.CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockGcpApi.CREATE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockGcpApi.REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockGcpApi.REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT;
 import static bio.terra.workspace.db.WorkspaceActivityLogDao.ACTIVITY_LOG_CHANGE_DETAILS_ROW_MAPPER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
@@ -44,11 +34,7 @@ import bio.terra.workspace.common.logging.model.ActivityLogChangedTarget;
 import bio.terra.workspace.generated.model.ApiAccessScope;
 import bio.terra.workspace.generated.model.ApiCloneControlledFlexibleResourceRequest;
 import bio.terra.workspace.generated.model.ApiCloneControlledFlexibleResourceResult;
-import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketRequest;
-import bio.terra.workspace.generated.model.ApiCloneControlledGcpGcsBucketResult;
 import bio.terra.workspace.generated.model.ApiCloneReferencedGcpDataRepoSnapshotResourceResult;
-import bio.terra.workspace.generated.model.ApiCloneReferencedGcpGcsBucketResourceResult;
-import bio.terra.workspace.generated.model.ApiCloneReferencedGcpGcsObjectResourceResult;
 import bio.terra.workspace.generated.model.ApiCloneReferencedGitRepoResourceResult;
 import bio.terra.workspace.generated.model.ApiCloneReferencedResourceRequestBody;
 import bio.terra.workspace.generated.model.ApiCloneWorkspaceRequest;
@@ -60,14 +46,10 @@ import bio.terra.workspace.generated.model.ApiControlledResourceMetadata;
 import bio.terra.workspace.generated.model.ApiCreateCloudContextRequest;
 import bio.terra.workspace.generated.model.ApiCreateCloudContextResult;
 import bio.terra.workspace.generated.model.ApiCreateControlledFlexibleResourceRequestBody;
-import bio.terra.workspace.generated.model.ApiCreateControlledGcpGcsBucketRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateDataRepoSnapshotReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiCreateGcpGcsBucketReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiCreateGcpGcsObjectReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateGitRepoReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiCreatedControlledFlexibleResource;
-import bio.terra.workspace.generated.model.ApiCreatedControlledGcpGcsBucket;
 import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotAttributes;
 import bio.terra.workspace.generated.model.ApiDataRepoSnapshotResource;
@@ -77,14 +59,7 @@ import bio.terra.workspace.generated.model.ApiFlexibleResource;
 import bio.terra.workspace.generated.model.ApiFlexibleResourceAttributes;
 import bio.terra.workspace.generated.model.ApiFlexibleResourceUpdateParameters;
 import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketAttributes;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketCreationParameters;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketDefaultStorageClass;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketLifecycle;
 import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
-import bio.terra.workspace.generated.model.ApiGcpGcsBucketUpdateParameters;
-import bio.terra.workspace.generated.model.ApiGcpGcsObjectAttributes;
-import bio.terra.workspace.generated.model.ApiGcpGcsObjectResource;
 import bio.terra.workspace.generated.model.ApiGitRepoAttributes;
 import bio.terra.workspace.generated.model.ApiGitRepoResource;
 import bio.terra.workspace.generated.model.ApiGrantRoleRequestBody;
@@ -107,10 +82,7 @@ import bio.terra.workspace.generated.model.ApiResourceType;
 import bio.terra.workspace.generated.model.ApiState;
 import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiUpdateControlledFlexibleResourceRequestBody;
-import bio.terra.workspace.generated.model.ApiUpdateControlledGcpGcsBucketRequestBody;
 import bio.terra.workspace.generated.model.ApiUpdateDataRepoSnapshotReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiUpdateGcsBucketObjectReferenceRequestBody;
-import bio.terra.workspace.generated.model.ApiUpdateGcsBucketReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiUpdateGitRepoReferenceRequestBody;
 import bio.terra.workspace.generated.model.ApiUpdateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
@@ -125,23 +97,13 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.RetrieveGcsBucketCloudAttributesStep;
 import bio.terra.workspace.service.resource.controlled.flight.clone.CheckControlledResourceAuthStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.CompleteTransferOperationStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.RemoveBucketRolesStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.SetBucketRolesStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.SetReferencedDestinationGcsBucketInWorkingMapStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.SetReferencedDestinationGcsBucketResponseStep;
-import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.TransferGcsBucketToGcsBucketStep;
-import bio.terra.workspace.service.resource.controlled.flight.update.RetrieveControlledResourceMetadataStep;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
-import bio.terra.workspace.service.resource.referenced.flight.create.CreateReferenceMetadataStep;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.google.common.collect.ImmutableList;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -736,16 +698,6 @@ public class MockMvcUtils {
     assertEquals(expectedLastUpdatedByEmail, actualWorkspace.getLastUpdatedBy());
   }
 
-  public void deleteReferencedGcsBucket(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    deleteResource(userRequest, workspaceId, resourceId, REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT);
-  }
-
-  public void deleteGcsObject(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    deleteResource(userRequest, workspaceId, resourceId, REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT);
-  }
-
   public void deleteDataRepoSnapshot(
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
     deleteResource(
@@ -763,270 +715,6 @@ public class MockMvcUtils {
     mockMvc
         .perform(addAuth(delete(String.format(path, workspaceId, resourceId)), userRequest))
         .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
-  }
-
-  public ApiCreatedControlledGcpGcsBucket createControlledGcsBucket(
-      AuthenticatedUserRequest userRequest,
-      UUID workspaceId,
-      String resourceName,
-      String bucketName,
-      String location,
-      ApiGcpGcsBucketDefaultStorageClass storageClass,
-      ApiGcpGcsBucketLifecycle lifecycle)
-      throws Exception {
-    ApiCreateControlledGcpGcsBucketRequestBody request =
-        new ApiCreateControlledGcpGcsBucketRequestBody()
-            .common(
-                ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi()
-                    .name(resourceName))
-            .gcsBucket(
-                new ApiGcpGcsBucketCreationParameters()
-                    .name(bucketName)
-                    .location(location)
-                    .defaultStorageClass(storageClass)
-                    .lifecycle(lifecycle));
-
-    String serializedResponse =
-        getSerializedResponseForPost(
-            userRequest,
-            CREATE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT,
-            workspaceId,
-            objectMapper.writeValueAsString(request));
-    return objectMapper.readValue(serializedResponse, ApiCreatedControlledGcpGcsBucket.class);
-  }
-
-  public ApiGcpGcsBucketResource getControlledGcsBucket(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    String serializedGetResponse =
-        getSerializedResponseForGet(
-            userRequest, CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT, workspaceId, resourceId);
-    return objectMapper.readValue(serializedGetResponse, ApiGcpGcsBucketResource.class);
-  }
-
-  public ApiGcpGcsBucketResource updateControlledGcsBucket(
-      AuthenticatedUserRequest userRequest,
-      UUID workspaceId,
-      UUID resourceId,
-      String newName,
-      String newDescription,
-      ApiCloningInstructionsEnum newCloningInstruction)
-      throws Exception {
-    ApiUpdateControlledGcpGcsBucketRequestBody requestBody =
-        new ApiUpdateControlledGcpGcsBucketRequestBody()
-            .name(newName)
-            .description(newDescription)
-            .updateParameters(
-                new ApiGcpGcsBucketUpdateParameters().cloningInstructions(newCloningInstruction));
-    return updateResource(
-        ApiGcpGcsBucketResource.class,
-        CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT,
-        workspaceId,
-        resourceId,
-        objectMapper.writeValueAsString(requestBody),
-        userRequest,
-        HttpStatus.SC_OK);
-  }
-
-  /** Call cloneGcsBucket() and wait for flight to finish. */
-  public ApiCreatedControlledGcpGcsBucket cloneControlledGcsBucket(
-      AuthenticatedUserRequest userRequest,
-      UUID sourceWorkspaceId,
-      UUID sourceResourceId,
-      UUID destWorkspaceId,
-      ApiCloningInstructionsEnum cloningInstructions,
-      @Nullable String destResourceName,
-      @Nullable String destBucketName,
-      @Nullable String destLocation)
-      throws Exception {
-    ApiCloneControlledGcpGcsBucketResult result =
-        cloneControlledGcsBucketAsync(
-            userRequest,
-            sourceWorkspaceId,
-            sourceResourceId,
-            destWorkspaceId,
-            cloningInstructions,
-            destResourceName,
-            destBucketName,
-            destLocation,
-            // clone_copyNothing sometimes returns SC_OK, even for the initial call. So accept both
-            // to avoid flakes.
-            JOB_SUCCESS_CODES,
-            /*shouldUndo=*/ false);
-    String jobId = result.getJobReport().getId();
-    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
-      Thread.sleep(/*millis=*/ 5000);
-      result = getCloneControlledGcsBucketResult(userRequest, sourceWorkspaceId, jobId);
-    }
-    assertEquals(StatusEnum.SUCCEEDED, result.getJobReport().getStatus());
-    logger.info(
-        "Controlled GCS bucket clone of resource %s completed. ".formatted(sourceResourceId));
-    return result.getBucket().getBucket();
-  }
-
-  /** Call cloneGcsBucket(), wait for flight to finish, return JobError. */
-  public ApiErrorReport cloneControlledGcsBucket_jobError(
-      AuthenticatedUserRequest userRequest,
-      UUID sourceWorkspaceId,
-      UUID sourceResourceId,
-      UUID destWorkspaceId,
-      ApiCloningInstructionsEnum cloningInstructions,
-      @Nullable String destBucketName,
-      int expectedCode)
-      throws Exception {
-    ApiCloneControlledGcpGcsBucketResult result =
-        cloneControlledGcsBucketAsync(
-            userRequest,
-            sourceWorkspaceId,
-            sourceResourceId,
-            destWorkspaceId,
-            cloningInstructions,
-            /*destResourceName=*/ null,
-            destBucketName,
-            /*destLocation=*/ null,
-            // clone_copyNothing sometimes returns SC_OK, even for the initial call. So accept both
-            // to avoid flakes.
-            JOB_SUCCESS_CODES,
-            /*shouldUndo=*/ false);
-    return cloneControlledGcsBucket_waitForJobError(
-        userRequest, sourceWorkspaceId, result.getJobReport().getId(), expectedCode);
-  }
-
-  public void cloneControlledGcsBucket_undo(
-      AuthenticatedUserRequest userRequest,
-      UUID sourceWorkspaceId,
-      UUID sourceResourceId,
-      UUID destWorkspaceId,
-      ApiCloningInstructionsEnum cloningInstructions,
-      String destResourceName)
-      throws Exception {
-    ApiCloneControlledGcpGcsBucketResult result =
-        cloneControlledGcsBucketAsync(
-            userRequest,
-            sourceWorkspaceId,
-            sourceResourceId,
-            destWorkspaceId,
-            cloningInstructions,
-            destResourceName,
-            /*destBucketName=*/ null,
-            /*destLocation=*/ null,
-            // clone_copyNothing sometimes returns SC_OK, even for the initial call. So accept both
-            // to avoid flakes.
-            JOB_SUCCESS_CODES,
-            /*shouldUndo=*/ true);
-    cloneControlledGcsBucket_waitForJobError(
-        userRequest,
-        sourceWorkspaceId,
-        result.getJobReport().getId(),
-        HttpStatus.SC_INTERNAL_SERVER_ERROR);
-  }
-
-  /** Call cloneGcsBucket() and return immediately; don't wait for flight to finish. */
-  public ApiCloneControlledGcpGcsBucketResult cloneControlledGcsBucketAsync(
-      AuthenticatedUserRequest userRequest,
-      UUID sourceWorkspaceId,
-      UUID sourceResourceId,
-      UUID destWorkspaceId,
-      ApiCloningInstructionsEnum cloningInstructions,
-      @Nullable String destResourceName,
-      @Nullable String destBucketName,
-      @Nullable String destLocation,
-      List<Integer> expectedCodes,
-      boolean shouldUndo)
-      throws Exception {
-    // Retry to ensure steps are idempotent
-    Map<String, StepStatus> retryableStepsMap = new HashMap<>();
-    List<Class> retryableSteps =
-        ImmutableList.of(
-            CheckControlledResourceAuthStep.class,
-            RetrieveControlledResourceMetadataStep.class,
-            RetrieveGcsBucketCloudAttributesStep.class,
-            SetReferencedDestinationGcsBucketInWorkingMapStep.class,
-            CreateReferenceMetadataStep.class,
-            SetReferencedDestinationGcsBucketResponseStep.class,
-            SetBucketRolesStep.class,
-            TransferGcsBucketToGcsBucketStep.class,
-            CompleteTransferOperationStep.class,
-            // TODO(PF-2271): Uncomment after PF-2271 is fixed
-            // DeleteStorageTransferServiceJobStep.class,
-            RemoveBucketRolesStep.class);
-    retryableSteps.forEach(
-        step -> retryableStepsMap.put(step.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY));
-    jobService.setFlightDebugInfoForTest(
-        FlightDebugInfo.newBuilder()
-            .doStepFailures(retryableStepsMap)
-            .lastStepFailure(shouldUndo)
-            .build());
-
-    ApiCloneControlledGcpGcsBucketRequest request =
-        new ApiCloneControlledGcpGcsBucketRequest()
-            .destinationWorkspaceId(destWorkspaceId)
-            .cloningInstructions(cloningInstructions)
-            .name(TestUtils.appendRandomNumber(DEST_BUCKET_RESOURCE_NAME))
-            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
-    if (!StringUtils.isEmpty(destResourceName)) {
-      request.name(destResourceName);
-    }
-    if (!StringUtils.isEmpty(destBucketName)) {
-      request.bucketName(destBucketName);
-    }
-    if (!StringUtils.isEmpty(destLocation)) {
-      request.location(destLocation);
-    }
-    MockHttpServletResponse response =
-        mockMvc
-            .perform(
-                addJsonContentType(
-                    addAuth(
-                        post(CLONE_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT.formatted(
-                                sourceWorkspaceId, sourceResourceId))
-                            .content(objectMapper.writeValueAsString(request)),
-                        userRequest)))
-            .andExpect(status().is(getExpectedCodesMatcher(expectedCodes)))
-            .andReturn()
-            .getResponse();
-
-    if (isErrorResponse(response)) {
-      return null;
-    }
-
-    String serializedResponse = response.getContentAsString();
-    return objectMapper.readValue(serializedResponse, ApiCloneControlledGcpGcsBucketResult.class);
-  }
-
-  private ApiErrorReport cloneControlledGcsBucket_waitForJobError(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, String jobId, int expectedCode)
-      throws Exception {
-    // While job is running, cloneGcsBucket returns ApiCloneControlledGcpGcsBucketResult
-    // After job fails, cloneGcsBucket returns ApiCloneControlledGcpGcsBucketResult OR
-    // ApiErrorReport.
-    ApiCloneControlledGcpGcsBucketResult result =
-        getCloneControlledGcsBucketResult(userRequest, workspaceId, jobId);
-    ApiErrorReport errorReport;
-    while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
-      Thread.sleep(/*millis=*/ 3000);
-      String serializedResponse =
-          getSerializedResponseForGetJobResult_error(
-              userRequest, CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT, workspaceId, jobId);
-      try {
-        result =
-            objectMapper.readValue(serializedResponse, ApiCloneControlledGcpGcsBucketResult.class);
-      } catch (UnrecognizedPropertyException e) {
-        errorReport = objectMapper.readValue(serializedResponse, ApiErrorReport.class);
-        assertEquals(expectedCode, errorReport.getStatusCode());
-        return errorReport;
-      }
-    }
-    // Job failed and cloneBigQueryData returned ApiCloneControlledGcpBigQueryDatasetResult
-    assertEquals(StatusEnum.FAILED, result.getJobReport().getStatus());
-    return result.getErrorReport();
-  }
-
-  private ApiCloneControlledGcpGcsBucketResult getCloneControlledGcsBucketResult(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, String jobId) throws Exception {
-    String serializedResponse =
-        getSerializedResponseForGetJobResult(
-            userRequest, CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT, workspaceId, jobId);
-    return objectMapper.readValue(serializedResponse, ApiCloneControlledGcpGcsBucketResult.class);
   }
 
   public ApiFlexibleResource getFlexibleResource(
@@ -1390,215 +1078,6 @@ public class MockMvcUtils {
     String serializedResponse = response.getContentAsString();
     return objectMapper
         .readValue(serializedResponse, ApiCloneReferencedGcpDataRepoSnapshotResourceResult.class)
-        .getResource();
-  }
-
-  public ApiGcpGcsBucketResource createReferencedGcsBucket(
-      AuthenticatedUserRequest userRequest,
-      UUID workspaceId,
-      String resourceName,
-      String bucketName)
-      throws Exception {
-    ApiGcpGcsBucketAttributes creationParameters =
-        new ApiGcpGcsBucketAttributes().bucketName(bucketName);
-    ApiCreateGcpGcsBucketReferenceRequestBody request =
-        new ApiCreateGcpGcsBucketReferenceRequestBody()
-            .metadata(
-                ReferenceResourceFixtures.makeDefaultReferencedResourceFieldsApi()
-                    .name(resourceName))
-            .bucket(creationParameters);
-    String serializedResponse =
-        getSerializedResponseForPost(
-            userRequest,
-            CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT,
-            workspaceId,
-            objectMapper.writeValueAsString(request));
-    return objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);
-  }
-
-  public ApiGcpGcsBucketResource getReferencedGcsBucket(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    String serializedResponse =
-        getSerializedResponseForGet(
-            userRequest, REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT, workspaceId, resourceId);
-    return objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);
-  }
-
-  public ApiGcpGcsBucketResource updateReferencedGcsBucket(
-      AuthenticatedUserRequest userRequest,
-      UUID workspaceId,
-      UUID resourceId,
-      String newName,
-      String newDescription,
-      String newBucketName,
-      ApiCloningInstructionsEnum newCloneInstruction)
-      throws Exception {
-    ApiUpdateGcsBucketReferenceRequestBody requestBody =
-        new ApiUpdateGcsBucketReferenceRequestBody()
-            .name(newName)
-            .description(newDescription)
-            .bucketName(newBucketName)
-            .cloningInstructions(newCloneInstruction);
-    var serializedResponse =
-        getSerializedResponseForPost(
-            userRequest,
-            String.format(REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT, workspaceId, resourceId),
-            objectMapper.writeValueAsString(requestBody));
-    return objectMapper.readValue(serializedResponse, ApiGcpGcsBucketResource.class);
-  }
-
-  public ApiGcpGcsBucketResource cloneReferencedGcsBucket(
-      AuthenticatedUserRequest userRequest,
-      UUID sourceWorkspaceId,
-      UUID sourceResourceId,
-      UUID destWorkspaceId,
-      ApiCloningInstructionsEnum cloningInstructions,
-      @Nullable String destResourceName)
-      throws Exception {
-    return cloneReferencedGcsBucket(
-        userRequest,
-        sourceWorkspaceId,
-        sourceResourceId,
-        destWorkspaceId,
-        cloningInstructions,
-        destResourceName,
-        HttpStatus.SC_OK);
-  }
-
-  public ApiGcpGcsBucketResource cloneReferencedGcsBucket(
-      AuthenticatedUserRequest userRequest,
-      UUID sourceWorkspaceId,
-      UUID sourceResourceId,
-      UUID destWorkspaceId,
-      ApiCloningInstructionsEnum cloningInstructions,
-      @Nullable String destResourceName,
-      int expectedCode)
-      throws Exception {
-    MockHttpServletResponse response =
-        cloneReferencedResource(
-            userRequest,
-            CLONE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT,
-            sourceWorkspaceId,
-            sourceResourceId,
-            destWorkspaceId,
-            cloningInstructions,
-            destResourceName,
-            expectedCode);
-
-    if (isErrorResponse(response)) {
-      return null;
-    }
-
-    String serializedResponse = response.getContentAsString();
-    return objectMapper
-        .readValue(serializedResponse, ApiCloneReferencedGcpGcsBucketResourceResult.class)
-        .getResource();
-  }
-
-  public ApiGcpGcsObjectResource createReferencedGcsObject(
-      AuthenticatedUserRequest userRequest,
-      UUID workspaceId,
-      String resourceName,
-      String bucketName,
-      String fileName)
-      throws Exception {
-    ApiGcpGcsObjectAttributes creationParameters =
-        new ApiGcpGcsObjectAttributes().bucketName(bucketName).fileName(fileName);
-    ApiCreateGcpGcsObjectReferenceRequestBody request =
-        new ApiCreateGcpGcsObjectReferenceRequestBody()
-            .metadata(
-                ReferenceResourceFixtures.makeDefaultReferencedResourceFieldsApi()
-                    .name(resourceName))
-            .file(creationParameters);
-    String serializedResponse =
-        getSerializedResponseForPost(
-            userRequest,
-            CREATE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT,
-            workspaceId,
-            objectMapper.writeValueAsString(request));
-    return objectMapper.readValue(serializedResponse, ApiGcpGcsObjectResource.class);
-  }
-
-  public ApiGcpGcsObjectResource getReferencedGcsObject(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    String serializedResponse =
-        getSerializedResponseForGet(
-            userRequest, REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT, workspaceId, resourceId);
-    return objectMapper.readValue(serializedResponse, ApiGcpGcsObjectResource.class);
-  }
-
-  public ApiGcpGcsObjectResource updateReferencedGcsObject(
-      UUID workspaceId,
-      UUID resourceId,
-      String newName,
-      String newDescription,
-      String newBucketName,
-      String newObjectName,
-      ApiCloningInstructionsEnum newCloningInstruction,
-      AuthenticatedUserRequest userRequest)
-      throws Exception {
-    ApiUpdateGcsBucketObjectReferenceRequestBody updateRequest =
-        new ApiUpdateGcsBucketObjectReferenceRequestBody();
-    updateRequest
-        .name(newName)
-        .description(newDescription)
-        .cloningInstructions(newCloningInstruction)
-        .bucketName(newBucketName)
-        .objectName(newObjectName);
-
-    var serializedResponse =
-        getSerializedResponseForPost(
-            userRequest,
-            String.format(REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT, workspaceId, resourceId),
-            objectMapper.writeValueAsString(updateRequest));
-    return objectMapper.readValue(serializedResponse, ApiGcpGcsObjectResource.class);
-  }
-
-  public ApiGcpGcsObjectResource cloneReferencedGcsObject(
-      AuthenticatedUserRequest userRequest,
-      UUID sourceWorkspaceId,
-      UUID sourceResourceId,
-      UUID destWorkspaceId,
-      ApiCloningInstructionsEnum cloningInstructions,
-      @Nullable String destResourceName)
-      throws Exception {
-    return cloneReferencedGcsObject(
-        userRequest,
-        sourceWorkspaceId,
-        sourceResourceId,
-        destWorkspaceId,
-        cloningInstructions,
-        destResourceName,
-        HttpStatus.SC_OK);
-  }
-
-  public ApiGcpGcsObjectResource cloneReferencedGcsObject(
-      AuthenticatedUserRequest userRequest,
-      UUID sourceWorkspaceId,
-      UUID sourceResourceId,
-      UUID destWorkspaceId,
-      ApiCloningInstructionsEnum cloningInstructions,
-      @Nullable String destResourceName,
-      int expectedCode)
-      throws Exception {
-    MockHttpServletResponse response =
-        cloneReferencedResource(
-            userRequest,
-            CLONE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT,
-            sourceWorkspaceId,
-            sourceResourceId,
-            destWorkspaceId,
-            cloningInstructions,
-            destResourceName,
-            expectedCode);
-
-    if (isErrorResponse(response)) {
-      return null;
-    }
-
-    String serializedResponse = response.getContentAsString();
-    return objectMapper
-        .readValue(serializedResponse, ApiCloneReferencedGcpGcsObjectResourceResult.class)
         .getResource();
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/danglingresource/DanglingResourceCleanupServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/danglingresource/DanglingResourceCleanupServiceTest.java
@@ -9,6 +9,7 @@ import bio.terra.cloudres.google.dataproc.DataprocCow;
 import bio.terra.workspace.app.configuration.external.DanglingResourceCleanupConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.utils.GcpUtils;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -37,13 +38,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Tag("connectedPlus")
 public class DanglingResourceCleanupServiceTest extends BaseConnectedTest {
   private Workspace workspace;
-  private final int ASSERT_RESOURCE_CLEANUP_RETRY_COUNT = 40;
-  private final int ASSERT_RESOURCE_CLEANUP_RETRY_SECONDS = 15;
+  private static final int ASSERT_RESOURCE_CLEANUP_RETRY_COUNT = 40;
+  private static final int ASSERT_RESOURCE_CLEANUP_RETRY_SECONDS = 15;
 
   @Autowired WorkspaceConnectedTestUtils workspaceUtils;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired WorkspaceService workspaceService;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired SamService samService;
   @Autowired ControlledResourceService controlledResourceService;
   @Autowired DanglingResourceCleanupConfiguration danglingResourceCleanupConfiguration;
@@ -68,7 +70,7 @@ public class DanglingResourceCleanupServiceTest extends BaseConnectedTest {
     String stagingBucketResourceName = TestUtils.appendRandomNumber("dataproc-staging-bucket");
     String stagingBucketCloudName = TestUtils.appendRandomNumber("dataproc-staging-bucket");
     ApiGcpGcsBucketResource stagingBucketResource =
-        mockMvcUtils
+        mockGcpApi
             .createControlledGcsBucket(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspace.getWorkspaceId(),
@@ -82,7 +84,7 @@ public class DanglingResourceCleanupServiceTest extends BaseConnectedTest {
     String tempBucketResourceName = TestUtils.appendRandomNumber("dataproc-temp-bucket");
     String tempBucketCloudName = TestUtils.appendRandomNumber("dataproc-temp-bucket");
     ApiGcpGcsBucketResource tempBucketResource =
-        mockMvcUtils
+        mockGcpApi
             .createControlledGcsBucket(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspace.getWorkspaceId(),
@@ -111,7 +113,7 @@ public class DanglingResourceCleanupServiceTest extends BaseConnectedTest {
 
     // Create a controlled dataproc cluster
     ApiGcpDataprocClusterResource cluster =
-        mockMvcUtils
+        mockGcpApi
             .createDataprocCluster(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspace.getWorkspaceId(),
@@ -122,7 +124,7 @@ public class DanglingResourceCleanupServiceTest extends BaseConnectedTest {
 
     // Create a controlled gce instance
     ApiGcpGceInstanceResource instance =
-        mockMvcUtils
+        mockGcpApi
             .createGceInstance(
                 userAccessUtils.defaultUserAuthRequest(), workspace.getWorkspaceId(), null)
             .getGceInstance();
@@ -131,7 +133,7 @@ public class DanglingResourceCleanupServiceTest extends BaseConnectedTest {
     String bucketResourceName = TestUtils.appendRandomNumber("my-bucket");
     String bucketCloudName = TestUtils.appendRandomNumber("my-bucket");
     ApiGcpGcsBucketResource bucket =
-        mockMvcUtils
+        mockGcpApi
             .createControlledGcsBucket(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspace.getWorkspaceId(),

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
@@ -326,7 +326,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
         Collections.singletonList(HttpStatus.SC_CONFLICT),
         false);
 
-    mockMvcUtils.cloneControlledGcsBucketAsync(
+    mockGcpApi.cloneControlledGcsBucketAsync(
         USER_REQUEST,
         workspaceUuid,
         bucketResource.getResourceId(),

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -22,6 +22,7 @@ import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
 import bio.terra.workspace.common.logging.model.ActivityLogChangedTarget;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
@@ -40,7 +41,6 @@ import bio.terra.workspace.generated.model.ApiWorkspaceStageModel;
 import bio.terra.workspace.service.datarepo.DataRepoService;
 import bio.terra.workspace.service.folder.model.Folder;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.job.JobService.JobResultOrException;
 import bio.terra.workspace.service.job.exception.InvalidResultStateException;
@@ -101,10 +101,10 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
   @Autowired private GcpCloudContextService gcpCloudContextService;
   @Autowired private JobService jobService;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockGcpApi mockGcpApi;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private ReferencedResourceService referenceResourceService;
   @Autowired private ResourceDao resourceDao;
-  @Autowired private SamService samService;
   @Autowired private SpendConnectedTestUtils spendUtils;
   @Autowired private UserAccessUtils userAccessUtils;
   @Autowired private WorkspaceService workspaceService;
@@ -234,7 +234,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
   private ApiGcpGcsBucketResource createControlledBucket() throws Exception {
     // Add a bucket resource
     String bucketName = "terra-test-" + UUID.randomUUID().toString().toLowerCase();
-    return mockMvcUtils
+    return mockGcpApi
         .createControlledGcsBucket(
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,


### PR DESCRIPTION
Rebase and merge after - https://github.com/DataBiosphere/terra-workspace-manager/pull/1394

- Part 3 of: Split MockMvcUtils to platform based components -> MockGcpApi (updated)
- moves functions of GCS Objects and GCS Buckets to MockGcpApi from MockMvcUtils
- Move few util functions to specific test files

Part 4 will move functions of DataRepo , Folder etc in next PR

