### PR TITLE
[BENCH-875] Handle "does not exist" exception message from aws

### DIFF
--- a/service/src/main/java/bio/terra/workspace/common/utils/AwsUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/AwsUtils.java
@@ -921,7 +921,9 @@ public class AwsUtils {
   public static void checkException(SdkException ex, String altMessage, boolean ignoreNotFound)
       throws NotFoundException, UnauthorizedException, BadRequestException, ApiException {
     String message = ex.getMessage();
-    if (message.contains("ResourceNotFoundException") || message.contains("RecordNotFound")) {
+    if (message.contains("ResourceNotFoundException")
+        || message.contains("RecordNotFound")
+        || message.contains("does not exist")) {
       if (ignoreNotFound) {
         return;
       }


### PR DESCRIPTION
Handle "does not exist" exception message from aws

Sample message - 

software.amazon.awssdk.services.sagemaker.model.SageMakerException: Notebook Instance <arn> does not exist (Service: SageMaker, Status Code: 400, Request ID: <id)