### PR TITLE
Add missing update param to dataproc PATCH

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
@@ -105,6 +105,11 @@ public class UpdateDataprocClusterStep implements Step {
     ApiGcpDataprocClusterLifecycleConfig lifecycleConfig = updateParameters.getLifecycleConfig();
     if (lifecycleConfig != null) {
       updatedCluster.getConfig().setLifecycleConfig(new LifecycleConfig());
+      updateMaskPaths.add(IDLE_DELETE_TTL);
+      updatedCluster
+          .getConfig()
+          .getLifecycleConfig()
+          .setIdleDeleteTtl(updateParameters.getLifecycleConfig().getIdleDeleteTtl());
       // Only one autoDeleteTtl and autoDeleteTime can be set (already validated in controller)
       if (lifecycleConfig.getAutoDeleteTtl() != null) {
         updateMaskPaths.add(AUTO_DELETE_TTL);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
@@ -106,10 +106,12 @@ public class UpdateDataprocClusterStep implements Step {
     if (lifecycleConfig != null) {
       updatedCluster.getConfig().setLifecycleConfig(new LifecycleConfig());
       updateMaskPaths.add(IDLE_DELETE_TTL);
-      updatedCluster
-          .getConfig()
-          .getLifecycleConfig()
-          .setIdleDeleteTtl(updateParameters.getLifecycleConfig().getIdleDeleteTtl());
+      if (lifecycleConfig.getIdleDeleteTtl() != null) {
+        updatedCluster
+            .getConfig()
+            .getLifecycleConfig()
+            .setIdleDeleteTtl(updateParameters.getLifecycleConfig().getIdleDeleteTtl());
+      }
       // Only one autoDeleteTtl and autoDeleteTime can be set (already validated in controller)
       if (lifecycleConfig.getAutoDeleteTtl() != null) {
         updateMaskPaths.add(AUTO_DELETE_TTL);


### PR DESCRIPTION
The integration test was setting `idleDeleteTtl` and the value wasn't properly updated. Fixes the submodule update error: https://github.com/verily-src/terra-service-ws-manager/actions/runs/5791161286/job/15695514025