### PR TITLE
AJ-1270: return tags from LZ resource listing

### DIFF
--- a/openapi/src/parts/azure_landing_zone.yaml
+++ b/openapi/src/parts/azure_landing_zone.yaml
@@ -333,6 +333,11 @@ components:
         region:
           description: A region where an Azure resource deployed.
           type: string
+        tags:
+          description: Tags for this Azure resource.
+          type: object
+          additionalProperties:
+            type: string
 
     AzureLandingZoneDefinitionList:
       type: object

--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
@@ -239,6 +239,7 @@ public class LandingZoneApiDispatch {
       return new ApiAzureLandingZoneDeployedResource()
           .resourceId(resource.resourceId())
           .resourceType(resource.resourceType())
+          .tags(resource.tags())
           .region(resource.region());
     }
     if (purpose.getClass().equals(SubnetResourcePurpose.class)) {
@@ -246,6 +247,7 @@ public class LandingZoneApiDispatch {
           .resourceParentId(resource.resourceParentId().orElse(null)) // Only available for subnets
           .resourceName(resource.resourceName().orElse(null)) // Only available for subnets
           .resourceType(resource.resourceType())
+          .tags(resource.tags())
           .region(resource.region());
     }
     throw new LandingZoneUnsupportedPurposeException(

--- a/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatchTest.java
+++ b/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatchTest.java
@@ -363,13 +363,13 @@ public class LandingZoneApiDispatchTest extends BaseAzureUnitTest {
                 .resourceId("Id32")
                 .resourceType("fooType32")
                 .region("fooRegion2")
-                .tags(Map.of("resourceTag1", "resourceValue1", "resourceTag3", "resourceValue4"))
+                .tags(Map.of("resourceTag1", "resourceValue1", "resourceTag3", "resourceValue3"))
                 .build(),
             LandingZoneResource.builder()
                 .resourceId("Id33")
                 .resourceType("fooType33")
                 .region("fooRegion1")
-                .tags(Map.of("resourceTag1", "resourceValue1", "resourceTag3", "resourceValue4"))
+                .tags(Map.of("resourceTag1", "resourceValue1", "resourceTag4", "resourceValue4"))
                 .build());
 
     when(landingZoneService.listResourcesByPurpose(

--- a/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatchTest.java
+++ b/service/src/test/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatchTest.java
@@ -154,23 +154,33 @@ public class LandingZoneApiDispatchTest extends BaseAzureUnitTest {
   void listAzureLandingZoneResources_TagPropagation() {
     setupLandingZoneResources();
     ApiAzureLandingZoneResourcesList response =
-            landingZoneApiDispatch.listAzureLandingZoneResources(BEARER_TOKEN, LANDING_ZONE_ID);
+        landingZoneApiDispatch.listAzureLandingZoneResources(BEARER_TOKEN, LANDING_ZONE_ID);
 
     verify(landingZoneService, times(1))
-            .listResourcesWithPurposes(
-                    eq(BEARER_TOKEN),
-                    eq(LANDING_ZONE_ID));
+        .listResourcesWithPurposes(eq(BEARER_TOKEN), eq(LANDING_ZONE_ID));
     assertNotNull(response);
     assertNotNull(response.getResources());
     assertEquals(2, response.getResources().size());
-    response.getResources().forEach( resGroup -> {
-      assertEquals(3, resGroup.getDeployedResources().size(),
-              "deployed resources size for type " + resGroup.getPurpose());
-      resGroup.getDeployedResources().forEach( res -> {
-        assertNotNull(res.getTags(), "tags null for resource id " + res.getResourceId());
-        assertEquals(2, res.getTags().size(), "tags size for resource id " + res.getResourceId());
-      });
-    });
+    response
+        .getResources()
+        .forEach(
+            resGroup -> {
+              assertEquals(
+                  3,
+                  resGroup.getDeployedResources().size(),
+                  "deployed resources size for type " + resGroup.getPurpose());
+              resGroup
+                  .getDeployedResources()
+                  .forEach(
+                      res -> {
+                        assertNotNull(
+                            res.getTags(), "tags null for resource id " + res.getResourceId());
+                        assertEquals(
+                            2,
+                            res.getTags().size(),
+                            "tags size for resource id " + res.getResourceId());
+                      });
+            });
   }
 
   @Test
@@ -369,9 +379,11 @@ public class LandingZoneApiDispatchTest extends BaseAzureUnitTest {
             BEARER_TOKEN, LANDING_ZONE_ID, ResourcePurpose.SHARED_RESOURCE))
         .thenReturn(listResources1);
     when(landingZoneService.listResourcesWithPurposes(BEARER_TOKEN, LANDING_ZONE_ID))
-        .thenReturn(new LandingZoneResourcesByPurpose(Map.of(
-            SubnetResourcePurpose.WORKSPACE_STORAGE_SUBNET, listSubnets1,
-            ResourcePurpose.SHARED_RESOURCE, listResources1)));
+        .thenReturn(
+            new LandingZoneResourcesByPurpose(
+                Map.of(
+                    SubnetResourcePurpose.WORKSPACE_STORAGE_SUBNET, listSubnets1,
+                    ResourcePurpose.SHARED_RESOURCE, listResources1)));
     landingZoneApiDispatch = new LandingZoneApiDispatch(landingZoneService, featureConfiguration);
   }
 


### PR DESCRIPTION
When listing the resources inside a landing zone, return the tags for those resources.

This will help with inspecting the landing zone to understand its configuration. The current use case is preparing to enable PgBouncer for the LZ Postgres server - we can set a tag on the Postgres resource if PgBouncer is enabled, and then Leo can read the tag (via WSM) and tell WDS and CBAS to connect to PgBouncer on port 6432 instead of Postgres on port 5432.

I am aware this will cause some duplication between tag values and elsewhere in the response, such as the WLZ-PURPOSE and WLZ-ID.

Slack discussion: https://broadinstitute.slack.com/archives/C02LMB1PQ6R/p1692376111128999

This is an additive change to an existing API. Will this cause any problems for services that use the WSM client? Are additive changes acceptable? It looks fine to me and seems to work in my bee, without updating the WSM client version in Rawls.

Tested in my bee. An example resource as returned from the API:
```json
       {
          "resourceId": "/subscriptions/0fa61a72-3a6b-4d51-a7e9-75fbeb7c7ed9/resourceGroups/mrg-terra-dev-previ-20230803171249/providers/Microsoft.DBforPostgreSQL/flexibleServers/lz6f76fb220ce486e4b7c73f8291f33e47bf2eec953e6c3b14bb3c140ebb90d",
          "resourceType": "Microsoft.DBforPostgreSQL/flexibleServers",
          "region": "eastus",
          "tags": {
            "WLZ-PURPOSE": "SHARED_RESOURCE",
            "WLZ-ID": "1b6ad2db-7c71-4b0b-8e63-bc9fac4e66eb",
            "mock-pgbouncer-tag": "enabled"
          }
        },
```



