### PR TITLE
[BENCH-826] Move Workspace V2 apis to mocks package

### DIFF
--- a/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiControllerTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.amalgam.landingzone.azure;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.AUTH_HEADER;
+import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
+import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -10,7 +11,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.common.exception.ForbiddenException;
-import bio.terra.common.iam.BearerToken;
 import bio.terra.landingzone.job.LandingZoneJobService;
 import bio.terra.landingzone.job.model.JobReport;
 import bio.terra.landingzone.library.landingzones.deployment.ResourcePurpose;
@@ -24,6 +24,8 @@ import bio.terra.landingzone.service.landingzone.azure.model.StartLandingZoneCre
 import bio.terra.landingzone.service.landingzone.azure.model.StartLandingZoneDeletion;
 import bio.terra.workspace.common.BaseAzureUnitTest;
 import bio.terra.workspace.common.fixtures.AzureLandingZoneFixtures;
+import bio.terra.workspace.generated.model.ApiCreateAzureLandingZoneRequestBody;
+import bio.terra.workspace.generated.model.ApiDeleteAzureLandingZoneRequestBody;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -52,9 +54,8 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
   private static final String JOB_ID = "newJobId";
   private static final UUID LANDING_ZONE_ID = UUID.randomUUID();
   private static final UUID BILLING_PROFILE_ID = UUID.randomUUID();
-  private static final BearerToken BEARER_TOKEN = new BearerToken("fake-token");
   @Autowired private MockMvc mockMvc;
-  @Autowired ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
   @Test
   public void createAzureLandingZoneJobRunning() throws Exception {
@@ -66,16 +67,17 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
         .thenReturn(asyncJobResult);
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
-    var requestBody =
+    ApiCreateAzureLandingZoneRequestBody requestBody =
         AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequest(JOB_ID, BILLING_PROFILE_ID);
 
     mockMvc
         .perform(
-            post(AZURE_LANDING_ZONE_PATH)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(requestBody))
-                .characterEncoding("utf-8")
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                post(AZURE_LANDING_ZONE_PATH)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestBody))
+                    .characterEncoding("utf-8"),
+                USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_ACCEPTED))
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport.id").exists())
@@ -94,16 +96,17 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     // TODO SG: check if we need name and description??
-    var requestBody =
+    ApiCreateAzureLandingZoneRequestBody requestBody =
         AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequest(JOB_ID, BILLING_PROFILE_ID);
 
     mockMvc
         .perform(
-            post(AZURE_LANDING_ZONE_PATH)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(requestBody))
-                .characterEncoding("utf-8")
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                post(AZURE_LANDING_ZONE_PATH)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestBody))
+                    .characterEncoding("utf-8"),
+                USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_OK))
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport.id").exists())
@@ -123,16 +126,17 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
         .thenReturn(asyncJobResult);
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
-    var requestBody =
+    ApiCreateAzureLandingZoneRequestBody requestBody =
         AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequestWithoutDefinition(JOB_ID);
 
     mockMvc
         .perform(
-            post(AZURE_LANDING_ZONE_PATH)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(requestBody))
-                .characterEncoding("utf-8")
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                post(AZURE_LANDING_ZONE_PATH)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestBody))
+                    .characterEncoding("utf-8"),
+                USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
   }
 
@@ -144,16 +148,17 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockLandingZoneService().getAsyncJobResult(any(), any())).thenReturn(asyncJobResult);
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
-    var requestBody =
+    ApiCreateAzureLandingZoneRequestBody requestBody =
         AzureLandingZoneFixtures.buildCreateAzureLandingZoneRequestWithoutTarget(JOB_ID);
 
     mockMvc
         .perform(
-            post(AZURE_LANDING_ZONE_PATH)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(requestBody))
-                .characterEncoding("utf-8")
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                post(AZURE_LANDING_ZONE_PATH)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestBody))
+                    .characterEncoding("utf-8"),
+                USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
   }
 
