### PR TITLE
[BENCH-826] Move workspace v1 functions to MockWorkspaceV1Api

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
@@ -163,7 +163,7 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
 
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
     assertThat(
         destWorkspace.getPolicies(),
         containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
@@ -135,16 +135,16 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
     }
 
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
@@ -170,8 +170,8 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
     Assertions.assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
@@ -213,9 +213,9 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
   void clone_copyResource_undo() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
     String destDescription = "new description";
-
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     mockFlexibleResourceApi.cloneFlexibleResourceAndExpect(
-        userAccessUtils.defaultUserAuthRequest(),
+        userRequest,
         /*sourceWorkspaceId=*/ workspaceId,
         sourceFlexResource.getMetadata().getResourceId(),
         /*destWorkspaceId=*/ workspaceId2,
@@ -226,8 +226,7 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
         /*shouldUndo=*/ true);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId2, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId2, destResourceName);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
@@ -87,7 +87,7 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
             .createWorkspaceWithoutCloudContext(userAccessUtils.defaultUserAuthRequest())
             .getId();
     workspaceId2 =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithPolicy(
                 userAccessUtils.defaultUserAuthRequest(),
                 new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
@@ -248,9 +248,9 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userRequest, workspaceId2, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
 
     // Always remove roles before test terminates.
@@ -267,21 +267,21 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
           List.of(HttpStatus.SC_FORBIDDEN),
           /*shouldUndo=*/ false);
     } finally {
-      mockMvcUtils.removeRole(
+      mockWorkspaceV1Api.removeRole(
           userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
-      mockMvcUtils.removeRole(
+      mockWorkspaceV1Api.removeRole(
           userRequest, workspaceId2, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
     }
   }
 
   @Test
   public void clone_SecondUserHasWriteAccessOnDestWorkspace_succeeds() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,
@@ -313,12 +313,12 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
           workspaceId2,
           clonedFlexResource.getMetadata().getResourceId());
     } finally {
-      mockMvcUtils.removeRole(
+      mockWorkspaceV1Api.removeRole(
           userAccessUtils.defaultUserAuthRequest(),
           workspaceId,
           WsmIamRole.READER,
           userAccessUtils.getSecondUserEmail());
-      mockMvcUtils.removeRole(
+      mockWorkspaceV1Api.removeRole(
           userAccessUtils.defaultUserAuthRequest(),
           workspaceId2,
           WsmIamRole.WRITER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
@@ -10,6 +10,7 @@ import bio.terra.workspace.common.GcpCloudUtils;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockFlexibleResourceApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
@@ -57,6 +58,7 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockFlexibleResourceApi mockFlexibleResourceApi;
   @Autowired ObjectMapper objectMapper;
@@ -81,7 +83,7 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
   @BeforeAll
   public void setup() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithoutCloudContext(userAccessUtils.defaultUserAuthRequest())
             .getId();
     workspaceId2 =

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerTest.java
@@ -272,6 +272,6 @@ public class ControlledFlexibleResourceApiControllerTest extends BaseUnitTest {
     assertNull(clonedFlexResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(USER_REQUEST, workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(USER_REQUEST, workspaceId, destResourceName);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.mocks.MockFlexibleResourceApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
@@ -40,6 +41,7 @@ public class ControlledFlexibleResourceApiControllerTest extends BaseUnitTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockFlexibleResourceApi mockFlexibleResourceApi;
   @Autowired ObjectMapper objectMapper;
   private static final String defaultDecodedData = "{\"name\":\"original JSON\"}";
@@ -78,13 +80,11 @@ public class ControlledFlexibleResourceApiControllerTest extends BaseUnitTest {
 
   @Test
   public void create() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     // Pass in encoded JSON data to ensure it is decoded to a JSON string within the database.
-
     // Create a JSON object with some data.
     JSONObject jsonData = new JSONObject();
-
     jsonData.put("name", "Aaron");
     jsonData.put("description", "Some description here.");
     jsonData.put("count", 23);
@@ -129,7 +129,7 @@ public class ControlledFlexibleResourceApiControllerTest extends BaseUnitTest {
 
   @Test
   public void create_rejectsLargeData() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     byte[] veryLargeData = new byte[6000];
     Arrays.fill(veryLargeData, (byte) 'a');
@@ -147,13 +147,12 @@ public class ControlledFlexibleResourceApiControllerTest extends BaseUnitTest {
 
   @Test
   public void update() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
-    var flexResource = createDefaultFlexResource(workspaceId).getFlexibleResource();
+    ApiFlexibleResource flexResource = createDefaultFlexResource(workspaceId).getFlexibleResource();
     UUID resourceId = flexResource.getMetadata().getResourceId();
-
-    var newName = "new-flex-resource-name";
-    var newDescription = "This is an updated description";
+    String newName = "new-flex-resource-name";
+    String newDescription = "This is an updated description";
 
     byte[] encodedNewData = defaultNewDecodedData.getBytes(StandardCharsets.UTF_8);
 
@@ -182,12 +181,11 @@ public class ControlledFlexibleResourceApiControllerTest extends BaseUnitTest {
 
   @Test
   public void update_onlyNameAndDescription() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     UUID resourceId = createDefaultFlexResource(workspaceId).getResourceId();
-
-    var newName = "new-flex-resource-name";
-    var newDescription = "This is an updated description";
+    String newName = "new-flex-resource-name";
+    String newDescription = "This is an updated description";
 
     ApiFlexibleResource updatedFlex =
         mockFlexibleResourceApi.updateFlexibleResource(
@@ -202,12 +200,10 @@ public class ControlledFlexibleResourceApiControllerTest extends BaseUnitTest {
 
   @Test
   public void update_onlyData() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
-    var originalFlex = createDefaultFlexResource(workspaceId).getFlexibleResource();
-
+    ApiFlexibleResource originalFlex = createDefaultFlexResource(workspaceId).getFlexibleResource();
     UUID resourceId = originalFlex.getMetadata().getResourceId();
-
     String originalDescription = originalFlex.getMetadata().getDescription();
 
     byte[] encodedNewData = defaultNewDecodedData.getBytes(StandardCharsets.UTF_8);
@@ -225,8 +221,7 @@ public class ControlledFlexibleResourceApiControllerTest extends BaseUnitTest {
 
   @Test
   public void update_rejectsLargeData() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     UUID resourceId = createDefaultFlexResource(workspaceId).getResourceId();
 
     byte[] veryLargeData = new byte[6000];
@@ -250,22 +245,19 @@ public class ControlledFlexibleResourceApiControllerTest extends BaseUnitTest {
 
   @Test
   public void delete() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     UUID resourceId = createDefaultFlexResourceWithData(workspaceId, null).getResourceId();
 
     mockFlexibleResourceApi.getFlexibleResourceExpect(workspaceId, resourceId, HttpStatus.SC_OK);
-
     mockFlexibleResourceApi.deleteFlexibleResource(USER_REQUEST, workspaceId, resourceId);
-
     mockFlexibleResourceApi.getFlexibleResourceExpect(
         workspaceId, resourceId, HttpStatus.SC_NOT_FOUND);
   }
 
   @Test
   void clone_copyNothing() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    var resourceId = createDefaultFlexResourceWithData(workspaceId, null).getResourceId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID resourceId = createDefaultFlexResourceWithData(workspaceId, null).getResourceId();
 
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
     ApiFlexibleResource clonedFlexResource =

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -46,6 +47,7 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends BaseConnectedTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired UserAccessUtils userAccessUtils;
@@ -56,7 +58,7 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
   @BeforeAll
   public void setup() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerAiNotebookConnectedTest.java
@@ -82,7 +82,7 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
 
   @Test
   public void createAiNotebookInstance_correctZone() throws Exception {
-    mockMvcUtils.updateWorkspaceProperties(
+    mockWorkspaceV1Api.updateWorkspaceProperties(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         List.of(
@@ -118,7 +118,7 @@ public class ControlledGcpResourceApiControllerAiNotebookConnectedTest extends B
         userAccessUtils.getDefaultUserEmail(),
         userAccessUtils.getDefaultUserEmail());
 
-    mockMvcUtils.deleteWorkspaceProperties(
+    mockWorkspaceV1Api.deleteWorkspaceProperties(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         List.of(WorkspaceConstants.Properties.DEFAULT_RESOURCE_LOCATION));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -127,12 +127,12 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
         mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
 
     // Setup 2nd user
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         defaultUserRequest,
         workspaceId,
         WsmIamRole.WRITER,
         userAccessUtils.secondUser().getEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         defaultUserRequest,
         workspaceId2,
         WsmIamRole.READER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -139,8 +139,9 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
         userAccessUtils.secondUser().getEmail());
 
     // Create the cloud contexts
-    mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId, apiCloudPlatform);
-    mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId2, apiCloudPlatform);
+    mockWorkspaceV1Api.createCloudContextAndWait(defaultUserRequest, workspaceId, apiCloudPlatform);
+    mockWorkspaceV1Api.createCloudContextAndWait(
+        defaultUserRequest, workspaceId2, apiCloudPlatform);
 
     ApiWorkspaceDescription workspace =
         mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -19,6 +19,7 @@ import bio.terra.workspace.common.GcpCloudUtils;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.GcpTestUtils;
 import bio.terra.workspace.common.utils.MockMvcUtils;
@@ -85,6 +86,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
@@ -120,8 +122,9 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
 
     // See note in ControlledGcpResourceApiControllerGcsBucketTest for details
     // on how we handle the grant permissions and avoid long propagation delays.
-    workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
-    workspaceId2 = mockMvcUtils.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
+    workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
+    workspaceId2 =
+        mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
 
     // Setup 2nd user
     mockMvcUtils.grantRole(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -143,11 +143,11 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
     mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId2, apiCloudPlatform);
 
     ApiWorkspaceDescription workspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     projectId = workspace.getGcpContext().getProjectId();
 
     ApiWorkspaceDescription workspace2 =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
     projectId2 = workspace2.getGcpContext().getProjectId();
 
     // Wait for 2nd user to have permission
@@ -707,7 +707,8 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
         /*destDatasetName*/ null);
 
     // Assert dest workspace policy is reduced to the narrower region.
-    ApiWorkspaceDescription destWorkspace = mockMvcUtils.getWorkspace(userRequest, workspaceId2);
+    ApiWorkspaceDescription destWorkspace =
+        mockWorkspaceV1Api.getWorkspace(userRequest, workspaceId2);
     assertThat(
         destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_NEVADA));
     Assertions.assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -302,7 +302,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
     mockGcpApi.createReferencedBqDataset(
         userRequest, workspaceId, newName, projectId, sourceDatasetName);
 
-    mockMvcUtils.updateResource(
+    mockWorkspaceV1Api.updateResourceAndExpect(
         ApiGcpBigQueryDatasetResource.class,
         CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT,
         workspaceId,
@@ -451,7 +451,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
     assertNull(clonedResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   @Test
@@ -761,7 +761,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
         destResourceName);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(userRequest, workspaceId2, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId2, destResourceName);
   }
 
   @Test
@@ -777,7 +777,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
         destResourceName);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   private void assertBqDataset(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -681,16 +681,16 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();
 
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userRequest, workspaceId);
-    mockMvcUtils.deletePolicies(userRequest, workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userRequest,
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_NEVADA),
         /*policiesToRemove=*/ null);
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userRequest,
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
@@ -715,8 +715,8 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
     Assertions.assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userRequest, workspaceId);
-    mockMvcUtils.deletePolicies(userRequest, workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId2);
   }
 
   private void cloneControlledBqDataset_undo(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
@@ -49,6 +50,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
     extends BaseConnectedTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired UserAccessUtils userAccessUtils;
@@ -61,7 +63,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
   @BeforeAll
   public void setup() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerDataprocClusterConnectedTest.java
@@ -119,7 +119,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
 
   @Test
   public void createDataprocCluster() throws Exception {
-    mockMvcUtils.updateWorkspaceProperties(
+    mockWorkspaceV1Api.updateWorkspaceProperties(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         List.of(
@@ -144,7 +144,7 @@ public class ControlledGcpResourceApiControllerDataprocClusterConnectedTest
         userAccessUtils.getDefaultUserEmail(),
         userAccessUtils.getDefaultUserEmail());
 
-    mockMvcUtils.deleteWorkspaceProperties(
+    mockWorkspaceV1Api.deleteWorkspaceProperties(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         List.of(WorkspaceConstants.Properties.DEFAULT_RESOURCE_LOCATION));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -46,6 +47,7 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends BaseConnectedTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired UserAccessUtils userAccessUtils;
@@ -56,7 +58,7 @@ public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends 
   @BeforeAll
   public void setup() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGceInstanceConnectedTest.java
@@ -82,7 +82,7 @@ public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends 
 
   @Test
   public void createGceInstance_correctZone() throws Exception {
-    mockMvcUtils.updateWorkspaceProperties(
+    mockWorkspaceV1Api.updateWorkspaceProperties(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         List.of(
@@ -118,7 +118,7 @@ public class ControlledGcpResourceApiControllerGceInstanceConnectedTest extends 
         userAccessUtils.getDefaultUserEmail(),
         userAccessUtils.getDefaultUserEmail());
 
-    mockMvcUtils.deleteWorkspaceProperties(
+    mockWorkspaceV1Api.deleteWorkspaceProperties(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         List.of(WorkspaceConstants.Properties.DEFAULT_RESOURCE_LOCATION));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -26,6 +26,7 @@ import bio.terra.workspace.common.GcsBucketUtils;
 import bio.terra.workspace.common.StairwayTestUtils;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.GcpTestUtils;
 import bio.terra.workspace.common.utils.MockMvcUtils;
@@ -118,6 +119,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
@@ -173,8 +175,9 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
     AuthenticatedUserRequest defaultUserRequest =
         userAccessUtils.defaultUser().getAuthenticatedRequest();
 
-    workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
-    workspaceId2 = mockMvcUtils.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
+    workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
+    workspaceId2 =
+        mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
 
     // Setup 2nd user
     mockMvcUtils.grantRole(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -196,11 +196,11 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
     mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId2, apiCloudPlatform);
 
     ApiWorkspaceDescription workspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     projectId = workspace.getGcpContext().getProjectId();
 
     ApiWorkspaceDescription workspace2 =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
     projectId2 = workspace2.getGcpContext().getProjectId();
 
     // Wait for both users to have permission in both projects
@@ -798,7 +798,8 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
         /*destLocation*/ null);
 
     // Assert dest workspace policy is reduced to the narrower region.
-    ApiWorkspaceDescription destWorkspace = mockMvcUtils.getWorkspace(userRequest, workspaceId2);
+    ApiWorkspaceDescription destWorkspace =
+        mockWorkspaceV1Api.getWorkspace(userRequest, workspaceId2);
     assertThat(
         destWorkspace.getPolicies(), containsInAnyOrder(PolicyFixtures.REGION_POLICY_NEVADA));
     Assertions.assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -180,12 +180,12 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
         mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(defaultUserRequest).getId();
 
     // Setup 2nd user
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         defaultUserRequest,
         workspaceId,
         WsmIamRole.WRITER,
         userAccessUtils.secondUser().getEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         defaultUserRequest,
         workspaceId2,
         WsmIamRole.READER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -404,23 +404,21 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
   public void update_throws409() throws Exception {
     String oldName = sourceBucket.getMetadata().getName();
     String newName = TestUtils.appendRandomNumber("newbucketresourcename");
-    mockGcpApi.createReferencedGcsBucket(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId, newName, sourceBucketName);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    mockGcpApi.createReferencedGcsBucket(userRequest, workspaceId, newName, sourceBucketName);
 
-    mockMvcUtils.updateResource(
+    mockWorkspaceV1Api.updateResourceAndExpect(
         ApiGcpGcsBucketResource.class,
         CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT,
         workspaceId,
         sourceBucket.getMetadata().getResourceId(),
         objectMapper.writeValueAsString(
             new ApiUpdateControlledGcpGcsBucketRequestBody().name(newName)),
-        userAccessUtils.defaultUserAuthRequest(),
+        userRequest,
         HttpStatus.SC_CONFLICT);
     ApiGcpGcsBucketResource getResource =
         mockGcpApi.getControlledGcsBucket(
-            userAccessUtils.defaultUserAuthRequest(),
-            workspaceId,
-            sourceBucket.getMetadata().getResourceId());
+            userRequest, workspaceId, sourceBucket.getMetadata().getResourceId());
     assertEquals(oldName, getResource.getMetadata().getName());
   }
 
@@ -547,7 +545,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
     assertNull(clonedResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   @Test
@@ -852,7 +850,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
         destResourceName);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(userRequest, workspaceId2, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId2, destResourceName);
   }
 
   @Test
@@ -868,7 +866,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
         destResourceName);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(userRequest, workspaceId2, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId2, destResourceName);
   }
 
   private void assertGcsBucket(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -192,8 +192,9 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
         userAccessUtils.secondUser().getEmail());
 
     // Create the cloud contexts
-    mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId, apiCloudPlatform);
-    mockMvcUtils.createCloudContextAndWait(defaultUserRequest, workspaceId2, apiCloudPlatform);
+    mockWorkspaceV1Api.createCloudContextAndWait(defaultUserRequest, workspaceId, apiCloudPlatform);
+    mockWorkspaceV1Api.createCloudContextAndWait(
+        defaultUserRequest, workspaceId2, apiCloudPlatform);
 
     ApiWorkspaceDescription workspace =
         mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -771,16 +771,16 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();
 
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userRequest, workspaceId);
-    mockMvcUtils.deletePolicies(userRequest, workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userRequest,
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_NEVADA),
         /*policiesToRemove=*/ null);
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userRequest,
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
@@ -806,8 +806,8 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
     Assertions.assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userRequest, workspaceId);
-    mockMvcUtils.deletePolicies(userRequest, workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId2);
   }
 
   public void cloneControlledGcsBucket_undo(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerTest.java
@@ -18,6 +18,7 @@ import bio.terra.workspace.app.controller.shared.PropertiesUtils;
 import bio.terra.workspace.common.BaseUnitTestMockGcpCloudContextService;
 import bio.terra.workspace.common.fixtures.ControlledGcpResourceFixtures;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiAiNotebookCloudId;
 import bio.terra.workspace.generated.model.ApiBqDatasetCloudId;
@@ -46,6 +47,7 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpCloudContextService {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired ObjectMapper objectMapper;
 
   @BeforeEach
@@ -75,7 +77,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void getCloudNameFromGcsBucketName() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiGenerateGcpGcsBucketCloudNameRequestBody bucketNameRequest =
         new ApiGenerateGcpGcsBucketCloudNameRequestBody().gcsBucketName("my-bucket");
 
@@ -106,7 +108,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void getCloudNameFromBigQueryDatasetName() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiGenerateGcpBigQueryDatasetCloudIDRequestBody bqDatasetNameRequest =
         new ApiGenerateGcpBigQueryDatasetCloudIDRequestBody().bigQueryDatasetName("bq-dataset");
 
@@ -135,7 +137,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void getCloudNameFromAiNotebookInstanceName() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiGenerateGcpAiNotebookCloudIdRequestBody aiNotebookNameRequest =
         new ApiGenerateGcpAiNotebookCloudIdRequestBody().aiNotebookName("ai-notebook");
 
@@ -164,7 +166,7 @@ public class ControlledGcpResourceApiControllerTest extends BaseUnitTestMockGcpC
 
   @Test
   public void createBigQueryDataset_resourceContainsInvalidFolderId_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiCreateControlledGcpBigQueryDatasetRequestBody datasetCreationRequest =
         new ApiCreateControlledGcpBigQueryDatasetRequestBody()
             .common(

--- a/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/FolderApiControllerTest.java
@@ -28,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiCreateFolderRequestBody;
 import bio.terra.workspace.generated.model.ApiFolder;
@@ -62,6 +63,7 @@ import org.testcontainers.shaded.org.apache.commons.lang3.builder.EqualsBuilder;
 public class FolderApiControllerTest extends BaseUnitTest {
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired ObjectMapper objectMapper;
 
   @BeforeEach
@@ -91,9 +93,9 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void createFolder_parentFolderIdIsNull_topLevelFolderCreated() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    var displayName = "foo";
-    var description = String.format("This is folder %s", displayName);
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    String displayName = "foo";
+    String description = String.format("This is folder %s", displayName);
 
     ApiFolder folder =
         createFolder(workspaceId, displayName, description, null, Map.of("foo", "bar"));
@@ -109,11 +111,10 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void createFolder_dateAndActorFieldsSet() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     ApiFolder folder =
         createFolder(workspaceId, "foo", "This is folder foo", null, Map.of("foo", "bar"));
-
     assertNotNull(folder.getId());
     assertNull(folder.getParentFolderId());
     assertEquals(USER_REQUEST.getEmail(), folder.getCreatedBy());
@@ -124,7 +125,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void createFolder_doesNotHaveWriteAccess_throws403() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     doThrow(new ForbiddenException("User has no write access"))
         .when(mockSamService())
         .checkAuthz(
@@ -138,7 +139,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void createFolder_parentFolderDoesNotExist_throws404() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     createFolderExpectCode(workspaceId, "foo", UUID.randomUUID(), HttpStatus.SC_NOT_FOUND);
   }
@@ -150,8 +151,8 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void createFolder_duplicateDisplayName_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    var displayName = "foo";
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    String displayName = "foo";
 
     // create a top-level folder foo.
     ApiFolder firstFolder = createFolder(workspaceId);
@@ -177,12 +178,12 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void createFolder_duplicateNameUnderDifferentParent_succeeds() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     ApiFolder firstFolder = createFolder(workspaceId);
     ApiFolder secondFolder =
         createFolder(workspaceId, /*displayName=*/ "bar", /*parentFolderId=*/ null);
 
-    var duplicateDisplayName = "foo";
+    String duplicateDisplayName = "foo";
     ApiFolder thirdFolder =
         createFolder(
             workspaceId,
@@ -204,9 +205,9 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void getFolder_returnsFolder() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    ApiFolder firstFolder = createFolder(workspaceId);
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
+    ApiFolder firstFolder = createFolder(workspaceId);
     ApiFolder retrievedFolder = getFolder(workspaceId, firstFolder.getId());
 
     assertEquals(firstFolder.createdDate(retrievedFolder.getCreatedDate()), retrievedFolder);
@@ -215,7 +216,8 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void getFolder_doesNotHaveReadAccess_throws403() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
         .when(mockSamService())
@@ -238,27 +240,27 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void getFolder_folderDoNotExist_throws404() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     getFolderExpectCode(workspaceId, /*folderId=*/ UUID.randomUUID(), HttpStatus.SC_NOT_FOUND);
   }
 
   @Test
   public void listFolders_listAllFoldersInAWorkspace() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    var displayName = "foo";
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    String displayName = "foo";
+
     ApiFolder firstFolder = createFolder(workspaceId, displayName, /*parentFolderId=*/ null);
     ApiFolder secondFolder =
         createFolder(workspaceId, displayName, /*parentFolderId=*/ firstFolder.getId());
-
     List<ApiFolder> retrievedFolders = listFolders(workspaceId).getFolders().stream().toList();
-
     assertThat(retrievedFolders, containsInAnyOrder(firstFolder, secondFolder));
   }
 
   @Test
   public void listFolders_doesNotHaveReadAccess_throws403() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+
     createFolderExpectCode(workspaceId, HttpStatus.SC_OK);
     doThrow(new ForbiddenException("User has no write access"))
         .when(mockSamService())
@@ -278,7 +280,8 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void deleteFolder_doesNotHaveWriteAccess_throws403() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
         .when(mockSamService())
@@ -295,14 +298,13 @@ public class FolderApiControllerTest extends BaseUnitTest {
   public void deleteFolders_workspaceAndFolderNotExist_throws404() throws Exception {
     deleteFolderExpectCode(UUID.randomUUID(), UUID.randomUUID(), HttpStatus.SC_NOT_FOUND);
 
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     deleteFolderExpectCode(workspaceId, UUID.randomUUID(), HttpStatus.SC_NOT_FOUND);
   }
 
   @Test
   public void deleteFolders_deleteTopLevelFolder_folderAndSubFoldersAllDeleted() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     ApiFolder firstFolder = createFolder(workspaceId);
     ApiFolder secondFolder =
@@ -320,14 +322,14 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   private ApiJobReport deleteFolderAndWaitForJob(UUID workspaceId, ApiFolder folder)
       throws Exception {
-    var serializedResponse =
+    String serializedResponse =
         deleteFolderExpectCode(workspaceId, folder.getId(), HttpStatus.SC_ACCEPTED)
             .andReturn()
             .getResponse()
             .getContentAsString();
-    var jobResult = objectMapper.readValue(serializedResponse, ApiJobResult.class);
-    var jobReport = jobResult.getJobReport();
-    var jobId = jobReport.getId();
+    ApiJobResult jobResult = objectMapper.readValue(serializedResponse, ApiJobResult.class);
+    ApiJobReport jobReport = jobResult.getJobReport();
+    String jobId = jobReport.getId();
     while (jobReport.getStatus() == StatusEnum.RUNNING) {
       Thread.sleep(Duration.ofSeconds(1).toMillis());
       jobReport =
@@ -341,14 +343,15 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void updateFolders_updateParentFalse_onlyUpdateNameAndDescription() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    var displayName = "foo";
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    String displayName = "foo";
+
     ApiFolder firstFolder = createFolder(workspaceId, displayName, /*parentFolderId=*/ null);
     ApiFolder secondFolder =
         createFolder(workspaceId, displayName, /*parentFolderId=*/ firstFolder.getId());
 
-    var newDisplayName = "sofoo";
-    var newDescription = "This is a very foo folder";
+    String newDisplayName = "sofoo";
+    String newDescription = "This is a very foo folder";
     ApiFolder updatedFolder =
         updateFolder(
             workspaceId,
@@ -366,8 +369,9 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void updateFolders_updateParentTrue_folderMovedToTopLevel() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    var displayName = "foo";
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    String displayName = "foo";
+
     ApiFolder firstFolder = createFolder(workspaceId, displayName, /*parentFolderId=*/ null);
     ApiFolder secondFolder =
         createFolder(workspaceId, displayName, /*parentFolderId=*/ firstFolder.getId());
@@ -387,7 +391,8 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void updateFolder_doesNotHaveWriteAccess_throws403() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
         .when(mockSamService())
@@ -412,11 +417,11 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void updateFolders_parentFolderNotExists_throws404() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    ApiFolder folder = createFolder(workspaceId);
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    String newDisplayName = "sofoo";
+    String newDescription = "This is a very foo folder";
 
-    var newDisplayName = "sofoo";
-    var newDescription = "This is a very foo folder";
+    ApiFolder folder = createFolder(workspaceId);
     updateFolderExpectCode(
         workspaceId,
         folder.getId(),
@@ -432,7 +437,8 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void updateFolderProperties_success() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+
     // create folder with foo=bar
     ApiFolder folder = createFolder(workspaceId);
 
@@ -471,7 +477,8 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void updateFolderProperties_userHasNoWritePermission_throws403() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
         .when(mockSamService())
@@ -487,7 +494,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void updateFolderProperties_folderNotExist_throws404() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     updateFolderPropertiesExpectCode(
         workspaceId,
@@ -499,9 +506,9 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void deleteFolderProperties_propertiesDeletedSuccessfully() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    ApiFolder folder = createFolder(workspaceId);
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
+    ApiFolder folder = createFolder(workspaceId);
     assertTrue(convertApiPropertyToMap(folder.getProperties()).containsKey("foo"));
     deleteFolderPropertiesExpectCode(
         workspaceId, folder.getId(), List.of("foo"), USER_REQUEST, HttpStatus.SC_NO_CONTENT);
@@ -514,7 +521,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void deleteFolderProperties_folderNotFound_throws404() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     deleteFolderPropertiesExpectCode(
         workspaceId, UUID.randomUUID(), List.of("foo"), USER_REQUEST, HttpStatus.SC_NOT_FOUND);
@@ -522,7 +529,8 @@ public class FolderApiControllerTest extends BaseUnitTest {
 
   @Test
   public void deleteFolderProperties_userHasNoWritePermission_throws403() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+
     ApiFolder folder = createFolder(workspaceId);
     doThrow(new ForbiddenException("User has no write access"))
         .when(mockSamService())
@@ -677,7 +685,7 @@ public class FolderApiControllerTest extends BaseUnitTest {
       @Nullable UUID parentFolderId,
       boolean updateParent)
       throws JsonProcessingException {
-    var requestBody =
+    ApiUpdateFolderRequestBody requestBody =
         new ApiUpdateFolderRequestBody()
             .description(newDescription)
             .displayName(newDisplayName)

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
@@ -407,16 +407,16 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
     }
 
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
@@ -441,8 +441,8 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   private void assertBqTable(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
@@ -311,9 +311,10 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
   @Test
   void clone_copyNothing() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     ApiGcpBigQueryDataTableResource clonedResource =
         mockGcpApi.cloneReferencedBqDataTable(
-            userAccessUtils.defaultUserAuthRequest(),
+            userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
@@ -324,8 +325,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
     assertNull(clonedResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
@@ -84,7 +84,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     projectId = workspace.getGcpContext().getProjectId();
     workspaceId2 =
         mockWorkspaceV1Api
@@ -434,7 +434,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
 
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
     assertThat(
         destWorkspace.getPolicies(),
         containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
@@ -57,6 +58,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
@@ -77,7 +79,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
   @BeforeAll
   public void setup() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
@@ -85,7 +87,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     projectId = workspace.getGcpContext().getProjectId();
     workspaceId2 =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithPolicy(
                 userAccessUtils.defaultUserAuthRequest(),
                 new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDataTableConnectedTest.java
@@ -144,7 +144,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
 
   @Test
   public void update() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -178,7 +178,7 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
         newTable,
         userAccessUtils.getDefaultUserEmail(),
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -228,12 +228,12 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
 
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -248,12 +248,12 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
         /*destResourceName=*/ null,
         HttpStatus.SC_FORBIDDEN);
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -262,12 +262,12 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
 
   @Test
   public void clone_secondUserHasWriteAccessOnDestWorkspace_succeeds() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,
@@ -292,12 +292,12 @@ public class ReferencedGcpResourceControllerBqDataTableConnectedTest extends Bas
         sourceTableId,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
         userAccessUtils.secondUserAuthRequest());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -307,9 +307,10 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
   @Test
   void clone_copyNothing() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     ApiGcpBigQueryDatasetResource clonedResource =
         mockGcpApi.cloneReferencedBqDataset(
-            userAccessUtils.defaultUserAuthRequest(),
+            userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
@@ -320,8 +321,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
     assertNull(clonedResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.GcpTestUtils;
 import bio.terra.workspace.common.utils.MockMvcUtils;
@@ -58,6 +59,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
@@ -78,7 +80,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
   @BeforeAll
   public void setup() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
@@ -86,7 +88,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
         mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     projectId = workspace.getGcpContext().getProjectId();
     workspaceId2 =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithPolicy(
                 userAccessUtils.defaultUserAuthRequest(),
                 new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))
@@ -116,7 +118,6 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
   @Test
   public void create() throws Exception {
     // Resource was created in setup()
-
     // Assert resource returned by create
     assertBqDataset(
         sourceResource,
@@ -146,10 +147,10 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
         WsmIamRole.WRITER,
         userAccessUtils.getSecondUserEmail());
 
-    var newName = TestUtils.appendRandomNumber("newdatatableresourcename");
-    var newDescription = "This is an updated description";
-    var newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
-    var newDataset = TestUtils.appendRandomNumber("newdataset");
+    String newName = TestUtils.appendRandomNumber("newdatatableresourcename");
+    String newDescription = "This is an updated description";
+    ApiCloningInstructionsEnum newCloningInstruction = ApiCloningInstructionsEnum.REFERENCE;
+    String newDataset = TestUtils.appendRandomNumber("newdataset");
     ApiGcpBigQueryDatasetResource updatedResource =
         mockGcpApi.updateReferencedBqDataset(
             userAccessUtils.secondUserAuthRequest(),
@@ -180,7 +181,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
   @Test
   public void update_throws409() throws Exception {
-    var newName = TestUtils.appendRandomNumber("newdataSetresourcename");
+    String newName = TestUtils.appendRandomNumber("newdataSetresourcename");
     mockGcpApi.createReferencedBqDataset(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -141,7 +141,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
   @Test
   public void update() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -172,7 +172,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
         userAccessUtils.getDefaultUserEmail(),
         userAccessUtils.getSecondUserEmail());
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -221,12 +221,12 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -241,12 +241,12 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
         /*destResourceName=*/ null,
         HttpStatus.SC_FORBIDDEN);
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -255,12 +255,12 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
   @Test
   public void clone_secondUserHasWriteAccessOnDestWorkspace_succeeds() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,
@@ -287,12 +287,12 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
         userAccessUtils.secondUserAuthRequest());
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -85,7 +85,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     projectId = workspace.getGcpContext().getProjectId();
     workspaceId2 =
         mockWorkspaceV1Api
@@ -432,7 +432,7 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
 
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
     assertThat(
         destWorkspace.getPolicies(),
         containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerBqDatasetConnectedTest.java
@@ -405,16 +405,16 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
     }
 
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
@@ -439,8 +439,8 @@ public class ReferencedGcpResourceControllerBqDatasetConnectedTest extends BaseC
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   private void assertBqDataset(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -136,7 +136,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   @Test
   public void update() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -167,7 +167,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
         newSnapshot,
         userAccessUtils.getDefaultUserEmail(),
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -217,12 +217,12 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -237,12 +237,12 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
         /*destResourceName=*/ null,
         HttpStatus.SC_FORBIDDEN);
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -251,12 +251,12 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   @Test
   public void clone_writerHasWriteAccessOnDestWorkspace_succeeds() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,
@@ -282,12 +282,12 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
         userAccessUtils.secondUserAuthRequest());
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockDataRepoApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
@@ -56,6 +57,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockDataRepoApi mockDataRepoApi;
   @Autowired ObjectMapper objectMapper;
@@ -74,7 +76,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
   @BeforeAll
   public void setup() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithoutCloudContext(userAccessUtils.defaultUserAuthRequest())
             .getId();
     workspaceId2 =

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -80,7 +80,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
             .createWorkspaceWithoutCloudContext(userAccessUtils.defaultUserAuthRequest())
             .getId();
     workspaceId2 =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithPolicy(
                 userAccessUtils.defaultUserAuthRequest(),
                 new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -399,16 +399,16 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
     }
 
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
@@ -433,8 +433,8 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   private void assertDataRepoSnapshot(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -426,7 +426,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
 
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
     assertThat(
         destWorkspace.getPolicies(),
         containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest.java
@@ -301,9 +301,10 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
   @Test
   void clone_copyNothing() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     ApiDataRepoSnapshotResource clonedResource =
         mockDataRepoApi.cloneReferencedDataRepoSnapshot(
-            userAccessUtils.defaultUserAuthRequest(),
+            userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
@@ -314,8 +315,7 @@ public class ReferencedGcpResourceControllerDataRepoSnapshotConnectedTest
     assertNull(clonedResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -130,7 +130,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   @Test
   public void update() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -160,7 +160,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         newBucketName,
         userAccessUtils.getDefaultUserEmail(),
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -169,7 +169,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   @Test
   public void update_nameAndDescriptionOnly() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -240,12 +240,12 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -260,12 +260,12 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         /*destResourceName=*/ null,
         HttpStatus.SC_FORBIDDEN);
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -274,12 +274,12 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   @Test
   public void clone_secondUserHasWriteAccessOnDestWorkspace_succeeds() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,
@@ -302,12 +302,12 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
         sourceBucketName,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
         userAccessUtils.secondUserAuthRequest());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.GcpTestUtils;
 import bio.terra.workspace.common.utils.MockMvcUtils;
@@ -54,6 +55,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
@@ -71,12 +73,12 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
   @BeforeAll
   public void setup() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     workspaceId2 =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithPolicy(
                 userAccessUtils.defaultUserAuthRequest(),
                 new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -321,9 +321,10 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
   @Test
   void clone_copyNothing() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     ApiGcpGcsBucketResource clonedResource =
         mockGcpApi.cloneReferencedGcsBucket(
-            userAccessUtils.defaultUserAuthRequest(),
+            userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
@@ -334,8 +335,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
     assertNull(clonedResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -408,16 +408,16 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
   @EnabledIf(expression = "${feature.tps-enabled}", loadContext = true)
   void clone_policiesMerged() throws Exception {
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
@@ -442,8 +442,8 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   private void assertGcsBucket(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsBucketConnectedTest.java
@@ -435,7 +435,7 @@ public class ReferencedGcpResourceControllerGcsBucketConnectedTest extends BaseC
 
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
     assertThat(
         destWorkspace.getPolicies(),
         containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -393,7 +393,8 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         destResourceName);
 
     // Assert dest workspace policy is reduced to the narrower region.
-    ApiWorkspaceDescription destWorkspace = mockMvcUtils.getWorkspace(userRequest, workspaceId2);
+    ApiWorkspaceDescription destWorkspace =
+        mockWorkspaceV1Api.getWorkspace(userRequest, workspaceId2);
     assertThat(
         destWorkspace.getPolicies(),
         containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -283,7 +283,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
     assertNull(clonedResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -367,16 +367,16 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
 
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userRequest, workspaceId);
-    mockMvcUtils.deletePolicies(userRequest, workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userRequest,
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userRequest,
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
@@ -401,8 +401,8 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userRequest, workspaceId);
-    mockMvcUtils.deletePolicies(userRequest, workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userRequest, workspaceId2);
   }
 
   private void assertGcsObject(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -137,7 +137,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
   @Test
   public void update() throws Exception {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userRequest, workspaceId, WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
 
     String newName = TestUtils.appendRandomNumber("newgcsobjectname");
@@ -167,7 +167,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         newObjectName,
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
         /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userRequest, workspaceId, WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
   }
 
@@ -210,9 +210,9 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userRequest, workspaceId2, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
 
     mockGcpApi.cloneReferencedGcsObjectAndExpect(
@@ -224,18 +224,18 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         /*destResourceName=*/ null,
         HttpStatus.SC_FORBIDDEN);
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userRequest, workspaceId2, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
   }
 
   @Test
   public void clone_secondUserHasWriteAccessOnDestWorkspace_succeeds() throws Exception {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userRequest, workspaceId2, WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
 
     ApiGcpGcsObjectResource clonedResource =
@@ -257,9 +257,9 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
         sourceFileName,
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
         userAccessUtils.secondUserAuthRequest());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userRequest, workspaceId, WsmIamRole.READER, userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userRequest, workspaceId2, WsmIamRole.WRITER, userAccessUtils.getSecondUserEmail());
     mockGcpApi.deleteReferencedGcsObject(
         userRequest, workspaceId2, clonedResource.getMetadata().getResourceId());

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGcsObjectConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
@@ -56,6 +57,7 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
@@ -77,9 +79,9 @@ public class ReferencedGcpResourceControllerGcsObjectConnectedTest extends BaseC
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
 
     workspaceId =
-        mockMvcUtils.createWorkspaceWithCloudContext(userRequest, apiCloudPlatform).getId();
+        mockWorkspaceV1Api.createWorkspaceWithCloudContext(userRequest, apiCloudPlatform).getId();
     workspaceId2 =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithPolicy(
                 userRequest,
                 new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -14,6 +14,7 @@ import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
 import bio.terra.workspace.common.mocks.MockGitRepoApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
@@ -56,6 +57,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired MockGitRepoApi mockGitRepoApi;
@@ -74,7 +76,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
   @BeforeAll
   public void setup() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithoutCloudContext(userAccessUtils.defaultUserAuthRequest())
             .getId();
     workspaceId2 =

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -414,7 +414,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
     // Assert dest workspace policy is reduced to the narrower region.
     ApiWorkspaceDescription destWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
     assertThat(
         destWorkspace.getPolicies(),
         containsInAnyOrder(PolicyFixtures.REGION_POLICY_IOWA, PolicyFixtures.GROUP_POLICY_DEFAULT));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -387,16 +387,16 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
     }
 
     // Clean up policies from previous runs, if any exist
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
 
     // Add broader region policy to destination, narrow policy on source.
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_IOWA),
         /*policiesToRemove=*/ null);
-    mockMvcUtils.updatePolicies(
+    mockWorkspaceV1Api.updatePolicies(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         /*policiesToAdd=*/ ImmutableList.of(PolicyFixtures.REGION_POLICY_USA),
@@ -421,8 +421,8 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
     assertFalse(destWorkspace.getPolicies().contains(PolicyFixtures.REGION_POLICY_USA));
 
     // Clean up: Delete policies
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
-    mockMvcUtils.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockWorkspaceV1Api.deletePolicies(userAccessUtils.defaultUserAuthRequest(), workspaceId2);
   }
 
   private void assertGitRepo(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -175,24 +175,22 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
   @Test
   public void update_throws409() throws Exception {
     String newName = TestUtils.appendRandomNumber("newgcsobjectresourcename");
-    mockGitRepoApi.createReferencedGitRepo(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId, newName, sourceGitRepoUrl);
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
+    mockGitRepoApi.createReferencedGitRepo(userRequest, workspaceId, newName, sourceGitRepoUrl);
 
-    mockMvcUtils.updateResource(
+    mockWorkspaceV1Api.updateResourceAndExpect(
         ApiGitRepoResource.class,
         REFERENCED_GIT_REPOS_PATH_FORMAT,
         workspaceId,
         sourceResource.getMetadata().getResourceId(),
         objectMapper.writeValueAsString(
             new ApiUpdateBigQueryDatasetReferenceRequestBody().name(newName)),
-        userAccessUtils.defaultUserAuthRequest(),
+        userRequest,
         HttpStatus.SC_CONFLICT);
 
     ApiGitRepoResource gotResource =
         mockGitRepoApi.getReferencedGitRepo(
-            userAccessUtils.defaultUserAuthRequest(),
-            workspaceId,
-            sourceResource.getMetadata().getResourceId());
+            userRequest, workspaceId, sourceResource.getMetadata().getResourceId());
     assertEquals(sourceResourceName, gotResource.getMetadata().getName());
   }
 
@@ -293,9 +291,10 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
   @Test
   void clone_copyNothing() throws Exception {
     String destResourceName = TestUtils.appendRandomNumber("dest-resource-name");
+    AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     ApiGitRepoResource clonedResource =
         mockGitRepoApi.cloneReferencedGitRepo(
-            userAccessUtils.defaultUserAuthRequest(),
+            userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
             /*destWorkspaceId=*/ workspaceId,
@@ -306,8 +305,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
     assertNull(clonedResource);
 
     // Assert clone doesn't exist. There's no resource ID, so search on resource name.
-    mockMvcUtils.assertNoResourceWithName(
-        userAccessUtils.defaultUserAuthRequest(), workspaceId, destResourceName);
+    mockWorkspaceV1Api.assertNoResourceWithName(userRequest, workspaceId, destResourceName);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -80,7 +80,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
             .createWorkspaceWithoutCloudContext(userAccessUtils.defaultUserAuthRequest())
             .getId();
     workspaceId2 =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithPolicy(
                 userAccessUtils.defaultUserAuthRequest(),
                 new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.GROUP_POLICY_DEFAULT))

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerGitRepoConnectedTest.java
@@ -135,7 +135,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @Test
   public void update() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -165,7 +165,7 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
         /*expectedCreatedBy=*/ userAccessUtils.getDefaultUserEmail(),
         /*expectedLastUpdatedBy=*/ userAccessUtils.getSecondUserEmail());
     // clean up permission of the second user.
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.WRITER,
@@ -210,12 +210,12 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -230,12 +230,12 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
         /*destResourceName=*/ null,
         HttpStatus.SC_FORBIDDEN);
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.READER,
@@ -244,12 +244,12 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
 
   @Test
   public void clone_secondUserHasWriteAccessOnDestWorkspace_succeeds() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,
@@ -274,12 +274,12 @@ public class ReferencedGcpResourceControllerGitRepoConnectedTest extends BaseCon
         /*expectedCreatedBy=*/ userAccessUtils.getSecondUserEmail(),
         userAccessUtils.secondUserAuthRequest());
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId,
         WsmIamRole.READER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspaceId2,
         WsmIamRole.WRITER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedGcpResourceControllerTest.java
@@ -9,6 +9,7 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.mocks.MockDataRepoApi;
 import bio.terra.workspace.common.mocks.MockGcpApi;
 import bio.terra.workspace.common.mocks.MockGitRepoApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.service.iam.model.SamConstants;
@@ -29,6 +30,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired MockDataRepoApi mockDataRepoApi;
   @Autowired MockGitRepoApi mockGitRepoApi;
@@ -60,7 +62,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedDataRepoSnapshot_copyDefinition_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockDataRepoApi.cloneReferencedDataRepoSnapshot(
         USER_REQUEST,
         workspaceId,
@@ -73,7 +75,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedDataRepoSnapshot_copyResource_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockDataRepoApi.cloneReferencedDataRepoSnapshot(
         USER_REQUEST,
         workspaceId,
@@ -86,7 +88,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedBqDataset_copyDefinition_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGcpApi.cloneReferencedBqDatasetAndExpect(
         USER_REQUEST,
         workspaceId,
@@ -99,7 +101,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedBqDataset_copyResource_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGcpApi.cloneReferencedBqDatasetAndExpect(
         USER_REQUEST,
         workspaceId,
@@ -112,7 +114,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedBqTable_copyDefinition_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGcpApi.cloneReferencedBqDataTableAndExpect(
         USER_REQUEST,
         workspaceId,
@@ -125,7 +127,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedBqTable_copyResource_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGcpApi.cloneReferencedBqDataTableAndExpect(
         USER_REQUEST,
         workspaceId,
@@ -138,7 +140,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedGcsBucket_copyDefinition_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGcpApi.cloneReferencedGcsBucketAndExpect(
         USER_REQUEST,
         workspaceId,
@@ -151,7 +153,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedGcsBucket_copyResource_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGcpApi.cloneReferencedGcsBucketAndExpect(
         USER_REQUEST,
         workspaceId,
@@ -164,7 +166,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedGcsObject_copyDefinition_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGcpApi.cloneReferencedGcsObjectAndExpect(
         USER_REQUEST,
         workspaceId,
@@ -177,7 +179,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedGcsObject_copyResource_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGcpApi.cloneReferencedGcsObjectAndExpect(
         USER_REQUEST,
         workspaceId,
@@ -190,7 +192,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedGitRepo_copyDefinition_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGitRepoApi.cloneReferencedGitRepo(
         USER_REQUEST,
         workspaceId,
@@ -203,7 +205,7 @@ public class ReferencedGcpResourceControllerTest extends BaseUnitTest {
 
   @Test
   public void cloneReferencedGitRepo_copyResource_throws400() throws Exception {
-    UUID workspaceId = mockMvcUtils.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
+    UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
     mockGitRepoApi.cloneReferencedGitRepo(
         USER_REQUEST,
         workspaceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
@@ -77,9 +77,9 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
 
   @AfterEach
   public void cleanup() throws Exception {
-    mockMvcUtils.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), sourceWorkspaceId);
+    mockWorkspaceV1Api.deleteWorkspace(userAccessUtils.defaultUserAuthRequest(), sourceWorkspaceId);
     if (destinationWorkspaceId != null) {
-      mockMvcUtils.deleteWorkspace(
+      mockWorkspaceV1Api.deleteWorkspace(
           userAccessUtils.defaultUserAuthRequest(), destinationWorkspaceId);
     }
   }
@@ -225,7 +225,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
   private void checkRegionPolicy(UUID workspaceUuid, List<String> expectedRegions)
       throws Exception {
     ApiWorkspaceDescription workspaceDescription =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceUuid);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceUuid);
 
     List<ApiWsmPolicyInput> policies = workspaceDescription.getPolicies();
     ApiWsmPolicyInput regionPolicy =
@@ -246,7 +246,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
 
   private void checkGroupPolicy(UUID workspaceUuid, List<String> expectedGroups) throws Exception {
     ApiWorkspaceDescription workspaceDescription =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceUuid);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceUuid);
 
     List<ApiWsmPolicyInput> policies = workspaceDescription.getPolicies();
     ApiWsmPolicyInput groupPolicy =
@@ -321,7 +321,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
     workspaceSetup(cloningInstructions);
 
     destinationWorkspaceId = UUID.randomUUID();
-    mockMvcUtils.cloneWorkspace(
+    mockWorkspaceV1Api.cloneWorkspace(
         userAccessUtils.defaultUserAuthRequest(),
         sourceWorkspaceId,
         "wm-default-spend-profile",
@@ -339,7 +339,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
     workspaceSetup(cloningInstructions);
 
     destinationWorkspaceId = UUID.randomUUID();
-    mockMvcUtils.cloneWorkspace(
+    mockWorkspaceV1Api.cloneWorkspace(
         userAccessUtils.defaultUserAuthRequest(),
         sourceWorkspaceId,
         "wm-default-spend-profile",

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
@@ -388,7 +388,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
     try {
       // Update the source workspace policy
       ApiWsmPolicyUpdateResult result =
-          mockMvcUtils.updatePolicies(
+          mockWorkspaceV1Api.updatePolicies(
               userAccessUtils.defaultUserAuthRequest(),
               sourceWorkspaceId,
               /*policiesToAdd*/ locationsToAdd,
@@ -406,7 +406,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
     try {
       // Update the source workspace policy
       ApiWsmPolicyUpdateResult result =
-          mockMvcUtils.updatePoliciesExpectStatus(
+          mockWorkspaceV1Api.updatePoliciesAndExpect(
               userAccessUtils.defaultUserAuthRequest(),
               sourceWorkspaceId,
               /*policiesToAdd*/ locationsToAdd,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
@@ -4,7 +4,7 @@ import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RES
 import static bio.terra.workspace.common.fixtures.PolicyFixtures.IOWA_REGION;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_NAME;
 import static bio.terra.workspace.common.mocks.MockGcpApi.CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CLONE_WORKSPACE_PATH_FORMAT;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_CLONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -187,7 +187,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
     mockMvcUtils.postExpect(
         userAccessUtils.defaultUserAuthRequest(),
         objectMapper.writeValueAsString(request),
-        CLONE_WORKSPACE_PATH_FORMAT.formatted(sourceWorkspaceId.toString()),
+        WORKSPACES_V1_CLONE.formatted(sourceWorkspaceId.toString()),
         HttpStatus.SC_CONFLICT);
   }
 
@@ -282,7 +282,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
 
   private void resourceSetup() throws Exception {
     sourceWorkspaceId = UUID.randomUUID();
-    var workspaceRequest =
+    ApiCreateWorkspaceRequestBody workspaceRequest =
         new ApiCreateWorkspaceRequestBody()
             .id(sourceWorkspaceId)
             .displayName("clone source")
@@ -295,7 +295,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
         userAccessUtils.defaultUserAuthRequest(), workspaceRequest);
 
     destinationWorkspaceId = UUID.randomUUID();
-    var workspace2Request =
+    ApiCreateWorkspaceRequestBody workspace2Request =
         new ApiCreateWorkspaceRequestBody()
             .id(destinationWorkspaceId)
             .displayName("clone destination")
@@ -349,7 +349,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
 
   private void workspaceSetup(ApiCloningInstructionsEnum cloningInstructions) throws Exception {
     sourceWorkspaceId = UUID.randomUUID();
-    var workspaceRequest =
+    ApiCreateWorkspaceRequestBody workspaceRequest =
         new ApiCreateWorkspaceRequestBody()
             .id(sourceWorkspaceId)
             .displayName("clone source")

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
@@ -14,6 +14,7 @@ import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -55,6 +56,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired UserAccessUtils userAccessUtils;
@@ -291,7 +293,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
             .spendProfile("wm-default-spend-profile")
             .policies(new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.REGION_POLICY_USA));
 
-    mockMvcUtils.createdWorkspaceWithoutCloudContext(
+    mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(
         userAccessUtils.defaultUserAuthRequest(), workspaceRequest);
 
     destinationWorkspaceId = UUID.randomUUID();
@@ -304,7 +306,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
             .spendProfile("wm-default-spend-profile")
             .policies(null);
 
-    mockMvcUtils.createdWorkspaceWithoutCloudContext(
+    mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(
         userAccessUtils.defaultUserAuthRequest(), workspace2Request);
 
     sourceResource =
@@ -358,7 +360,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
             .spendProfile("wm-default-spend-profile")
             .policies(new ApiWsmPolicyInputs().addInputsItem(PolicyFixtures.REGION_POLICY_USA));
 
-    mockMvcUtils.createdWorkspaceWithoutCloudContext(
+    mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(
         userAccessUtils.defaultUserAuthRequest(), workspaceRequest);
 
     // Create the bucket with the test cloning instructions

--- a/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
@@ -3,7 +3,7 @@ package bio.terra.workspace.app.controller;
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertApiPropertyToMap;
 import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertMapToApiProperties;
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.DEFAULT_RESOURCE_PROPERTIES;
-import static bio.terra.workspace.common.utils.MockMvcUtils.RESOURCE_PROPERTIES_V1_PATH_FORMAT;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_RESOURCES_PROPERTIES;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static bio.terra.workspace.service.workspace.model.WorkspaceConstants.ResourceProperties.FOLDER_ID_KEY;
@@ -80,7 +80,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
           mockGcpApi.createControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId);
       UUID resourceId = resource.getResourceId();
-      var folderIdKey = "terra_workspace_folder_id";
+      String folderIdKey = "terra_workspace_folder_id";
       Map<String, String> newProperties =
           Map.of(
               "terra_workspace_folder_id",
@@ -102,7 +102,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
           expectedProperties,
           convertApiPropertyToMap(updatedResource.getMetadata().getProperties()));
 
-      var newFolderId = UUID.randomUUID();
+      UUID newFolderId = UUID.randomUUID();
       // Change property terra_workspace_folder_id to new UUID.
       updateResourcePropertiesExpectCode(
           workspaceId,
@@ -261,7 +261,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
                   addAuth(
                       patch(
                               String.format(
-                                  RESOURCE_PROPERTIES_V1_PATH_FORMAT, workspaceId, resourceId))
+                                  WORKSPACES_V1_RESOURCES_PROPERTIES, workspaceId, resourceId))
                           .contentType(MediaType.APPLICATION_JSON_VALUE)
                           .accept(MediaType.APPLICATION_JSON)
                           .characterEncoding("UTF-8")
@@ -296,7 +296,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
         .perform(
             addJsonContentType(
                 addAuth(
-                    post(String.format(RESOURCE_PROPERTIES_V1_PATH_FORMAT, workspaceId, resourceId))
+                    post(String.format(WORKSPACES_V1_RESOURCES_PROPERTIES, workspaceId, resourceId))
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8")

--- a/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerConnectedTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -49,6 +50,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
@@ -156,7 +158,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
           mockGcpApi.createControlledBqDataset(
               userAccessUtils.defaultUserAuthRequest(), workspaceId);
       UUID resourceId = resource.getResourceId();
-      mockMvcUtils.grantRole(
+      mockWorkspaceV1Api.grantRole(
           userAccessUtils.defaultUserAuthRequest(),
           workspaceId,
           WsmIamRole.READER,
@@ -223,7 +225,7 @@ public class ResourceApiControllerConnectedTest extends BaseConnectedTest {
           resourceId,
           Map.of("foo", "bar", "sweet", "cake", "cute", "puppy"),
           HttpStatus.SC_NO_CONTENT);
-      mockMvcUtils.grantRole(
+      mockWorkspaceV1Api.grantRole(
           userAccessUtils.defaultUserAuthRequest(),
           workspaceId,
           WsmIamRole.READER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
@@ -6,6 +6,7 @@ import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.GcpCloudUtils;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
@@ -38,6 +39,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
 
   @Autowired MockMvc mockMvc;
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
@@ -67,7 +69,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
   @Test
   public void setupAndWaitBucket() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
@@ -102,7 +104,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
   @Test
   public void setupAndWaitNotebook() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
@@ -126,7 +128,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
   @Test
   public void setupAndWaitBigQuery() throws Exception {
     workspaceId =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();

--- a/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/TempGrantConnectedTest.java
@@ -74,7 +74,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     String projectId = workspace.getGcpContext().getProjectId();
 
     logger.info("Created workspace {} with project {}", workspaceId, projectId);
@@ -109,7 +109,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     String projectId = workspace.getGcpContext().getProjectId();
 
     logger.info("Created workspace {} with project {}", workspaceId, projectId);
@@ -133,7 +133,7 @@ public class TempGrantConnectedTest extends BaseConnectedTest {
                 userAccessUtils.defaultUserAuthRequest(), apiCloudPlatform)
             .getId();
     ApiWorkspaceDescription workspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+        mockWorkspaceV1Api.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspaceId);
     String projectId = workspace.getGcpContext().getProjectId();
 
     logger.info("Created workspace {} with project {}", workspaceId, projectId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -4,11 +4,11 @@ import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.SHORT_DESCRI
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.TYPE_PROPERTY;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.USER_SET_PROPERTY;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.VERSION_PROPERTY;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UFID_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UUID_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_EXPLAIN_POLICIES_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_MERGE_CHECK_POLICIES_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_PATH;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_BY_UFID;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_CREATE;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_POLICIES_EXPLAIN;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_POLICIES_MERGE_CHECK;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static bio.terra.workspace.common.utils.MockMvcUtils.buildWsmRegionPolicyInput;
@@ -663,8 +663,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   private ApiWorkspaceDescription getWorkspace(
       AuthenticatedUserRequest request, UUID id, Optional<ApiIamRole> minimumHighestRole)
       throws Exception {
-    MockHttpServletRequestBuilder requestBuilder =
-        get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, id));
+    MockHttpServletRequestBuilder requestBuilder = get(String.format(WORKSPACES_V1, id));
     minimumHighestRole.ifPresent(
         apiIamRole -> requestBuilder.param("minimumHighestRole", apiIamRole.name()));
     String serializedResponse =
@@ -683,8 +682,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       Optional<ApiIamRole> minimumHighestRole,
       int statusCode)
       throws Exception {
-    MockHttpServletRequestBuilder requestBuilder =
-        get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, id));
+    MockHttpServletRequestBuilder requestBuilder = get(String.format(WORKSPACES_V1, id));
     minimumHighestRole.ifPresent(
         apiIamRole -> requestBuilder.param("minimumHighestRole", apiIamRole.name()));
     mockMvc.perform(addAuth(requestBuilder, userRequest)).andExpect(status().is(statusCode));
@@ -702,7 +700,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       Optional<ApiIamRole> minimumHighestRole)
       throws Exception {
     MockHttpServletRequestBuilder requestBuilder =
-        get(String.format(WORKSPACES_V1_BY_UFID_PATH_FORMAT, userFacingId));
+        get(String.format(WORKSPACES_V1_BY_UFID, userFacingId));
     minimumHighestRole.ifPresent(
         apiIamRole -> requestBuilder.param("minimumHighestRole", apiIamRole.name()));
     String serializedResponse =
@@ -722,7 +720,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       int statusCode)
       throws Exception {
     MockHttpServletRequestBuilder requestBuilder =
-        get(String.format(WORKSPACES_V1_BY_UFID_PATH_FORMAT, userFacingId));
+        get(String.format(WORKSPACES_V1_BY_UFID, userFacingId));
     minimumHighestRole.ifPresent(
         apiIamRole -> requestBuilder.param("minimumHighestRole", apiIamRole.name()));
     mockMvc.perform(addAuth(requestBuilder, userRequest)).andExpect(status().is(statusCode));
@@ -735,7 +733,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   private List<ApiWorkspaceDescription> listWorkspaces(
       AuthenticatedUserRequest request, Optional<ApiIamRole> minimumHighestRole) throws Exception {
-    MockHttpServletRequestBuilder requestBuilder = get(WORKSPACES_V1_PATH);
+    MockHttpServletRequestBuilder requestBuilder = get(WORKSPACES_V1_CREATE);
     minimumHighestRole.ifPresent(
         apiIamRole -> requestBuilder.param("minimumHighestRole", apiIamRole.name()));
     String serializedResponse =
@@ -756,7 +754,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
         mockMvc
             .perform(
                 addAuth(
-                    get(String.format(WORKSPACES_V1_EXPLAIN_POLICIES_PATH_FORMAT, workspaceId))
+                    get(String.format(WORKSPACES_V1_POLICIES_EXPLAIN, workspaceId))
                         .queryParam("depth", String.valueOf(depth)),
                     userRequest))
             .andExpect(status().is(HttpStatus.SC_OK))
@@ -775,8 +773,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
             .perform(
                 addAuth(
                     addJsonContentType(
-                        post(String.format(
-                                WORKSPACES_V1_MERGE_CHECK_POLICIES_PATH_FORMAT, targetWorkspaceId))
+                        post(String.format(WORKSPACES_V1_POLICIES_MERGE_CHECK, targetWorkspaceId))
                             .content(objectMapper.writeValueAsString(request))),
                     userRequest))
             .andExpect(status().is(HttpStatus.SC_ACCEPTED))

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -9,9 +9,9 @@ import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_
 import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_CREATE;
 import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_POLICIES_EXPLAIN;
 import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_POLICIES_MERGE_CHECK;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.buildWsmRegionPolicyInput;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
-import static bio.terra.workspace.common.utils.MockMvcUtils.buildWsmRegionPolicyInput;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyString;
@@ -553,7 +553,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     // add attributes
     String usRegion = PolicyFixtures.US_REGION;
     ApiWsmPolicyUpdateResult result =
-        mockMvcUtils.updateRegionPolicy(
+        mockWorkspaceV1Api.updateRegionPolicy(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId(), usRegion);
 
     assertTrue(result.isUpdateApplied());
@@ -566,7 +566,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
     // remove attributes
     ApiWsmPolicyUpdateResult removeResult =
-        mockMvcUtils.removeRegionPolicy(
+        mockWorkspaceV1Api.removeRegionPolicy(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId(), usRegion);
 
     assertTrue(removeResult.isUpdateApplied());
@@ -586,7 +586,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
     String usRegion = PolicyFixtures.US_REGION;
     ApiWsmPolicyUpdateResult result =
-        mockMvcUtils.updateRegionPolicy(
+        mockWorkspaceV1Api.updateRegionPolicy(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId(), usRegion);
 
     assertTrue(result.isUpdateApplied());
@@ -595,18 +595,18 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
             userAccessUtils.defaultUserAuthRequest(), workspace.getId());
     assertEquals(1, updatedWorkspace.getPolicies().size());
 
-    mockMvcUtils.updatePoliciesExpect(
+    mockWorkspaceV1Api.updatePoliciesAndExpect(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
-        HttpStatus.SC_CONFLICT,
         buildWsmRegionPolicyInput(PolicyFixtures.EUROPE_REGION),
-        ApiWsmPolicyUpdateMode.FAIL_ON_CONFLICT);
-    mockMvcUtils.updatePoliciesExpect(
+        ApiWsmPolicyUpdateMode.FAIL_ON_CONFLICT,
+        HttpStatus.SC_CONFLICT);
+    mockWorkspaceV1Api.updatePoliciesAndExpect(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
-        HttpStatus.SC_CONFLICT,
         buildWsmRegionPolicyInput("asiapacific"),
-        ApiWsmPolicyUpdateMode.ENFORCE_CONFLICT);
+        ApiWsmPolicyUpdateMode.ENFORCE_CONFLICT,
+        HttpStatus.SC_CONFLICT);
     updatedWorkspace =
         mockWorkspaceV1Api.getWorkspace(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId());
@@ -615,7 +615,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
         usRegion, updatedWorkspace.getPolicies().get(0).getAdditionalData().get(0).getValue());
 
     // clean up
-    mockMvcUtils.removeRegionPolicy(
+    mockWorkspaceV1Api.removeRegionPolicy(
         userAccessUtils.defaultUserAuthRequest(), workspace.getId(), usRegion);
   }
 
@@ -627,12 +627,12 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
         WsmIamRole.WRITER,
         userAccessUtils.noBillingUser().getEmail());
 
-    mockMvcUtils.updatePoliciesExpect(
+    mockWorkspaceV1Api.updatePoliciesAndExpect(
         userAccessUtils.noBillingAccessUserAuthRequest(),
         workspace.getId(),
-        HttpStatus.SC_FORBIDDEN,
         buildWsmRegionPolicyInput("asiapacific"),
-        ApiWsmPolicyUpdateMode.ENFORCE_CONFLICT);
+        ApiWsmPolicyUpdateMode.ENFORCE_CONFLICT,
+        HttpStatus.SC_FORBIDDEN);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -379,12 +379,12 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void mergeCheck_workspaceWithDifferentRegion() throws Exception {
     // Create workspace with US region constraint.
     UUID targetWorkspaceId =
-        mockMvcUtils.createWorkspaceWithRegionConstraint(
+        mockWorkspaceV1Api.createWorkspaceWithRegionConstraint(
             userAccessUtils.defaultUserAuthRequest(), PolicyFixtures.US_REGION);
 
     // Create workspace with Europe region constraint.
     UUID sourceWorkspaceId =
-        mockMvcUtils.createWorkspaceWithRegionConstraint(
+        mockWorkspaceV1Api.createWorkspaceWithRegionConstraint(
             userAccessUtils.defaultUserAuthRequest(), PolicyFixtures.EUROPE_REGION);
 
     // Both workspaces have conflicting policy.
@@ -404,7 +404,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     try {
       //  Create target workspace with US region constraint.
       targetWorkspaceId =
-          mockMvcUtils.createWorkspaceWithRegionConstraintAndCloudContext(
+          mockWorkspaceV1Api.createWorkspaceWithRegionConstraintAndCloudContext(
               userRequest, apiCloudPlatform, PolicyFixtures.US_REGION);
 
       // Then add a resource with US east region to the target.
@@ -419,7 +419,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
       // Create source workspace with US central region constraint.
       sourceWorkspaceId =
-          mockMvcUtils.createWorkspaceWithRegionConstraint(userRequest, "gcp.us-central1");
+          mockWorkspaceV1Api.createWorkspaceWithRegionConstraint(userRequest, "gcp.us-central1");
 
       // Target workspace has compatible policy (usa) with source.
       // However, target has resource (us-east1) that will conflict with the policy (us-central1) in
@@ -443,7 +443,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     try {
       //  Create target workspace with US region constraint.
       targetWorkspaceId =
-          mockMvcUtils.createWorkspaceWithRegionConstraintAndCloudContext(
+          mockWorkspaceV1Api.createWorkspaceWithRegionConstraintAndCloudContext(
               userRequest, apiCloudPlatform, PolicyFixtures.US_REGION);
 
       // Then add a resource with US east region to the target.
@@ -476,7 +476,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     try {
       //  Create target workspace with US region constraint.
       targetWorkspaceId =
-          mockMvcUtils.createWorkspaceWithRegionConstraintAndCloudContext(
+          mockWorkspaceV1Api.createWorkspaceWithRegionConstraintAndCloudContext(
               userRequest, apiCloudPlatform, PolicyFixtures.US_REGION);
 
       // Then add a resource with US east region to the target.
@@ -491,7 +491,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
       // Create source workspace with US central region constraint.
       sourceWorkspaceId =
-          mockMvcUtils.createWorkspaceWithRegionConstraint(userRequest, "gcp.us-central1");
+          mockWorkspaceV1Api.createWorkspaceWithRegionConstraint(userRequest, "gcp.us-central1");
 
       // Target workspace has a compatible policy with the source.
       // But target has a resource in US-CENTRAL1, which doesn't match the casing of the policy.
@@ -519,10 +519,11 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
     UUID sourceWorkspaceId = null;
     try {
       targetWorkspaceId =
-          mockMvcUtils.createWorkspaceWithGroupConstraint(
+          mockWorkspaceV1Api.createWorkspaceWithGroupConstraint(
               userRequest, PolicyFixtures.DEFAULT_GROUP);
       sourceWorkspaceId =
-          mockMvcUtils.createWorkspaceWithGroupConstraint(userRequest, PolicyFixtures.ALT_GROUP);
+          mockWorkspaceV1Api.createWorkspaceWithGroupConstraint(
+              userRequest, PolicyFixtures.ALT_GROUP);
 
       ApiWsmPolicyMergeCheckResult result =
           mergeCheck(userRequest, targetWorkspaceId, sourceWorkspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -123,7 +123,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Test
   public void getWorkspace_requesterIsDiscoverer_requestMinHighestRoleNotSet_throws()
       throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -139,7 +139,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Test
   public void getWorkspace_requesterIsDiscoverer_requestMinHighestRoleSetToReader_throws()
       throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -156,7 +156,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       getWorkspace_requesterIsDiscoverer_requestMinHighestRoleSetToDiscoverer_returnsStrippedWorkspace()
           throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -191,7 +191,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
         mockWorkspaceV1Api.getWorkspace(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId());
 
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -212,7 +212,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
         mockWorkspaceV1Api.getWorkspace(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId());
 
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -233,7 +233,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
         mockWorkspaceV1Api.getWorkspace(
             userAccessUtils.defaultUserAuthRequest(), workspace.getId());
 
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -263,7 +263,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Test
   public void listWorkspaces_requesterIsDiscoverer_requestMinHighestRoleNotSet_returnsNoWorkspaces()
       throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -280,7 +280,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       listWorkspaces_requesterIsDiscoverer_requestMinHighestRoleSetToReader_returnsNoWorkspaces()
           throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -295,7 +295,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Test
   public void grantRole_logsAnActivity() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -313,13 +313,13 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Test
   public void removeRole_logsAnActivity() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
         userAccessUtils.getSecondUserEmail());
 
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -339,7 +339,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void
       listWorkspaces_requesterIsDiscoverer_requestMinHighestRoleSetToDiscoverer_returnsStrippedWorkspace()
           throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.DISCOVERER,
@@ -621,7 +621,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Test
   public void updatePolicies_requesterIsWriter_throws() throws Exception {
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.WRITER,
@@ -639,30 +639,30 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void workspaceOwnerCannotAbandonWorkspace() throws Exception {
     // Default user should be the only workspace owner, and so should not be able to remove
     // themselves.
-    mockMvcUtils.removeRoleExpectBadRequest(
+    mockWorkspaceV1Api.removeRoleExpectBadRequest(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.OWNER,
         userAccessUtils.getDefaultUserEmail());
     // After adding a second user, they should be able to remove themselves.
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.OWNER,
         userAccessUtils.getSecondUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.defaultUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.OWNER,
         userAccessUtils.getDefaultUserEmail());
     // Reset workspace to starting setup, where default user is an owner and secondary user has no
     // role.
-    mockMvcUtils.grantRole(
+    mockWorkspaceV1Api.grantRole(
         userAccessUtils.secondUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.OWNER,
         userAccessUtils.getDefaultUserEmail());
-    mockMvcUtils.removeRole(
+    mockWorkspaceV1Api.removeRole(
         userAccessUtils.secondUserAuthRequest(),
         workspace.getId(),
         WsmIamRole.OWNER,

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -30,6 +30,7 @@ import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.PolicyFixtures;
 import bio.terra.workspace.common.logging.model.ActivityLogChangedTarget;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
@@ -86,6 +87,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired private MockGcpApi mockGcpApi;
   @Autowired private ObjectMapper objectMapper;
@@ -99,7 +101,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @BeforeAll
   public void setup() throws Exception {
     workspace =
-        mockMvcUtils.createWorkspaceWithoutCloudContext(userAccessUtils.defaultUserAuthRequest());
+        mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(
+            userAccessUtils.defaultUserAuthRequest());
   }
 
   /** Clean up workspaces from Broad dev SAM. */

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerConnectedTest.java
@@ -174,7 +174,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @Test
   public void getWorkspaceByUserFacingId_requesterIsOwner_returnsFullWorkspace() throws Exception {
     ApiWorkspaceDescription workspaceDescription =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
 
     ApiWorkspaceDescription gotWorkspace =
         getWorkspaceByUserFacingId(
@@ -187,7 +188,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   public void getWorkspaceByUserFacingId_requesterIsDiscoverer_requestMinHighestRoleNotSet_throws()
       throws Exception {
     ApiWorkspaceDescription workspaceDescription =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
 
     mockMvcUtils.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
@@ -207,7 +209,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       getWorkspaceByUserFacingId_requesterIsDiscoverer_requestMinHighestRoleSetToReader_throws()
           throws Exception {
     ApiWorkspaceDescription workspaceDescription =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
 
     mockMvcUtils.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
@@ -227,7 +230,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       getWorkspaceByUserFacingId_requesterIsDiscoverer_requestMinHighestRoleSetToDiscoverer_returnsStrippedWorkspace()
           throws Exception {
     ApiWorkspaceDescription workspaceDescription =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
 
     mockMvcUtils.grantRole(
         userAccessUtils.defaultUserAuthRequest(),
@@ -430,8 +434,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       assertEquals(0, result.getConflicts().size());
       assertEquals(1, result.getResourcesWithConflict().size());
     } finally {
-      mockMvcUtils.deleteWorkspace(userRequest, targetWorkspaceId);
-      mockMvcUtils.deleteWorkspace(userRequest, sourceWorkspaceId);
+      mockWorkspaceV1Api.deleteWorkspace(userRequest, targetWorkspaceId);
+      mockWorkspaceV1Api.deleteWorkspace(userRequest, sourceWorkspaceId);
     }
   }
 
@@ -463,7 +467,7 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       assertEquals(0, result.getConflicts().size());
       assertEquals(0, result.getResourcesWithConflict().size());
     } finally {
-      mockMvcUtils.deleteWorkspace(userRequest, targetWorkspaceId);
+      mockWorkspaceV1Api.deleteWorkspace(userRequest, targetWorkspaceId);
     }
   }
 
@@ -503,10 +507,10 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       assertEquals(0, result.getResourcesWithConflict().size());
     } finally {
       if (targetWorkspaceId != null) {
-        mockMvcUtils.deleteWorkspace(userRequest, targetWorkspaceId);
+        mockWorkspaceV1Api.deleteWorkspace(userRequest, targetWorkspaceId);
       }
       if (sourceWorkspaceId != null) {
-        mockMvcUtils.deleteWorkspace(userRequest, sourceWorkspaceId);
+        mockWorkspaceV1Api.deleteWorkspace(userRequest, sourceWorkspaceId);
       }
     }
   }
@@ -533,8 +537,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
       assertEquals(PolicyFixtures.NAMESPACE, result.getConflicts().get(0).getNamespace());
       assertEquals(PolicyFixtures.GROUP_CONSTRAINT, result.getConflicts().get(0).getName());
     } finally {
-      mockMvcUtils.deleteWorkspace(userRequest, targetWorkspaceId);
-      mockMvcUtils.deleteWorkspace(userRequest, sourceWorkspaceId);
+      mockWorkspaceV1Api.deleteWorkspace(userRequest, targetWorkspaceId);
+      mockWorkspaceV1Api.deleteWorkspace(userRequest, sourceWorkspaceId);
     }
   }
 
@@ -542,7 +546,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @EnabledIf(expression = "${feature.tps-enabled}", loadContext = true)
   public void updatePolicies_tpsEnabledAndPolicyUpdated() throws Exception {
     ApiWorkspaceDescription workspaceWithoutPolicy =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
     assertTrue(workspaceWithoutPolicy.getPolicies().isEmpty());
 
     // add attributes
@@ -553,7 +558,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
     assertTrue(result.isUpdateApplied());
     ApiWorkspaceDescription updatedWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
     assertEquals(1, updatedWorkspace.getPolicies().size());
     assertEquals(
         usRegion, updatedWorkspace.getPolicies().get(0).getAdditionalData().get(0).getValue());
@@ -565,7 +571,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
     assertTrue(removeResult.isUpdateApplied());
     workspaceWithoutPolicy =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
     assertEquals(0, workspaceWithoutPolicy.getPolicies().size());
   }
 
@@ -573,7 +580,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
   @EnabledIf(expression = "${feature.tps-enabled}", loadContext = true)
   public void updatePolicies_tpsEnabledAndPolicyConflict() throws Exception {
     ApiWorkspaceDescription workspaceWithoutPolicy =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
     assertTrue(workspaceWithoutPolicy.getPolicies().isEmpty());
 
     String usRegion = PolicyFixtures.US_REGION;
@@ -583,7 +591,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
 
     assertTrue(result.isUpdateApplied());
     ApiWorkspaceDescription updatedWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
     assertEquals(1, updatedWorkspace.getPolicies().size());
 
     mockMvcUtils.updatePoliciesExpect(
@@ -599,7 +608,8 @@ public class WorkspaceApiControllerConnectedTest extends BaseConnectedTest {
         buildWsmRegionPolicyInput("asiapacific"),
         ApiWsmPolicyUpdateMode.ENFORCE_CONFLICT);
     updatedWorkspace =
-        mockMvcUtils.getWorkspace(userAccessUtils.defaultUserAuthRequest(), workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(
+            userAccessUtils.defaultUserAuthRequest(), workspace.getId());
     assertEquals(1, updatedWorkspace.getPolicies().size());
     assertEquals(
         usRegion, updatedWorkspace.getPolicies().get(0).getAdditionalData().get(0).getValue());

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -248,7 +248,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
     UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
 
     // Delete terra-type, userkey properties
-    mockMvcUtils.deleteWorkspaceProperties(
+    mockWorkspaceV1Api.deleteWorkspaceProperties(
         USER_REQUEST, workspaceId, List.of(Properties.TYPE, "userkey"));
 
     // Assert remaining 2 properties
@@ -277,7 +277,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
     // Change userkey value to uservalue2. Add new property foo=bar.
     ApiProperty newUserProperty = new ApiProperty().key("userkey").value("uservalue2");
     ApiProperty fooProperty = new ApiProperty().key("foo").value("bar");
-    mockMvcUtils.updateWorkspaceProperties(
+    mockWorkspaceV1Api.updateWorkspaceProperties(
         USER_REQUEST, workspaceId, List.of(newUserProperty, fooProperty));
 
     // Assert 5 properties.

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -534,7 +534,8 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
     OffsetDateTime lastChangedDate = lastChangeDetails.changeDate();
     assertEquals(OperationType.CREATE, lastChangeDetails.operationType());
 
-    ApiWsmPolicyUpdateResult result = mockMvcUtils.updatePolicies(USER_REQUEST, workspace.getId());
+    ApiWsmPolicyUpdateResult result =
+        mockWorkspaceV1Api.updatePolicies(USER_REQUEST, workspace.getId());
     assertTrue(result.isUpdateApplied());
     ActivityLogChangeDetails secondChangeDetails =
         workspaceActivityLogService.getLastUpdatedDetails(workspace.getId()).get();
@@ -560,7 +561,8 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         workspaceActivityLogService.getLastUpdatedDetails(workspace.getId()).get();
     assertEquals(OperationType.CREATE, lastChangeDetails.operationType());
 
-    ApiWsmPolicyUpdateResult result = mockMvcUtils.updatePolicies(USER_REQUEST, workspace.getId());
+    ApiWsmPolicyUpdateResult result =
+        mockWorkspaceV1Api.updatePolicies(USER_REQUEST, workspace.getId());
     assertFalse(result.isUpdateApplied());
     assertEquals(
         lastChangeDetails,
@@ -575,7 +577,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
     when(mockTpsApiDispatch().listValidRegions(eq(workspace.getId()), any()))
         .thenReturn(expectedRegions);
 
-    ApiRegions result = mockMvcUtils.listValidRegions(USER_REQUEST, workspace.getId(), "GCP");
+    ApiRegions result = mockWorkspaceV1Api.listValidRegions(USER_REQUEST, workspace.getId(), "GCP");
     assertEquals(expectedRegions, result);
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -179,7 +179,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST);
 
     ApiWorkspaceDescription getWorkspace =
-        mockMvcUtils.getWorkspace(USER_REQUEST, workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(USER_REQUEST, workspace.getId());
     assertEquals(WORKSPACE_NAME, getWorkspace.getDisplayName());
     assertEquals(
         WorkspaceFixtures.getUserFacingId(workspace.getId()), getWorkspace.getUserFacingId());
@@ -200,7 +200,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
     String newDisplayName = "new workspace display name";
     String newDescription = "new description for the workspace";
     ApiWorkspaceDescription updatedWorkspace =
-        mockMvcUtils.updateWorkspace(
+        mockWorkspaceV1Api.updateWorkspace(
             USER_REQUEST, workspace.getId(), newUserFacingId, newDisplayName, newDescription);
 
     // Assert updated workspace
@@ -218,7 +218,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
     when(mockSamService().getUserStatusInfo(any())).thenReturn(newUser);
     String secondNewDescription = "This is yet another description";
     ApiWorkspaceDescription secondUpdatedWorkspace =
-        mockMvcUtils.updateWorkspace(
+        mockWorkspaceV1Api.updateWorkspace(
             USER_REQUEST,
             workspace.getId(),
             /*newUserFacingId=*/ null,
@@ -252,7 +252,8 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         USER_REQUEST, workspaceId, List.of(Properties.TYPE, "userkey"));
 
     // Assert remaining 2 properties
-    ApiWorkspaceDescription gotWorkspace = mockMvcUtils.getWorkspace(USER_REQUEST, workspaceId);
+    ApiWorkspaceDescription gotWorkspace =
+        mockWorkspaceV1Api.getWorkspace(USER_REQUEST, workspaceId);
     assertProperties(
         List.of(SHORT_DESCRIPTION_PROPERTY, VERSION_PROPERTY), gotWorkspace.getProperties());
 
@@ -280,7 +281,8 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         USER_REQUEST, workspaceId, List.of(newUserProperty, fooProperty));
 
     // Assert 5 properties.
-    ApiWorkspaceDescription gotWorkspace = mockMvcUtils.getWorkspace(USER_REQUEST, workspaceId);
+    ApiWorkspaceDescription gotWorkspace =
+        mockWorkspaceV1Api.getWorkspace(USER_REQUEST, workspaceId);
     assertProperties(
         List.of(
             SHORT_DESCRIPTION_PROPERTY,
@@ -306,16 +308,17 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
     when(mockFeatureConfiguration().isTpsEnabled()).thenReturn(false);
 
     UUID workspaceId = mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST).getId();
-    ApiWorkspaceDescription sourceWorkspace = mockMvcUtils.getWorkspace(USER_REQUEST, workspaceId);
+    ApiWorkspaceDescription sourceWorkspace =
+        mockWorkspaceV1Api.getWorkspace(USER_REQUEST, workspaceId);
 
     ApiCloneWorkspaceResult cloneWorkspace =
-        mockMvcUtils.cloneWorkspace(
+        mockWorkspaceV1Api.cloneWorkspace(
             USER_REQUEST, workspaceId, DEFAULT_SPEND_PROFILE_NAME, null, null);
     jobService.waitForJob(cloneWorkspace.getJobReport().getId());
 
     UUID destinationWorkspaceId = cloneWorkspace.getWorkspace().getDestinationWorkspaceId();
     ApiWorkspaceDescription destinationWorkspace =
-        mockMvcUtils.getWorkspace(USER_REQUEST, destinationWorkspaceId);
+        mockWorkspaceV1Api.getWorkspace(USER_REQUEST, destinationWorkspaceId);
 
     assertEquals(sourceWorkspace.getProperties(), destinationWorkspace.getProperties());
     assertEquals(
@@ -373,7 +376,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
     UUID destinationWorkspaceId = UUID.randomUUID();
 
     ApiCloneWorkspaceResult cloneWorkspace =
-        mockMvcUtils.cloneWorkspace(
+        mockWorkspaceV1Api.cloneWorkspace(
             USER_REQUEST,
             sourceWorkspaceId,
             DEFAULT_SPEND_PROFILE_NAME,
@@ -417,7 +420,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         .thenReturn(getPolicyResult);
 
     ApiWorkspaceDescription gotWorkspace =
-        mockMvcUtils.getWorkspace(USER_REQUEST, workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(USER_REQUEST, workspace.getId());
     assertEquals(1, gotWorkspace.getPolicies().size());
     // The workspace polices from the REST API are in "ApiTps*" form.
     // So we have to convert from TPS form to API form to compare.
@@ -433,7 +436,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
         mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST);
 
     ApiWorkspaceDescription gotWorkspace =
-        mockMvcUtils.getWorkspace(USER_REQUEST, workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(USER_REQUEST, workspace.getId());
     assertEquals(0, gotWorkspace.getPolicies().size());
   }
 
@@ -516,7 +519,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
                     workspace.getId(), WsmIamRole.OWNER, Collections.emptyList())));
 
     ApiWorkspaceDescription gotWorkspace =
-        mockMvcUtils.getWorkspace(USER_REQUEST, workspace.getId());
+        mockWorkspaceV1Api.getWorkspace(USER_REQUEST, workspace.getId());
     assertEquals(0, gotWorkspace.getPolicies().size());
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -5,8 +5,8 @@ import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.SHORT_DESCRI
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.TYPE_PROPERTY;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.VERSION_PROPERTY;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_NAME;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_CREATE;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_PATH;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -592,7 +592,7 @@ public class WorkspaceApiControllerTest extends BaseUnitTestMockDataRepoService 
   private List<ApiWorkspaceDescription> listWorkspaces() throws Exception {
     String serializedResponse =
         mockMvc
-            .perform(addJsonContentType(addAuth(get(WORKSPACES_V1_PATH), USER_REQUEST)))
+            .perform(addJsonContentType(addAuth(get(WORKSPACES_V1_CREATE), USER_REQUEST)))
             .andExpect(status().is(HttpStatus.SC_OK))
             .andReturn()
             .getResponse()

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockDataRepoApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockDataRepoApi.java
@@ -28,6 +28,7 @@ public class MockDataRepoApi {
       REFERENCED_DATA_REPO_SNAPSHOTS_PATH_FORMAT + "/clone";
 
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired private ObjectMapper objectMapper;
 
   public ApiDataRepoSnapshotResource createReferencedDataRepoSnapshot(
@@ -58,7 +59,7 @@ public class MockDataRepoApi {
 
   public void deleteReferencedDataRepoSnapshot(
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    mockMvcUtils.deleteResource(
+    mockWorkspaceV1Api.deleteResource(
         userRequest, workspaceId, resourceId, REFERENCED_DATA_REPO_SNAPSHOTS_PATH_FORMAT);
   }
 
@@ -123,7 +124,7 @@ public class MockDataRepoApi {
       int expectedCode)
       throws Exception {
     MockHttpServletResponse response =
-        mockMvcUtils.cloneReferencedResource(
+        mockWorkspaceV1Api.cloneReferencedResourceAndExpect(
             userRequest,
             CLONE_REFERENCED_DATA_REPO_SNAPSHOTS_PATH_FORMAT,
             sourceWorkspaceId,

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockFlexibleResourceApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockFlexibleResourceApi.java
@@ -56,6 +56,7 @@ public class MockFlexibleResourceApi {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private JobService jobService;
 
@@ -97,7 +98,7 @@ public class MockFlexibleResourceApi {
 
   public void deleteFlexibleResource(
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    mockMvcUtils.deleteResource(
+    mockWorkspaceV1Api.deleteResource(
         userRequest, workspaceId, resourceId, CONTROLLED_FLEXIBLE_RESOURCES_PATH_FORMAT);
   }
 
@@ -132,7 +133,7 @@ public class MockFlexibleResourceApi {
             getUpdateFlexibleResourceRequestBody(
                 newResourceName, newDescription, newData, newCloningInstructions));
 
-    return mockMvcUtils.updateResource(
+    return mockWorkspaceV1Api.updateResourceAndExpect(
         ApiFlexibleResource.class,
         CONTROLLED_FLEXIBLE_RESOURCES_PATH_FORMAT,
         workspaceId,
@@ -156,7 +157,7 @@ public class MockFlexibleResourceApi {
             getUpdateFlexibleResourceRequestBody(
                 newResourceName, newDescription, newData, newCloningInstructions));
 
-    mockMvcUtils.updateResource(
+    mockWorkspaceV1Api.updateResourceAndExpect(
         ApiFlexibleResource.class,
         CONTROLLED_FLEXIBLE_RESOURCES_PATH_FORMAT,
         workspaceId,

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockGcpApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockGcpApi.java
@@ -262,7 +262,7 @@ public class MockGcpApi {
         new ApiCloneControlledGcpGcsBucketRequest()
             .destinationWorkspaceId(destWorkspaceId)
             .cloningInstructions(cloningInstructions)
-            .name(TestUtils.appendRandomNumber(MockMvcUtils.DEST_BUCKET_RESOURCE_NAME))
+            .name(TestUtils.appendRandomNumber("i-am-the-cloned-bucket"))
             .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
     if (!StringUtils.isEmpty(destResourceName)) {
       request.name(destResourceName);

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockGcpApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockGcpApi.java
@@ -102,6 +102,7 @@ public class MockGcpApi {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private JobService jobService;
 
@@ -169,7 +170,7 @@ public class MockGcpApi {
             .description(newDescription)
             .updateParameters(
                 new ApiGcpGcsBucketUpdateParameters().cloningInstructions(newCloningInstruction));
-    return mockMvcUtils.updateResource(
+    return mockWorkspaceV1Api.updateResourceAndExpect(
         ApiGcpGcsBucketResource.class,
         CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT,
         workspaceId,
@@ -208,7 +209,7 @@ public class MockGcpApi {
     while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
       Thread.sleep(/*millis=*/ 5000);
       result =
-          mockMvcUtils.getCreateResourceJobResult(
+          mockWorkspaceV1Api.createResourceJobResult(
               ApiCloneControlledGcpGcsBucketResult.class,
               userRequest,
               CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT,
@@ -302,7 +303,7 @@ public class MockGcpApi {
     // After job fails, cloneGcsBucket returns ApiCloneControlledGcpGcsBucketResult OR
     // ApiErrorReport.
     ApiCloneControlledGcpGcsBucketResult result =
-        mockMvcUtils.getCreateResourceJobResult(
+        mockWorkspaceV1Api.createResourceJobResult(
             ApiCloneControlledGcpGcsBucketResult.class,
             userRequest,
             CLONE_RESULT_CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT,
@@ -362,7 +363,7 @@ public class MockGcpApi {
 
   public void deleteReferencedGcsBucket(
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    mockMvcUtils.deleteResource(
+    mockWorkspaceV1Api.deleteResource(
         userRequest, workspaceId, resourceId, REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT);
   }
 
@@ -425,7 +426,7 @@ public class MockGcpApi {
       int expectedCode)
       throws Exception {
     MockHttpServletResponse response =
-        mockMvcUtils.cloneReferencedResource(
+        mockWorkspaceV1Api.cloneReferencedResourceAndExpect(
             userRequest,
             CLONE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT,
             sourceWorkspaceId,
@@ -485,7 +486,7 @@ public class MockGcpApi {
 
   public void deleteReferencedGcsObject(
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    mockMvcUtils.deleteResource(
+    mockWorkspaceV1Api.deleteResource(
         userRequest, workspaceId, resourceId, REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT);
   }
 
@@ -552,7 +553,7 @@ public class MockGcpApi {
       int expectedCode)
       throws Exception {
     MockHttpServletResponse response =
-        mockMvcUtils.cloneReferencedResource(
+        mockWorkspaceV1Api.cloneReferencedResourceAndExpect(
             userRequest,
             CLONE_REFERENCED_GCP_GCS_OBJECTS_PATH_FORMAT,
             sourceWorkspaceId,
@@ -638,7 +639,7 @@ public class MockGcpApi {
       UUID resourceId,
       StewardshipType stewardshipType)
       throws Exception {
-    mockMvcUtils.deleteResource(
+    mockWorkspaceV1Api.deleteResource(
         userRequest,
         workspaceId,
         resourceId,
@@ -676,7 +677,7 @@ public class MockGcpApi {
             .updateParameters(
                 new ApiGcpBigQueryDatasetUpdateParameters()
                     .cloningInstructions(newCloningInstruction));
-    return mockMvcUtils.updateResource(
+    return mockWorkspaceV1Api.updateResourceAndExpect(
         ApiGcpBigQueryDatasetResource.class,
         CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT,
         workspaceId,
@@ -741,7 +742,7 @@ public class MockGcpApi {
     while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
       Thread.sleep(/*millis=*/ 5000);
       result =
-          mockMvcUtils.getCreateResourceJobResult(
+          mockWorkspaceV1Api.createResourceJobResult(
               ApiCloneControlledGcpBigQueryDatasetResult.class,
               userRequest,
               CLONE_RESULT_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT,
@@ -833,7 +834,7 @@ public class MockGcpApi {
     // After job fails, cloneBigQueryDataset returns ApiCloneControlledGcpBigQueryDatasetResult OR
     // ApiErrorReport.
     ApiCloneControlledGcpBigQueryDatasetResult result =
-        mockMvcUtils.getCreateResourceJobResult(
+        mockWorkspaceV1Api.createResourceJobResult(
             ApiCloneControlledGcpBigQueryDatasetResult.class,
             userRequest,
             CLONE_RESULT_CONTROLLED_GCP_BQ_DATASETS_PATH_FORMAT,
@@ -950,7 +951,7 @@ public class MockGcpApi {
       int expectedCode)
       throws Exception {
     MockHttpServletResponse response =
-        mockMvcUtils.cloneReferencedResource(
+        mockWorkspaceV1Api.cloneReferencedResourceAndExpect(
             userRequest,
             CLONE_REFERENCED_GCP_BQ_DATASET_PATH_FORMAT,
             sourceWorkspaceId,
@@ -1007,7 +1008,7 @@ public class MockGcpApi {
 
   public void deleteReferencedBqDataTable(
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    mockMvcUtils.deleteResource(
+    mockWorkspaceV1Api.deleteResource(
         userRequest, workspaceId, resourceId, REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT);
   }
 
@@ -1074,7 +1075,7 @@ public class MockGcpApi {
       int expectedCode)
       throws Exception {
     MockHttpServletResponse response =
-        mockMvcUtils.cloneReferencedResource(
+        mockWorkspaceV1Api.cloneReferencedResourceAndExpect(
             userRequest,
             CLONE_REFERENCED_GCP_BQ_DATA_TABLE_PATH_FORMAT,
             sourceWorkspaceId,
@@ -1155,7 +1156,7 @@ public class MockGcpApi {
     while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
       TimeUnit.SECONDS.sleep(5);
       result =
-          mockMvcUtils.getCreateResourceJobResult(
+          mockWorkspaceV1Api.createResourceJobResult(
               ApiCreatedControlledGcpAiNotebookInstanceResult.class,
               userRequest,
               CREATE_RESULT_CONTROLLED_GCP_AI_NOTEBOOKS_PATH_FORMAT,
@@ -1227,7 +1228,7 @@ public class MockGcpApi {
     while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
       Thread.sleep(/*millis=*/ 5000);
       result =
-          mockMvcUtils.getCreateResourceJobResult(
+          mockWorkspaceV1Api.createResourceJobResult(
               ApiCreatedControlledGcpGceInstanceResult.class,
               userRequest,
               CREATE_RESULT_CONTROLLED_GCP_GCE_INSTANCES_PATH_FORMAT,
@@ -1317,7 +1318,7 @@ public class MockGcpApi {
     while (StairwayTestUtils.jobIsRunning(result.getJobReport())) {
       Thread.sleep(/*millis=*/ 5000);
       result =
-          mockMvcUtils.getCreateResourceJobResult(
+          mockWorkspaceV1Api.createResourceJobResult(
               ApiCreatedControlledGcpDataprocClusterResult.class,
               userRequest,
               CREATE_RESULT_CONTROLLED_GCP_DATAPROC_CLUSTERS_PATH_FORMAT,

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockGitRepoApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockGitRepoApi.java
@@ -28,6 +28,7 @@ public class MockGitRepoApi {
       REFERENCED_GIT_REPOS_PATH_FORMAT + "/clone";
 
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired private ObjectMapper objectMapper;
 
   public ApiGitRepoResource createReferencedGitRepo(
@@ -54,7 +55,7 @@ public class MockGitRepoApi {
 
   public void deleteReferencedGitRepo(
       AuthenticatedUserRequest userRequest, UUID workspaceId, UUID resourceId) throws Exception {
-    mockMvcUtils.deleteResource(
+    mockWorkspaceV1Api.deleteResource(
         userRequest, workspaceId, resourceId, REFERENCED_GIT_REPOS_PATH_FORMAT);
   }
 
@@ -88,7 +89,7 @@ public class MockGitRepoApi {
     if (cloningInstructionsEnum != null) {
       requestBody.cloningInstructions(cloningInstructionsEnum);
     }
-    return mockMvcUtils.updateResource(
+    return mockWorkspaceV1Api.updateResourceAndExpect(
         ApiGitRepoResource.class,
         REFERENCED_GIT_REPOS_PATH_FORMAT,
         workspaceId,
@@ -126,7 +127,7 @@ public class MockGitRepoApi {
       int expectedCode)
       throws Exception {
     MockHttpServletResponse response =
-        mockMvcUtils.cloneReferencedResource(
+        mockWorkspaceV1Api.cloneReferencedResourceAndExpect(
             userRequest,
             CLONE_REFERENCED_GIT_REPOS_PATH_FORMAT,
             sourceWorkspaceId,

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV1Api.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV1Api.java
@@ -1,0 +1,44 @@
+package bio.terra.workspace.common.mocks;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MockWorkspaceV1Api {
+
+  // Workspace
+
+  public static final String WORKSPACES_V1_CREATE = "/api/workspaces/v1";
+  public static final String WORKSPACES_V1 = WORKSPACES_V1_CREATE + "/%s";
+  public static final String WORKSPACES_V1_BY_UFID =
+      WORKSPACES_V1_CREATE + "/workspaceByUserFacingId/%s";
+  public static final String WORKSPACES_V1_CLONE = WORKSPACES_V1 + "/clone";
+  public static final String WORKSPACES_V1_CLONE_RESULT = WORKSPACES_V1 + "/clone-result/%s";
+
+  // Cloud context
+
+  public static final String CLOUD_CONTEXTS_V1 = WORKSPACES_V1 + "/cloudcontexts";
+  public static final String CLOUD_CONTEXT_V2_CREATE_RESULT = CLOUD_CONTEXTS_V1 + "/result/%s";
+
+  // Properties
+
+  public static final String WORKSPACES_V1_PROPERTIES = WORKSPACES_V1 + "/properties";
+
+  // Policies & region
+
+  public static final String WORKSPACES_V1_POLICIES = WORKSPACES_V1 + "/policies";
+  public static final String WORKSPACES_V1_POLICIES_EXPLAIN = WORKSPACES_V1_POLICIES + "/explain";
+  public static final String WORKSPACES_V1_POLICIES_MERGE_CHECK =
+      WORKSPACES_V1_POLICIES + "/mergeCheck";
+  public static final String WORKSPACES_V1_LIST_VALID_REGIONS = WORKSPACES_V1 + "/listValidRegions";
+
+  // Roles
+
+  public static final String WORKSPACES_V1_GRANT_ROLE = WORKSPACES_V1 + "/roles/%s/members";
+  public static final String WORKSPACES_V1_REMOVE_ROLE = WORKSPACES_V1_GRANT_ROLE + "/%s";
+
+  // Resources
+
+  public static final String WORKSPACES_V1_RESOURCES = WORKSPACES_V1 + "/resources";
+  public static final String WORKSPACES_V1_RESOURCES_PROPERTIES =
+      WORKSPACES_V1_RESOURCES + "/%s/properties";
+}

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV1Api.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV1Api.java
@@ -24,6 +24,8 @@ import bio.terra.workspace.generated.model.ApiCreatedWorkspace;
 import bio.terra.workspace.generated.model.ApiErrorReport;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport.StatusEnum;
+import bio.terra.workspace.generated.model.ApiProperty;
+import bio.terra.workspace.generated.model.ApiPropertyKeys;
 import bio.terra.workspace.generated.model.ApiUpdateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWorkspaceStageModel;
@@ -33,6 +35,7 @@ import bio.terra.workspace.generated.model.ApiWsmPolicyPair;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -351,6 +354,33 @@ public class MockWorkspaceV1Api {
   // Properties
 
   public static final String WORKSPACES_V1_PROPERTIES = WORKSPACES_V1 + "/properties";
+
+  public void updateWorkspaceProperties(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, List<ApiProperty> properties)
+      throws Exception {
+    mockMvcUtils.getSerializedResponseForPost(
+        userRequest,
+        WORKSPACES_V1_PROPERTIES,
+        workspaceId,
+        objectMapper.writeValueAsString(properties));
+  }
+
+  public void deleteWorkspaceProperties(
+      AuthenticatedUserRequest userRequest, UUID workspaceId, List<String> propertyKeys)
+      throws Exception {
+    ApiPropertyKeys apiPropertyKeys = new ApiPropertyKeys();
+    apiPropertyKeys.addAll(propertyKeys);
+    mockMvc
+        .perform(
+            addAuth(
+                patch(String.format(WORKSPACES_V1_PROPERTIES, workspaceId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .content(objectMapper.writeValueAsString(apiPropertyKeys)),
+                userRequest))
+        .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
+  }
 
   // Policies & region
 

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV2Api.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV2Api.java
@@ -154,10 +154,10 @@ public class MockWorkspaceV2Api {
 
   // Cloud context
 
-  public static final String CLOUD_CONTEXTS_V2 = WORKSPACES_V2 + "/cloudcontexts";
-  public static final String CLOUD_CONTEXT_V2_DELETE = CLOUD_CONTEXTS_V2 + "/%s/delete";
-  public static final String CLOUD_CONTEXT_V2_DELETE_RESULT =
-      CLOUD_CONTEXTS_V2 + "/delete-result/%s";
+  public static final String CLOUD_CONTEXTS_V2_CREATE = WORKSPACES_V2 + "/cloudcontexts";
+  public static final String CLOUD_CONTEXTS_V2_DELETE = CLOUD_CONTEXTS_V2_CREATE + "/%s/delete";
+  public static final String CLOUD_CONTEXTS_V2_DELETE_RESULT =
+      CLOUD_CONTEXTS_V2_CREATE + "/delete-result/%s";
 
   public ApiJobResult deleteCloudContextAsync(
       AuthenticatedUserRequest userRequest,
@@ -172,7 +172,7 @@ public class MockWorkspaceV2Api {
         cloudPlatform,
         jobId);
     String path =
-        String.format(CLOUD_CONTEXT_V2_DELETE, workspaceId, cloudPlatform.toApiModel().toString());
+        String.format(CLOUD_CONTEXTS_V2_DELETE, workspaceId, cloudPlatform.toApiModel().toString());
     ApiDeleteCloudContextV2Request request =
         new ApiDeleteCloudContextV2Request().jobControl(new ApiJobControl().id(jobId));
     MockHttpServletResponse response =
@@ -193,7 +193,7 @@ public class MockWorkspaceV2Api {
         userRequest.getEmail(),
         workspaceId,
         jobId);
-    String path = String.format(CLOUD_CONTEXT_V2_DELETE_RESULT, workspaceId, jobId);
+    String path = String.format(CLOUD_CONTEXTS_V2_DELETE_RESULT, workspaceId, jobId);
     MockHttpServletResponse response =
         mockMvc
             .perform(MockMvcUtils.addJsonContentType(MockMvcUtils.addAuth(get(path), userRequest)))

--- a/service/src/test/java/bio/terra/workspace/common/utils/GcpUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/GcpUtilsTest.java
@@ -15,6 +15,8 @@ import org.mockito.Mock;
 
 public class GcpUtilsTest extends BaseUnitTest {
 
+  public static final String DEFAULT_GCP_RESOURCE_REGION = "us-central1";
+
   @Mock private OperationCow<Operation> mockOperationCow;
   @Mock private OperationCow.OperationAdapter<Operation> mockOperationAdapter;
   @Mock private OperationCow.OperationAdapter.StatusAdapter mockOperationStatusAdapter;

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -29,7 +29,6 @@ import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiControlledResourceMetadata;
 import bio.terra.workspace.generated.model.ApiErrorReport;
-import bio.terra.workspace.generated.model.ApiGrantRoleRequestBody;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.generated.model.ApiJobResult;
 import bio.terra.workspace.generated.model.ApiManagedBy;
@@ -53,7 +52,6 @@ import bio.terra.workspace.generated.model.ApiWsmPolicyUpdateRequest;
 import bio.terra.workspace.generated.model.ApiWsmPolicyUpdateResult;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
-import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.model.OperationType;
@@ -426,43 +424,6 @@ public class MockMvcUtils {
         .forEach(
             actualResource ->
                 assertNotEquals(unexpectedResourceName, actualResource.getMetadata().getName()));
-  }
-
-  public void grantRole(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, WsmIamRole role, String memberEmail)
-      throws Exception {
-    var request = new ApiGrantRoleRequestBody().memberEmail(memberEmail);
-    mockMvc
-        .perform(
-            addJsonContentType(
-                addAuth(
-                    post(String.format(WORKSPACES_V1_GRANT_ROLE, workspaceId, role.name()))
-                        .content(objectMapper.writeValueAsString(request)),
-                    userRequest)))
-        .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
-  }
-
-  public void removeRole(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, WsmIamRole role, String memberEmail)
-      throws Exception {
-    removeRoleInternal(userRequest, workspaceId, role, memberEmail)
-        .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
-  }
-
-  public void removeRoleExpectBadRequest(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, WsmIamRole role, String memberEmail)
-      throws Exception {
-    removeRoleInternal(userRequest, workspaceId, role, memberEmail)
-        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
-  }
-
-  private ResultActions removeRoleInternal(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, WsmIamRole role, String memberEmail)
-      throws Exception {
-    return mockMvc.perform(
-        addAuth(
-            delete(String.format(WORKSPACES_V1_REMOVE_ROLE, workspaceId, role.name(), memberEmail)),
-            userRequest));
   }
 
   public ApiJobReport getJobReport(String path, AuthenticatedUserRequest userRequest)

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -121,9 +121,7 @@ public class MockMvcUtils {
   public static final AuthenticatedUserRequest USER_REQUEST =
       new AuthenticatedUserRequest(
           DEFAULT_USER_EMAIL, DEFAULT_USER_SUBJECT_ID, Optional.of("ThisIsNotARealBearerToken"));
-  public static final String DEFAULT_GCP_RESOURCE_REGION = "us-central1";
-  public static final String DEST_BUCKET_RESOURCE_NAME =
-      TestUtils.appendRandomNumber("i-am-the-cloned-bucket");
+
   public static final List<Integer> JOB_SUCCESS_CODES =
       List.of(HttpStatus.SC_OK, HttpStatus.SC_ACCEPTED);
 

--- a/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MockMvcUtils.java
@@ -35,8 +35,6 @@ import bio.terra.workspace.generated.model.ApiJobResult;
 import bio.terra.workspace.generated.model.ApiManagedBy;
 import bio.terra.workspace.generated.model.ApiPrivateResourceState;
 import bio.terra.workspace.generated.model.ApiPrivateResourceUser;
-import bio.terra.workspace.generated.model.ApiProperty;
-import bio.terra.workspace.generated.model.ApiPropertyKeys;
 import bio.terra.workspace.generated.model.ApiRegions;
 import bio.terra.workspace.generated.model.ApiResourceDescription;
 import bio.terra.workspace.generated.model.ApiResourceLineage;
@@ -137,33 +135,6 @@ public class MockMvcUtils {
     Assertions.fail(
         String.format("Expected OK or ACCEPTED, but received %d; body: %s", statusCode, content));
     return null;
-  }
-
-  public void updateWorkspaceProperties(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, List<ApiProperty> properties)
-      throws Exception {
-    getSerializedResponseForPost(
-        userRequest,
-        WORKSPACES_V1_PROPERTIES,
-        workspaceId,
-        objectMapper.writeValueAsString(properties));
-  }
-
-  public void deleteWorkspaceProperties(
-      AuthenticatedUserRequest userRequest, UUID workspaceId, List<String> propertyKeys)
-      throws Exception {
-    ApiPropertyKeys apiPropertyKeys = new ApiPropertyKeys();
-    apiPropertyKeys.addAll(propertyKeys);
-    mockMvc
-        .perform(
-            addAuth(
-                patch(String.format(WORKSPACES_V1_PROPERTIES, workspaceId))
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .content(objectMapper.writeValueAsString(apiPropertyKeys)),
-                userRequest))
-        .andExpect(status().is(HttpStatus.SC_NO_CONTENT));
   }
 
   public ApiWsmPolicyUpdateResult updatePolicies(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -2,8 +2,8 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
 import static bio.terra.workspace.common.mocks.MockAzureApi.CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT;
 import static bio.terra.workspace.common.mocks.MockAzureApi.CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.GET_CLOUD_CONTEXT_PATH_FORMAT;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.CLOUD_CONTEXTS_V1;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.CLOUD_CONTEXT_V2_CREATE_RESULT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -25,6 +25,7 @@ import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -57,7 +58,7 @@ public class AzureDisabledTest extends BaseConnectedTest {
   public void azureDisabledTest() throws Exception {
     Workspace workspace =
         connectedTestUtils.createWorkspace(userAccessUtils.defaultUserAuthRequest());
-    var workspaceUuid = workspace.getWorkspaceId();
+    UUID workspaceUuid = workspace.getWorkspaceId();
 
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     String fakeJobId = "a pretend job ID";
@@ -69,7 +70,7 @@ public class AzureDisabledTest extends BaseConnectedTest {
         .perform(
             addJsonContentType(
                 addAuth(
-                    post(String.format(CREATE_CLOUD_CONTEXT_PATH_FORMAT, workspaceUuid))
+                    post(String.format(CLOUD_CONTEXTS_V1, workspaceUuid))
                         .content(objectMapper.writeValueAsString(request)),
                     userRequest)))
         .andExpect(status().is(HttpStatus.SC_NOT_IMPLEMENTED));
@@ -77,7 +78,7 @@ public class AzureDisabledTest extends BaseConnectedTest {
     mockMvc
         .perform(
             (addAuth(
-                get(String.format(GET_CLOUD_CONTEXT_PATH_FORMAT, workspaceUuid, fakeJobId)),
+                get(String.format(CLOUD_CONTEXT_V2_CREATE_RESULT, workspaceUuid, fakeJobId)),
                 userRequest)))
         .andExpect(status().is(HttpStatus.SC_NOT_FOUND));
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDisabledTest.java
@@ -2,8 +2,8 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
 import static bio.terra.workspace.common.mocks.MockAzureApi.CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT;
 import static bio.terra.workspace.common.mocks.MockAzureApi.CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT;
-import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.CLOUD_CONTEXTS_V1;
-import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.CLOUD_CONTEXT_V2_CREATE_RESULT;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.CLOUD_CONTEXTS_V1_CREATE;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.CLOUD_CONTEXTS_V1_CREATE_RESULT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -70,7 +70,7 @@ public class AzureDisabledTest extends BaseConnectedTest {
         .perform(
             addJsonContentType(
                 addAuth(
-                    post(String.format(CLOUD_CONTEXTS_V1, workspaceUuid))
+                    post(String.format(CLOUD_CONTEXTS_V1_CREATE, workspaceUuid))
                         .content(objectMapper.writeValueAsString(request)),
                     userRequest)))
         .andExpect(status().is(HttpStatus.SC_NOT_IMPLEMENTED));
@@ -78,7 +78,7 @@ public class AzureDisabledTest extends BaseConnectedTest {
     mockMvc
         .perform(
             (addAuth(
-                get(String.format(CLOUD_CONTEXT_V2_CREATE_RESULT, workspaceUuid, fakeJobId)),
+                get(String.format(CLOUD_CONTEXTS_V1_CREATE_RESULT, workspaceUuid, fakeJobId)),
                 userRequest)))
         .andExpect(status().is(HttpStatus.SC_NOT_FOUND));
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/WorkspaceCloneUtilsTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.workspace;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
-import static bio.terra.workspace.common.utils.MockMvcUtils.DEFAULT_GCP_RESOURCE_REGION;
+import static bio.terra.workspace.common.utils.GcpUtilsTest.DEFAULT_GCP_RESOURCE_REGION;
 import static bio.terra.workspace.service.resource.controlled.flight.clone.workspace.WorkspaceCloneUtils.buildDestinationControlledBigQueryDataset;
 import static bio.terra.workspace.service.resource.controlled.flight.clone.workspace.WorkspaceCloneUtils.buildDestinationControlledGcsBucket;
 import static bio.terra.workspace.service.workspace.model.WorkspaceConstants.ResourceProperties.FOLDER_ID_KEY;

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AnyResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AnyResourceStateFailureTest.java
@@ -20,6 +20,7 @@ import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.mocks.MockFlexibleResourceApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceDao;
@@ -57,6 +58,7 @@ public class AnyResourceStateFailureTest extends BaseUnitTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired private MockFlexibleResourceApi mockFlexibleResourceApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired ReferencedResourceService referencedResourceService;
@@ -70,7 +72,7 @@ public class AnyResourceStateFailureTest extends BaseUnitTest {
   @BeforeEach
   void setup() throws Exception {
     // Construct after the autowiring is done
-    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils);
+    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils, mockWorkspaceV1Api);
 
     // Everything is authorized!
     when(mockSamService().isAuthorized(any(), any(), any(), any())).thenReturn(true);

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AwsResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AwsResourceStateFailureTest.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.common.BaseAwsUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.WorkspaceUnitTestUtils;
 import bio.terra.workspace.db.ResourceDao;
@@ -40,6 +41,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired ObjectMapper objectMapper;
   @Autowired ReferencedResourceService referencedResourceService;
   @Autowired ResourceDao resourceDao;
@@ -50,7 +52,7 @@ public class AwsResourceStateFailureTest extends BaseAwsUnitTest {
 
   @BeforeEach
   void setup() throws Exception {
-    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils);
+    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils, mockWorkspaceV1Api);
 
     // Everything is authorized!
     when(mockSamService().isAuthorized(any(), any(), any(), any())).thenReturn(true);

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/AzureResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/AzureResourceStateFailureTest.java
@@ -19,6 +19,7 @@ import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.WorkspaceUnitTestUtils;
 import bio.terra.workspace.db.ResourceDao;
@@ -53,6 +54,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired ObjectMapper objectMapper;
   @Autowired ReferencedResourceService referencedResourceService;
   @Autowired ResourceDao resourceDao;
@@ -66,7 +68,7 @@ public class AzureResourceStateFailureTest extends BaseUnitTest {
 
   @BeforeEach
   void setup() throws Exception {
-    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils);
+    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils, mockWorkspaceV1Api);
 
     // Everything is authorized!
     when(mockSamService().isAuthorized(any(), any(), any(), any())).thenReturn(true);

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
@@ -13,12 +13,12 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import bio.terra.landingzone.service.landingzone.azure.LandingZoneService;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledGcpResourceFixtures;
 import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.common.utils.TestUtils;
 import bio.terra.workspace.common.utils.WorkspaceUnitTestUtils;
@@ -58,27 +58,25 @@ import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 public class GcpResourceStateFailureTest extends BaseUnitTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired private MockGcpApi mockGcpApi;
   @Autowired ObjectMapper objectMapper;
   @Autowired ReferencedResourceService referencedResourceService;
   @Autowired ResourceDao resourceDao;
   @Autowired private WorkspaceDao workspaceDao;
 
-  @MockBean private LandingZoneService mockLandingZoneService;
-
   private static final String RESOURCE_NAME = "resourcename";
   private StateTestUtils stateTestUtils;
 
   @BeforeEach
   void setup() throws Exception {
-    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils);
+    stateTestUtils = new StateTestUtils(mockMvc, mockMvcUtils, mockWorkspaceV1Api);
     // Everything is authorized!
     when(mockSamService().isAuthorized(any(), any(), any(), any())).thenReturn(true);
     when(mockSamService().getUserStatusInfo(any()))

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/StateTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/StateTestUtils.java
@@ -4,6 +4,7 @@ import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
@@ -12,10 +13,13 @@ import org.springframework.test.web.servlet.MockMvc;
 public class StateTestUtils {
   private final MockMvc mockMvc;
   private final MockMvcUtils mockMvcUtils;
+  private final MockWorkspaceV1Api mockWorkspaceV1Api;
 
-  public StateTestUtils(MockMvc mockMvc, MockMvcUtils mockMvcUtils) {
+  public StateTestUtils(
+      MockMvc mockMvc, MockMvcUtils mockMvcUtils, MockWorkspaceV1Api mockWorkspaceV1Api) {
     this.mockMvc = mockMvc;
     this.mockMvcUtils = mockMvcUtils;
+    this.mockWorkspaceV1Api = mockWorkspaceV1Api;
   }
 
   void patchResourceExpectConflict(
@@ -48,7 +52,7 @@ public class StateTestUtils {
   <T> void updateControlledResource(
       Class<T> clazz, UUID workspaceUuid, UUID resourceId, String pathFormat, String body)
       throws Exception {
-    mockMvcUtils.updateResource(
+    mockWorkspaceV1Api.updateResourceAndExpect(
         clazz, pathFormat, workspaceUuid, resourceId, body, USER_REQUEST, HttpStatus.SC_CONFLICT);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -125,7 +125,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
     doReturn(true).when(mockDataRepoService).snapshotReadable(any(), any(), any());
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();
     workspaceId =
-        mockMvcUtils.createWorkspaceWithCloudContext(userRequest, apiCloudPlatform).getId();
+        mockWorkspaceV1Api.createWorkspaceWithCloudContext(userRequest, apiCloudPlatform).getId();
     projectId = gcpCloudContextService.getRequiredGcpProject(workspaceId);
     workspaceId2 = null;
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -141,7 +141,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
     try {
       if (workspaceId != null) {
         int status =
-            mockMvcUtils.deleteWorkspaceNoCheck(
+            mockWorkspaceV1Api.deleteWorkspaceIfExists(
                 userAccessUtils.defaultUserAuthRequest(), workspaceId);
         assertTrue(
             status == HttpStatus.NO_CONTENT.value() || status == HttpStatus.NOT_FOUND.value());
@@ -149,7 +149,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
       }
       if (workspaceId2 != null) {
         int status =
-            mockMvcUtils.deleteWorkspaceNoCheck(
+            mockWorkspaceV1Api.deleteWorkspaceIfExists(
                 userAccessUtils.defaultUserAuthRequest(), workspaceId2);
         assertTrue(
             status == HttpStatus.NO_CONTENT.value() || status == HttpStatus.NOT_FOUND.value());
@@ -193,7 +193,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
     ApiErrorReport errorReport = objectMapper.readValue(errorResponseString, ApiErrorReport.class);
     assertEquals(HttpStatus.NOT_FOUND.value(), errorReport.getStatusCode());
 
-    mockMvcUtils.deleteWorkspace(userRequest, workspaceId);
+    mockWorkspaceV1Api.deleteWorkspace(userRequest, workspaceId);
     workspaceId = null;
 
     // Check that project is now being deleted.

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -23,6 +23,7 @@ import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
 import bio.terra.workspace.common.logging.model.ActivityLogChangedTarget;
 import bio.terra.workspace.common.mocks.MockGcpApi;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.utils.MockMvcUtils;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.connected.WorkspaceConnectedTestUtils;
@@ -102,6 +103,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
   @Autowired private GcpCloudContextService gcpCloudContextService;
   @Autowired private JobService jobService;
   @Autowired private MockMvcUtils mockMvcUtils;
+  @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired private MockGcpApi mockGcpApi;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private ReferencedResourceService referenceResourceService;
@@ -218,7 +220,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
   @DisabledIfEnvironmentVariable(named = "TEST_ENV", matches = BUFFER_SERVICE_DISABLED_ENVS_REG_EX)
   void createGoogleContext_logCreation() throws Exception {
     workspaceId2 =
-        mockMvcUtils
+        mockWorkspaceV1Api
             .createWorkspaceWithoutCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), ApiWorkspaceStageModel.MC_WORKSPACE)
             .getId();

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -59,6 +59,7 @@ import bio.terra.workspace.service.resource.referenced.ReferencedResourceService
 import bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset.ReferencedBigQueryDatasetResource;
 import bio.terra.workspace.service.spendprofile.SpendConnectedTestUtils;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.OperationType;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
@@ -85,7 +86,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @Tag("connectedPlus")
 @ActiveProfiles({"app-test"})
 class GcpCloudContextConnectedTest extends BaseConnectedTest {
-  public static final String SPEND_PROFILE_ID = "wm-default-spend-profile";
+  private static final String SPEND_PROFILE_ID = "wm-default-spend-profile";
   private static final Logger logger = LoggerFactory.getLogger(GcpCloudContextConnectedTest.class);
   // Name of the test WSM application. This must match the identifier in the
   // application-app-test.yml file.
@@ -172,7 +173,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
     ApiGcpGcsBucketResource bucketResource = createControlledBucket();
 
     // Delete the cloud context
-    mockMvcUtils.deleteGcpCloudContext(userRequest, workspaceId);
+    mockMvcUtils.deleteCloudContext(userRequest, workspaceId, CloudPlatform.GCP);
 
     // Make sure the bucket gets deleted when we delete the cloud context
     String errorResponseString =
@@ -202,7 +203,8 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
   void createGetDeleteGoogleContext_deleteGcpProjectAndLog() throws Exception {
     assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceId).isPresent());
 
-    mockMvcUtils.deleteGcpCloudContext(userAccessUtils.defaultUserAuthRequest(), workspaceId);
+    mockMvcUtils.deleteCloudContext(
+        userAccessUtils.defaultUserAuthRequest(), workspaceId, CloudPlatform.GCP);
 
     assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceId).isEmpty());
     ActivityLogChangeDetails changeDetails =

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -102,7 +102,6 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
   @Autowired private FolderDao folderDao;
   @Autowired private GcpCloudContextService gcpCloudContextService;
   @Autowired private JobService jobService;
-  @Autowired private MockMvcUtils mockMvcUtils;
   @Autowired private MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired private MockGcpApi mockGcpApi;
   @Autowired private ObjectMapper objectMapper;
@@ -175,7 +174,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
     ApiGcpGcsBucketResource bucketResource = createControlledBucket();
 
     // Delete the cloud context
-    mockMvcUtils.deleteCloudContext(userRequest, workspaceId, CloudPlatform.GCP);
+    mockWorkspaceV1Api.deleteCloudContext(userRequest, workspaceId, CloudPlatform.GCP);
 
     // Make sure the bucket gets deleted when we delete the cloud context
     String errorResponseString =
@@ -205,7 +204,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
   void createGetDeleteGoogleContext_deleteGcpProjectAndLog() throws Exception {
     assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceId).isPresent());
 
-    mockMvcUtils.deleteCloudContext(
+    mockWorkspaceV1Api.deleteCloudContext(
         userAccessUtils.defaultUserAuthRequest(), workspaceId, CloudPlatform.GCP);
 
     assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceId).isEmpty());
@@ -224,7 +223,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
             .createWorkspaceWithoutCloudContext(
                 userAccessUtils.defaultUserAuthRequest(), ApiWorkspaceStageModel.MC_WORKSPACE)
             .getId();
-    mockMvcUtils.createCloudContextAndWait(
+    mockWorkspaceV1Api.createCloudContextAndWait(
         userAccessUtils.defaultUserAuthRequest(), workspaceId2, apiCloudPlatform);
 
     assertTrue(gcpCloudContextService.getGcpCloudContext(workspaceId2).isPresent());

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -1,9 +1,9 @@
 package bio.terra.workspace.service.workspace;
 
-import static bio.terra.workspace.common.utils.MockMvcUtils.CREATE_CLOUD_CONTEXT_PATH_FORMAT;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.CLOUD_CONTEXTS_V1;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_BY_UFID;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UFID_PATH_FORMAT;
-import static bio.terra.workspace.common.utils.MockMvcUtils.WORKSPACES_V1_BY_UUID_PATH_FORMAT;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.utils.MockMvcUtils.addJsonContentType;
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
@@ -30,6 +30,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.fixtures.ReferenceResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
+import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.db.WorkspaceActivityLogDao;
 import bio.terra.workspace.db.exception.WorkspaceNotFoundException;
@@ -69,6 +70,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
@@ -159,10 +161,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .when(mockSamService)
         .checkAuthz(any(), any(), any(), any());
     mockMvc
-        .perform(
-            addAuth(
-                get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, UUID.randomUUID())),
-                USER_REQUEST))
+        .perform(addAuth(get(String.format(WORKSPACES_V1, UUID.randomUUID())), USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_NOT_FOUND));
   }
 
@@ -175,10 +174,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .when(mockSamService)
         .checkAuthz(any(), any(), any(), any());
     mockMvc
-        .perform(
-            addAuth(
-                get(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, request.getWorkspaceId())),
-                USER_REQUEST))
+        .perform(addAuth(get(String.format(WORKSPACES_V1, request.getWorkspaceId())), USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_FORBIDDEN));
   }
 
@@ -212,9 +208,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .checkAuthz(any(), any(), any(), any());
     mockMvc
         .perform(
-            addAuth(
-                get(String.format(WORKSPACES_V1_BY_UFID_PATH_FORMAT, "missing-workspace")),
-                USER_REQUEST))
+            addAuth(get(String.format(WORKSPACES_V1_BY_UFID, "missing-workspace")), USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_NOT_FOUND));
   }
 
@@ -229,9 +223,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .when(mockSamService)
         .checkAuthz(any(), any(), any(), any());
     mockMvc
-        .perform(
-            addAuth(
-                get(String.format(WORKSPACES_V1_BY_UFID_PATH_FORMAT, userFacingId)), USER_REQUEST))
+        .perform(addAuth(get(String.format(WORKSPACES_V1_BY_UFID, userFacingId)), USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_FORBIDDEN));
     assertThrows(
         ForbiddenException.class,
@@ -280,6 +272,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   void duplicateWorkspaceIdRequestsRejected() {
     Workspace request = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(request, null, null, null, USER_REQUEST);
+
     Workspace duplicateWorkspace =
         WorkspaceFixtures.defaultWorkspaceBuilder(request.getWorkspaceId())
             .description("slightly different workspace")
@@ -363,9 +356,12 @@ class WorkspaceServiceTest extends BaseConnectedTest {
   void testUpdateWorkspace() {
     Workspace request = WorkspaceFixtures.buildMcWorkspace();
     workspaceService.createWorkspace(request, null, null, null, USER_REQUEST);
+
     UUID workspaceUuid = request.getWorkspaceId();
-    var lastUpdateDetails = workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
+    Optional<ActivityLogChangeDetails> lastUpdateDetails =
+        workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
     assertTrue(lastUpdateDetails.isPresent());
+
     Workspace createdWorkspace = workspaceService.getWorkspace(request.getWorkspaceId());
     assertEquals(request.getWorkspaceId(), createdWorkspace.getWorkspaceId());
     assertTrue(createdWorkspace.getDisplayName().isEmpty());
@@ -380,7 +376,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
             workspaceUuid, userFacingId, name, description, USER_REQUEST);
     Workspace updatedWorkspace = updatedWorkspaceDescription.workspace();
 
-    var workspaceUpdateChangeDetails = workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
+    Optional<ActivityLogChangeDetails> workspaceUpdateChangeDetails =
+        workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
     assertTrue(
         lastUpdateDetails
             .get()
@@ -401,7 +398,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         workspaceService.updateWorkspace(
             workspaceUuid, /*userFacingId=*/ null, /*name=*/ null, otherDescription, USER_REQUEST);
     Workspace secondUpdatedWorkspace = secondUpdatedWorkspaceDescription.workspace();
-    var secondUpdateChangeDetails = workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
+    Optional<ActivityLogChangeDetails> secondUpdateChangeDetails =
+        workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
     assertTrue(
         workspaceUpdateChangeDetails
             .get()
@@ -420,7 +418,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         workspaceService.updateWorkspace(workspaceUuid, userFacingId, "", "", USER_REQUEST);
     Workspace thirdUpdatedWorkspace = thirdUpdatedWorkspaceDescription.workspace();
 
-    var thirdUpdatedDateAfterWorkspaceUpdate =
+    Optional<ActivityLogChangeDetails> thirdUpdatedDateAfterWorkspaceUpdate =
         workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
     assertTrue(
         secondUpdateChangeDetails
@@ -442,7 +440,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
                 /*name=*/ null,
                 /*description=*/ null,
                 USER_REQUEST));
-    var failedUpdateDate = workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
+    Optional<ActivityLogChangeDetails> failedUpdateDate =
+        workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
     assertEquals(
         thirdUpdatedDateAfterWorkspaceUpdate.get().changeDate(),
         failedUpdateDate.get().changeDate());
@@ -483,7 +482,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     Workspace request = WorkspaceFixtures.defaultWorkspaceBuilder(null).build();
     workspaceService.createWorkspace(request, null, null, null, USER_REQUEST);
     UUID workspaceUuid = request.getWorkspaceId();
-    var lastUpdateDetails = workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
+    Optional<ActivityLogChangeDetails> lastUpdateDetails =
+        workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
     OffsetDateTime lastUpdatedDate = lastUpdateDetails.get().changeDate();
     assertNotNull(lastUpdatedDate);
 
@@ -491,7 +491,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     workspaceService.updateWorkspaceProperties(workspaceUuid, propertyMap, USER_REQUEST);
     Workspace updatedWorkspace = workspaceService.getWorkspace(workspaceUuid);
 
-    var updateDetailsAfterWorkspaceUpdate =
+    Optional<ActivityLogChangeDetails> updateDetailsAfterWorkspaceUpdate =
         workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
     assertTrue(lastUpdatedDate.isBefore(updateDetailsAfterWorkspaceUpdate.get().changeDate()));
     assertEquals(
@@ -606,7 +606,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         WorkspaceFixtures.defaultWorkspaceBuilder(null).properties(propertyMap).build();
     workspaceService.createWorkspace(request, null, null, null, USER_REQUEST);
     UUID workspaceUuid = request.getWorkspaceId();
-    var lastUpdateDetails = workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
+    Optional<ActivityLogChangeDetails> lastUpdateDetails =
+        workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
     assertTrue(lastUpdateDetails.isPresent());
 
     List<String> propertyKeys = new ArrayList<>(Arrays.asList("foo", "foo1"));
@@ -614,7 +615,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     workspaceService.deleteWorkspaceProperties(workspaceUuid, propertyKeys, USER_REQUEST);
     Workspace deletedWorkspace = workspaceService.getWorkspace(workspaceUuid);
 
-    var updateDetailsAfterWorkspaceUpdate =
+    Optional<ActivityLogChangeDetails> updateDetailsAfterWorkspaceUpdate =
         workspaceActivityLogDao.getLastUpdatedDetails(workspaceUuid);
     assertTrue(
         lastUpdateDetails
@@ -634,10 +635,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
         .when(mockSamService)
         .checkAuthz(any(), any(), any(), any());
     mockMvc
-        .perform(
-            addAuth(
-                delete(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, UUID.randomUUID())),
-                USER_REQUEST))
+        .perform(addAuth(delete(String.format(WORKSPACES_V1, UUID.randomUUID())), USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_NOT_FOUND));
   }
 
@@ -652,9 +650,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
 
     mockMvc
         .perform(
-            addAuth(
-                delete(String.format(WORKSPACES_V1_BY_UUID_PATH_FORMAT, request.getWorkspaceId())),
-                USER_REQUEST))
+            addAuth(delete(String.format(WORKSPACES_V1, request.getWorkspaceId())), USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_FORBIDDEN));
   }
 
@@ -710,9 +706,7 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     mockMvc
         .perform(
             addJsonContentType(
-                    addAuth(
-                        post(String.format(CREATE_CLOUD_CONTEXT_PATH_FORMAT, workspaceId)),
-                        USER_REQUEST))
+                    addAuth(post(String.format(CLOUD_CONTEXTS_V1, workspaceId)), USER_REQUEST))
                 .content(objectMapper.writeValueAsString(contextRequest)))
         .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceServiceTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
-import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.CLOUD_CONTEXTS_V1;
+import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.CLOUD_CONTEXTS_V1_CREATE;
 import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1;
 import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_BY_UFID;
 import static bio.terra.workspace.common.utils.MockMvcUtils.USER_REQUEST;
@@ -706,7 +706,8 @@ class WorkspaceServiceTest extends BaseConnectedTest {
     mockMvc
         .perform(
             addJsonContentType(
-                    addAuth(post(String.format(CLOUD_CONTEXTS_V1, workspaceId)), USER_REQUEST))
+                    addAuth(
+                        post(String.format(CLOUD_CONTEXTS_V1_CREATE, workspaceId)), USER_REQUEST))
                 .content(objectMapper.writeValueAsString(contextRequest)))
         .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
   }


### PR DESCRIPTION
- Move workspace v1 functions to MockWorkspaceV1Api
- The large number of files in this PR is due to the various functions mocked for workspace v1. Changes are simple, straightforward
- No new functions, no change in tests
- Last of the large PRs for MockMvcUtils file split. 

I remaining PR after this to cleanup remainder functions in MockMvcUtils