### PR TITLE
Support multiple dataproc initialization scripts

### DIFF
--- a/openapi/src/parts/controlled_gcp_dataproc_cluster.yaml
+++ b/openapi/src/parts/controlled_gcp_dataproc_cluster.yaml
@@ -194,9 +194,11 @@ components:
         region:
           type: string
           description: GCP region.
-        initializationScript:
-          type: string
-          description: Path to the initialization script.
+        initializationScripts:
+          type: array
+          items:
+            type: string
+          description: List of initialization scripts to run on create. In gs url format.
         components:
           type: array
           items:

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -221,13 +222,14 @@ public class CreateDataprocClusterStep implements Step {
 
     // Set initialization script
     // TODO PF-2828: Add WSM default post-startup script
-    if (!StringUtils.isEmpty(creationParameters.getInitializationScript())) {
+    List<String> initializationScripts = creationParameters.getInitializationScripts();
+    if (initializationScripts != null) {
       cluster
           .getConfig()
           .setInitializationActions(
-              List.of(
-                  new NodeInitializationAction()
-                      .setExecutableFile(creationParameters.getInitializationScript())));
+              initializationScripts.stream()
+                  .map(script -> new NodeInitializationAction().setExecutableFile(script))
+                  .collect(Collectors.toList()));
     }
 
     // Configure cluster lifecycle


### PR DESCRIPTION
Dataproc clusters support passing in a list of startup scripts. The wsm api should also support it to allow users to provide their own custom startup scripts to install any software they need.