### PR TITLE
BENCH-892: Patch workspace policies should allow updating groups

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -465,7 +465,7 @@ public class SamService {
       String resourceType,
       String resourceId,
       List<String> groups)
-      throws Exception {
+      throws InterruptedException {
     ResourcesApi resourceApi = samResourcesApi(userRequest.getRequiredToken());
     // TODO: [PF-2938] We should use the service account to add these groups.
     // ResourcesApi resourceApi = samResourcesApi(getWsmServiceAccountToken());

--- a/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
@@ -124,9 +124,7 @@ public class PolicyValidator {
       Workspace workspace, TpsPaoGetResult policies, AuthenticatedUserRequest userRequest) {
     var currentPao =
         Rethrow.onInterrupted(() -> tpsApiDispatch.getPao((workspace.getWorkspaceId())), "getPao");
-    HashSet<String> removedGroups =
-        TpsUtilities.getRemovedGroups(
-            currentPao.getEffectiveAttributes(), policies.getAttributes());
+    HashSet<String> removedGroups = TpsUtilities.getRemovedGroups(currentPao, policies);
 
     if (!removedGroups.isEmpty()) {
       return List.of("Removing group constraints not yet supported for this api call");

--- a/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.service.resource.exception.PolicyConflictException;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -115,24 +116,22 @@ public class PolicyValidator {
     return validationErrors;
   }
 
+  /**
+   * @param policies the updated/dryrun policies
+   * @return validation errors *
+   */
   public List<String> validateWorkspaceConformsToGroupPolicy(
       Workspace workspace, TpsPaoGetResult policies, AuthenticatedUserRequest userRequest) {
-    var groups = TpsUtilities.getGroupConstraintsFromInputs(policies.getEffectiveAttributes());
     var currentPao =
         Rethrow.onInterrupted(() -> tpsApiDispatch.getPao((workspace.getWorkspaceId())), "getPao");
-    var existingGroups =
-        (currentPao == null)
-            ? new ArrayList<String>()
-            : TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes());
+    HashSet<String> removedGroups =
+        TpsUtilities.getRemovedGroups(
+            currentPao.getEffectiveAttributes(), policies.getAttributes());
 
-    if (!groups.isEmpty()) {
-      if (groups.containsAll(existingGroups) && existingGroups.containsAll(groups)) {
-        // groups have not changed.
-        return List.of();
-      }
-      return List.of("policies with group constraints not yet supported for this api call");
-    } else {
-      return List.of();
+    if (!removedGroups.isEmpty()) {
+      return List.of("Removing group constraints not yet supported for this api call");
     }
+
+    return List.of();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.policy;
 
 import bio.terra.policy.model.TpsPolicyInputs;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 public class TpsUtilities {
@@ -25,6 +26,38 @@ public class TpsUtilities {
             result.add(data.getValue());
           }
         }
+      }
+    }
+
+    return result;
+  }
+
+  public static HashSet<String> getAddedGroups(
+      TpsPolicyInputs originalPolicies, TpsPolicyInputs updatedPolicies) {
+    HashSet<String> result = new HashSet<>();
+    var originalGroups =
+        new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(originalPolicies));
+    var updatedGroups = new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(updatedPolicies));
+
+    for (String updatedGroup : updatedGroups) {
+      if (!originalGroups.contains(updatedGroup)) {
+        result.add(updatedGroup);
+      }
+    }
+
+    return result;
+  }
+
+  public static HashSet<String> getRemovedGroups(
+      TpsPolicyInputs originalPolicies, TpsPolicyInputs updatedPolicies) {
+    HashSet<String> result = new HashSet<>();
+    var originalGroups =
+        new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(originalPolicies));
+    var updatedGroups = new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(updatedPolicies));
+
+    for (String originalGroup : originalGroups) {
+      if (!updatedGroups.contains(originalGroup)) {
+        result.add(originalGroup);
       }
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.service.policy;
 
+import bio.terra.policy.model.TpsPaoGetResult;
 import bio.terra.policy.model.TpsPolicyInputs;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -33,11 +34,22 @@ public class TpsUtilities {
   }
 
   public static HashSet<String> getAddedGroups(
-      TpsPolicyInputs originalPolicies, TpsPolicyInputs updatedPolicies) {
+      TpsPaoGetResult originalPolicies, TpsPaoGetResult updatedPolicies) {
     HashSet<String> result = new HashSet<>();
-    var originalGroups =
-        new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(originalPolicies));
-    var updatedGroups = new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(updatedPolicies));
+
+    HashSet<String> originalGroups =
+        originalPolicies == null
+            ? new HashSet<>()
+            : new HashSet<>(
+                TpsUtilities.getGroupConstraintsFromInputs(
+                    originalPolicies.getEffectiveAttributes()));
+
+    HashSet<String> updatedGroups =
+        updatedPolicies == null
+            ? new HashSet<>()
+            : new HashSet<>(
+                TpsUtilities.getGroupConstraintsFromInputs(
+                    updatedPolicies.getEffectiveAttributes()));
 
     for (String updatedGroup : updatedGroups) {
       if (!originalGroups.contains(updatedGroup)) {
@@ -49,11 +61,22 @@ public class TpsUtilities {
   }
 
   public static HashSet<String> getRemovedGroups(
-      TpsPolicyInputs originalPolicies, TpsPolicyInputs updatedPolicies) {
+      TpsPaoGetResult originalPolicies, TpsPaoGetResult updatedPolicies) {
     HashSet<String> result = new HashSet<>();
-    var originalGroups =
-        new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(originalPolicies));
-    var updatedGroups = new HashSet<>(TpsUtilities.getGroupConstraintsFromInputs(updatedPolicies));
+
+    HashSet<String> originalGroups =
+        originalPolicies == null
+            ? new HashSet<>()
+            : new HashSet<>(
+                TpsUtilities.getGroupConstraintsFromInputs(
+                    originalPolicies.getEffectiveAttributes()));
+
+    HashSet<String> updatedGroups =
+        updatedPolicies == null
+            ? new HashSet<>()
+            : new HashSet<>(
+                TpsUtilities.getGroupConstraintsFromInputs(
+                    updatedPolicies.getEffectiveAttributes()));
 
     for (String originalGroup : originalGroups) {
       if (!updatedGroups.contains(originalGroup)) {

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
@@ -35,8 +35,6 @@ public class TpsUtilities {
 
   public static HashSet<String> getAddedGroups(
       TpsPaoGetResult originalPolicies, TpsPaoGetResult updatedPolicies) {
-    HashSet<String> result = new HashSet<>();
-
     HashSet<String> originalGroups =
         originalPolicies == null
             ? new HashSet<>()
@@ -51,19 +49,12 @@ public class TpsUtilities {
                 TpsUtilities.getGroupConstraintsFromInputs(
                     updatedPolicies.getEffectiveAttributes()));
 
-    for (String updatedGroup : updatedGroups) {
-      if (!originalGroups.contains(updatedGroup)) {
-        result.add(updatedGroup);
-      }
-    }
-
-    return result;
+    updatedGroups.removeAll(originalGroups);
+    return updatedGroups;
   }
 
   public static HashSet<String> getRemovedGroups(
       TpsPaoGetResult originalPolicies, TpsPaoGetResult updatedPolicies) {
-    HashSet<String> result = new HashSet<>();
-
     HashSet<String> originalGroups =
         originalPolicies == null
             ? new HashSet<>()
@@ -78,13 +69,8 @@ public class TpsUtilities {
                 TpsUtilities.getGroupConstraintsFromInputs(
                     updatedPolicies.getEffectiveAttributes()));
 
-    for (String originalGroup : originalGroups) {
-      if (!updatedGroups.contains(originalGroup)) {
-        result.add(originalGroup);
-      }
-    }
-
-    return result;
+    originalGroups.removeAll(updatedGroups);
+    return originalGroups;
   }
 
   public static boolean containsProtectedDataPolicy(TpsPolicyInputs inputs) {

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
@@ -32,9 +32,7 @@ public class ValidateGroupPolicyAttributesStep implements Step {
 
     // In Milestone 2, we are able to add additional groups but cannot remove them.
     TpsPaoGetResult currentPao = tpsApiDispatch.getPao(workspaceId);
-    HashSet<String> removedGroups =
-        TpsUtilities.getRemovedGroups(
-            currentPao.getEffectiveAttributes(), mergedPao.getEffectiveAttributes());
+    HashSet<String> removedGroups = TpsUtilities.getRemovedGroups(currentPao, mergedPao);
     if (!removedGroups.isEmpty()) {
       throw new PolicyConflictException("Cannot remove groups from policy.");
     }

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/ValidateGroupPolicyAttributesStep.java
@@ -32,19 +32,14 @@ public class ValidateGroupPolicyAttributesStep implements Step {
 
     // In Milestone 2, we are able to add additional groups but cannot remove them.
     TpsPaoGetResult currentPao = tpsApiDispatch.getPao(workspaceId);
-
-    HashSet<String> currentGroup =
-        new HashSet<>(
-            TpsUtilities.getGroupConstraintsFromInputs(currentPao.getEffectiveAttributes()));
-    HashSet<String> mergedGroup =
-        new HashSet<>(
-            TpsUtilities.getGroupConstraintsFromInputs(mergedPao.getEffectiveAttributes()));
-
-    if (mergedGroup.containsAll(currentGroup)) {
-      return StepResult.getStepResultSuccess();
+    HashSet<String> removedGroups =
+        TpsUtilities.getRemovedGroups(
+            currentPao.getEffectiveAttributes(), mergedPao.getEffectiveAttributes());
+    if (!removedGroups.isEmpty()) {
+      throw new PolicyConflictException("Cannot remove groups from policy.");
     }
 
-    throw new PolicyConflictException("Cannot remove groups from policy.");
+    return StepResult.getStepResultSuccess();
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -968,9 +968,7 @@ public class WorkspaceService {
       }
 
       HashSet<String> addedGroups =
-          TpsUtilities.getAddedGroups(
-              paoBeforeUpdate.getEffectiveAttributes(),
-              dryRun.getResultingPao().getEffectiveAttributes());
+          TpsUtilities.getAddedGroups(paoBeforeUpdate, dryRun.getResultingPao());
       if (!addedGroups.isEmpty()) {
         logger.info(
             "Group policies have changed, adding additional groups to auth domain in Sam for workspace {}",

--- a/service/src/test/java/bio/terra/workspace/service/policy/TpsUtilitiesTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/TpsUtilitiesTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import bio.terra.policy.model.TpsPaoGetResult;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.policy.model.TpsPolicyPair;
@@ -60,14 +61,19 @@ public class TpsUtilitiesTest extends BaseUnitTest {
 
   @Test
   void testGetAddedGroups_noGroupPolicies() {
-    TpsPolicyInputs inputs = new TpsPolicyInputs().addInputsItem(createProtectedPolicyInput());
+    TpsPaoGetResult inputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(new TpsPolicyInputs().addInputsItem(createProtectedPolicyInput()));
     HashSet<String> results = TpsUtilities.getAddedGroups(inputs, inputs);
     assertIterableEquals(List.of(), results);
   }
 
   @Test
   void testGetAddedGroups_noGroupsAdded() {
-    TpsPolicyInputs inputs = new TpsPolicyInputs().addInputsItem(createGroupPolicyInput("group1"));
+    TpsPaoGetResult inputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs().addInputsItem(createGroupPolicyInput("group1")));
     HashSet<String> results = TpsUtilities.getAddedGroups(inputs, inputs);
     assertIterableEquals(List.of(), results);
   }
@@ -77,12 +83,16 @@ public class TpsUtilitiesTest extends BaseUnitTest {
     String group1Name = "group1";
     String group2Name = "group2";
 
-    TpsPolicyInputs originalInputs =
-        new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name));
-    TpsPolicyInputs addedGroupInputs =
-        new TpsPolicyInputs()
-            .addInputsItem(createGroupPolicyInput(group1Name))
-            .addInputsItem(createGroupPolicyInput(group2Name));
+    TpsPaoGetResult originalInputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name)));
+    TpsPaoGetResult addedGroupInputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs()
+                    .addInputsItem(createGroupPolicyInput(group1Name))
+                    .addInputsItem(createGroupPolicyInput(group2Name)));
 
     HashSet<String> results = TpsUtilities.getAddedGroups(originalInputs, addedGroupInputs);
     assertIterableEquals(List.of(group2Name), results);
@@ -93,12 +103,16 @@ public class TpsUtilitiesTest extends BaseUnitTest {
     String group1Name = "group1";
     String group2Name = "group2";
 
-    TpsPolicyInputs originalInputs =
-        new TpsPolicyInputs()
-            .addInputsItem(createGroupPolicyInput(group1Name))
-            .addInputsItem(createGroupPolicyInput(group2Name));
-    TpsPolicyInputs removedGroupInputs =
-        new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name));
+    TpsPaoGetResult originalInputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs()
+                    .addInputsItem(createGroupPolicyInput(group1Name))
+                    .addInputsItem(createGroupPolicyInput(group2Name)));
+    TpsPaoGetResult removedGroupInputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name)));
 
     HashSet<String> results = TpsUtilities.getAddedGroups(originalInputs, removedGroupInputs);
     assertIterableEquals(List.of(), results);
@@ -106,14 +120,19 @@ public class TpsUtilitiesTest extends BaseUnitTest {
 
   @Test
   void testGetRemovedGroups_noGroupPolicies() {
-    TpsPolicyInputs inputs = new TpsPolicyInputs().addInputsItem(createProtectedPolicyInput());
+    TpsPaoGetResult inputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(new TpsPolicyInputs().addInputsItem(createProtectedPolicyInput()));
     HashSet<String> results = TpsUtilities.getRemovedGroups(inputs, inputs);
     assertIterableEquals(List.of(), results);
   }
 
   @Test
   void testGetRemovedGroups_noGroupsRemoved() {
-    TpsPolicyInputs inputs = new TpsPolicyInputs().addInputsItem(createGroupPolicyInput("group1"));
+    TpsPaoGetResult inputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs().addInputsItem(createGroupPolicyInput("group1")));
     HashSet<String> results = TpsUtilities.getRemovedGroups(inputs, inputs);
     assertIterableEquals(List.of(), results);
   }
@@ -121,12 +140,16 @@ public class TpsUtilitiesTest extends BaseUnitTest {
   @Test
   void testGetRemovedGroups_groupAdded() {
     String group1Name = "group1";
-    TpsPolicyInputs originalInputs =
-        new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name));
-    TpsPolicyInputs addedGroupInputs =
-        new TpsPolicyInputs()
-            .addInputsItem(createGroupPolicyInput(group1Name))
-            .addInputsItem(createGroupPolicyInput("group2"));
+    TpsPaoGetResult originalInputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name)));
+    TpsPaoGetResult addedGroupInputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs()
+                    .addInputsItem(createGroupPolicyInput(group1Name))
+                    .addInputsItem(createGroupPolicyInput("group2")));
     HashSet<String> results = TpsUtilities.getRemovedGroups(originalInputs, addedGroupInputs);
     assertIterableEquals(List.of(), results);
   }
