### PR TITLE
Dataproc Update Fixes

### DIFF
--- a/integration/src/main/java/scripts/testscripts/PrivateControlledDataprocClusterLifeCycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledDataprocClusterLifeCycle.java
@@ -246,7 +246,7 @@ public class PrivateControlledDataprocClusterLifeCycle extends WorkspaceAllocate
 
     // Verify that WSM throws a bad request exception
     assertThat(
-        "Error from GCP is 403 or 404",
+        "WSM throws a bad request exception",
         badClusterUpdateParameter.getCode(),
         equalTo(HttpStatus.SC_NOT_FOUND));
 

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledDataprocClusterLifeCycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledDataprocClusterLifeCycle.java
@@ -248,7 +248,7 @@ public class PrivateControlledDataprocClusterLifeCycle extends WorkspaceAllocate
     assertThat(
         "WSM throws a bad request exception",
         badClusterUpdateParameter.getCode(),
-        equalTo(HttpStatus.SC_NOT_FOUND));
+        equalTo(HttpStatus.SC_BAD_REQUEST));
 
     // Delete the Dataproc cluster through WSM.
     DataprocUtils.deleteControlledDataprocCluster(getWorkspaceId(), resourceId, resourceUserApi);

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledDataprocClusterLifeCycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledDataprocClusterLifeCycle.java
@@ -186,6 +186,7 @@ public class PrivateControlledDataprocClusterLifeCycle extends WorkspaceAllocate
     var newName = "new-cluster-name";
     var newDescription = "new description for the cluster";
     int newNumPrimaryWorkers = 3;
+    int newNumSecondaryWorkers = 3;
     GcpDataprocClusterResource updatedResource =
         resourceUserApi.updateDataprocCluster(
             new UpdateControlledGcpDataprocClusterRequestBody()
@@ -193,7 +194,8 @@ public class PrivateControlledDataprocClusterLifeCycle extends WorkspaceAllocate
                 .name(newName)
                 .updateParameters(
                     new ControlledDataprocClusterUpdateParameters()
-                        .numPrimaryWorkers(newNumPrimaryWorkers)),
+                        .numPrimaryWorkers(newNumPrimaryWorkers)
+                        .numSecondaryWorkers(newNumSecondaryWorkers)),
             getWorkspaceId(),
             resourceId);
 
@@ -201,7 +203,10 @@ public class PrivateControlledDataprocClusterLifeCycle extends WorkspaceAllocate
     assertEquals(newDescription, updatedResource.getMetadata().getDescription());
     // Directly fetch the cluster to verify that non wsm managed fields are updated.
     RetryUtils.getWithRetry(
-        cluster -> newNumPrimaryWorkers == cluster.getConfig().getWorkerConfig().getNumInstances(),
+        cluster ->
+            newNumPrimaryWorkers == cluster.getConfig().getWorkerConfig().getNumInstances()
+                && newNumSecondaryWorkers
+                    == cluster.getConfig().getSecondaryWorkerConfig().getNumInstances(),
         () -> dataproc.projects().regions().clusters().get(projectId, region, clusterId).execute(),
         "Timed out waiting for cluster to update");
 

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledDataprocClusterLifeCycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledDataprocClusterLifeCycle.java
@@ -229,6 +229,27 @@ public class PrivateControlledDataprocClusterLifeCycle extends WorkspaceAllocate
         () -> dataproc.projects().regions().clusters().get(projectId, region, clusterId).execute(),
         "Timed out waiting for cluster to update");
 
+    // Update the cluster with a bad parameter format
+    String badAutoscalingPolicy = "bad-policy";
+    ApiException badClusterUpdateParameter =
+        assertThrows(
+            ApiException.class,
+            () ->
+                resourceUserApi.updateDataprocCluster(
+                    new UpdateControlledGcpDataprocClusterRequestBody()
+                        .updateParameters(
+                            new ControlledDataprocClusterUpdateParameters()
+                                .autoscalingPolicy(badAutoscalingPolicy)),
+                    getWorkspaceId(),
+                    resourceId),
+            "Cluster update with bad parameter format");
+
+    // Verify that WSM throws a bad request exception
+    assertThat(
+        "Error from GCP is 403 or 404",
+        badClusterUpdateParameter.getCode(),
+        equalTo(HttpStatus.SC_NOT_FOUND));
+
     // Delete the Dataproc cluster through WSM.
     DataprocUtils.deleteControlledDataprocCluster(getWorkspaceId(), resourceId, resourceUserApi);
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/RetrieveDataprocClusterResourceAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/RetrieveDataprocClusterResourceAttributesStep.java
@@ -49,9 +49,9 @@ public class RetrieveDataprocClusterResourceAttributesStep implements Step {
       }
       // GracefulDecommissionTimeout is a property on the autoscaling policy, not the cluster.
 
