### PR TITLE
WOR-1157 Add consumer pact for TPS

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id 'ru.vyarus.quality' version '4.5.0'
     id 'org.gradle.test-retry' version '1.4.0'
     id "org.sonarqube" version "3.5.0.2730"
-    id "au.com.dius.pact" version "4.3.10"
+    id "au.com.dius.pact" version "4.3.19"
 }
 
 // constants visible to all .gradle files in this project

--- a/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
@@ -9,20 +9,31 @@ import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
 import au.com.dius.pact.consumer.junit5.PactTestFor;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
-import bio.terra.policy.model.TpsComponent;
-import bio.terra.policy.model.TpsObjectType;
-import bio.terra.policy.model.TpsPolicyInput;
-import bio.terra.policy.model.TpsPolicyInputs;
+import bio.terra.policy.model.*;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.app.configuration.external.PolicyServiceConfiguration;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
+import bio.terra.workspace.service.policy.exception.PolicyServiceDuplicateException;
+import bio.terra.workspace.service.policy.exception.PolicyServiceNotFoundException;
+import bio.terra.workspace.service.resource.exception.PolicyConflictException;
+import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import bio.terra.workspace.service.workspace.model.WorkspaceStage;
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 
+import static au.com.dius.pact.consumer.dsl.DslPart.UUID_REGEX;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,100 +45,74 @@ import java.util.stream.Collectors;
 @ExtendWith(PactConsumerTestExt.class)
 public class TpsApiTest {
 
+  // Note: the header must match exactly so pact doesn't add it's own
+  // if "Content-type" is specified instead,
+  // pact will also have a required header for "Content-Type: application/json; charset=UTF-8"
+  // which will cause the request to fail to match,
+  // since our client doesn't include the encoding in the content type header
+  static Map<String, String> contentTypeJsonHeader = Map.of("Content-Type", "application/json");
 
+  // TODO don't use a random value
   UUID objectId = UUID.randomUUID();
 
+  static PactDslJsonBody tpsPolicyInputsObjectShape = new PactDslJsonBody().object(
+      "inputs",
+      new PactDslJsonArray().eachArrayLike().object().stringType("namespace").stringType("name").closeObject()
+  );
+
+  static PactDslJsonBody workspacePolicyCreateRequestShape = new PactDslJsonBody()
+      .uuid("objectId")
+      .stringMatcher(
+          "objectType",
+          Arrays.stream(TpsObjectType.values()).map(TpsObjectType::getValue).collect(Collectors.joining("|"))
+      )
+      .stringMatcher(
+          "component",
+          Arrays.stream(TpsComponent.values()).map(TpsComponent::getValue).collect(Collectors.joining("|"))
+      )
+      .object("attributes", tpsPolicyInputsObjectShape);
+
+
+  TpsApiDispatch dispatch;
+
+  
+  @BeforeEach
+  void setup(MockServer mockServer) throws Exception {
+    var tpsConfig = mock(PolicyServiceConfiguration.class);
+    when(tpsConfig.getAccessToken()).thenReturn("dummyToken");
+    when(tpsConfig.getBasePath()).thenReturn(mockServer.getUrl());
+    var featureConfig = new FeatureConfiguration();
+    featureConfig.setTpsEnabled(true);
+    dispatch = new TpsApiDispatch(featureConfig, tpsConfig);
+  }
+
+
   @Pact(consumer = "wsm", provider = "tps")
-  public RequestResponsePact retrievingAnExistingWorkspacePolicy(PactDslWithProvider builder) {
-    var inputsShape = new PactDslJsonBody().object(
-        "inputs",
-        new PactDslJsonArray().eachArrayLike().object().stringType("namespace").stringType("name").closeObject()
-    );
+  public RequestResponsePact getPaoWithAnExistingWorkspacePolicy(PactDslWithProvider builder) {
     var policyResponseShape = new PactDslJsonBody()
         .valueFromProviderState("objectId", "${objectId}", objectId)
         .stringValue("component", TpsComponent.WSM.getValue())
         .stringValue("objectType", TpsObjectType.WORKSPACE.getValue())
-        .object("attributes", inputsShape);
+        .object("effectiveAttributes", tpsPolicyInputsObjectShape)
+        .object("attributes", tpsPolicyInputsObjectShape);
 
     return builder
         .given("an existing policy for a workspace")
-        .uponReceiving("A request to create a policy")
+        .uponReceiving("A request to retrieve a policy")
         .method("GET")
         .pathFromProviderState(
             "/api/policy/v1alpha1/pao/${objectId}",
             String.format("/api/policy/v1alpha1/pao/%s", objectId))
         .willRespondWith()
-        .status(200)
+        .status(HttpStatus.OK.value())
         .body(policyResponseShape)
         .toPact();
   }
 
 
-  @Pact(consumer = "wsm", provider = "tps")
-  public RequestResponsePact creatingWithNoExistingPolicy(PactDslWithProvider builder) {
-    var inputShape = new PactDslJsonBody().object(
-        "inputs",
-        new PactDslJsonArray().eachArrayLike().object().stringType("namespace").stringType("name").closeObject()
-    );
-
-    var requestShape = new PactDslJsonBody()
-        .uuid("objectId")
-        .stringMatcher(
-            "objectType",
-            Arrays.stream(TpsObjectType.values()).map(TpsObjectType::getValue).collect(Collectors.joining("|"))
-        )
-        .stringMatcher(
-            "component",
-            Arrays.stream(TpsComponent.values()).map(TpsComponent::getValue).collect(Collectors.joining("|"))
-        )
-        .object("attributes", inputShape);
-
-    var pact = builder
-        .uponReceiving("A request to create a policy")
-        .method("POST")
-        .path("/api/policy/v1alpha1/pao")
-        .body(requestShape)
-        // Note: the header must match exactly so pact doesn't add it's own
-        // if "Content-type" is specified instead,
-        // pact will also have a required header for "Content-Type: application/json; charset=UTF-8"
-        // which will cause the request to fail to match,
-        // since our client doesn't include the encoding in the content type header
-        .headers(Map.of("Content-Type","application/json"))
-        .willRespondWith()
-        .status(200)
-        .toPact();
-    return pact;
-
-  }
-
   @Test
-  @PactTestFor(pactMethod = "creatingWithNoExistingPolicy")
-  public void testCreatingAPolicyWithNoExistingPolicy(MockServer mockServer) throws Exception {
-    var tpsConfig = mock(PolicyServiceConfiguration.class);
-    when(tpsConfig.getAccessToken()).thenReturn("dummyToken");
-    when(tpsConfig.getBasePath()).thenReturn(mockServer.getUrl());
-    var featureConfig = new FeatureConfiguration();
-    featureConfig.setTpsEnabled(true);
-    var dispatch = new TpsApiDispatch(featureConfig, tpsConfig);
-    var inputs = List.of(new TpsPolicyInput().name("test_name").namespace("test_namespace"));
-    dispatch.createPao(
-        UUID.randomUUID(),
-        new TpsPolicyInputs().inputs(inputs),
-        TpsComponent.WSM,
-        TpsObjectType.WORKSPACE
-    );
-  }
-
-
-  @Test
-  @PactTestFor(pactMethod = "retrievingAnExistingWorkspacePolicy")
-  public void retrievingAnExistingWorkspacePolicy(MockServer mockServer) throws Exception {
-    var tpsConfig = mock(PolicyServiceConfiguration.class);
-    when(tpsConfig.getAccessToken()).thenReturn("dummyToken");
-    when(tpsConfig.getBasePath()).thenReturn(mockServer.getUrl());
-    var featureConfig = new FeatureConfiguration();
-    featureConfig.setTpsEnabled(true);
-    var dispatch = new TpsApiDispatch(featureConfig, tpsConfig);
+  @PactTestFor(pactMethod = "getPaoWithAnExistingWorkspacePolicy")
+  public void retrievingAnExistingWorkspacePolicy() throws Exception {
     var result = dispatch.getPao(objectId);
     assertNotNull(result);
     assertEquals(TpsComponent.WSM, result.getComponent());
@@ -145,4 +130,220 @@ public class TpsApiTest {
     assertFalse(policy.getNamespace().isEmpty());
   }
 
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact getPaoThatDoesNotExist(PactDslWithProvider builder) {
+    return builder
+        .uponReceiving("A request to retrieve a policy that doesn't exist")
+        .method("GET")
+        .matchPath("/api/policy/v1alpha1/pao/%s" .formatted(UUID_REGEX))
+        .willRespondWith()
+        .status(HttpStatus.NOT_FOUND.value())
+        .toPact();
+  }
+
+
+  @Test
+  @PactTestFor(pactMethod = "getPaoThatDoesNotExist")
+  public void retrievingAPolicyThatDoesNotExist() {
+    assertThrows(PolicyServiceNotFoundException.class, () -> dispatch.getPao(objectId));
+  }
+
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact createPaoWithNoExistingPolicy(PactDslWithProvider builder) {
+    return builder
+        .uponReceiving("A request to create a policy")
+        .method("POST")
+        .path("/api/policy/v1alpha1/pao")
+        .body(workspacePolicyCreateRequestShape)
+        .headers(contentTypeJsonHeader)
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        .toPact();
+  }
+
+
+  @Test
+  @PactTestFor(pactMethod = "createPaoWithNoExistingPolicy")
+  public void testCreatingAPolicyWithNoExistingPolicy() throws Exception {
+    dispatch.createPao(
+        UUID.randomUUID(),
+        new TpsPolicyInputs().inputs(List.of(new TpsPolicyInput().name("test_name").namespace("test_namespace"))),
+        TpsComponent.WSM,
+        TpsObjectType.WORKSPACE
+    );
+  }
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact createPaoWithAPreexistingPolicy(PactDslWithProvider builder) {
+    return builder
+        .given("an existing policy for a workspace")
+        .uponReceiving("A request to create a policy")
+        .method("POST")
+        .path("/api/policy/v1alpha1/pao")
+        .body(workspacePolicyCreateRequestShape)
+        .headers(contentTypeJsonHeader)
+        .willRespondWith()
+        .status(HttpStatus.CONFLICT.value())
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "createPaoWithAPreexistingPolicy")
+  public void creatingAPolicyThatAlreadyExists() {
+    assertThrows(
+        PolicyConflictException.class,
+        () -> dispatch.createPao(
+            objectId,
+            new TpsPolicyInputs().inputs(List.of(new TpsPolicyInput().name("test_name").namespace("test_namespace"))),
+            TpsComponent.WSM,
+            TpsObjectType.WORKSPACE
+        )
+    );
+  }
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact deletePaoThatExists(PactDslWithProvider builder) {
+    return builder
+        .given("an existing policy for a workspace")
+        .uponReceiving("A request to delete a policy")
+        .method("DELETE")
+        .pathFromProviderState(
+            "/api/policy/v1alpha1/pao/${objectId}",
+            String.format("/api/policy/v1alpha1/pao/%s", objectId))
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        .toPact();
+  }
+
+
+  @Test
+  @PactTestFor(pactMethod = "deletePaoThatExists")
+  public void deletingAnExistingPolicy() throws Exception {
+    dispatch.deletePao(objectId);
+  }
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact explainingAWorkspacePolicy(PactDslWithProvider builder) {
+    var explainResponse = new PactDslJsonBody()
+        .numberType("depth")
+        .valueFromProviderState("objectId", "${objectId}", objectId.toString())
+        .object(
+            "policyInput",
+            new PactDslJsonBody().stringType("namespace").stringType("name").closeObject()
+        );
+    return builder
+        .given("an existing policy for a workspace")
+        .uponReceiving("A request to explain the policy")
+        .method("GET")
+        .query("depth=1")
+        .pathFromProviderState(
+            "/api/policy/v1alpha1/pao/${objectId}/explain",
+            String.format("/api/policy/v1alpha1/pao/%s/explain", objectId))
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        .body(explainResponse)
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "explainingAWorkspacePolicy")
+  public void explainingAPolicy() throws Exception {
+    var workspace =  Workspace.builder()
+        .workspaceId(objectId)
+        .workspaceStage(WorkspaceStage.MC_WORKSPACE)
+        .createdByEmail("")
+        .build();
+    var userRequest = mock(AuthenticatedUserRequest.class, RETURNS_SMART_NULLS);
+    var workspaceService = mock(WorkspaceService.class);
+    when(workspaceService.validateWorkspaceAndAction(any(),any(), any())).thenReturn(workspace);
+    var result = dispatch.explain(objectId, 1,workspaceService, userRequest);
+    assertNotNull(result);
+  }
+
+  /*
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact linkingTwoPolicies(PactDslWithProvider builder) {
+
+    return builder
+        .given("an existing policy for a workspace")
+        .given("another existing policy")
+        .uponReceiving("A request to link the policies")
+        .method("GET")
+        .query("depth=1")
+        .pathFromProviderState(
+            "/api/policy/v1alpha1/pao/${objectId}/explain",
+            String.format("/api/policy/v1alpha1/pao/%s/explain", objectId))
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        //.body(explainResponse)
+        .toPact();
+  }*/
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact listValidRegions(PactDslWithProvider builder) {
+    return builder
+        .given("an existing policy for a workspace")
+        .uponReceiving("A request to list the valid regions for a policy")
+        .method("GET")
+        .query("platform=%s".formatted(CloudPlatform.AZURE.toTps()))
+        .pathFromProviderState(
+            "/api/policy/v1alpha1/region/${objectId}/list-valid",
+            "/api/policy/v1alpha1/region/%s/list-valid".formatted(objectId))
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        .body(new PactDslJsonArray().stringType())
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "listValidRegions")
+  public void listingValidRegionsOnAWorkspace() throws Exception {
+    var result = dispatch.listValidRegions(objectId, CloudPlatform.AZURE);
+    assertNotNull(result);
+  }
+
+
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact listValidByPolicyInput(PactDslWithProvider builder) {
+    return builder
+        .given("an existing policy")
+        .uponReceiving("A request to list the valid regions for a policy")
+        .method("POST")
+        .body(tpsPolicyInputsObjectShape)
+        .query("platform=%s".formatted(CloudPlatform.AZURE.toTps()))
+        .path("/api/policy/v1alpha1/location/list-valid")
+        .headers(contentTypeJsonHeader)
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        .body(new PactDslJsonArray().stringType())
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "listValidByPolicyInput")
+  public void listingValidRegionsOnAPolicy() throws Exception {
+    var inputs = new TpsPolicyInputs()
+        .inputs(List.of(new TpsPolicyInput().name("test_name").namespace("test_namespace")));
+    var tpsPao = new TpsPaoGetResult()
+        .objectId(objectId)
+        .attributes(inputs)
+        .effectiveAttributes(inputs);
+    var result = dispatch.listValidRegionsForPao(tpsPao, CloudPlatform.AZURE);
+    assertNotNull(result);
+  }
+  /*
+    TODO:
+      Link Pao
+        - different update modes
+          we use TpsUpdateMode.FAIL_ON_CONFLICT, and TpsUpdateMode.DRY_RUN
+          ENFORCE_CONFLICT is not found in the project
+        - different results
+      Merge Pao
+      Replace Pao
+      update Pao
+      getLocationInfo
+   */
 }

--- a/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
@@ -49,12 +49,8 @@ public class TpsApiTest {
   static String existingPolicyState = "an existing policy";
   static String existingPolicyProviderStateValue = "${policyId}";
   static UUID secondPolicyId = UUID.fromString("a254714b-4519-4ce4-ad87-19a7143376f4");
-  // TODO: better second policy state name
-  static String secondPolicyState = "another existing policy";
-
-  // uuid
-  // state
-  // uuid provider value string
+  static String secondPolicyState = "a second existing policy";
+  static String secondPolicyProviderStateValue = "${secondPolicyId}";
 
   // A regex that matches any value of CloudPlatform that has a tps string
   static String cloudPlatformTpsRegex =
@@ -247,7 +243,8 @@ public class TpsApiTest {
   public RequestResponsePact linkPaoWhenBothExist(PactDslWithProvider builder) {
     var linkRequestShape =
         new PactDslJsonBody()
-            .valueFromProviderState("sourceObjectId", "${secondObjectId}", secondPolicyId)
+            .valueFromProviderState(
+                "sourceObjectId", secondPolicyProviderStateValue, secondPolicyId)
             .stringMatcher("updateMode", updateModeRegex);
     var linkResponseShape =
         new PactDslJsonBody()
@@ -282,7 +279,8 @@ public class TpsApiTest {
   public RequestResponsePact mergePaoWhenBothExist(PactDslWithProvider builder) {
     var linkRequestShape =
         new PactDslJsonBody()
-            .valueFromProviderState("sourceObjectId", "${secondObjectId}", secondPolicyId)
+            .valueFromProviderState(
+                "sourceObjectId", secondPolicyProviderStateValue, secondPolicyId)
             .stringMatcher("sourceObjectId", UUID_REGEX)
             .stringMatcher("updateMode", updateModeRegex);
     var linkResponseShape =

--- a/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
@@ -520,7 +520,6 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-
   @Pact(consumer = "wsm", provider = "tps")
   public RequestResponsePact getLocationInfoWithNullLocation(PactDslWithProvider builder) {
     var locationArray =

--- a/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
@@ -481,6 +481,7 @@ public class TpsApiTest {
     when(workspaceService.validateWorkspaceAndAction(any(), any(), any())).thenReturn(workspace);
     var result = dispatch.explain(existingPolicyId, 1, workspaceService, userRequest);
     assertNotNull(result);
+    assertNotNull(result.toApi());
   }
 
   @Pact(consumer = "wsm", provider = "tps")

--- a/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
@@ -520,11 +520,7 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-  /**
-   * The location parameter for PolicyApiController.getLocationInfo is marked as nullable, So
-   * presumably we can call TPS without the location. It would be nice to be able to specify this in
-   * a single pact, but the query arg matching doesn't give us that level of control
-   */
+
   @Pact(consumer = "wsm", provider = "tps")
   public RequestResponsePact getLocationInfoWithNullLocation(PactDslWithProvider builder) {
     var locationArray =
@@ -555,6 +551,7 @@ public class TpsApiTest {
   @Test
   @PactTestFor(pactMethod = "getLocationInfoWithNullLocation")
   public void retrievingInformationOnANullLocation() throws Exception {
+    // when location is null, it defaults to "global" in TPS
     var result = dispatch.getLocationInfo(CloudPlatform.AZURE, null);
     assertNotNull(result);
   }

--- a/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
@@ -75,7 +75,7 @@ public class TpsApiTest {
 
   TpsApiDispatch dispatch;
 
-  
+
   @BeforeEach
   void setup(MockServer mockServer) throws Exception {
     var tpsConfig = mock(PolicyServiceConfiguration.class);
@@ -84,69 +84,6 @@ public class TpsApiTest {
     var featureConfig = new FeatureConfiguration();
     featureConfig.setTpsEnabled(true);
     dispatch = new TpsApiDispatch(featureConfig, tpsConfig);
-  }
-
-
-  @Pact(consumer = "wsm", provider = "tps")
-  public RequestResponsePact getPaoWithAnExistingWorkspacePolicy(PactDslWithProvider builder) {
-    var policyResponseShape = new PactDslJsonBody()
-        .valueFromProviderState("objectId", "${objectId}", objectId)
-        .stringValue("component", TpsComponent.WSM.getValue())
-        .stringValue("objectType", TpsObjectType.WORKSPACE.getValue())
-        .object("effectiveAttributes", tpsPolicyInputsObjectShape)
-        .object("attributes", tpsPolicyInputsObjectShape);
-
-    return builder
-        .given("an existing policy for a workspace")
-        .uponReceiving("A request to retrieve a policy")
-        .method("GET")
-        .pathFromProviderState(
-            "/api/policy/v1alpha1/pao/${objectId}",
-            String.format("/api/policy/v1alpha1/pao/%s", objectId))
-        .willRespondWith()
-        .status(HttpStatus.OK.value())
-        .body(policyResponseShape)
-        .toPact();
-  }
-
-
-  @Test
-  @PactTestFor(pactMethod = "getPaoWithAnExistingWorkspacePolicy")
-  public void retrievingAnExistingWorkspacePolicy() throws Exception {
-    var result = dispatch.getPao(objectId);
-    assertNotNull(result);
-    assertEquals(TpsComponent.WSM, result.getComponent());
-    assertEquals(TpsObjectType.WORKSPACE, result.getObjectType());
-    assertEquals(objectId, result.getObjectId());
-    assertNotNull(result.getAttributes());
-    assertNotNull(result.getAttributes().getInputs());
-    var inputs = result.getAttributes().getInputs();
-    assertTrue(inputs.size() > 0);
-    var policy = inputs.get(0);
-    assertNotNull(policy);
-    assertNotNull(policy.getName());
-    assertNotNull(policy.getNamespace());
-    assertFalse(policy.getName().isEmpty());
-    assertFalse(policy.getNamespace().isEmpty());
-  }
-
-
-  @Pact(consumer = "wsm", provider = "tps")
-  public RequestResponsePact getPaoThatDoesNotExist(PactDslWithProvider builder) {
-    return builder
-        .uponReceiving("A request to retrieve a policy that doesn't exist")
-        .method("GET")
-        .matchPath("/api/policy/v1alpha1/pao/%s" .formatted(UUID_REGEX))
-        .willRespondWith()
-        .status(HttpStatus.NOT_FOUND.value())
-        .toPact();
-  }
-
-
-  @Test
-  @PactTestFor(pactMethod = "getPaoThatDoesNotExist")
-  public void retrievingAPolicyThatDoesNotExist() {
-    assertThrows(PolicyServiceNotFoundException.class, () -> dispatch.getPao(objectId));
   }
 
 
@@ -224,6 +161,151 @@ public class TpsApiTest {
     dispatch.deletePao(objectId);
   }
 
+
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact getPaoWithAnExistingWorkspacePolicy(PactDslWithProvider builder) {
+    var policyResponseShape = new PactDslJsonBody()
+        .valueFromProviderState("objectId", "${objectId}", objectId)
+        .stringValue("component", TpsComponent.WSM.getValue())
+        .stringValue("objectType", TpsObjectType.WORKSPACE.getValue())
+        .object("effectiveAttributes", tpsPolicyInputsObjectShape)
+        .object("attributes", tpsPolicyInputsObjectShape);
+
+    return builder
+        .given("an existing policy for a workspace")
+        .uponReceiving("A request to retrieve a policy")
+        .method("GET")
+        .pathFromProviderState(
+            "/api/policy/v1alpha1/pao/${objectId}",
+            String.format("/api/policy/v1alpha1/pao/%s", objectId))
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        .body(policyResponseShape)
+        .toPact();
+  }
+
+
+  @Test
+  @PactTestFor(pactMethod = "getPaoWithAnExistingWorkspacePolicy")
+  public void retrievingAnExistingWorkspacePolicy() throws Exception {
+    var result = dispatch.getPao(objectId);
+    assertNotNull(result);
+    assertEquals(TpsComponent.WSM, result.getComponent());
+    assertEquals(TpsObjectType.WORKSPACE, result.getObjectType());
+    assertEquals(objectId, result.getObjectId());
+    assertNotNull(result.getAttributes());
+    assertNotNull(result.getAttributes().getInputs());
+    var inputs = result.getAttributes().getInputs();
+    assertTrue(inputs.size() > 0);
+    var policy = inputs.get(0);
+    assertNotNull(policy);
+    assertNotNull(policy.getName());
+    assertNotNull(policy.getNamespace());
+    assertFalse(policy.getName().isEmpty());
+    assertFalse(policy.getNamespace().isEmpty());
+  }
+
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact getPaoThatDoesNotExist(PactDslWithProvider builder) {
+    return builder
+        .uponReceiving("A request to retrieve a policy that doesn't exist")
+        .method("GET")
+        .matchPath("/api/policy/v1alpha1/pao/%s" .formatted(UUID_REGEX))
+        .willRespondWith()
+        .status(HttpStatus.NOT_FOUND.value())
+        .toPact();
+  }
+
+
+  @Test
+  @PactTestFor(pactMethod = "getPaoThatDoesNotExist")
+  public void retrievingAPolicyThatDoesNotExist() {
+    assertThrows(PolicyServiceNotFoundException.class, () -> dispatch.getPao(objectId));
+  }
+
+
+  /*
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact linkPaoWhenBothExist(PactDslWithProvider builder) {
+
+    return builder
+        .given("an existing policy for a workspace")
+        .given("another existing policy")
+        .uponReceiving("A request to link the policies")
+        .method("GET")
+        .query("depth=1")
+        .pathFromProviderState(
+            "/api/policy/v1alpha1/pao/${objectId}/explain",
+            String.format("/api/policy/v1alpha1/pao/%s/explain", objectId))
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        //.body(explainResponse)
+        .toPact();
+  }*/
+
+
+  // link Pao
+  // merge Pao
+  // replace Pao
+  // update Pao
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact listValidRegions(PactDslWithProvider builder) {
+    return builder
+        .given("an existing policy for a workspace")
+        .uponReceiving("A request to list the valid regions for a policy")
+        .method("GET")
+        .query("platform=%s".formatted(CloudPlatform.AZURE.toTps()))
+        .pathFromProviderState(
+            "/api/policy/v1alpha1/region/${objectId}/list-valid",
+            "/api/policy/v1alpha1/region/%s/list-valid".formatted(objectId))
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        .body(new PactDslJsonArray().stringType())
+        .toPact();
+  }
+
+
+  @Test
+  @PactTestFor(pactMethod = "listValidRegions")
+  public void listingValidRegionsOnAWorkspace() throws Exception {
+    var result = dispatch.listValidRegions(objectId, CloudPlatform.AZURE);
+    assertNotNull(result);
+  }
+
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact listValidByPolicyInput(PactDslWithProvider builder) {
+    return builder
+        .given("an existing policy")
+        .uponReceiving("A request to list the valid regions for a policy")
+        .method("POST")
+        .body(tpsPolicyInputsObjectShape)
+        .query("platform=%s".formatted(CloudPlatform.AZURE.toTps()))
+        .path("/api/policy/v1alpha1/location/list-valid")
+        .headers(contentTypeJsonHeader)
+        .willRespondWith()
+        .status(HttpStatus.OK.value())
+        .body(new PactDslJsonArray().stringType())
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "listValidByPolicyInput")
+  public void listingValidRegionsOnAPolicy() throws Exception {
+    var inputs = new TpsPolicyInputs()
+        .inputs(List.of(new TpsPolicyInput().name("test_name").namespace("test_namespace")));
+    var tpsPao = new TpsPaoGetResult()
+        .objectId(objectId)
+        .attributes(inputs)
+        .effectiveAttributes(inputs);
+    var result = dispatch.listValidRegionsForPao(tpsPao, CloudPlatform.AZURE);
+    assertNotNull(result);
+  }
+
+
   @Pact(consumer = "wsm", provider = "tps")
   public RequestResponsePact explainingAWorkspacePolicy(PactDslWithProvider builder) {
     var explainResponse = new PactDslJsonBody()
@@ -262,78 +344,39 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-  /*
-  @Pact(consumer = "wsm", provider = "tps")
-  public RequestResponsePact linkingTwoPolicies(PactDslWithProvider builder) {
 
-    return builder
-        .given("an existing policy for a workspace")
-        .given("another existing policy")
-        .uponReceiving("A request to link the policies")
-        .method("GET")
-        .query("depth=1")
-        .pathFromProviderState(
-            "/api/policy/v1alpha1/pao/${objectId}/explain",
-            String.format("/api/policy/v1alpha1/pao/%s/explain", objectId))
-        .willRespondWith()
-        .status(HttpStatus.OK.value())
-        //.body(explainResponse)
-        .toPact();
-  }*/
 
   @Pact(consumer = "wsm", provider = "tps")
-  public RequestResponsePact listValidRegions(PactDslWithProvider builder) {
+  public RequestResponsePact getLocationInfo(PactDslWithProvider builder) {
+    var locationArray = new PactDslJsonArray().eachArrayLike().object().stringType("name")
+        .stringType("description")
+        .object("regions", new PactDslJsonArray().stringType()).closeObject();
+    var responseShape = new PactDslJsonBody()
+        .stringType("name")
+        .stringType("description")
+        .object("regions", new PactDslJsonArray().stringType())
+        .object("locations", locationArray);
     return builder
-        .given("an existing policy for a workspace")
-        .uponReceiving("A request to list the valid regions for a policy")
+        .uponReceiving("A for information about a location")
         .method("GET")
-        .query("platform=%s".formatted(CloudPlatform.AZURE.toTps()))
-        .pathFromProviderState(
-            "/api/policy/v1alpha1/region/${objectId}/list-valid",
-            "/api/policy/v1alpha1/region/%s/list-valid".formatted(objectId))
+        // TODO: find a way to improve query string matching (this may require updating pact
+        .query("platform=%s&location=%s".formatted(CloudPlatform.AZURE.toTps(), "West"))
+        //.query("location=%s".formatted("West"))
+        .path("/api/policy/v1alpha1/location")
         .willRespondWith()
         .status(HttpStatus.OK.value())
-        .body(new PactDslJsonArray().stringType())
+        .body(responseShape)
         .toPact();
   }
 
   @Test
-  @PactTestFor(pactMethod = "listValidRegions")
-  public void listingValidRegionsOnAWorkspace() throws Exception {
-    var result = dispatch.listValidRegions(objectId, CloudPlatform.AZURE);
+  @PactTestFor(pactMethod = "getLocationInfo")
+  public void retrievingInformationOnARegion() throws Exception {
+    var result = dispatch.getLocationInfo(CloudPlatform.AZURE, "West");
     assertNotNull(result);
   }
 
 
-
-  @Pact(consumer = "wsm", provider = "tps")
-  public RequestResponsePact listValidByPolicyInput(PactDslWithProvider builder) {
-    return builder
-        .given("an existing policy")
-        .uponReceiving("A request to list the valid regions for a policy")
-        .method("POST")
-        .body(tpsPolicyInputsObjectShape)
-        .query("platform=%s".formatted(CloudPlatform.AZURE.toTps()))
-        .path("/api/policy/v1alpha1/location/list-valid")
-        .headers(contentTypeJsonHeader)
-        .willRespondWith()
-        .status(HttpStatus.OK.value())
-        .body(new PactDslJsonArray().stringType())
-        .toPact();
-  }
-
-  @Test
-  @PactTestFor(pactMethod = "listValidByPolicyInput")
-  public void listingValidRegionsOnAPolicy() throws Exception {
-    var inputs = new TpsPolicyInputs()
-        .inputs(List.of(new TpsPolicyInput().name("test_name").namespace("test_namespace")));
-    var tpsPao = new TpsPaoGetResult()
-        .objectId(objectId)
-        .attributes(inputs)
-        .effectiveAttributes(inputs);
-    var result = dispatch.listValidRegionsForPao(tpsPao, CloudPlatform.AZURE);
-    assertNotNull(result);
-  }
   /*
     TODO:
       Link Pao
@@ -344,6 +387,5 @@ public class TpsApiTest {
       Merge Pao
       Replace Pao
       update Pao
-      getLocationInfo
    */
 }

--- a/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
@@ -1,0 +1,116 @@
+package bio.terra.workspace.pact;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import bio.terra.policy.model.TpsComponent;
+import bio.terra.policy.model.TpsObjectType;
+import bio.terra.policy.model.TpsPolicyInput;
+import bio.terra.policy.model.TpsPolicyInputs;
+import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.app.configuration.external.PolicyServiceConfiguration;
+import bio.terra.workspace.service.policy.TpsApiDispatch;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Tag("pact-test")
+@ExtendWith(PactConsumerTestExt.class)
+public class TpsApiTest {
+
+
+  UUID objectId = UUID.randomUUID();
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact retrievingAnExistingWorkspacePolicy(PactDslWithProvider builder) {
+    return builder
+        .uponReceiving("A request to create a policy")
+        .method("GET")
+        .pathFromProviderState(
+            "/api/policy/v1alpha1/pao/${objectId}",
+            String.format("/api/policy/v1alpha1/pao/%s", objectId))
+        .willRespondWith()
+        .status(200)
+        .body("{\"component\": \"WSM\"}")
+        .headers(Map.of("Content-type","application/json"))
+        .toPact();
+  }
+
+
+  @Pact(consumer = "wsm", provider = "tps")
+  public RequestResponsePact creatingWithNoExistingPolicy(PactDslWithProvider builder) {
+    var inputShape = new PactDslJsonBody().object(
+        "inputs",
+        new PactDslJsonArray().eachArrayLike().object().stringType("namespace").stringType("name").closeObject()
+    );
+
+    var requestShape = new PactDslJsonBody()
+        .uuid("objectId")
+        .stringMatcher(
+            "objectType",
+            Arrays.stream(TpsObjectType.values()).map(TpsObjectType::getValue).collect(Collectors.joining("|"))
+        )
+        .stringMatcher(
+            "component",
+            Arrays.stream(TpsComponent.values()).map(TpsComponent::getValue).collect(Collectors.joining("|"))
+        )
+        .object("attributes", inputShape);
+
+    var pact = builder
+        .uponReceiving("A request to create a policy")
+        .method("POST")
+        .path("/api/policy/v1alpha1/pao")
+        //.body(requestShape)
+        //.headers("Content-type","application/json")
+        .willRespondWith()
+        .status(200)
+        .toPact();
+    return pact;
+
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "creatingWithNoExistingPolicy")
+  public void testCreatingAPolicyWithNoExistingPolicy(MockServer mockServer) throws Exception {
+    var tpsConfig = mock(PolicyServiceConfiguration.class);
+    when(tpsConfig.getAccessToken()).thenReturn("dummyToken");
+    when(tpsConfig.getBasePath()).thenReturn(mockServer.getUrl());
+    var featureConfig = new FeatureConfiguration();
+    featureConfig.setTpsEnabled(true);
+    var dispatch = new TpsApiDispatch(featureConfig, tpsConfig);
+    var inputs = List.of(new TpsPolicyInput().name("test_name").namespace("test_namespace"));
+    dispatch.createPao(
+        UUID.randomUUID(),
+        new TpsPolicyInputs().inputs(inputs),
+        TpsComponent.WSM,
+        TpsObjectType.WORKSPACE
+    );
+  }
+
+
+  @Test
+  @PactTestFor(pactMethod = "retrievingAnExistingWorkspacePolicy")
+  public void retrievingAnExistingWorkspacePolicy(MockServer mockServer) throws Exception {
+    var tpsConfig = mock(PolicyServiceConfiguration.class);
+    when(tpsConfig.getAccessToken()).thenReturn("dummyToken");
+    when(tpsConfig.getBasePath()).thenReturn(mockServer.getUrl());
+    var featureConfig = new FeatureConfiguration();
+    featureConfig.setTpsEnabled(true);
+    var dispatch = new TpsApiDispatch(featureConfig, tpsConfig);
+    var inputs = List.of(new TpsPolicyInput().name("test_name").namespace("test_namespace"));
+    var result = dispatch.getPao(objectId);
+  }
+}


### PR DESCRIPTION
[WOR-1157](https://broadworkbench.atlassian.net/browse/WOR-1157)

Adds consumer-side contract tests from WSM to TPS.

The changes in this PR don't include changes to publish all pacts to pact broker, yet. 

[WOR-1157]: https://broadworkbench.atlassian.net/browse/WOR-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