@@ -166,8 +171,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
 
     mockMvc
         .perform(
-            get(GET_CREATE_AZURE_LANDING_ZONE_RESULT + "/{jobId}", JOB_ID)
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(get(GET_CREATE_AZURE_LANDING_ZONE_RESULT + "/{jobId}", JOB_ID), USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_ACCEPTED))
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport.id").exists())
@@ -184,8 +188,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
 
     mockMvc
         .perform(
-            get(GET_CREATE_AZURE_LANDING_ZONE_RESULT + "/{jobId}", JOB_ID)
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(get(GET_CREATE_AZURE_LANDING_ZONE_RESULT + "/{jobId}", JOB_ID), USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_OK))
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport.id").exists())
@@ -198,7 +201,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
 
   @Test
   public void listAzureLandingZoneDefinitionsSuccess() throws Exception {
-    var definitions =
+    List<LandingZoneDefinition> definitions =
         List.of(
             LandingZoneDefinition.builder()
                 .definition("fooDefinition")
@@ -222,9 +225,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
     mockMvc
-        .perform(
-            get(LIST_AZURE_LANDING_ZONES_DEFINITIONS_PATH)
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+        .perform(addAuth(get(LIST_AZURE_LANDING_ZONES_DEFINITIONS_PATH), USER_REQUEST))
         .andExpect(status().isOk())
         .andExpect(MockMvcResultMatchers.jsonPath("$.landingzones").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.landingzones").isArray());
@@ -239,15 +240,17 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
         .thenReturn(asyncJobResult);
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
 
-    var requestBody = AzureLandingZoneFixtures.buildDeleteAzureLandingZoneRequest(JOB_ID);
+    ApiDeleteAzureLandingZoneRequestBody requestBody =
+        AzureLandingZoneFixtures.buildDeleteAzureLandingZoneRequest(JOB_ID);
 
     mockMvc
         .perform(
-            post(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}", LANDING_ZONE_ID)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(requestBody))
-                .characterEncoding("utf-8")
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                post(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}", LANDING_ZONE_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestBody))
+                    .characterEncoding("utf-8"),
+                USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_ACCEPTED))
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport.id").exists());
@@ -270,13 +273,14 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
 
     mockMvc
         .perform(
-            get(
-                    AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/delete-result/{jobId}",
-                    LANDING_ZONE_ID,
-                    JOB_ID)
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("utf-8")
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                get(
+                        AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/delete-result/{jobId}",
+                        LANDING_ZONE_ID,
+                        JOB_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8"),
+                USER_REQUEST))
         .andExpect(status().is(expectedHttpStatus))
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport.id").exists())
@@ -307,8 +311,9 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
-            get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/resources", LANDING_ZONE_ID)
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/resources", LANDING_ZONE_ID),
+                USER_REQUEST))
         .andExpect(status().isOk())
         .andExpect(MockMvcResultMatchers.jsonPath("$.id").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.id", Matchers.is(LANDING_ZONE_ID.toString())))
@@ -337,8 +342,9 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
-            get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/resources", LANDING_ZONE_ID)
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}/resources", LANDING_ZONE_ID),
+                USER_REQUEST))
         .andExpect(status().isOk())
         .andExpect(MockMvcResultMatchers.jsonPath("$.id").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.resources").exists())
@@ -360,8 +366,8 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
-            get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}", LANDING_ZONE_ID)
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}", LANDING_ZONE_ID), USER_REQUEST))
         .andExpect(status().isOk())
         .andExpect(MockMvcResultMatchers.jsonPath("$.landingZoneId").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.definition").exists())
@@ -385,10 +391,11 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
-            get(
+            addAuth(
+                get(
                     AZURE_LANDING_ZONE_PATH + "?billingProfileId={billingProfileId}",
-                    BILLING_PROFILE_ID)
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+                    BILLING_PROFILE_ID),
+                USER_REQUEST))
         .andExpect(status().isOk())
         .andExpect(MockMvcResultMatchers.jsonPath("$.landingzones").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.landingzones").isArray())
@@ -424,10 +431,11 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
-            get(
+            addAuth(
+                get(
                     AZURE_LANDING_ZONE_PATH + "?billingProfileId={billingProfileId}",
-                    BILLING_PROFILE_ID)
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+                    BILLING_PROFILE_ID),
+                USER_REQUEST))
         .andExpect(status().isConflict());
   }
 
@@ -444,8 +452,7 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockLandingZoneService().listLandingZones(any())).thenReturn(List.of(landingZone));
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
-        .perform(
-            get(AZURE_LANDING_ZONE_PATH).header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+        .perform(addAuth(get(AZURE_LANDING_ZONE_PATH), USER_REQUEST))
         .andExpect(status().isOk())
         .andExpect(MockMvcResultMatchers.jsonPath("$.landingzones").exists())
         .andExpect(MockMvcResultMatchers.jsonPath("$.landingzones").isArray())
@@ -465,8 +472,8 @@ public class LandingZoneApiControllerTest extends BaseAzureUnitTest {
     when(mockFeatureConfiguration().isAzureEnabled()).thenReturn(true);
     mockMvc
         .perform(
-            get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}", LANDING_ZONE_ID)
-                .header(AUTH_HEADER, "Bearer " + BEARER_TOKEN.getToken()))
+            addAuth(
+                get(AZURE_LANDING_ZONE_PATH + "/{landingZoneId}", LANDING_ZONE_ID), USER_REQUEST))
         .andExpect(status().isForbidden());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
@@ -10,6 +10,7 @@ import bio.terra.workspace.common.GcpCloudUtils;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockFlexibleResourceApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -56,6 +57,7 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockFlexibleResourceApi mockFlexibleResourceApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
@@ -115,8 +117,9 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId2);
   }
 
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAccessScope;
@@ -45,6 +46,7 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends BaseConnectedTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired JobService jobService;
@@ -72,7 +74,8 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }
 
   @Test