-      // Due to the irreversible nature of lifecycleConfig, we do not track its value. Cannot add
-      // lifecycle to clusters without it. So if we remove a cluster's lifecycleConfig, we cannot
-      // add it back.
+      // Due to the irreversible nature of lifecycleConfig, we do not track its value. Lifecycle
+      // configurations (idleDeleteTtl, autoDeleteTime, autoDeleteTtl) can only be modified or
+      // removed, not added.
 
       workingMap.put(ControlledResourceKeys.PREVIOUS_UPDATE_PARAMETERS, existingUpdateParameters);
     } catch (GoogleJsonResponseException e) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
@@ -93,7 +93,8 @@ public class UpdateDataprocClusterStep implements Step {
       updateMaskPaths.add(NUM_SECONDARY_WORKERS);
       updatedCluster
           .getConfig()
-          .setSecondaryWorkerConfig(new InstanceGroupConfig().setNumInstances(3));
+          .setSecondaryWorkerConfig(
+              new InstanceGroupConfig().setNumInstances(updateParameters.getNumSecondaryWorkers()));
     }
     if (updateParameters.getAutoscalingPolicy() != null) {
       updateMaskPaths.add(AUTOSCALING_POLICY);
@@ -105,11 +106,13 @@ public class UpdateDataprocClusterStep implements Step {
     ApiGcpDataprocClusterLifecycleConfig lifecycleConfig = updateParameters.getLifecycleConfig();
     if (lifecycleConfig != null) {
       updatedCluster.getConfig().setLifecycleConfig(new LifecycleConfig());
-      updateMaskPaths.add(IDLE_DELETE_TTL);
-      updatedCluster
-          .getConfig()
-          .getLifecycleConfig()
-          .setIdleDeleteTtl(updateParameters.getLifecycleConfig().getIdleDeleteTtl());
+      if (lifecycleConfig.getIdleDeleteTtl() != null) {
+        updateMaskPaths.add(IDLE_DELETE_TTL);
+        updatedCluster
+            .getConfig()
+            .getLifecycleConfig()
+            .setIdleDeleteTtl(updateParameters.getLifecycleConfig().getIdleDeleteTtl());
+      }
       // Only one autoDeleteTtl and autoDeleteTime can be set (already validated in controller)
       if (lifecycleConfig.getAutoDeleteTtl() != null) {
         updateMaskPaths.add(AUTO_DELETE_TTL);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
@@ -129,6 +129,13 @@ public class UpdateDataprocClusterStep implements Step {
                 updateParameters.getLifecycleConfig().getAutoDeleteTime().toString());
       }
     }
+
+    // Do not update if there are no fields to update. The cluster update api requires at least one
+    // field to update.
+    if (updateMaskPaths.size() == 0) {
+      return StepResult.getStepResultSuccess();
+    }
+
     try {
       crlService
           .getDataprocCow()


### PR DESCRIPTION
This change includes the following fixes:
- Fix a bad property set on cluster secondary workers.
- Add a check to to skip the update call if there are no parameters to update. This caused a dismal failure in the update undo step when there were no previous parameters to update to, resulting in an empty update call error.
- Add a null check on `idleDeleteTtl`, though it should never be null if its parent `lifecycleConfig` exists.

Note: I intentional rely on the gcp api to handle validation errors. There are a few parameters that cannot be fully validated locally:
- num secondary workers have dynamic constraints depending on the autoscaling policy attached to the cluster
- the autoscaling policy provided may or may not exist in the project.
Ideally these validation errors cause the flight to fail normally and report the error back to the caller.