### PR TITLE
Stop deleting workspace records on duplicate create request

### DIFF
--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -9,6 +9,7 @@ import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
+import bio.terra.workspace.db.exception.ResourceStateConflictException;
 import bio.terra.workspace.db.model.DbResource;
 import bio.terra.workspace.db.model.DbUpdater;
 import bio.terra.workspace.db.model.UniquenessCheckAttributes;
@@ -805,16 +806,27 @@ public class ResourceDao {
       String flightId,
       @Nullable Exception exception,
       WsmResourceStateRule resourceStateRule) {
-
+    DbResource dbResource =
+        getDbResourceFromIds(resource.getWorkspaceId(), resource.getResourceId());
     switch (resourceStateRule) {
       case DELETE_ON_FAILURE -> {
-        deleteResourceWorker(
-            resource.getWorkspaceId(), resource.getResourceId(), /*resourceType=*/ null);
+        // There is no guarantee this is the flight which created this resource. Validate that it
+        // is before attempting to delete the workspace.
+        try {
+          stateDao.updateState(
+              dbResource, flightId, /*targetFlightId=*/ null, WsmResourceState.NOT_EXISTS, null);
+          deleteResourceWorker(
+              resource.getWorkspaceId(), resource.getResourceId(), /*resourceType=*/ null);
+        } catch (ResourceStateConflictException e) {
+          // Thrown by updateState during an invalid state transition. This indicates that the
+          // caller is not the same flight that created the resource.
+          logger.info(
+              "Skipping resource delete in createResourceFailure. This is expected for duplicate 'createResource' requests. Cause: ",
+              e);
+        }
       }
 
       case BROKEN_ON_FAILURE -> {
-        DbResource dbResource =
-            getDbResourceFromIds(resource.getWorkspaceId(), resource.getResourceId());
         stateDao.updateState(
             dbResource, flightId, /*flightId=*/ null, WsmResourceState.BROKEN, exception);
       }

--- a/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/ResourceDao.java
@@ -808,29 +808,28 @@ public class ResourceDao {
       WsmResourceStateRule resourceStateRule) {
     DbResource dbResource =
         getDbResourceFromIds(resource.getWorkspaceId(), resource.getResourceId());
-    switch (resourceStateRule) {
-      case DELETE_ON_FAILURE -> {
-        // There is no guarantee this is the flight which created this resource. Validate that it
-        // is before attempting to delete the workspace.
-        try {
+    try {
+      switch (resourceStateRule) {
+        case DELETE_ON_FAILURE -> {
+          // There is no guarantee this is the flight which created this resource. Validate that it
+          // is before attempting to delete the workspace.
           stateDao.updateState(
               dbResource, flightId, /*targetFlightId=*/ null, WsmResourceState.NOT_EXISTS, null);
           deleteResourceWorker(
               resource.getWorkspaceId(), resource.getResourceId(), /*resourceType=*/ null);
-        } catch (ResourceStateConflictException e) {
-          // Thrown by updateState during an invalid state transition. This indicates that the
-          // caller is not the same flight that created the resource.
-          logger.info(
-              "Skipping resource delete in createResourceFailure. This is expected for duplicate 'createResource' requests. Cause: ",
-              e);
         }
+        case BROKEN_ON_FAILURE -> {
+          stateDao.updateState(
+              dbResource, flightId, /*flightId=*/ null, WsmResourceState.BROKEN, exception);
+        }
+        default -> throw new InternalLogicException("Invalid switch case");
       }
-
-      case BROKEN_ON_FAILURE -> {
-        stateDao.updateState(
-            dbResource, flightId, /*flightId=*/ null, WsmResourceState.BROKEN, exception);
-      }
-      default -> throw new InternalLogicException("Invalid switch case");
+    } catch (ResourceStateConflictException e) {
+      // Thrown by updateState during an invalid state transition. This indicates that the
+      // caller is not the same flight that created the resource.
+      logger.info(
+          "Skipping resource delete in createResourceFailure. This is expected for duplicate 'createResource' requests. Cause: ",
+          e);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
+++ b/service/src/main/java/bio/terra/workspace/db/WorkspaceDao.java
@@ -873,7 +873,8 @@ public class WorkspaceDao {
         try {
           stateDao.updateState(
               cloudContext, flightId, /*targetFlightId=*/ null, WsmResourceState.NOT_EXISTS, null);
-          deleteCloudContextWorker(workspaceUuid, cloudPlatform, flightId);
+          // flightId is now null due to the updateState call above.
+          deleteCloudContextWorker(workspaceUuid, cloudPlatform, null);
         } catch (ResourceStateConflictException e) {
           // Thrown by updateState during an invalid state transition. This indicates that the
           // caller is not the same flight that created the cloud context.

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/SetCreateResponseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/SetCreateResponseStep.java
@@ -1,8 +1,12 @@
 package bio.terra.workspace.service.resource.controlled.flight.create;
 
+import static java.lang.Boolean.TRUE;
+
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
@@ -11,6 +15,7 @@ import bio.terra.workspace.service.logging.WorkspaceActivityLogService;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceStateRule;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys;
 import bio.terra.workspace.service.workspace.model.OperationType;
 
 public class SetCreateResponseStep implements Step {
@@ -42,9 +47,12 @@ public class SetCreateResponseStep implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
+    FlightMap workingMap = flightContext.getWorkingMap();
+    workingMap.put(ResourceKeys.UPDATE_COMPLETE, Boolean.FALSE);
     WsmResource responseResource =
         resourceDao.createResourceSuccess(resource, flightContext.getFlightId());
     flightContext.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), responseResource);
+    workingMap.put(ResourceKeys.UPDATE_COMPLETE, TRUE);
     workspaceActivityLogService.writeActivity(
         userRequest,
         resource.getWorkspaceId(),
@@ -56,6 +64,16 @@ public class SetCreateResponseStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    Boolean didUpdate =
+        flightContext.getWorkingMap().get(ResourceKeys.UPDATE_COMPLETE, Boolean.class);
+    if (TRUE.equals(didUpdate)) {
+      // If the update is complete, then we cannot undo it. This is a teeny tiny window
+      // where the error occurs after the update, but before the success return. However,
+      // the DebugInfo.lastStepFailure will always hit it.
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL, new RuntimeException("dismal failure"));
+    }
+    // Failed before update - perform undo
     return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/SetCreateResponseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/create/SetCreateResponseStep.java
@@ -51,8 +51,8 @@ public class SetCreateResponseStep implements Step {
     workingMap.put(ResourceKeys.UPDATE_COMPLETE, Boolean.FALSE);
     WsmResource responseResource =
         resourceDao.createResourceSuccess(resource, flightContext.getFlightId());
-    flightContext.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), responseResource);
     workingMap.put(ResourceKeys.UPDATE_COMPLETE, TRUE);
+    workingMap.put(JobMapKeys.RESPONSE.getKeyName(), responseResource);
     workspaceActivityLogService.writeActivity(
         userRequest,
         resource.getWorkspaceId(),

--- a/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/ResourceDaoTest.java
@@ -35,6 +35,7 @@ import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.CommonUpdateParameters;
 import bio.terra.workspace.service.resource.model.StewardshipType;
 import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.model.WsmResourceStateRule;
 import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.GcpCloudContextService;
 import bio.terra.workspace.service.workspace.exceptions.MissingRequiredFieldsException;
@@ -281,6 +282,29 @@ public class ResourceDaoTest extends BaseUnitTest {
                       r.getResourceId().equals(resource.getResourceId())
                           && r.partialEqual(resource)));
     }
+  }
+
+  @Test
+  public void duplicateResourceCreateDoesNotDelete() {
+    String bucketName = "my-real-bucket-name";
+    // Run the normal case
+    ControlledGcsBucketResource initialBucket =
+        ControlledGcpResourceFixtures.makeDefaultControlledGcsBucketBuilder(workspaceUuid)
+            .bucketName(bucketName)
+            .build();
+    ControlledResourceFixtures.insertControlledResourceRow(resourceDao, initialBucket);
+    // Later calls to createResourceFailure (e.g. from duplicate requests) should not undo
+    // resources they did not create.
+    resourceDao.createResourceFailure(
+        initialBucket,
+        UUID.randomUUID().toString(),
+        /*exception=*/ null,
+        WsmResourceStateRule.DELETE_ON_FAILURE);
+    ControlledGcsBucketResource retrievedBucket =
+        resourceDao
+            .getResource(initialBucket.getWorkspaceId(), initialBucket.getResourceId())
+            .castByEnum(WsmResourceType.CONTROLLED_GCP_GCS_BUCKET);
+    assertTrue(initialBucket.partialEqual(retrievedBucket));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceBucketTest.java
@@ -140,8 +140,18 @@ public class ControlledResourceServiceBucketTest extends BaseConnectedTest {
     Map<String, StepStatus> retrySteps = new HashMap<>();
     retrySteps.put(CreateGcsBucketStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(GcsBucketCloudSyncStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    jobService.setFlightDebugInfoForTest(
-        FlightDebugInfo.newBuilder().undoStepFailures(retrySteps).lastStepFailure(true).build());
+
+    // The finish step is not undoable, so we make the failure at the penultimate step.
+    Map<String, StepStatus> triggerFailureStep = new HashMap<>();
+    triggerFailureStep.put(
+        GcsBucketCloudSyncStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_FATAL);
+
+    FlightDebugInfo debugInfo =
+        FlightDebugInfo.newBuilder()
+            .doStepFailures(triggerFailureStep)
+            .undoStepFailures(retrySteps)
+            .build();
+    jobService.setFlightDebugInfoForTest(debugInfo);
     // Service methods which wait for a flight to complete will throw an
     // InvalidResultStateException when that flight fails without a cause, which occurs when a
     // flight fails via debugInfo.

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceNotebookTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/ControlledResourceServiceNotebookTest.java
@@ -46,6 +46,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.Note
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.RetrieveAiNotebookResourceAttributesStep;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.ainotebook.UpdateAiNotebookAttributesStep;
 import bio.terra.workspace.service.resource.controlled.exception.ReservedMetadataKeyException;
+import bio.terra.workspace.service.resource.controlled.flight.update.UpdateControlledResourceRegionStep;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.resource.exception.DuplicateResourceException;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
@@ -269,12 +270,18 @@ public class ControlledResourceServiceNotebookTest extends BaseConnectedTest {
     retrySteps.put(
         CreateAiNotebookInstanceStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
     retrySteps.put(UpdateFinishStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY);
-    jobService.setFlightDebugInfoForTest(
+
+    // The finish step is not undoable, so we make the failure at the penultimate step.
+    Map<String, StepStatus> triggerFailureStep = new HashMap<>();
+    triggerFailureStep.put(
+        UpdateControlledResourceRegionStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_FATAL);
+
+    FlightDebugInfo debugInfo =
         FlightDebugInfo.newBuilder()
-            // Fail after the last step to test that everything is deleted on undo.
-            .lastStepFailure(true)
+            .doStepFailures(triggerFailureStep)
             .undoStepFailures(retrySteps)
-            .build());
+            .build();
+    jobService.setFlightDebugInfoForTest(debugInfo);
 
     // Revoke user's Pet SA access, if they have it. Because these tests re-use a common workspace,
     // the user may have pet SA access enabled prior to this test.


### PR DESCRIPTION
Previously, workspace/cloud context/resource creation flights would always delete DB records on undo with the `DELETE_ON_FAILURE` rule, even if the flight was not the one which created those objects originally. 

This change adds a state transition to validate that the object was created by the calling flight. The method does not throw an error if this validation fails (as I believe we just want to return the 400 response from the `do` step), but no longer deletes the DB row.

Several controlled resource tests inadvertently depended on this behavior and had to be modified. Additionally, I changed the createControlledResource flight to throw a dismal failure if the flight fails between releasing the resource state lock (the last step) and flight completion to keep resource state in line with behavior for workspaces and cloud contexts. Functionally, this is a test-only change.