### PR TITLE
[BENCH-859] Handle duplicate delete requests from applications

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/BuildAndValidateResourceListStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/BuildAndValidateResourceListStep.java
@@ -10,6 +10,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.workspace.CloudContextService;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,8 +55,12 @@ public class BuildAndValidateResourceListStep implements Step {
     // Generate pairs of (resourceId, flightId) maintaining the ordering
     List<ResourceDeleteFlightPair> resourcePairs = new ArrayList<>();
     for (ControlledResource resource : resources) {
-      resourcePairs.add(
-          new ResourceDeleteFlightPair(resource.getResourceId(), UUID.randomUUID().toString()));
+      // Resources already in delete flight are added to the list without creating a new flight
+      String flightId =
+          ((resource.getState() == WsmResourceState.DELETING) && (resource.getFlightId() != null))
+              ? resource.getFlightId()
+              : UUID.randomUUID().toString();
+      resourcePairs.add(new ResourceDeleteFlightPair(resource.getResourceId(), flightId));
     }
     logger.info(
         "Flight {} BuildAndValidateResourceListStep found {} resources to delete",

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/DeleteResourcesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/DeleteResourcesStep.java
@@ -51,7 +51,6 @@ public class DeleteResourcesStep implements Step {
   }
 
   @Override
-  //  @SuppressWarnings("unchecked")
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     // Jackson does not deserialize the list properly with a TypeReference. The array form works.
     ResourceDeleteFlightPair[] resourcePairsArray =


### PR DESCRIPTION
error: cloud context delete fails
root cause: previous delete is still running and conflicts with cloud context delete
fix: don't create duplicate delete resource flights

sample flow:

- User calls resource delete, which times out but is still running on server
- User now calls Workspace delete (internally calls cloud context delete)
- Cloud context delete created a new delete flight for the resource (since the previous delete is running)
- Flight flight completes and resource entries are deleted in DB
- Second flight attempts to update DB entry for resource (to start delete) and fails with 'resource not found'

with above fix:

- Cloud context delete will create a new resource delete flight only if there is no existing delete flight for that resource
- If there exists a flight, add it to the list and wait for it as usual
