### PR TITLE
Use admin credentials on AKS

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/KubernetesClientProviderImpl.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/KubernetesClientProviderImpl.java
@@ -46,7 +46,7 @@ public class KubernetesClientProviderImpl implements KubernetesClientProvider {
             .manager()
             .serviceClient()
             .getManagedClusters()
-            .listClusterUserCredentials(mrgName, aksClusterName)
+            .listClusterAdminCredentials(mrgName, aksClusterName)
             .kubeconfigs()
             .stream()
             .findFirst()


### PR DESCRIPTION
Related PRs: 
https://github.com/broadinstitute/workbench-libs/pull/1494
https://github.com/DataBiosphere/terra-landing-zone-service/pull/211

Switch to using admin credentials for kubernetes as the user credentials will now require AAD authentication. 