### PR TITLE
[PF-2925] Default to empty string when azure.customer.usage-attribute is not defined

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
@@ -76,7 +76,7 @@ public class CrlService {
   /** How long to keep the resource before Janitor does the cleanup. */
   private static final Duration TEST_RESOURCE_TIME_TO_LIVE = Duration.ofHours(1);
 
-  @Value("${azure.customer.usage-attribute}")
+  @Value("${azure.customer.usage-attribute:}")
   private String azureCustomerUsageAttribute;
 
   private final ClientConfig clientConfig;

--- a/service/src/test/java/bio/terra/workspace/service/danglingresource/DanglingResourceCleanupServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/danglingresource/DanglingResourceCleanupServiceTest.java
@@ -9,6 +9,7 @@ import bio.terra.cloudres.google.dataproc.DataprocCow;
 import bio.terra.workspace.app.configuration.external.DanglingResourceCleanupConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.utils.GcpUtils;
+import bio.terra.workspace.common.utils.MockGcpApi;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -44,6 +45,7 @@ public class DanglingResourceCleanupServiceTest extends BaseConnectedTest {
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired WorkspaceService workspaceService;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockGcpApi mockGcpApi;
   @Autowired SamService samService;
   @Autowired ControlledResourceService controlledResourceService;
   @Autowired DanglingResourceCleanupConfiguration danglingResourceCleanupConfiguration;
@@ -111,7 +113,7 @@ public class DanglingResourceCleanupServiceTest extends BaseConnectedTest {
 
     // Create a controlled dataproc cluster
     ApiGcpDataprocClusterResource cluster =
-        mockMvcUtils
+        mockGcpApi
             .createDataprocCluster(
                 userAccessUtils.defaultUserAuthRequest(),
                 workspace.getWorkspaceId(),
@@ -122,7 +124,7 @@ public class DanglingResourceCleanupServiceTest extends BaseConnectedTest {
 
     // Create a controlled gce instance
     ApiGcpGceInstanceResource instance =
-        mockMvcUtils
+        mockGcpApi
             .createGceInstance(
                 userAccessUtils.defaultUserAuthRequest(), workspace.getWorkspaceId(), null)
             .getGceInstance();


### PR DESCRIPTION
Currently, if the `azure.customer.usage-attribute` config value is not defined, Spring will fail to construct the CrlService component, which will crash WSM. This change will default it to an empty String instead, which seems like the right value per earlier comments: https://github.com/DataBiosphere/terra-workspace-manager/pull/1384#discussion_r1265939340

This also fixes a `mockMvcUtils` merge conflict between https://github.com/DataBiosphere/terra-workspace-manager/pull/1394 and https://github.com/DataBiosphere/terra-workspace-manager/pull/1387 that git didn't notice