### PR TITLE
WOR-1148 capture pod logs

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/AzureConfiguration.java
@@ -20,6 +20,7 @@ public class AzureConfiguration {
   private String azureMonitorLinuxAgentVersion;
   private List<String> protectedDataLandingZoneDefs;
   private String azureDatabaseUtilImage;
+  private Integer azureDatabaseUtilLogsTailLines;
 
   public String getManagedAppClientId() {
     return managedAppClientId;
@@ -100,5 +101,13 @@ public class AzureConfiguration {
 
   public void setAzureDatabaseUtilImage(String azureDatabaseUtilImage) {
     this.azureDatabaseUtilImage = azureDatabaseUtilImage;
+  }
+
+  public Integer getAzureDatabaseUtilLogsTailLines() {
+    return azureDatabaseUtilLogsTailLines;
+  }
+
+  public void setAzureDatabaseUtilLogsTailLines(Integer azureDatabaseUtilLogsTailLines) {
+    this.azureDatabaseUtilLogsTailLines = azureDatabaseUtilLogsTailLines;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStep.java
@@ -19,6 +19,7 @@ import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
+import io.kubernetes.client.PodLogs;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -27,6 +28,9 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodStatus;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +46,7 @@ public class CreateAzureDatabaseStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(CreateAzureDatabaseStep.class);
   public static final String POD_FAILED = "Failed";
   public static final String POD_SUCCEEDED = "Succeeded";
+  public static final String CREATE_DB_CONTAINER = "createdb";
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final ControlledAzureDatabaseResource resource;
@@ -104,6 +109,7 @@ public class CreateAzureDatabaseStep implements Step {
             containerServiceManager, azureCloudContext.getAzureResourceGroupId(), clusterResource);
     var podName = getPodName(GetManagedIdentityStep.getManagedIdentityName(context));
     try {
+      logger.info("Creating pod {}", podName);
       startCreateDatabaseContainer(
           aksApi,
           bearerToken,
@@ -121,6 +127,7 @@ public class CreateAzureDatabaseStep implements Step {
     } catch (Exception e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
     } finally {
+      logPodLogs(aksApi, podName, azureConfig.getAzureDatabaseUtilLogsTailLines());
       deleteCreateDatabaseContainer(aksApi, podName);
     }
 
@@ -144,6 +151,30 @@ public class CreateAzureDatabaseStep implements Step {
         Duration.ofSeconds(10),
         0.0,
         Duration.ofSeconds(10));
+  }
+
+  private void logPodLogs(CoreV1Api aksApi, String podName, Integer tailLines) {
+    try {
+      var pod = aksApi.readNamespacedPod(podName, aksNamespace, null);
+      logger.info("Pod {} final status: {}", podName, pod.getStatus());
+
+      try (InputStream logs =
+          new PodLogs(aksApi.getApiClient())
+              .streamNamespacedPodLog(
+                  aksNamespace,
+                  podName,
+                  CREATE_DB_CONTAINER,
+                  null,
+                  Optional.ofNullable(tailLines).orElse(1000),
+                  false)) {
+
+        new BufferedReader(new InputStreamReader(logs))
+            .lines()
+            .forEach(line -> logger.info("Pod {} log line: {}", podName, line));
+      }
+    } catch (Exception e) {
+      logger.info("Pod {}, failed to get pod logs", podName, e);
+    }
   }
 
   private Optional<String> getPodStatus(CoreV1Api aksApi, String podName) throws ApiException {
@@ -192,7 +223,7 @@ public class CreateAzureDatabaseStep implements Step {
                       .restartPolicy("Never")
                       .addContainersItem(
                           new V1Container()
-                              .name("createdb")
+                              .name(CREATE_DB_CONTAINER)
                               .image(azureConfig.getAzureDatabaseUtilImage())
                               .env(
                                   List.of(

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -148,6 +148,7 @@ workspace:
     cors-allowed-origins:
     protected-data-landing-zone-defs: ["ProtectedDataResourcesFactory"]
     azure-database-util-image: "us.gcr.io/broad-dsp-gcr-public/azure-database-utils:${version.gitHash}"
+    azure-database-util-logs-tail-lines: 1000
 
 terra.common:
   kubernetes:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1148

Example logs from a successful test run
```
2023-07-21 10:27:00.763   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b final status: class V1PodStatus {
    conditions: [class V1PodCondition {
        lastProbeTime: null
        lastTransitionTime: 2023-07-21T14:26:30Z
        message: null
        reason: PodCompleted
        status: True
        type: Initialized
    }, class V1PodCondition {
        lastProbeTime: null
        lastTransitionTime: 2023-07-21T14:26:49Z
        message: null
        reason: PodCompleted
        status: False
        type: Ready
    }, class V1PodCondition {
        lastProbeTime: null
        lastTransitionTime: 2023-07-21T14:26:49Z
        message: null
        reason: PodCompleted
        status: False
        type: ContainersReady
    }, class V1PodCondition {
        lastProbeTime: null
        lastTransitionTime: 2023-07-21T14:26:30Z
        message: null
        reason: null
        status: True
        type: PodScheduled
    }]
    containerStatuses: [class V1ContainerStatus {
        containerID: containerd://440d612ef88d19ec005d18b43a7c172b53bd2f437211c683753cd3b643033771
        image: us.gcr.io/broad-dsp-gcr-public/azure-database-utils:04d28963415ef80831e7379ac485311b4fb8457c
        imageID: us.gcr.io/broad-dsp-gcr-public/azure-database-utils@sha256:ffca0a29b3ca78fac0eb9923a4383c854ccb5fd85b9f7969b600b2ea6ffc7659
        lastState: class V1ContainerState {
            running: null
            terminated: null
            waiting: null
        }
        name: createdb
        ready: false
        restartCount: 0
        started: false
        state: class V1ContainerState {
            running: null
            terminated: class V1ContainerStateTerminated {
                containerID: containerd://440d612ef88d19ec005d18b43a7c172b53bd2f437211c683753cd3b643033771
                exitCode: 0
                finishedAt: 2023-07-21T14:26:48Z
                message: null
                reason: Completed
                signal: null
                startedAt: 2023-07-21T14:26:32Z
            }
            waiting: null
        }
    }]
    ephemeralContainerStatuses: null
    hostIP: 10.1.0.4
    initContainerStatuses: null
    message: null
    nominatedNodeName: null
    phase: Succeeded
    podIP: 10.244.0.129
    podIPs: [class V1PodIP {
        ip: 10.244.0.129
    }]
    qosClass: BestEffort
    reason: null
    startTime: 2023-07-21T14:26:30Z
}
2023-07-21 10:27:00.810   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 
2023-07-21 10:27:00.810   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line:   .   ____          _            __ _ _
2023-07-21 10:27:00.810   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line:  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
2023-07-21 10:27:00.810   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: ( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
2023-07-21 10:27:00.810   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line:  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
2023-07-21 10:27:00.810   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line:   '  |____| .__|_| |_|_| |_\__, | / / / /
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line:  =========|_|==============|___/=/_/_/_/
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line:  :: Spring Boot ::                (v3.1.1)
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:35.544Z  INFO 1 --- [           main] b.t.w.a.AzureDatabaseUtilsApplication    : Starting AzureDatabaseUtilsApplication using Java 17.0.7 with PID 1 (/app/classes started by nonroot in /home/nonroot)
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:35.555Z  INFO 1 --- [           main] b.t.w.a.AzureDatabaseUtilsApplication    : The following 1 profile is active: "CreateDatabase"
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:37.720Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JDBC repositories in DEFAULT mode.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:37.988Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 160 ms. Found 0 JDBC repository interfaces.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:39.788Z  INFO 1 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:42.333Z  INFO 1 --- [           main] c.a.i.e.i.t.AccessTokenResolverOptions   : Ossrdbms scope set to https://ossrdbms-aad.database.windows.net/.default.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:42.389Z  INFO 1 --- [           main] c.azure.identity.ChainedTokenCredential  : Azure Identity => Attempted credential EnvironmentCredential is unavailable.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:46.281Z  INFO 1 --- [       Thread-1] c.azure.identity.ChainedTokenCredential  : Azure Identity => Attempted credential WorkloadIdentityCredential returns a token
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:46.502Z  INFO 1 --- [           main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@707ca986
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:46.511Z  INFO 1 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:46.724Z  INFO 1 --- [onnection adder] c.a.i.e.i.t.AccessTokenResolverOptions   : Ossrdbms scope set to https://ossrdbms-aad.database.windows.net/.default.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:46.725Z  INFO 1 --- [onnection adder] c.azure.identity.ChainedTokenCredential  : Azure Identity => Attempted credential EnvironmentCredential is unavailable.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:47.082Z  INFO 1 --- [       Thread-6] c.azure.identity.ChainedTokenCredential  : Azure Identity => Attempted credential WorkloadIdentityCredential returns a token
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:47.314Z  INFO 1 --- [onnection adder] c.a.i.e.i.t.AccessTokenResolverOptions   : Ossrdbms scope set to https://ossrdbms-aad.database.windows.net/.default.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:47.315Z  INFO 1 --- [onnection adder] c.azure.identity.ChainedTokenCredential  : Azure Identity => Attempted credential EnvironmentCredential is unavailable.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:47.458Z  INFO 1 --- [           main] b.t.w.a.AzureDatabaseUtilsApplication    : Started AzureDatabaseUtilsApplication in 14.007 seconds (process running for 15.293)
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:47.476Z  INFO 1 --- [           main] b.t.w.a.create.CreateDatabaseService     : Creating database azdb534ec42a224f485e9feb482597e61cc0 with user azuami8e63fe66b50d40ee8fee1621db25d17b and OID 538b196a-24be-4a53-93cc-a3ded3c48bd2
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:47.726Z  INFO 1 --- [       Thread-7] c.azure.identity.ChainedTokenCredential  : Azure Identity => Attempted credential WorkloadIdentityCredential returns a token
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:47.982Z  INFO 1 --- [onnection adder] c.a.i.e.i.t.AccessTokenResolverOptions   : Ossrdbms scope set to https://ossrdbms-aad.database.windows.net/.default.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:47.983Z  INFO 1 --- [onnection adder] c.azure.identity.ChainedTokenCredential  : Azure Identity => Attempted credential EnvironmentCredential is unavailable.
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:48.133Z  INFO 1 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:48.156Z  INFO 1 --- [       Thread-8] c.azure.identity.ChainedTokenCredential  : Azure Identity => Attempted credential WorkloadIdentityCredential returns a token
2023-07-21 10:27:00.811   INFO 38214 --- [pool-8-thread-4] .t.w.s.r.c.c.a.d.CreateAzureDatabaseStep : Pod ecb5155d-e8ca-4390-9de4-b72f363583a8azdb534ec42a224f485e9feb482597e61cc0azuami8e63fe66b50d40ee8fee1621db25d17b log line: 2023-07-21T14:26:48.197Z  INFO 1 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
```