### PR TITLE
Allow configuring dataproc image version

### DIFF
--- a/openapi/src/parts/controlled_gcp_dataproc_cluster.yaml
+++ b/openapi/src/parts/controlled_gcp_dataproc_cluster.yaml
@@ -194,6 +194,9 @@ components:
         region:
           type: string
           description: GCP region.
+        imageVersion:
+          type: string
+          description: Dataproc image version with specific software versions installed for Spark, Hadoop, etc. Defaults to the latest debian image if not specified. See https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-version-clusters#supported_dataproc_versions.
         initializationScripts:
           type: array
           items:

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -221,7 +221,7 @@ public class CreateDataprocClusterStep implements Step {
                         .setOptionalComponents(creationParameters.getComponents())));
 
     // Set dataproc image version
-    if(creationParameters.getImageVersion() != null) {
+    if (creationParameters.getImageVersion() != null) {
       cluster.getConfig().getSoftwareConfig().setImageVersion(creationParameters.getImageVersion());
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -220,6 +220,11 @@ public class CreateDataprocClusterStep implements Step {
                         .setProperties(creationParameters.getProperties())
                         .setOptionalComponents(creationParameters.getComponents())));
 
+    // Set dataproc image version
+    if(creationParameters.getImageVersion() != null) {
+      cluster.getConfig().getSoftwareConfig().setImageVersion(creationParameters.getImageVersion());
+    }
+
     // Set initialization script
     // TODO PF-2828: Add WSM default post-startup script
     List<String> initializationScripts = creationParameters.getInitializationScripts();


### PR DESCRIPTION
With this change, the cli/ui can specify the set of installed software versions for (spark/hadoop/etc). The default debian image that's used has older versions incompatible with the latest version of [hail](https://hail.is/).