### PR TITLE
Add null checks to cluster metadata check

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/RetrieveDataprocClusterResourceAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/RetrieveDataprocClusterResourceAttributesStep.java
@@ -35,10 +35,14 @@ public class RetrieveDataprocClusterResourceAttributesStep implements Step {
       ApiControlledDataprocClusterUpdateParameters existingUpdateParameters =
           new ApiControlledDataprocClusterUpdateParameters();
 
-      existingUpdateParameters.setNumPrimaryWorkers(
-          cluster.getConfig().getWorkerConfig().getNumInstances());
-      existingUpdateParameters.setNumSecondaryWorkers(
-          cluster.getConfig().getSecondaryWorkerConfig().getNumInstances());
+      if (cluster.getConfig().getWorkerConfig() != null) {
+        existingUpdateParameters.setNumPrimaryWorkers(
+            cluster.getConfig().getWorkerConfig().getNumInstances());
+      }
+      if (cluster.getConfig().getSecondaryWorkerConfig() != null) {
+        existingUpdateParameters.setNumSecondaryWorkers(
+            cluster.getConfig().getSecondaryWorkerConfig().getNumInstances());
+      }
       if (cluster.getConfig().getAutoscalingConfig() != null) {
         existingUpdateParameters.setAutoscalingPolicy(
             cluster.getConfig().getAutoscalingConfig().getPolicyUri());


### PR DESCRIPTION
Dataproc cluster get api doesn't return any worker configuration value like machine-type or machine uri if its node count has been created or updated to 0... Unclear why they chose this behavior but it's causing an error when updating a cluster worker count size from 0 to any value.