@@ -136,12 +159,16 @@ public class TpsUtilitiesTest extends BaseUnitTest {
     String group1Name = "group1";
     String group2Name = "group2";
 
-    TpsPolicyInputs originalInputs =
-        new TpsPolicyInputs()
-            .addInputsItem(createGroupPolicyInput(group1Name))
-            .addInputsItem(createGroupPolicyInput(group2Name));
-    TpsPolicyInputs removedGroupInputs =
-        new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name));
+    TpsPaoGetResult originalInputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs()
+                    .addInputsItem(createGroupPolicyInput(group1Name))
+                    .addInputsItem(createGroupPolicyInput(group2Name)));
+    TpsPaoGetResult removedGroupInputs =
+        new TpsPaoGetResult()
+            .effectiveAttributes(
+                new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name)));
 
     HashSet<String> results = TpsUtilities.getRemovedGroups(originalInputs, removedGroupInputs);
     assertIterableEquals(List.of(group2Name), results);

--- a/service/src/test/java/bio/terra/workspace/service/policy/TpsUtilitiesTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/TpsUtilitiesTest.java
@@ -8,6 +8,7 @@ import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.policy.model.TpsPolicyPair;
 import bio.terra.workspace.common.BaseUnitTest;
+import java.util.HashSet;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -58,14 +59,99 @@ public class TpsUtilitiesTest extends BaseUnitTest {
   }
 
   @Test
