### PR TITLE
[WOR-978] Remove check for DELETE on workspace resources during cloud context deletion

### DIFF
--- a/integration/src/main/resources/testusers/README.md
+++ b/integration/src/main/resources/testusers/README.md
@@ -5,7 +5,7 @@ Workspace Manager currently uses 3 test users for running integration tests with
 - `elijah.thunderlord@test.firecloud.org`
 - `liam.dragonmaw@test.firecloud.org`
 
-Tests generate credentials for these users via domain-wide delegation. More information about test user configuration (including information for setting up additional test users) is available [on Confluence](https://broadinstitute.atlassian.net/wiki/spaces/GAWB/pages/115259774/The+Testerson+Family+and+the+Order+of+the+QA). See the linked "Test Horde" sheet when setting up additional test users.
+Tests generate credentials for these users via domain-wide delegation. More information about test user configuration (including information for setting up additional test users) is available [on Confluence](https://broadworkbench.atlassian.net/wiki/spaces/QA/pages/2730524689/The+Testerson+Family+and+the+Order+of+the+QA). See the linked "Test Horde" sheet when setting up additional test users.
 
 Workspace Manager integration tests also talk to a number of external resources.
 These include:

--- a/scripts/write-config.sh
+++ b/scripts/write-config.sh
@@ -316,6 +316,13 @@ workspace:
 feature:
   tps-enabled: true
   temporary-grant-enabled: true
+landingzone:
+  sam:
+    landing-zone-resource-users:
+      - leonardo-dev@broad-dsde-dev.iam.gserviceaccount.com
+      - workspace-wsmtest@terra-kernel-k8s.iam.gserviceaccount.com
+      - Elizabeth.Shadowmoon@test.firecloud.org
+
 EOF
 else
   cat /dev/null > "${outputdir}/local-properties.yml"

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/BuildAndValidateResourceListStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/BuildAndValidateResourceListStep.java
@@ -43,15 +43,6 @@ public class BuildAndValidateResourceListStep implements Step {
     // respected throughout the rest of the flight.
     List<ControlledResource> resources = cloudContextService.makeOrderedResourceList(workspaceUuid);
 
-    // Verify that the caller is allowed to delete all resources.
-    for (ControlledResource resource : resources) {
-      samService.checkAuthz(
-          userRequest,
-          resource.getCategory().getSamResourceName(),
-          resource.getResourceId().toString(),
-          SamConstants.SamControlledResourceActions.DELETE_ACTION);
-    }
-
     // Generate pairs of (resourceId, flightId) maintaining the ordering
     List<ResourceDeleteFlightPair> resourcePairs = new ArrayList<>();
     for (ControlledResource resource : resources) {

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/BuildAndValidateResourceListStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/delete/cloudcontext/BuildAndValidateResourceListStep.java
@@ -8,7 +8,6 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
-import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.workspace.CloudContextService;


### PR DESCRIPTION
## Context
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-978)
[Related one-pager](https://docs.google.com/document/d/1uLT4VcIdqjo_RPZzAP0D6FsGzUbviUbnW1OtZ_k0iPc/edit)
Application controlled resources may be orphaned by their stewarding application prior to workspace deletion. When this happens, the workspace becomes undelete-able due to the Sam checks against the application controlled resources. 

## This PR
* Removes the checks in the `BuildAndValidateResourceListStep` class that is run at the start of cloud context deletion. The premise is that the principal running the deletion flight has DELETE on the workspace, and all resources should be deleted regardless of their stewardship. 
   * I had originally planned on making modifications to the `SamService` to delete the related resource Sam entries with the WSM SA but that has [already been implemented](https://github.com/DataBiosphere/terra-workspace-manager/blob/693729f4f9e2f0cd2a6184ae691e03ae35994419/service/src/main/java/bio/terra/workspace/service/workspace/flight/cloud/any/DeleteControlledSamResourcesStep.java#L19).
* Updates the `write-config.sh` dev script to emit needed landing zone users so applications may create resources in an Azure workspace during local development. 