### PR TITLE
[PF-2884] Fix broken connectedPlus tests

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/CloneControlledGcpBigQueryDatasetResourceFlight.java
@@ -58,7 +58,7 @@ public class CloneControlledGcpBigQueryDatasetResourceFlight extends Flight {
 
     if (CloningInstructions.COPY_NOTHING == resolvedCloningInstructions) {
       addStep(
-          new SetNoOpBucketCloneResponseStep(
+          new SetNoOpDatasetCloneResponseStep(
               sourceResource.castByEnum(WsmResourceType.CONTROLLED_GCP_BIG_QUERY_DATASET)));
       return;
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/SetNoOpDatasetCloneResponseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/dataset/SetNoOpDatasetCloneResponseStep.java
@@ -10,10 +10,10 @@ import bio.terra.workspace.generated.model.ApiCloningInstructionsEnum;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.bqdataset.ControlledBigQueryDatasetResource;
 import org.springframework.http.HttpStatus;
 
-public class SetNoOpBucketCloneResponseStep implements Step {
+public class SetNoOpDatasetCloneResponseStep implements Step {
   private final ControlledBigQueryDatasetResource sourceDataset;
 
-  public SetNoOpBucketCloneResponseStep(ControlledBigQueryDatasetResource sourceDataset) {
+  public SetNoOpDatasetCloneResponseStep(ControlledBigQueryDatasetResource sourceDataset) {
     this.sourceDataset = sourceDataset;
   }
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledFlexibleResourceApiControllerConnectedTest.java
@@ -27,7 +27,6 @@ import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.generated.model.ApiWsmPolicyInputs;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
-import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.iam.model.WsmIamRole;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.logging.WorkspaceActivityLogService;
@@ -68,7 +67,6 @@ public class ControlledFlexibleResourceApiControllerConnectedTest extends BaseCo
   @Autowired FeatureConfiguration features;
   @Autowired CrlService crlService;
   @Autowired WorkspaceActivityLogService activityLogService;
-  @Autowired SamService samService;
 
   private UUID workspaceId;
   private UUID workspaceId2;

--- a/service/src/test/java/bio/terra/workspace/service/admin/AdminServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/admin/AdminServiceTest.java
@@ -2,11 +2,9 @@ package bio.terra.workspace.service.admin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.cloudres.google.iam.IamCow;
-import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.stairway.FlightDebugInfo;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
@@ -209,15 +207,6 @@ public class AdminServiceTest extends BaseConnectedTest {
     assertTrue(newChangeTimestampOfWorkspace1.isEqual(lastChangeTimestampOfWorkspace1));
 
     cleanUpWorkspace();
-  }
-
-  @Test
-  public void syncIamRoles_noProjectsFound_throwsInternalServerErrorException() {
-    assertThrows(
-        InternalServerErrorException.class,
-        () ->
-            adminService.syncIamRoleForAllGcpProjects(
-                userAccessUtils.defaultUserAuthRequest(), /*wetRun=*/ false));
   }
 
   private void updateCustomRole(CustomGcpIamRole customRole, String projectId)

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/RemoveUserFromWorkspaceFlightTest.java
@@ -71,7 +71,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
@@ -80,7 +79,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Tag("connectedPlus")
-@Disabled("Until PF-2884 is finished")
 public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
   private static final Logger logger =
       LoggerFactory.getLogger(RemoveUserFromWorkspaceFlightTest.class);


### PR DESCRIPTION
WSM's nightly connectedPlus tests have been failing for a few weeks, there were a few independent fixes required:

- `WorkspaceServiceTest` was a connected test which injected a mock SamService using `@MockBean`, which replaces the bean in the Spring context with the mock. However, it seems like the context wasn't restarted after this injection, so other connectedPlus tests which expected a real SamService were actually calling this mock. This would only appear if the test was run in the same context as `WorkspaceServiceTest`, which made it hard to reproduce.
  - Given that `WorkspaceServiceTest` used a mock Sam and never called GCP, I've moved it to a unit test instead.
  - I've also re-enabled `RemoveUserFromWorkspaceFlightTest` now that the SamService issue is resolved.
- The  MockGcpApi methods for cloning buckets and datasets were setting FlightDebugInfos on the wrong steps, leading to missed coverage and in some cases leading to the flight unintentionally succeeding.
- Remove `syncIamRoles_noProjectsFound_throwsInternalServerErrorException()`. This test relies on there being no workspaces in the DB, which often fails due to other test classes. Given that this only covers a small case, I don't think it's worth the risk of flakiness.
- Fix the `assertPolicyGroupsSynced` helper method to handle the new `PROJECT_OWNER` role and also stop syncing roles it shouldn't.
- Renamed `SetNoOpBucketCloneResponseStep` to `SetNoOpDatasetCloneResponseStep`. This step was only used in BQ dataset clone flights, it looks it was a typo.

The AzureConnectedPlusTests seem to be failing due to an Azure-specific error, those will need to be handled separately.