+  void testGetAddedGroups_noGroupPolicies() {
+    TpsPolicyInputs inputs = new TpsPolicyInputs().addInputsItem(createProtectedPolicyInput());
+    HashSet<String> results = TpsUtilities.getAddedGroups(inputs, inputs);
+    assertIterableEquals(List.of(), results);
+  }
+
+  @Test
+  void testGetAddedGroups_noGroupsAdded() {
+    TpsPolicyInputs inputs = new TpsPolicyInputs().addInputsItem(createGroupPolicyInput("group1"));
+    HashSet<String> results = TpsUtilities.getAddedGroups(inputs, inputs);
+    assertIterableEquals(List.of(), results);
+  }
+
+  @Test
+  void testGetAddedGroups_groupAdded() {
+    String group1Name = "group1";
+    String group2Name = "group2";
+
+    TpsPolicyInputs originalInputs =
+        new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name));
+    TpsPolicyInputs addedGroupInputs =
+        new TpsPolicyInputs()
+            .addInputsItem(createGroupPolicyInput(group1Name))
+            .addInputsItem(createGroupPolicyInput(group2Name));
+
+    HashSet<String> results = TpsUtilities.getAddedGroups(originalInputs, addedGroupInputs);
+    assertIterableEquals(List.of(group2Name), results);
+  }
+
+  @Test
+  void testGetAddedGroups_groupRemoved() {
+    String group1Name = "group1";
+    String group2Name = "group2";
+
+    TpsPolicyInputs originalInputs =
+        new TpsPolicyInputs()
+            .addInputsItem(createGroupPolicyInput(group1Name))
+            .addInputsItem(createGroupPolicyInput(group2Name));
+    TpsPolicyInputs removedGroupInputs =
+        new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name));
+
+    HashSet<String> results = TpsUtilities.getAddedGroups(originalInputs, removedGroupInputs);
+    assertIterableEquals(List.of(), results);
+  }
+
+  @Test
+  void testGetRemovedGroups_noGroupPolicies() {
+    TpsPolicyInputs inputs = new TpsPolicyInputs().addInputsItem(createProtectedPolicyInput());
+    HashSet<String> results = TpsUtilities.getRemovedGroups(inputs, inputs);
+    assertIterableEquals(List.of(), results);
+  }
+
+  @Test
+  void testGetRemovedGroups_noGroupsRemoved() {
+    TpsPolicyInputs inputs = new TpsPolicyInputs().addInputsItem(createGroupPolicyInput("group1"));
+    HashSet<String> results = TpsUtilities.getRemovedGroups(inputs, inputs);
+    assertIterableEquals(List.of(), results);
+  }
+
+  @Test
+  void testGetRemovedGroups_groupAdded() {
+    String group1Name = "group1";
+    TpsPolicyInputs originalInputs =
+        new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name));
+    TpsPolicyInputs addedGroupInputs =
+        new TpsPolicyInputs()
+            .addInputsItem(createGroupPolicyInput(group1Name))
+            .addInputsItem(createGroupPolicyInput("group2"));
+    HashSet<String> results = TpsUtilities.getRemovedGroups(originalInputs, addedGroupInputs);
+    assertIterableEquals(List.of(), results);
+  }
+
+  @Test
+  void testGetRemovedGroups_groupRemoved() {
+    String group1Name = "group1";
+    String group2Name = "group2";
+
+    TpsPolicyInputs originalInputs =
+        new TpsPolicyInputs()
+            .addInputsItem(createGroupPolicyInput(group1Name))
+            .addInputsItem(createGroupPolicyInput(group2Name));
+    TpsPolicyInputs removedGroupInputs =
+        new TpsPolicyInputs().addInputsItem(createGroupPolicyInput(group1Name));
+
+    HashSet<String> results = TpsUtilities.getRemovedGroups(originalInputs, removedGroupInputs);
+    assertIterableEquals(List.of(group2Name), results);
+  }
+
+  @Test
   void testContainsProtectedDataPolicy() {
     assertTrue(
         TpsUtilities.containsProtectedDataPolicy(
-            new TpsPolicyInputs()
-                .addInputsItem(
-                    new TpsPolicyInput()
-                        .namespace(TpsUtilities.TERRA_NAMESPACE)
-                        .name(TpsUtilities.PROTECTED_DATA_POLICY_NAME))));
+            new TpsPolicyInputs().addInputsItem(createProtectedPolicyInput())));
   }
 
   @Test
@@ -82,5 +168,18 @@ public class TpsUtilitiesTest extends BaseUnitTest {
   @Test
   void testContainsProtectedDataPolicy_null() {
     assertFalse(TpsUtilities.containsProtectedDataPolicy(null));
+  }
+
+  private TpsPolicyInput createGroupPolicyInput(String groupName) {
+    return new TpsPolicyInput()
+        .namespace(TpsUtilities.TERRA_NAMESPACE)
+        .name(TpsUtilities.GROUP_CONSTRAINT)
+        .addAdditionalDataItem(new TpsPolicyPair().key(TpsUtilities.GROUP_KEY).value(groupName));
+  }
+
+  private TpsPolicyInput createProtectedPolicyInput() {
+    return new TpsPolicyInput()
+        .namespace(TpsUtilities.TERRA_NAMESPACE)
+        .name(TpsUtilities.PROTECTED_DATA_POLICY_NAME);
   }
 }


### PR DESCRIPTION
We have an endpoint for updating policies on workspaces, but it didn't appropriately handle adding groups. This update will let that endpoint also call Sam if the group policies on the workspace change.