### PR TITLE
[BENCH-895] Remove duplicated definitions of WsmResource.castByEnum

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/ControlledFlexibleResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/any/flexibleresource/ControlledFlexibleResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.any.flexibleresource;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
@@ -64,16 +63,6 @@ public class ControlledFlexibleResource extends ControlledResource {
 
   public static ControlledFlexibleResource.Builder builder() {
     return new ControlledFlexibleResource.Builder();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   // -- getters used in serialization --

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.aws.s3StorageFolder;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.stairway.RetryRule;
 import bio.terra.workspace.common.utils.FlightBeanBag;
@@ -64,16 +63,6 @@ public class ControlledAwsS3StorageFolderResource extends ControlledResource {
 
   public static ControlledAwsS3StorageFolderResource.Builder builder() {
     return new ControlledAwsS3StorageFolderResource.Builder();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   // -- getters used in serialization --

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
@@ -70,16 +70,6 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
     return new Builder();
   }
 
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
-  }
-
   // -- getters used in serialization --
   @JsonProperty("wsmResourceFields")
   public WsmResourceFields getWsmResourceFields() {
@@ -146,7 +136,8 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
   public void addDeleteSteps(DeleteControlledResourcesFlight flight, FlightBeanBag flightBeanBag) {
     RetryRule cloudRetry = RetryRules.cloud();
     boolean forceDelete =
-        flight.getInputParameters().get(ControlledResourceKeys.FORCE_DELETE, Boolean.class);
+        Boolean.TRUE.equals(
+            flight.getInputParameters().get(ControlledResourceKeys.FORCE_DELETE, Boolean.class));
 
     // Notebooks must be stopped before deletion. If requested, stop instance before delete attempt
     if (forceDelete) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.common.utils.RetryRules;
@@ -234,15 +233,6 @@ public class ControlledAzureBatchPoolResource extends ControlledResource {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
-  }
-
-  @Override
   public void validate() {
     super.validate();
     if (getResourceType() != WsmResourceType.CONTROLLED_AZURE_BATCH_POOL
@@ -266,7 +256,7 @@ public class ControlledAzureBatchPoolResource extends ControlledResource {
       }
     }
     if (userAssignedIdentities != null) {
-      var inconsistentUamiCount =
+      long inconsistentUamiCount =
           userAssignedIdentities.stream()
               .filter(uami -> uami.name() != null && uami.clientId() != null)
               .count();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/ControlledAzureDatabaseResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/ControlledAzureDatabaseResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.database;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.RetryRule;
@@ -83,16 +82,6 @@ public class ControlledAzureDatabaseResource extends ControlledResource {
     return new Builder();
   }
 
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
-  }
-
   // -- getters used in serialization --
 
   @Override
@@ -158,7 +147,7 @@ public class ControlledAzureDatabaseResource extends ControlledResource {
 
   @VisibleForTesting
   List<Step> getAddSteps(FlightBeanBag flightBeanBag) {
-    var steps = new ArrayList<Step>();
+    ArrayList<Step> steps = new ArrayList<>();
     steps.add(new ValidateDatabaseOwnerStep(this, flightBeanBag.getResourceDao()));
     steps.add(
         new AzureDatabaseGuardStep(
@@ -188,13 +177,13 @@ public class ControlledAzureDatabaseResource extends ControlledResource {
    * database. The absence of k8sNamespace indicates that this is a subsequent iteration where a
    * KubernetesNamespace controlled resource takes care of that.
    *
-   * @param flightBeanBag
-   * @param steps
+   * @param flightBeanBag flightBeanBag
+   * @param steps steps
    */
   private void maybeSetupFederatedIdentity(FlightBeanBag flightBeanBag, ArrayList<Step> steps) {
     // TODO: remove as part of https://broadworkbench.atlassian.net/browse/WOR-1165
     if (k8sNamespace != null) {
-      var getManagedIdentityStep =
+      Step getManagedIdentityStep =
           switch (getAccessScope()) {
             case ACCESS_SCOPE_SHARED -> new GetWorkspaceManagedIdentityStep(
                 flightBeanBag.getAzureConfig(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.disk;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.RetryRule;
@@ -58,16 +57,6 @@ public class ControlledAzureDiskResource extends ControlledResource {
 
   public static ControlledAzureDiskResource.Builder builder() {
     return new ControlledAzureDiskResource.Builder();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   // -- getters used in serialization --

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ControlledAzureManagedIdentityResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ControlledAzureManagedIdentityResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.RetryRule;
@@ -54,16 +53,6 @@ public class ControlledAzureManagedIdentityResource extends ControlledResource {
 
   public static Builder builder() {
     return new Builder();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   // -- getters used in serialization --

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/ControlledAzureStorageContainerResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.RetryRule;
@@ -52,16 +51,6 @@ public class ControlledAzureStorageContainerResource extends ControlledResource 
 
   public static ControlledAzureStorageContainerResource.Builder builder() {
     return new ControlledAzureStorageContainerResource.Builder();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   // -- getters used in serialization --

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.RetryRule;
@@ -34,7 +33,6 @@ public class ControlledAzureVmResource extends ControlledResource {
   private final String vmName;
   private final String vmSize;
   private final String vmImage;
-
   private final UUID diskId;
 
   @JsonCreator
@@ -62,16 +60,6 @@ public class ControlledAzureVmResource extends ControlledResource {
     this.vmSize = vmSize;
     this.diskId = diskId;
     validate();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   // -- getters used in serialization --

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/ControlledAiNotebookInstanceResource.java
@@ -96,16 +96,6 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
     return new Builder();
   }
 
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
-  }
-
   // -- getters used in serialization --
   @Override
   @JsonProperty("wsmResourceFields")
@@ -292,9 +282,8 @@ public class ControlledAiNotebookInstanceResource extends ControlledResource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ControlledAiNotebookInstanceResource)) return false;
+    if (!(o instanceof ControlledAiNotebookInstanceResource resource)) return false;
     if (!super.equals(o)) return false;
-    ControlledAiNotebookInstanceResource resource = (ControlledAiNotebookInstanceResource) o;
     return Objects.equal(instanceId, resource.instanceId)
         && Objects.equal(location, resource.location)
         && Objects.equal(projectId, resource.projectId);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/bqdataset/ControlledBigQueryDatasetResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.RetryRule;
@@ -75,16 +74,6 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
 
   public static ControlledBigQueryDatasetResource.Builder builder() {
     return new ControlledBigQueryDatasetResource.Builder();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   // -- getters used in serialization --
@@ -166,8 +155,8 @@ public class ControlledBigQueryDatasetResource extends ControlledResource {
 
   @Override
   public void addUpdateSteps(UpdateResourceFlight flight, FlightBeanBag flightBeanBag) {
-    final RetryRule gcpRetryRule = RetryRules.cloud();
-    flight.addStep(new UpdateBigQueryDatasetStep(flightBeanBag.getCrlService()), gcpRetryRule);
+    flight.addStep(
+        new UpdateBigQueryDatasetStep(flightBeanBag.getCrlService()), RetryRules.cloud());
   }
 
   public ApiGcpBigQueryDatasetAttributes toApiAttributes() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/ControlledDataprocClusterResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/ControlledDataprocClusterResource.java
@@ -71,16 +71,6 @@ public class ControlledDataprocClusterResource extends ControlledResource {
     return new Builder();
   }
 
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
-  }
-
   // -- getters used in serialization --
   @Override
   @JsonProperty("wsmResourceFields")
@@ -246,9 +236,8 @@ public class ControlledDataprocClusterResource extends ControlledResource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ControlledDataprocClusterResource)) return false;
+    if (!(o instanceof ControlledDataprocClusterResource resource)) return false;
     if (!super.equals(o)) return false;
-    ControlledDataprocClusterResource resource = (ControlledDataprocClusterResource) o;
     return Objects.equal(clusterId, resource.clusterId)
         && Objects.equal(region, resource.region)
         && Objects.equal(projectId, resource.projectId);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/ControlledGceInstanceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/ControlledGceInstanceResource.java
@@ -84,16 +84,6 @@ public class ControlledGceInstanceResource extends ControlledResource {
     return new Builder();
   }
 
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
-  }
-
   // -- getters used in serialization --
   @Override
   @JsonProperty("wsmResourceFields")
@@ -263,9 +253,8 @@ public class ControlledGceInstanceResource extends ControlledResource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ControlledGceInstanceResource)) return false;
+    if (!(o instanceof ControlledGceInstanceResource resource)) return false;
     if (!super.equals(o)) return false;
-    ControlledGceInstanceResource resource = (ControlledGceInstanceResource) o;
     return Objects.equal(instanceId, resource.instanceId)
         && Objects.equal(zone, resource.zone)
         && Objects.equal(projectId, resource.projectId);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gcsbucket/ControlledGcsBucketResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.stairway.RetryRule;
@@ -67,16 +66,6 @@ public class ControlledGcsBucketResource extends ControlledResource {
 
   public static ControlledGcsBucketResource.Builder builder() {
     return new ControlledGcsBucketResource.Builder();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   // -- getters used in serialization --

--- a/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/model/WsmResource.java
@@ -5,6 +5,7 @@ import static bio.terra.workspace.service.resource.model.CloningInstructions.COP
 import static bio.terra.workspace.service.resource.model.CloningInstructions.COPY_REFERENCE;
 import static bio.terra.workspace.service.workspace.model.WorkspaceConstants.ResourceProperties.FOLDER_ID_KEY;
 
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.ErrorReportException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.exception.CloneInstructionNotSupportedException;
@@ -174,7 +175,13 @@ public abstract class WsmResource {
    * @param <T> implicit
    * @return cast to subtype
    */
-  public abstract <T> T castByEnum(WsmResourceType expectedType);
+  @SuppressWarnings("unchecked")
+  public <T> T castByEnum(WsmResourceType expectedType) {
+    if (getResourceType() != expectedType) {
+      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
+    }
+    return (T) this;
+  }
 
   /**
    * The UpdateResourceFlight calls this method to populate the resource-specific step(s) to modify

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/datareposnapshot/ReferencedDataRepoSnapshotResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/datareposnapshot/ReferencedDataRepoSnapshotResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.referenced.cloud.any.datareposnapshot;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.db.DbSerDes;
@@ -111,16 +110,6 @@ public class ReferencedDataRepoSnapshotResource extends ReferencedResource {
     return new ApiDataRepoSnapshotResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/any/gitrepo/ReferencedGitRepoResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.referenced.cloud.any.gitrepo;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
@@ -54,16 +53,6 @@ public class ReferencedGitRepoResource extends ReferencedResource {
         DbSerDes.fromJson(dbResource.getAttributes(), ReferencedGitRepoAttributes.class);
     this.gitRepoUrl = attributes.getGitRepoUrl();
     validate();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   // -- getters used in serialization --

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdataset/ReferencedBigQueryDatasetResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdataset;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.db.DbSerDes;
@@ -116,16 +115,6 @@ public class ReferencedBigQueryDatasetResource extends ReferencedResource {
     return new ApiGcpBigQueryDatasetResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/bqdatatable/ReferencedBigQueryDataTableResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.referenced.cloud.gcp.bqdatatable;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.db.DbSerDes;
@@ -128,16 +127,6 @@ public class ReferencedBigQueryDataTableResource extends ReferencedResource {
     return new ApiGcpBigQueryDataTableResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsbucket/ReferencedGcsBucketResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsbucket;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
@@ -97,16 +96,6 @@ public class ReferencedGcsBucketResource extends ReferencedResource {
     return new ApiGcpGcsBucketResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/cloud/gcp/gcsobject/ReferencedGcsObjectResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.referenced.cloud.gcp.gcsobject;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InconsistentFieldsException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
@@ -104,16 +103,6 @@ public class ReferencedGcsObjectResource extends ReferencedResource {
     return new ApiGcpGcsObjectResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/referenced/terra/workspace/ReferencedTerraWorkspaceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/referenced/terra/workspace/ReferencedTerraWorkspaceResource.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.service.resource.referenced.terra.workspace;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.db.DbSerDes;
@@ -99,16 +98,6 @@ public class ReferencedTerraWorkspaceResource extends ReferencedResource {
     return new ApiTerraWorkspaceResource()
         .metadata(super.toApiMetadata())
         .attributes(toApiAttributes());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T castByEnum(WsmResourceType expectedType) {
-    if (getResourceType() != expectedType) {
-      throw new BadRequestException(String.format("Resource is not a %s", expectedType));
-    }
-    return (T) this;
   }
 
   @Override


### PR DESCRIPTION
Remove duplicated definitions of WsmResource.castByEnum by moving default definition to the interface. This can still be overridden by implementing classes if needed. 
Minor cleanup and addressed warnings in files already being modified

