### PR TITLE
[WOR-1194] Set max header size to 32KB

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -46,6 +46,7 @@ spring.config.import: optional:file:../config/local-properties.yml
 logging.pattern.level: '%X{requestId} %5p'
 
 server:
+  max-http-header-size: 32KB
   compression:
     enabled: true
     mime-types: text/css,application/javascript


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1194)

Large access tokens exceed the default configured spring boot header size limit of 8k. I have verified this behavior with a token borrowed from a dev who was encountering this issue. A similar [fix](https://github.com/DataBiosphere/terra-billing-profile-manager/pulls?q=is%3Apr+is%3Aclosed) in BPM mitigated the issue, this ports it to WSM where we are also seeing errors.

