### PR TITLE
Do not require primary worker config in dataproc cluster creation

### DIFF
--- a/integration/src/main/java/scripts/utils/DataprocUtils.java
+++ b/integration/src/main/java/scripts/utils/DataprocUtils.java
@@ -96,6 +96,10 @@ public class DataprocUtils {
                 new GcpDataprocClusterInstanceGroupConfig()
                     .numInstances(2)
                     .machineType("n2-standard-2"))
+            .secondaryWorkerConfig(
+                new GcpDataprocClusterInstanceGroupConfig()
+                    .numInstances(2)
+                    .machineType("n2-standard-2"))
             .components(List.of("JUPYTER"))
             .lifecycleConfig(new GcpDataprocClusterLifecycleConfig().idleDeleteTtl("3600s"));
 

--- a/openapi/src/parts/controlled_gcp_dataproc_cluster.yaml
+++ b/openapi/src/parts/controlled_gcp_dataproc_cluster.yaml
@@ -194,6 +194,9 @@ components:
         region:
           type: string
           description: GCP region.
+        imageVersion:
+          type: string
+          description: Dataproc image version with specific software versions installed for Spark, Hadoop, etc. Defaults to the latest debian image if not specified. See https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-version-clusters#supported_dataproc_versions.
         initializationScripts:
           type: array
           items:

--- a/openapi/src/parts/controlled_gcp_dataproc_cluster.yaml
+++ b/openapi/src/parts/controlled_gcp_dataproc_cluster.yaml
@@ -186,7 +186,6 @@ components:
       - configBucket
       - tempBucket
       - managerNodeConfig
-      - primaryWorkerConfig
       properties:
         clusterId:
           type: string

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -221,7 +221,7 @@ public class CreateDataprocClusterStep implements Step {
                         .setOptionalComponents(creationParameters.getComponents())));
 
     // Set dataproc image version
-    if(creationParameters.getImageVersion() != null) {
+    if (creationParameters.getImageVersion() != null) {
       cluster.getConfig().getSoftwareConfig().setImageVersion(creationParameters.getImageVersion());
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -234,13 +234,17 @@ public class CreateDataprocClusterStep implements Step {
       cluster
           .getConfig()
           .setWorkerConfig(
-              getInstanceGroupConfig(creationParameters.getPrimaryWorkerConfig(), false));
+              getInstanceGroupConfig(
+                  creationParameters.getPrimaryWorkerConfig(),
+                  /* isSecondaryWorkerConfig=*/ false));
     }
     if (creationParameters.getSecondaryWorkerConfig() != null) {
       cluster
           .getConfig()
           .setSecondaryWorkerConfig(
-              getInstanceGroupConfig(creationParameters.getSecondaryWorkerConfig(), true));
+              getInstanceGroupConfig(
+                  creationParameters.getSecondaryWorkerConfig(),
+                  /* isSecondaryWorkerConfig=*/ true));
     }
 
     // Configure cluster lifecycle

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -220,6 +220,11 @@ public class CreateDataprocClusterStep implements Step {
                         .setProperties(creationParameters.getProperties())
                         .setOptionalComponents(creationParameters.getComponents())));
 
+    // Set dataproc image version
+    if(creationParameters.getImageVersion() != null) {
+      cluster.getConfig().getSoftwareConfig().setImageVersion(creationParameters.getImageVersion());
+    }
+
     // Set initialization script
     // TODO PF-2828: Add WSM default post-startup script
     List<String> initializationScripts = creationParameters.getInitializationScripts();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -195,14 +195,6 @@ public class CreateDataprocClusterStep implements Step {
                 .setTempBucket(tempBucketName)
                 .setMasterConfig(
                     getInstanceGroupConfig(creationParameters.getManagerNodeConfig(), false))
-                .setWorkerConfig(
-                    getInstanceGroupConfig(creationParameters.getPrimaryWorkerConfig(), false))
-                .setSecondaryWorkerConfig(
-                    creationParameters.getSecondaryWorkerConfig() != null
-                        ? getInstanceGroupConfig(
-                            creationParameters.getSecondaryWorkerConfig(), true)
-                        : getInstanceGroupConfig(
-                            creationParameters.getPrimaryWorkerConfig(), false))
                 .setGceClusterConfig(
                     new GceClusterConfig()
                         // TODO PF-2878: replace leonardo tag once new dataproc firewall rule is in
@@ -235,6 +227,20 @@ public class CreateDataprocClusterStep implements Step {
               initializationScripts.stream()
                   .map(script -> new NodeInitializationAction().setExecutableFile(script))
                   .collect(Collectors.toList()));
+    }
+
+    // Set primary and secondary worker configs
+    if (creationParameters.getPrimaryWorkerConfig() != null) {
+      cluster
+          .getConfig()
+          .setWorkerConfig(
+              getInstanceGroupConfig(creationParameters.getPrimaryWorkerConfig(), false));
+    }
+    if (creationParameters.getSecondaryWorkerConfig() != null) {
+      cluster
+          .getConfig()
+          .setSecondaryWorkerConfig(
+              getInstanceGroupConfig(creationParameters.getSecondaryWorkerConfig(), true));
     }
 
     // Configure cluster lifecycle

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledGcpResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledGcpResourceFixtures.java
@@ -423,6 +423,10 @@ public class ControlledGcpResourceFixtures {
             new ApiGcpDataprocClusterInstanceGroupConfig()
                 .numInstances(2)
                 .machineType("n2-standard-2"))
+        .secondaryWorkerConfig(
+            new ApiGcpDataprocClusterInstanceGroupConfig()
+                .numInstances(2)
+                .machineType("n2-standard-2"))
         .lifecycleConfig(new ApiGcpDataprocClusterLifecycleConfig().idleDeleteTtl("3600s"));
   }
 


### PR DESCRIPTION
Single node clusters require passing null for primary and secondary worker configs to the dataproc api. This is not possible with the current wsm create api. This change changes primary worker config to an optional property. Also removes the logic of setting secondary worker config be the same as primary worker config, the UI/CLI is already doing this.