### PR TITLE
[BENCH-958] Service startup tester

### DIFF
--- a/.github/workflows/server-startup-test.yaml
+++ b/.github/workflows/server-startup-test.yaml
@@ -2,7 +2,6 @@
 # This test can be manually launched to just start the server and
 # immediately exit. The immediate exist is accomplished by setting
 # specific configuration flags.
-
 name: Server Startup Test
 on:
   workflow_dispatch: {}
@@ -71,6 +70,12 @@ jobs:
           vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
           target: local
 
+      # Configure up so the cronjobs do not start
       - name: Start the server with immediate exit
-        run: |
-          ./gradlew service:bootRun --args='--workspace.startup.exit-after-initialization=true --workspace.dangling-resource-cleanup.enabled=false --workspace.temporary-grant-revoke.revokeenabled=false --workspace.private-resource-cleanup.enabled=false'
+        env:
+          spring_profiles_active: human-readable-logging
+          workspace_startup_exitafterinitialization: true
+          workspace_danglingresourcecleanup_enabled: false
+          workspace_temporarygrantrevoke_revokeenabled: false
+          workspace_privateresourcecleanup_enabled: false
+        run: ./gradlew service:bootRun

--- a/.github/workflows/server-startup-test.yaml
+++ b/.github/workflows/server-startup-test.yaml
@@ -1,0 +1,76 @@
+# Sometimes the server fails to start in the GHA environment.
+# This test can be manually launched to just start the server and
+# immediately exit. The immediate exist is accomplished by setting
+# specific configuration flags.
+
+name: Server Startup Test
+on:
+  workflow_dispatch: {}
+
+jobs:
+  server-startup-test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13.1
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Initialize Postgres DB for local server test run
+        env:
+          PGPASSWORD: postgres
+        run: psql -h 127.0.0.1 -U postgres -f ./service/local-dev/local-postgres-init.sql
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Get Vault token
+        id: vault-token-step
+        env:
+          VAULT_ADDR: https://clotho.broadinstitute.org:8200
+        run: |
+          VAULT_TOKEN=$(docker run --rm --cap-add IPC_LOCK \
+            -e "VAULT_ADDR=${VAULT_ADDR}" \
+            vault:1.1.0 \
+            vault write -field token \
+              auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
+              secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+          echo ::add-mask::$VAULT_TOKEN    
+          echo vault-token=$VAULT_TOKEN >> $GITHUB_OUTPUT
+
+      - name: Write config
+        id: config
+        uses: ./.github/actions/write-config
+        with:
+          vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
+          target: local
+
+      - name: Start the server with immediate exit
+        run: |
+          ./gradlew service:bootRun --args='--workspace.startup.exit-after-initialization=true --workspace.dangling-resource-cleanup.enabled=false --workspace.temporary-grant-revoke.revokeenabled=false --workspace.private-resource-cleanup.enabled=false'

--- a/.github/workflows/workflow-tester.yml
+++ b/.github/workflows/workflow-tester.yml
@@ -76,6 +76,12 @@ jobs:
           vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
           target: local
 
+      # Configure up so the cronjobs do not start
       - name: Start the server with immediate exit
-        run: |
-          ./gradlew service:bootRun --args='--workspace.startup.exit-after-initialization=true --workspace.dangling-resource-cleanup.enabled=false --workspace.temporary-grant-revoke.revokeenabled=false --workspace.private-resource-cleanup.enabled=false'
+        env:
+          spring_profiles_active: human-readable-logging
+          workspace_startup_exitafterinitialization: true
+          workspace_danglingresourcecleanup_enabled: false
+          workspace_temporarygrantrevoke_revokeenabled: false
+          workspace_privateresourcecleanup_enabled: false
+        run: ./gradlew service:bootRun

--- a/.github/workflows/workflow-tester.yml
+++ b/.github/workflows/workflow-tester.yml
@@ -11,24 +11,9 @@
 name: Workflow Tester
 on:
   workflow_dispatch: {}
-# Action for running a user-defined suite of integration tests against PRs. This test uses local
-# server changes but runs a published version of the client, so it will not pick
-# up local client changes.
-#
-# The idea of this workflow is to help debug integration tests. On your branch:
-# - modify service and integration code
-# - edit suites/TempTestSuite.json with the tests you want to run
-# - push your branch to github - NO PR NEEDED!
-# - use the workflow dispatch to run this workflow.
-# This does not report results anywhere, so you have to check the github action page
-# to see when it finished.
-
-#name: Run Integration Temp Test Suite
-#on:
-#  workflow_dispatch: {}
 
 jobs:
-  any-integration-job:
+  server-startup-test:
     runs-on: ubuntu-latest
 
     services:
@@ -91,22 +76,6 @@ jobs:
           vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
           target: local
 
-      - name: Launch local server
-        uses: ./.github/actions/start-local-server
-
-      - name: Run the integration test suite
-        id: integration-test
-        uses: ./.github/actions/integration-test
-        with:
-          test-server: workspace-local.json
-          test: suites/TempTestSuite.json
-
-      - name: Archive WSM and TestRunner logs
-        id: archive_logs
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: wsm-and-testrunner-logs
-          path: |
-            wsm.log
-            ${{ steps.integration-test.outputs.results-dir }}
+      - name: Start the server with immediate exit
+        run: |
+          ./gradlew service:bootRun --args='--workspace.startup.exit-after-initialization=true --workspace.dangling-resource-cleanup.enabled=false --workspace.temporary-grant-revoke.revokeenabled=false --workspace.private-resource-cleanup.enabled=false'

--- a/service/src/main/java/bio/terra/workspace/app/Main.java
+++ b/service/src/main/java/bio/terra/workspace/app/Main.java
@@ -1,9 +1,13 @@
 package bio.terra.workspace.app;
 
 import bio.terra.common.logging.LoggingInitializer;
+import bio.terra.workspace.app.configuration.external.StartupConfiguration;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.retry.annotation.EnableRetry;
@@ -52,6 +56,20 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 public class Main {
   public static void main(String[] args) {
-    new SpringApplicationBuilder(Main.class).initializers(new LoggingInitializer()).run(args);
+    ConfigurableApplicationContext ctx =
+      new SpringApplicationBuilder(Main.class).initializers(new LoggingInitializer()).run(args);
+
+    // Exit after initialization, if requested.
+    // This is used for debugging server startup issues within the github action context.
+    // Normally we do not get the log for the local server startup in a GHA. This lets us
+    // automate a test that will simply start the local server and exit.
+    StartupConfiguration startupConfiguration = ctx.getBean(StartupConfiguration.class);
+    System.out.printf("Exit after initialization is: %s%n", startupConfiguration.isExitAfterInitialization());
+    if (startupConfiguration.isExitAfterInitialization()) {
+      System.out.println("Exit after initialization requested - exiting");
+      ctx.close();
+      System.out.println("Application Context closed");
+      System.exit(0);
+    }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/Main.java
+++ b/service/src/main/java/bio/terra/workspace/app/Main.java
@@ -2,11 +2,9 @@ package bio.terra.workspace.app;
 
 import bio.terra.common.logging.LoggingInitializer;
 import bio.terra.workspace.app.configuration.external.StartupConfiguration;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -57,14 +55,15 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 public class Main {
   public static void main(String[] args) {
     ConfigurableApplicationContext ctx =
-      new SpringApplicationBuilder(Main.class).initializers(new LoggingInitializer()).run(args);
+        new SpringApplicationBuilder(Main.class).initializers(new LoggingInitializer()).run(args);
 
     // Exit after initialization, if requested.
     // This is used for debugging server startup issues within the github action context.
     // Normally we do not get the log for the local server startup in a GHA. This lets us
     // automate a test that will simply start the local server and exit.
     StartupConfiguration startupConfiguration = ctx.getBean(StartupConfiguration.class);
-    System.out.printf("Exit after initialization is: %s%n", startupConfiguration.isExitAfterInitialization());
+    System.out.printf(
+        "Exit after initialization is: %s%n", startupConfiguration.isExitAfterInitialization());
     if (startupConfiguration.isExitAfterInitialization()) {
       System.out.println("Exit after initialization requested - exiting");
       ctx.close();

--- a/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
+++ b/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
@@ -11,10 +11,8 @@ import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.logging.StackdriverExporter;
 import bio.terra.workspace.service.workspace.WsmApplicationService;
 import javax.sql.DataSource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.SpringApplication;
 import org.springframework.context.ApplicationContext;
 
 public final class StartupInitializer {

--- a/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
+++ b/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
@@ -4,15 +4,21 @@ import bio.terra.common.db.DataSourceInitializer;
 import bio.terra.common.migrate.LiquibaseMigrator;
 import bio.terra.landingzone.library.LandingZoneMain;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.app.configuration.external.StartupConfiguration;
 import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfiguration;
 import bio.terra.workspace.db.WorkspaceDao;
 import bio.terra.workspace.service.job.JobService;
 import bio.terra.workspace.service.logging.StackdriverExporter;
 import bio.terra.workspace.service.workspace.WsmApplicationService;
 import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
 import org.springframework.context.ApplicationContext;
 
 public final class StartupInitializer {
+  private static final Logger logger = LoggerFactory.getLogger(StartupInitializer.class);
   private static final String changelogPath = "db/changelog.xml";
 
   public static void initialize(ApplicationContext applicationContext) {
@@ -24,6 +30,8 @@ public final class StartupInitializer {
     WsmApplicationService appService = applicationContext.getBean(WsmApplicationService.class);
     FeatureConfiguration featureConfiguration =
         applicationContext.getBean(FeatureConfiguration.class);
+    StartupConfiguration startupConfiguration =
+        applicationContext.getBean(StartupConfiguration.class);
 
     // Log the state of the feature flags
     featureConfiguration.logFeatures();

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/StartupConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/StartupConfiguration.java
@@ -1,0 +1,19 @@
+package bio.terra.workspace.app.configuration.external;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "workspace.startup")
+public class StartupConfiguration {
+  private boolean exitAfterInitialization;
+
+  public boolean isExitAfterInitialization() {
+    return exitAfterInitialization;
+  }
+
+  public StartupConfiguration setExitAfterInitialization(boolean exitAfterInitialization) {
+    this.exitAfterInitialization = exitAfterInitialization;
+    return this;
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -99,6 +99,9 @@ workspace:
     uri: ${env.db.host}/${env.db.stairway.name}
     username: ${env.db.stairway.user}
 
+  startup:
+    exit-after-initialization: false
+
   status-check:
     enabled: true
     polling-interval-seconds: 60


### PR DESCRIPTION
When we start the WSM server for integration tests, it is done in a subprocess and the output is not available in the github log. If something goes wrong, it is hard to debug. Also, if something is slow, we cannot see where the delay is.

This PR includes two things:
 1. StartupConfiguration that allows requesting immediate exit after the service is up and running
 2. A manually dispatched github workflow that sets that config and simply starts the service.

I put the new workflow into workflow-tester so I could test ahead of commit. You can ignore that file.

