### PR TITLE
[PF-2930] Fix component URIs in Azure spec

### DIFF
--- a/openapi/src/parts/controlled_azure_database.yaml
+++ b/openapi/src/parts/controlled_azure_database.yaml
@@ -69,7 +69,7 @@ paths:
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
-          $ref: '#components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 

--- a/openapi/src/parts/controlled_azure_disk.yaml
+++ b/openapi/src/parts/controlled_azure_disk.yaml
@@ -66,7 +66,7 @@ paths:
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
-          $ref: '#components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 
@@ -87,7 +87,7 @@ paths:
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
-          $ref: '#components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 

--- a/openapi/src/parts/controlled_azure_managed_identity.yaml
+++ b/openapi/src/parts/controlled_azure_managed_identity.yaml
@@ -55,7 +55,7 @@ paths:
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
-          $ref: '#components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 

--- a/openapi/src/parts/controlled_azure_vm.yaml
+++ b/openapi/src/parts/controlled_azure_vm.yaml
@@ -80,7 +80,7 @@ paths:
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
-          $ref: '#components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 
@@ -100,7 +100,7 @@ paths:
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
-          $ref: '#components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 


### PR DESCRIPTION
golang's oapi-codegen was failing to parse the malformed URIs.