@@ -121,7 +124,7 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
 
   @Test
   public void createAiNotebookInstance_duplicateInstanceId() throws Exception {
-    var duplicateName = "not-unique-name";
+    String duplicateName = "not-unique-name";
     ApiGcpAiNotebookInstanceResource unused =
         mockGcpApi
             .createAiNotebookInstanceAndWait(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -48,6 +49,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
     extends BaseConnectedTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired JobService jobService;
@@ -109,7 +111,8 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }
 
   @Test
@@ -147,7 +150,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
 
   @Test
   public void createDataprocCluster_duplicateInstanceId() throws Exception {
-    var duplicateName = "not-unique-name";
+    String duplicateName = "not-unique-name";
     ApiGcpDataprocClusterResource unused =
         mockGcpApi
             .createDataprocClusterAndWait(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAccessScope;
@@ -45,6 +46,7 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends BaseConnectedTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired UserAccessUtils userAccessUtils;
   @Autowired JobService jobService;
@@ -72,7 +74,8 @@ public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends 
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }
 
   @Test
@@ -121,7 +124,7 @@ public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends 
 
   @Test
   public void createGceInstance_duplicateInstanceId() throws Exception {
-    var duplicateName = "not-unique-name";
+    String duplicateName = "not-unique-name";
     ApiGcpGceInstanceResource unused =
         mockGcpApi
             .createGceInstanceAndWait(

--- a/service/src/test/java/bio/terra/workspace/app/controller/PolicyApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/PolicyApiControllerConnectedTest.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.app.controller;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.POLICY_V1_GET_REGION_INFO_PATH;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,6 +27,8 @@ import org.springframework.test.web.servlet.ResultActions;
 @Tag("connected")
 @TestInstance(Lifecycle.PER_CLASS)
 public class PolicyApiControllerConnectedTest extends BaseConnectedTest {
+
+  public static final String POLICY_V1_GET_LOCATION_INFO = "/api/policies/v1/getLocationInfo";
 
   @Autowired MockMvc mockMvc;
   @Autowired ObjectMapper objectMapper;
@@ -69,7 +70,7 @@ public class PolicyApiControllerConnectedTest extends BaseConnectedTest {
     }
     Queue<ApiWsmPolicyLocation> subLocations = new ArrayDeque<>(location.getSublocations());
     while (!subLocations.isEmpty()) {
-      var subLocation = subLocations.poll();
+      ApiWsmPolicyLocation subLocation = subLocations.poll();
       if (subLocation.getName().equals(name)) {
         return subLocation;
       } else if (subLocation.getSublocations() != null) {
@@ -91,7 +92,7 @@ public class PolicyApiControllerConnectedTest extends BaseConnectedTest {
   }
 
   private ApiWsmPolicyLocation getLocationInfo(String platform, String location) throws Exception {
-    var serializedResponse =
+    String serializedResponse =
         getRegionInfoExpect(platform, location, HttpStatus.SC_OK)
             .andReturn()
             .getResponse()
@@ -104,7 +105,7 @@ public class PolicyApiControllerConnectedTest extends BaseConnectedTest {
     return mockMvc
         .perform(
             addAuth(
-                get(POLICY_V1_GET_REGION_INFO_PATH)
+                get(POLICY_V1_GET_LOCATION_INFO)
                     .queryParam("platform", platform)
                     .queryParam("location", region),
                 USER_REQUEST))

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -56,6 +57,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
@@ -107,8 +109,9 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId2);
   }
 
   @Test
@@ -145,12 +148,12 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
         WsmIamRole.WRITER,
         userAccessUtils.getSecondUserEmail());
 
-    var newName = TestUtils.appendRandomNumber("newdatatableresourcename");
-    var newDescription = "This is an updated description";
-    var newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
-    var newProjectId = TestUtils.appendRandomNumber("newProjectid");
-    var newDataset = TestUtils.appendRandomNumber("newdataset");
-    var newTable = TestUtils.appendRandomNumber("newtable");
+    String newName = TestUtils.appendRandomNumber("newdatatableresourcename");
+    String newDescription = "This is an updated description";
+    ApiCloningInstructionsEnum newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
+    String newProjectId = TestUtils.appendRandomNumber("newProjectid");
+    String newDataset = TestUtils.appendRandomNumber("newdataset");
+    String newTable = TestUtils.appendRandomNumber("newtable");
     ApiGcpBigQueryDataTableResource updatedResource =
         mockGcpApi.updateReferencedBqDataTable(
             userAccessUtils.secondUserAuthRequest(),
@@ -182,7 +185,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
 
   @Test
   public void update_throws409() throws Exception {
-    var newName = TestUtils.appendRandomNumber("newdatatableresourcename");
+    String newName = TestUtils.appendRandomNumber("newdatatableresourcename");
     mockGcpApi.createReferencedBqDataTable(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.mocks.MockGcpApi.REFERENCED_GCP_BQ_DATASET_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.assertApiBqDatasetEquals;
 import static bio.terra.workspace.common.utils.MockMvcUtils.assertResourceMetadata;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -13,6 +12,8 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
+import bio.terra.workspace.common.utils.GcpTestUtils;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -57,6 +58,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
@@ -106,8 +108,9 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId2);
   }
 
   @Test
@@ -132,7 +135,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,
             sourceResource.getMetadata().getResourceId());
-    assertApiBqDatasetEquals(sourceResource, gotResource);
+    GcpTestUtils.assertApiBqDatasetEquals(sourceResource, gotResource);
   }
 
   @Test
@@ -352,7 +355,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId,
             clonedResource.getMetadata().getResourceId());
-    assertApiBqDatasetEquals(clonedResource, gotResource);
+    GcpTestUtils.assertApiBqDatasetEquals(clonedResource, gotResource);
   }
 
   @Test
@@ -387,7 +390,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
             userAccessUtils.defaultUserAuthRequest(),
             workspaceId2,
             clonedResource.getMetadata().getResourceId());
-    assertApiBqDatasetEquals(clonedResource, gotResource);
+    GcpTestUtils.assertApiBqDatasetEquals(clonedResource, gotResource);
   }
 
   // Destination workspace policy is the merge of source workspace policy and pre-clone destination

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockDataRepoApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -55,6 +56,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockDataRepoApi mockDataRepoApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
@@ -100,8 +102,9 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId2);
   }
 
   @Test
