### PR TITLE
[BENCH-888] fix gcp connected plus test errors

### DIFF
--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerBqDatasetConnectedTest.java
@@ -320,7 +320,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
 
   @Test
   public void clone_requesterNoReadAccessOnSourceWorkspace_throws403() throws Exception {
-    mockGcpApi.cloneControlledBqDatasetAsync(
+    mockGcpApi.cloneControlledBqDatasetAsyncAndExpect(
         userAccessUtils.noBillingUser().getAuthenticatedRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
@@ -337,7 +337,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
 
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
-    mockGcpApi.cloneControlledBqDatasetAsync(
+    mockGcpApi.cloneControlledBqDatasetAsyncAndExpect(
         userAccessUtils.secondUser().getAuthenticatedRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
@@ -354,7 +354,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
 
   @Test
   public void clone_requestContainsInvalidField_throws400() throws Exception {
-    mockGcpApi.cloneControlledBqDatasetAsync(
+    mockGcpApi.cloneControlledBqDatasetAsyncAndExpect(
         userAccessUtils.defaultUser().getAuthenticatedRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceResource.getMetadata().getResourceId(),
@@ -412,7 +412,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
   void clone_duplicateDatasetName_jobThrows409() throws Exception {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUserAuthRequest();
     ApiCloneControlledGcpBigQueryDatasetResult result =
-        mockGcpApi.cloneControlledBqDatasetAsync(
+        mockGcpApi.cloneControlledBqDatasetAsyncAndExpect(
             userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceResource.getMetadata().getResourceId(),
@@ -728,7 +728,7 @@ public class ControlledGcpResourceApiControllerBqDatasetConnectedTest extends Ba
       String destResourceName)
       throws Exception {
     ApiCloneControlledGcpBigQueryDatasetResult result =
-        mockGcpApi.cloneControlledBqDatasetAsync(
+        mockGcpApi.cloneControlledBqDatasetAsyncAndExpect(
             userRequest,
             sourceWorkspaceId,
             sourceResourceId,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledGcpResourceApiControllerGcsBucketConnectedTest.java
@@ -424,7 +424,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
 
   @Test
   public void clone_requesterNoReadAccessOnSourceWorkspace_throws403() throws Exception {
-    mockGcpApi.cloneControlledGcsBucketAsync(
+    mockGcpApi.cloneControlledGcsBucketAsyncAndExpect(
         userAccessUtils.noBillingUser().getAuthenticatedRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceBucket.getMetadata().getResourceId(),
@@ -439,7 +439,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
 
   @Test
   public void clone_requesterNoWriteAccessOnDestWorkspace_throws403() throws Exception {
-    mockGcpApi.cloneControlledGcsBucketAsync(
+    mockGcpApi.cloneControlledGcsBucketAsyncAndExpect(
         userAccessUtils.secondUser().getAuthenticatedRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         /*sourceResourceId=*/ sourceBucket.getMetadata().getResourceId(),
@@ -489,7 +489,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
   void clone_duplicateBucketName_jobThrows409() throws Exception {
     AuthenticatedUserRequest userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();
     ApiCloneControlledGcpGcsBucketResult result =
-        mockGcpApi.cloneControlledGcsBucketAsync(
+        mockGcpApi.cloneControlledGcsBucketAsyncAndExpect(
             userRequest,
             /*sourceWorkspaceId=*/ workspaceId,
             sourceBucket.getMetadata().getResourceId(),
@@ -513,7 +513,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
   @Test
   public void cloneGcsBucket_badRequest_throws400() throws Exception {
     // Cannot set bucketName for COPY_REFERENCE clone
-    mockGcpApi.cloneControlledGcsBucketAsync(
+    mockGcpApi.cloneControlledGcsBucketAsyncAndExpect(
         userAccessUtils.defaultUser().getAuthenticatedRequest(),
         /*sourceWorkspaceId=*/ workspaceId,
         sourceBucket.getMetadata().getResourceId(),
@@ -817,7 +817,7 @@ public class ControlledGcpResourceApiControllerGcsBucketConnectedTest extends Ba
       String destResourceName)
       throws Exception {
     ApiCloneControlledGcpGcsBucketResult result =
-        mockGcpApi.cloneControlledGcsBucketAsync(
+        mockGcpApi.cloneControlledGcsBucketAsyncAndExpect(
             userRequest,
             sourceWorkspaceId,
             sourceResourceId,

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockFlexibleResourceApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockFlexibleResourceApi.java
@@ -24,8 +24,8 @@ import bio.terra.workspace.generated.model.ApiStewardshipType;
 import bio.terra.workspace.generated.model.ApiUpdateControlledFlexibleResourceRequestBody;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.CreateGcsBucketStep;
 import bio.terra.workspace.service.resource.controlled.flight.clone.CheckControlledResourceAuthStep;
+import bio.terra.workspace.service.resource.controlled.flight.clone.flexibleresource.CloneFlexibleResourceStep;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -226,7 +226,8 @@ public class MockFlexibleResourceApi {
         step -> failureSteps.put(step.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY));
 
     if (shouldUndo) {
-      failureSteps.put(CreateGcsBucketStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_FATAL);
+      failureSteps.put(
+          CloneFlexibleResourceStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_FATAL);
     }
 
     jobService.setFlightDebugInfoForTest(

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockGcpApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockGcpApi.java
@@ -61,6 +61,7 @@ import bio.terra.workspace.generated.model.ApiUpdateGcsBucketReferenceRequestBod
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.CreateGcsBucketStep;
+import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.GcsBucketCloudSyncStep;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.RetrieveGcsBucketCloudAttributesStep;
 import bio.terra.workspace.service.resource.controlled.flight.clone.CheckControlledResourceAuthStep;
 import bio.terra.workspace.service.resource.controlled.flight.clone.bucket.CompleteTransferOperationStep;
@@ -255,7 +256,8 @@ public class MockGcpApi {
         step -> failureSteps.put(step.getName(), StepStatus.STEP_RESULT_FAILURE_RETRY));
 
     if (shouldUndo) {
-      failureSteps.put(CreateGcsBucketStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_FATAL);
+      failureSteps.put(
+          GcsBucketCloudSyncStep.class.getName(), StepStatus.STEP_RESULT_FAILURE_FATAL);
     }
 
     jobService.setFlightDebugInfoForTest(

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
@@ -310,7 +310,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
         WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID,
         createContextFlightId);
 
-    mockGcpApi.cloneControlledBqDatasetAsync(
+    mockGcpApi.cloneControlledBqDatasetAsyncAndExpect(
         USER_REQUEST,
         workspaceUuid,
         bqResource.getResourceId(),
@@ -324,7 +324,7 @@ public class GcpResourceStateFailureTest extends BaseUnitTest {
         Collections.singletonList(HttpStatus.SC_CONFLICT),
         false);
 
-    mockGcpApi.cloneControlledGcsBucketAsync(
+    mockGcpApi.cloneControlledGcsBucketAsyncAndExpect(
         USER_REQUEST,
         workspaceUuid,
         bucketResource.getResourceId(),


### PR DESCRIPTION
fixed connected plus tests -

<img width="873" alt="image" src="https://github.com/DataBiosphere/terra-workspace-manager/assets/2914285/4052e007-2731-4ebe-a499-1aecb7c46a52">

> Task :service:connectedPlusTest

ControlledFlexibleResourceApiControllerConnectedTest > clone_copyResource_undo() STARTED

ControlledFlexibleResourceApiControllerConnectedTest > clone_copyResource_undo() PASSED


