### PR TITLE
[PF-2951] Add retry on assertBucketHasNoFiles to handle permission propagation

### DIFF
--- a/service/src/test/java/bio/terra/workspace/common/GcsBucketUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/GcsBucketUtils.java
@@ -23,6 +23,7 @@ import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -153,15 +154,34 @@ public class GcsBucketUtils {
     assertEquals(fileContent, actualContents);
   }
 
-  /** Asserts table is populated as per populateBqTable(). */
+  /**
+   * Asserts that the bucket is empty. Retries for 5 minutes to accommodate permission propagation
+   * delay
+   */
   public void assertBucketHasNoFiles(
-      AuthenticatedUserRequest userRequest, String projectId, String bucketName) {
+      AuthenticatedUserRequest userRequest, String projectId, String bucketName) throws Exception {
     StorageCow storageCow = crlService.createStorageCow(projectId, userRequest);
+    RetryUtils.getWithRetryOnException(
+        () -> countFiles(storageCow, bucketName),
+        /*totalDuration=*/ Duration.ofMinutes(5),
+        /*initialSleep=*/ Duration.ofSeconds(5),
+        /*factorIncrease=*/ 1.0,
+        /*sleepDurationMax=*/ Duration.ofSeconds(30),
+        null);
+
     int numFiles = 0;
     for (BlobCow blob : storageCow.get(bucketName).list().iterateAll()) {
       numFiles++;
     }
     assertEquals(0, numFiles);
+  }
+
+  private Integer countFiles(StorageCow storageCow, String bucketName) {
+    int numFiles = 0;
+    for (BlobCow blob : storageCow.get(bucketName).list().iterateAll()) {
+      numFiles++;
+    }
+    return numFiles;
   }
 
   public void assertBucketAttributes(

--- a/service/src/test/java/bio/terra/workspace/common/GcsBucketUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/GcsBucketUtils.java
@@ -161,22 +161,18 @@ public class GcsBucketUtils {
   public void assertBucketHasNoFiles(
       AuthenticatedUserRequest userRequest, String projectId, String bucketName) throws Exception {
     StorageCow storageCow = crlService.createStorageCow(projectId, userRequest);
-    RetryUtils.getWithRetryOnException(
-        () -> countFiles(storageCow, bucketName),
-        /*totalDuration=*/ Duration.ofMinutes(5),
-        /*initialSleep=*/ Duration.ofSeconds(5),
-        /*factorIncrease=*/ 1.0,
-        /*sleepDurationMax=*/ Duration.ofSeconds(30),
-        null);
-
-    int numFiles = 0;
-    for (BlobCow blob : storageCow.get(bucketName).list().iterateAll()) {
-      numFiles++;
-    }
+    int numFiles =
+        RetryUtils.getWithRetryOnException(
+            () -> countFiles(storageCow, bucketName),
+            /*totalDuration=*/ Duration.ofMinutes(5),
+            /*initialSleep=*/ Duration.ofSeconds(5),
+            /*factorIncrease=*/ 1.0,
+            /*sleepDurationMax=*/ Duration.ofSeconds(30),
+            null);
     assertEquals(0, numFiles);
   }
 
-  private Integer countFiles(StorageCow storageCow, String bucketName) {
+  private int countFiles(StorageCow storageCow, String bucketName) {
     int numFiles = 0;
     for (BlobCow blob : storageCow.get(bucketName).list().iterateAll()) {
       numFiles++;


### PR DESCRIPTION
The bucket test `clone_copyDefinition` has been flaky on and off. I think I figured out that it is a permission setting delay:
- WSM sets permissions on the bucket resource from Sam sync'd groups
- (My hypothesis is there is a propagation delay of some sort here)
- Test calls GCP immediately to check for files. Sometimes we see 403.

I added a retry on the file check. If things are actually broken, it will slow the test down by 5 minutes. But for the normal case, it will allow us to wait for propagation, the check will pass, and the test won't flake out.