@@ -137,11 +140,11 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
         WsmIamRole.WRITER,
         userAccessUtils.getSecondUserEmail());
 
-    var newName = TestUtils.appendRandomNumber("newdatareporesourcename");
-    var newDescription = "This is an updated description";
-    var newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
-    var newInstanceName = TestUtils.appendRandomNumber("newinstance");
-    var newSnapshot = TestUtils.appendRandomNumber("newsnapshot");
+    String newName = TestUtils.appendRandomNumber("newdatareporesourcename");
+    String newDescription = "This is an updated description";
+    ApiCloningInstructionsEnum newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
+    String newInstanceName = TestUtils.appendRandomNumber("newinstance");
+    String newSnapshot = TestUtils.appendRandomNumber("newsnapshot");
     ApiDataRepoSnapshotResource updatedResource =
         mockDataRepoApi.updateReferencedDataRepoSnapshot(
             userAccessUtils.secondUserAuthRequest(),
@@ -171,7 +174,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   @Test
   public void update_throws409() throws Exception {
-    var newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
+    String newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
     mockDataRepoApi.createReferencedDataRepoSnapshot(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -55,6 +56,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
@@ -101,8 +103,8 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
   @AfterAll
   public void cleanup() throws Exception {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    mockMvcUtils.deleteWorkspaceV2AndWait(userRequest, workspaceId);
-    mockMvcUtils.deleteWorkspaceV2AndWait(userRequest, workspaceId2);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId2);
   }
 
   @Test
@@ -136,11 +138,12 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
     mockMvcUtils.grantRole(
         userRequest, workspaceId, WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
 
-    var newName = TestUtils.appendRandomNumber("newgcsobjectname");
-    var newBucketName = TestUtils.appendRandomNumber("newgcsbucketname");
-    var newObjectName = TestUtils.appendRandomNumber("newobjectname");
-    var newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
+    String newName = TestUtils.appendRandomNumber("newgcsobjectname");
+    String newBucketName = TestUtils.appendRandomNumber("newgcsbucketname");
+    String newObjectName = TestUtils.appendRandomNumber("newobjectname");
+    ApiCloningInstructionsEnum newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
     String newDescription = "This is an updated description";
+
     ApiGcpGcsObjectResource updatedResource =
         mockGcpApi.updateReferencedGcsObject(
             workspaceId,
@@ -168,7 +171,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
   @Test
   public void update_throws409() throws Exception {
-    var newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
+    String newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
 
     mockGcpApi.createReferencedGcsObject(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -14,6 +14,7 @@ import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
 import bio.terra.workspace.common.mocks.MockGitRepoApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -55,6 +56,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired MockGitRepoApi mockGitRepoApi;
   @Autowired ObjectMapper objectMapper;
@@ -100,8 +102,9 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceId2);
   }
 
   @Test
@@ -169,7 +172,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @Test
   public void update_throws409() throws Exception {
-    var newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
+    String newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
     mockGitRepoApi.createReferencedGitRepo(
         userAccessUtils.defaultUserAuthRequest(), workspaceId, newName, sourceGitRepoUrl);
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
@@ -48,6 +49,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
@@ -65,7 +67,8 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
   @AfterAll
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }
 
   @Nested

--- a/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
@@ -6,6 +6,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.GcpCloudUtils;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -37,6 +38,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
@@ -58,7 +60,8 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
 
   @After
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspaceV2AndWait(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledResourceFixtures.java
@@ -101,7 +101,7 @@ public class ControlledResourceFixtures {
 
   // Flexible resources
 
-  public static final byte[] DEFAULT_UPDATE_FLEX_DATA =
+  static final byte[] DEFAULT_UPDATE_FLEX_DATA =
       "{\"description\":\"this is new JSON\"}".getBytes(StandardCharsets.UTF_8);
 
   public static ApiControlledFlexibleResourceCreationParameters

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV2Api.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV2Api.java
@@ -1,9 +1,10 @@
-package bio.terra.workspace.common.utils;
+package bio.terra.workspace.common.mocks;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiCreateWorkspaceV2Request;
 import bio.terra.workspace.generated.model.ApiCreateWorkspaceV2Result;
@@ -20,7 +21,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,27 +28,25 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
 
-/*
- * NOTE: I am putting the workspaceV2 endpoints here. The current MockMvcUtils file is
- * too big (~3000 loc) and should be busted up. This is a downpayment...
- */
 @Component
-public class MvcWorkspaceApi {
-  private static final Logger logger = LoggerFactory.getLogger(MvcWorkspaceApi.class);
+public class MockWorkspaceV2Api {
+  private static final Logger logger = LoggerFactory.getLogger(MockWorkspaceV2Api.class);
 
-  public static final String WORKSPACES_V2_CREATE = "/api/workspaces/v2";
-  public static final String WORKSPACES_V2_CREATE_RESULT = "/api/workspaces/v2/result/%s";
-  public static final String WORKSPACES_V2_DELETE = "/api/workspaces/v2/%s/delete";
-  public static final String WORKSPACES_V2_DELETE_RESULT = "/api/workspaces/v2/%s/delete-result/%s";
-  public static final String CLOUD_CONTEXT_V2_DELETE =
-      "/api/workspaces/v2/%s/cloudcontexts/%s/delete";
-  public static final String CLOUD_CONTEXT_V2_DELETE_RESULT =
-      "/api/workspaces/v2/%s/cloudcontexts/delete-result/%s";
   private static final Duration POLLING_INTERVAL = Duration.ofSeconds(15);
+
   // Do not Autowire UserAccessUtils. UserAccessUtils are for connected tests and not unit tests
   // (since unit tests don't use real SAM). Instead, each method must take in userRequest.
   @Autowired private MockMvc mockMvc;
+  @Autowired private MockMvcUtils mockMvcUtils;
   @Autowired private ObjectMapper objectMapper;
+
+  // Workspace
+
+  public static final String WORKSPACES_V2_CREATE = "/api/workspaces/v2";
+  public static final String WORKSPACES_V2_CREATE_RESULT = WORKSPACES_V2_CREATE + "/result/%s";
+  public static final String WORKSPACES_V2 = WORKSPACES_V2_CREATE + "/%s";
+  public static final String WORKSPACES_V2_DELETE = WORKSPACES_V2 + "/delete";
+  public static final String WORKSPACES_V2_DELETE_RESULT = WORKSPACES_V2 + "/delete-result/%s";
 
   // pass null cloudPlatform to skip creating a cloud context
   public ApiCreateWorkspaceV2Result createWorkspaceAsync(
@@ -69,7 +67,7 @@ public class MvcWorkspaceApi {
         request.getCloudPlatform(),
         jobId);
 
-    var response =
+    MockHttpServletResponse response =
         mockMvc
             .perform(
                 MockMvcUtils.addJsonContentType(
@@ -80,25 +78,25 @@ public class MvcWorkspaceApi {
             .andReturn()
             .getResponse();
 
-    return getCheckedJobResult(response, ApiCreateWorkspaceV2Result.class);
+    return mockMvcUtils.getCheckedJobResult(response, ApiCreateWorkspaceV2Result.class);
   }
 
   public ApiCreateWorkspaceV2Result createWorkspaceAsyncResult(
       AuthenticatedUserRequest userRequest, String jobId) throws Exception {
     logger.info("mvc-createWorkspaceAsyncResult user: {} jobId: {}", userRequest.getEmail(), jobId);
-    var path = String.format(WORKSPACES_V2_CREATE_RESULT, jobId);
-    var response =
+    String path = String.format(WORKSPACES_V2_CREATE_RESULT, jobId);
+    MockHttpServletResponse response =
         mockMvc
             .perform(MockMvcUtils.addJsonContentType(MockMvcUtils.addAuth(get(path), userRequest)))
             .andReturn()
             .getResponse();
-    return getCheckedJobResult(response, ApiCreateWorkspaceV2Result.class);
+    return mockMvcUtils.getCheckedJobResult(response, ApiCreateWorkspaceV2Result.class);
   }
 
   public ApiCreateWorkspaceV2Result createWorkspaceAndWait(
       AuthenticatedUserRequest userRequest, ApiCloudPlatform cloudPlatform) throws Exception {
-    var jobId = UUID.randomUUID().toString();
-    var jobResult = createWorkspaceAsync(userRequest, cloudPlatform, jobId);
+    String jobId = UUID.randomUUID().toString();
+    ApiCreateWorkspaceV2Result jobResult = createWorkspaceAsync(userRequest, cloudPlatform, jobId);
     while (jobResult.getJobReport().getStatusCode() == HttpStatus.SC_ACCEPTED) {
       TimeUnit.SECONDS.sleep(POLLING_INTERVAL.getSeconds());
       jobResult = createWorkspaceAsyncResult(userRequest, jobId);
@@ -113,9 +111,10 @@ public class MvcWorkspaceApi {
         userRequest.getEmail(),
         workspaceId,
         jobId);
-    var path = String.format(WORKSPACES_V2_DELETE, workspaceId);
-    var request = new ApiDeleteWorkspaceV2Request().jobControl(new ApiJobControl().id(jobId));
-    var response =
+    String path = String.format(WORKSPACES_V2_DELETE, workspaceId);
+    ApiDeleteWorkspaceV2Request request =
+        new ApiDeleteWorkspaceV2Request().jobControl(new ApiJobControl().id(jobId));
+    MockHttpServletResponse response =
         mockMvc
             .perform(
                 MockMvcUtils.addJsonContentType(
@@ -123,7 +122,7 @@ public class MvcWorkspaceApi {
                         post(path).content(objectMapper.writeValueAsString(request)), userRequest)))
             .andReturn()
             .getResponse();
-    return getCheckedJobResult(response, ApiJobResult.class);
+    return mockMvcUtils.getCheckedJobResult(response, ApiJobResult.class);
   }
 
   public ApiJobResult deleteWorkspaceAsyncResult(
@@ -133,25 +132,32 @@ public class MvcWorkspaceApi {
         userRequest.getEmail(),
         workspaceId,
         jobId);
-    var path = String.format(WORKSPACES_V2_DELETE_RESULT, workspaceId, jobId);
-    var response =
+    String path = String.format(WORKSPACES_V2_DELETE_RESULT, workspaceId, jobId);
+    MockHttpServletResponse response =
         mockMvc
             .perform(MockMvcUtils.addJsonContentType(MockMvcUtils.addAuth(get(path), userRequest)))
             .andReturn()
             .getResponse();
-    return getCheckedJobResult(response, ApiJobResult.class);
+    return mockMvcUtils.getCheckedJobResult(response, ApiJobResult.class);
   }
 
   public ApiJobResult deleteWorkspaceAndWait(AuthenticatedUserRequest userRequest, UUID workspaceId)
       throws Exception {
-    var jobId = UUID.randomUUID().toString();
-    var jobResult = deleteWorkspaceAsync(userRequest, workspaceId, jobId);
+    String jobId = UUID.randomUUID().toString();
+    ApiJobResult jobResult = deleteWorkspaceAsync(userRequest, workspaceId, jobId);
     while (jobResult.getJobReport().getStatusCode() == HttpStatus.SC_ACCEPTED) {
       TimeUnit.SECONDS.sleep(POLLING_INTERVAL.getSeconds());
       jobResult = deleteWorkspaceAsyncResult(userRequest, workspaceId, jobId);
     }
     return jobResult;
   }
+
+  // Cloud context
+
+  public static final String CLOUD_CONTEXTS_V2 = WORKSPACES_V2 + "/cloudcontexts";
+  public static final String CLOUD_CONTEXT_V2_DELETE = CLOUD_CONTEXTS_V2 + "/%s/delete";
+  public static final String CLOUD_CONTEXT_V2_DELETE_RESULT =
+      CLOUD_CONTEXTS_V2 + "/delete-result/%s";
 
   public ApiJobResult deleteCloudContextAsync(
       AuthenticatedUserRequest userRequest,
@@ -165,10 +171,11 @@ public class MvcWorkspaceApi {
         workspaceId,
         cloudPlatform,
         jobId);
-    var path =
+    String path =
         String.format(CLOUD_CONTEXT_V2_DELETE, workspaceId, cloudPlatform.toApiModel().toString());
-    var request = new ApiDeleteCloudContextV2Request().jobControl(new ApiJobControl().id(jobId));
-    var response =
+    ApiDeleteCloudContextV2Request request =
+        new ApiDeleteCloudContextV2Request().jobControl(new ApiJobControl().id(jobId));
+    MockHttpServletResponse response =
         mockMvc
             .perform(
                 MockMvcUtils.addJsonContentType(
@@ -176,7 +183,7 @@ public class MvcWorkspaceApi {
                         post(path).content(objectMapper.writeValueAsString(request)), userRequest)))
             .andReturn()
             .getResponse();
-    return getCheckedJobResult(response, ApiJobResult.class);
+    return mockMvcUtils.getCheckedJobResult(response, ApiJobResult.class);
   }
 
   public ApiJobResult deleteCloudContextAsyncResult(
@@ -186,36 +193,25 @@ public class MvcWorkspaceApi {
         userRequest.getEmail(),
         workspaceId,
         jobId);
-    var path = String.format(CLOUD_CONTEXT_V2_DELETE_RESULT, workspaceId, jobId);
-    var response =
+    String path = String.format(CLOUD_CONTEXT_V2_DELETE_RESULT, workspaceId, jobId);
+    MockHttpServletResponse response =
         mockMvc
             .perform(MockMvcUtils.addJsonContentType(MockMvcUtils.addAuth(get(path), userRequest)))
             .andReturn()
             .getResponse();
-    return getCheckedJobResult(response, ApiJobResult.class);
+    return mockMvcUtils.getCheckedJobResult(response, ApiJobResult.class);
   }
 
   public ApiJobResult deleteCloudContextAndWait(
       AuthenticatedUserRequest userRequest, UUID workspaceId, CloudPlatform cloudPlatform)
       throws Exception {
-    var jobId = UUID.randomUUID().toString();
-    var jobResult = deleteCloudContextAsync(userRequest, workspaceId, cloudPlatform, jobId);
+    String jobId = UUID.randomUUID().toString();
+    ApiJobResult jobResult =
+        deleteCloudContextAsync(userRequest, workspaceId, cloudPlatform, jobId);
     while (jobResult.getJobReport().getStatusCode() == HttpStatus.SC_ACCEPTED) {
       TimeUnit.SECONDS.sleep(POLLING_INTERVAL.getSeconds());
       jobResult = deleteCloudContextAsyncResult(userRequest, workspaceId, jobId);
     }
     return jobResult;
-  }
-
-  private <T> T getCheckedJobResult(MockHttpServletResponse response, Class<T> clazz)
-      throws Exception {
-    int statusCode = response.getStatus();
-    String content = response.getContentAsString();
-    if (statusCode == HttpStatus.SC_OK || statusCode == HttpStatus.SC_ACCEPTED) {
-      return objectMapper.readValue(content, clazz);
-    }
-    Assertions.fail(
-        String.format("Expected OK or ACCEPTED, but received %d; body: %s", statusCode, content));
-    return null;
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsConnectedTestUtils.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.common.utils;
 import bio.terra.aws.resource.discovery.Environment;
 import bio.terra.workspace.app.configuration.external.AwsConfiguration;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.workspace.model.AwsCloudContext;
 import bio.terra.workspace.service.workspace.model.AwsCloudContextFields;
@@ -15,7 +16,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class AwsConnectedTestUtils {
   @Autowired private AwsConfiguration awsConfiguration;
-  @Autowired MvcWorkspaceApi mvcWorkspaceApi;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
 
   private Environment environment;
 

--- a/service/src/test/java/bio/terra/workspace/common/utils/GcpTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/GcpTestUtils.java
@@ -1,0 +1,24 @@
+package bio.terra.workspace.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.workspace.generated.model.ApiGcpBigQueryDatasetResource;
+import bio.terra.workspace.generated.model.ApiGcpGcsBucketResource;
+
+// Test Utils for GCP (unit & connected) tests
+public class GcpTestUtils {
+
+  public static void assertApiGcsBucketEquals(
+      ApiGcpGcsBucketResource expectedBucket, ApiGcpGcsBucketResource actualBucket) {
+    MockMvcUtils.assertResourceMetadataEquals(
+        expectedBucket.getMetadata(), actualBucket.getMetadata());
+    assertEquals(expectedBucket.getAttributes(), actualBucket.getAttributes());
+  }
+
+  public static void assertApiBqDatasetEquals(
+      ApiGcpBigQueryDatasetResource expectedDataset, ApiGcpBigQueryDatasetResource actualDataset) {
+    MockMvcUtils.assertResourceMetadataEquals(
+        expectedDataset.getMetadata(), actualDataset.getMetadata());
+    assertEquals(expectedDataset.getAttributes(), actualDataset.getAttributes());
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/AwsS3StorageFolderFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/AwsS3StorageFolderFlightTest.java
@@ -14,8 +14,8 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.BaseAwsConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.AwsUtils;
-import bio.terra.workspace.common.utils.MvcWorkspaceApi;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAwsS3StorageFolderCreationParameters;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -49,7 +49,7 @@ public class AwsS3StorageFolderFlightTest extends BaseAwsConnectedTest {
   @Autowired private ControlledResourceService controlledResourceService;
   @Autowired private JobService jobService;
   @Autowired private StairwayComponent stairwayComponent;
-  @Autowired MvcWorkspaceApi mvcWorkspaceApi;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired UserAccessUtils userAccessUtils;
 
   private AuthenticatedUserRequest userRequest;
@@ -62,7 +62,7 @@ public class AwsS3StorageFolderFlightTest extends BaseAwsConnectedTest {
     super.init();
     userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();
     workspaceUuid =
-        mvcWorkspaceApi.createWorkspaceAndWait(userRequest, apiCloudPlatform).getWorkspaceId();
+        mockWorkspaceV2Api.createWorkspaceAndWait(userRequest, apiCloudPlatform).getWorkspaceId();
     landingZone =
         awsCloudContextService
             .getLandingZone(
@@ -77,7 +77,7 @@ public class AwsS3StorageFolderFlightTest extends BaseAwsConnectedTest {
 
   @AfterAll
   public void cleanUp() throws Exception {
-    mvcWorkspaceApi.deleteWorkspaceAndWait(userRequest, workspaceUuid);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceUuid);
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/BaseAwsSageMakerNotebookFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/BaseAwsSageMakerNotebookFlightTest.java
@@ -6,8 +6,8 @@ import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.app.configuration.external.CliConfiguration;
 import bio.terra.workspace.common.BaseAwsConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.AwsUtils;
-import bio.terra.workspace.common.utils.MvcWorkspaceApi;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
@@ -31,7 +31,7 @@ public abstract class BaseAwsSageMakerNotebookFlightTest extends BaseAwsConnecte
   @Autowired protected ControlledResourceService controlledResourceService;
   @Autowired protected JobService jobService;
   @Autowired protected StairwayComponent stairwayComponent;
-  @Autowired protected MvcWorkspaceApi mvcWorkspaceApi;
+  @Autowired protected MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired protected UserAccessUtils userAccessUtils;
   @Autowired protected CliConfiguration cliConfiguration;
 
@@ -45,7 +45,7 @@ public abstract class BaseAwsSageMakerNotebookFlightTest extends BaseAwsConnecte
     super.init();
     userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();
     workspaceUuid =
-        mvcWorkspaceApi.createWorkspaceAndWait(userRequest, apiCloudPlatform).getWorkspaceId();
+        mockWorkspaceV2Api.createWorkspaceAndWait(userRequest, apiCloudPlatform).getWorkspaceId();
     environment = awsCloudContextService.discoverEnvironment();
     awsCredentialsProvider =
         AwsUtils.createWsmCredentialProvider(
@@ -56,7 +56,7 @@ public abstract class BaseAwsSageMakerNotebookFlightTest extends BaseAwsConnecte
 
   @AfterAll
   public void cleanUp() throws Exception {
-    mvcWorkspaceApi.deleteWorkspaceAndWait(userRequest, workspaceUuid);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceUuid);
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2ConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2ConnectedTest.java
@@ -8,8 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.workspace.common.BaseAwsConnectedTest;
 import bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures;
 import bio.terra.workspace.common.mocks.MockAwsApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.AwsTestUtils;
-import bio.terra.workspace.common.utils.MvcWorkspaceApi;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiAwsS3StorageFolderCreationParameters;
 import bio.terra.workspace.generated.model.ApiAwsS3StorageFolderResource;
@@ -30,7 +30,7 @@ import software.amazon.awssdk.regions.Region;
 @Tag("aws-connected")
 public class AwsWorkspaceV2ConnectedTest extends BaseAwsConnectedTest {
   @Autowired private ControlledResourceService controlledResourceService;
-  @Autowired MvcWorkspaceApi mvcWorkspaceApi;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockAwsApi mockAwsApi;
   @Autowired UserAccessUtils userAccessUtils;
 
@@ -40,7 +40,7 @@ public class AwsWorkspaceV2ConnectedTest extends BaseAwsConnectedTest {
 
     // create workspace (with cloud context)
     ApiCreateWorkspaceV2Result createResult =
-        mvcWorkspaceApi.createWorkspaceAndWait(userRequest, apiCloudPlatform);
+        mockWorkspaceV2Api.createWorkspaceAndWait(userRequest, apiCloudPlatform);
     assertEquals(StatusEnum.SUCCEEDED, createResult.getJobReport().getStatus());
     UUID workspaceUuid = createResult.getWorkspaceId();
 
@@ -81,7 +81,8 @@ public class AwsWorkspaceV2ConnectedTest extends BaseAwsConnectedTest {
     assertEquals(creationParameters.getFolderName(), fetchedResource.getAttributes().getPrefix());
 
     // delete workspace (with cloud context)
-    ApiJobResult deleteResult = mvcWorkspaceApi.deleteWorkspaceAndWait(userRequest, workspaceUuid);
+    ApiJobResult deleteResult =
+        mockWorkspaceV2Api.deleteWorkspaceAndWait(userRequest, workspaceUuid);
     assertEquals(StatusEnum.SUCCEEDED, deleteResult.getJobReport().getStatus());
 
     // cloud context should have been deleted

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceV2ApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceV2ApiTest.java
@@ -1,8 +1,8 @@
 package bio.terra.workspace.service.workspace;
 
 import bio.terra.workspace.common.BaseConnectedTest;
+import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
-import bio.terra.workspace.common.utils.MvcWorkspaceApi;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiCreateWorkspaceV2Result;
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Tag("connected")
 public class WorkspaceV2ApiTest extends BaseConnectedTest {
   @Autowired MockMvcUtils mockMvcUtils;
-  @Autowired MvcWorkspaceApi mvcWorkspaceApi;
+  @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired UserAccessUtils userAccessUtils;
 
   @Test
@@ -34,9 +34,9 @@ public class WorkspaceV2ApiTest extends BaseConnectedTest {
         userAccessUtils.defaultUser().getAuthenticatedRequest();
     // Create the workspace with no cloud context
     ApiCreateWorkspaceV2Result result =
-        mvcWorkspaceApi.createWorkspaceAndWait(defaultUserRequest, cloudPlatform);
+        mockWorkspaceV2Api.createWorkspaceAndWait(defaultUserRequest, cloudPlatform);
     UUID workspaceUuid = result.getWorkspaceId();
 
-    mvcWorkspaceApi.deleteWorkspaceAndWait(defaultUserRequest, workspaceUuid);
+    mockWorkspaceV2Api.deleteWorkspaceAndWait(defaultUserRequest, workspaceUuid);
   }
 }


### PR DESCRIPTION
- Ongoing cleanup of MockMvcUtils
- Move Workspace V2 apis to mocks package
- Remove duplicate definitions of V2 workspace APIs in MockMvcUtils
- Use AddAuth util function in LandingZoneApiControllerTest
- Move gcp test utils to GcpTestUtils