### PR TITLE
PF-1040: Surface google json exception errors

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/GcpFlightExceptionUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/GcpFlightExceptionUtils.java
@@ -1,0 +1,22 @@
+package bio.terra.workspace.service.resource;
+
+import bio.terra.common.exception.BadRequestException;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import org.springframework.http.HttpStatus;
+
+/** Utility methods for handling GCP exceptions during flights */
+public class GcpFlightExceptionUtils {
+
+  /**
+   * On gcp calls with malformed parameters, throw a {@link BadRequestException} and surface the GCP
+   * error message
+   */
+  public static void handleGcpBadRequestException(GoogleJsonResponseException e)
+      throws BadRequestException {
+    if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()
+        || HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
+      // Don't retry bad requests, which won't change. Instead, fail faster.
+      throw new BadRequestException(e.getDetails().getMessage());
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -150,9 +150,10 @@ public class CreateDataprocClusterStep implements Step {
         if (HttpStatus.CONFLICT.value() == e.getStatusCode()) {
           logger.debug("Dataproc cluster {} already created.", clusterName.formatName());
           return StepResult.getStepResultSuccess();
-        } else if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()) {
+        } else if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()
+            || HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
           // Don't retry bad requests, which won't change. Instead, fail faster.
-          return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
+          throw new BadRequestException(e.getDetails().getMessage());
         }
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
       }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/CreateDataprocClusterStep.java
@@ -26,6 +26,7 @@ import bio.terra.workspace.generated.model.ApiGcpDataprocClusterCreationParamete
 import bio.terra.workspace.generated.model.ApiGcpDataprocClusterInstanceGroupConfig;
 import bio.terra.workspace.generated.model.ApiGcpDataprocClusterLifecycleConfig;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.GcpFlightExceptionUtils;
 import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstants;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.gcsbucket.ControlledGcsBucketResource;
@@ -150,11 +151,9 @@ public class CreateDataprocClusterStep implements Step {
         if (HttpStatus.CONFLICT.value() == e.getStatusCode()) {
           logger.debug("Dataproc cluster {} already created.", clusterName.formatName());
           return StepResult.getStepResultSuccess();
-        } else if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()
-            || HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
-          // Don't retry bad requests, which won't change. Instead, fail faster.
-          throw new BadRequestException(e.getDetails().getMessage());
         }
+        // Throw bad request exception for malformed parameters
+        GcpFlightExceptionUtils.handleGcpBadRequestException(e);
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
       }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
@@ -4,7 +4,6 @@ import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKey
 import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ResourceKeys.UPDATE_PARAMETERS;
 
 import bio.terra.cloudres.google.dataproc.ClusterName;
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -15,6 +14,7 @@ import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.generated.model.ApiControlledDataprocClusterUpdateParameters;
 import bio.terra.workspace.generated.model.ApiGcpDataprocClusterLifecycleConfig;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.GcpFlightExceptionUtils;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.dataproc.model.AutoscalingConfig;
 import com.google.api.services.dataproc.model.Cluster;
@@ -24,7 +24,6 @@ import com.google.api.services.dataproc.model.LifecycleConfig;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.http.HttpStatus;
 
 public class UpdateDataprocClusterStep implements Step {
 
@@ -148,10 +147,8 @@ public class UpdateDataprocClusterStep implements Step {
               updateParameters.getGracefulDecommissionTimeout())
           .execute();
     } catch (GoogleJsonResponseException e) {
-      if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()
-          || HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
-        throw new BadRequestException(e.getDetails().getMessage());
-      }
+      // Throw bad request exception for malformed parameters
+      GcpFlightExceptionUtils.handleGcpBadRequestException(e);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     } catch (IOException e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/UpdateDataprocClusterStep.java
@@ -5,7 +5,6 @@ import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKey
 
 import bio.terra.cloudres.google.dataproc.ClusterName;
 import bio.terra.common.exception.BadRequestException;
-import bio.terra.common.exception.NotFoundException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -149,11 +148,9 @@ public class UpdateDataprocClusterStep implements Step {
               updateParameters.getGracefulDecommissionTimeout())
           .execute();
     } catch (GoogleJsonResponseException e) {
-      if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()) {
-        throw new BadRequestException(
-            String.format("Bad cluster update parameters: %s", e.getMessage()));
-      } else if (HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
-        throw new NotFoundException(String.format("Cluster not found: %s", e.getMessage()));
+      if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()
+          || HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
+        throw new BadRequestException(e.getDetails().getMessage());
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     } catch (IOException e) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
@@ -9,7 +9,6 @@ import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKey
 
 import bio.terra.cloudres.google.api.services.common.OperationCow;
 import bio.terra.cloudres.google.compute.CloudComputeCow;
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -23,6 +22,7 @@ import bio.terra.workspace.common.utils.GcpUtils;
 import bio.terra.workspace.generated.model.ApiGcpGceInstanceCreationParameters;
 import bio.terra.workspace.generated.model.ApiGcpGceInstanceGuestAccelerator;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.GcpFlightExceptionUtils;
 import bio.terra.workspace.service.resource.controlled.cloud.gcp.GcpResourceConstants;
 import bio.terra.workspace.service.resource.controlled.exception.ReservedMetadataKeyException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
@@ -131,11 +131,9 @@ public class CreateGceInstanceStep implements Step {
               zone,
               resource.getInstanceId());
           return StepResult.getStepResultSuccess();
-        } else if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()
-            || HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
-          // Don't retry bad requests, which won't change. Instead, fail faster.
-          throw new BadRequestException(e.getDetails().getMessage());
         }
+        // Throw bad request exception for malformed parameters
+        GcpFlightExceptionUtils.handleGcpBadRequestException(e);
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
       }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/gceinstance/CreateGceInstanceStep.java
@@ -9,6 +9,7 @@ import static bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKey
 
 import bio.terra.cloudres.google.api.services.common.OperationCow;
 import bio.terra.cloudres.google.compute.CloudComputeCow;
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -130,9 +131,10 @@ public class CreateGceInstanceStep implements Step {
               zone,
               resource.getInstanceId());
           return StepResult.getStepResultSuccess();
-        } else if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()) {
-          // Don't retry bad requests, which won't change. Instead fail faster.
-          return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
+        } else if (HttpStatus.BAD_REQUEST.value() == e.getStatusCode()
+            || HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
+          // Don't retry bad requests, which won't change. Instead, fail faster.
+          throw new BadRequestException(e.getDetails().getMessage());
         }
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
       }


### PR DESCRIPTION
Fix the create compute resource flights to throw `BadRequestException` instead of a 500 `InternalServerException` if there are issues with parameters in the flight's gcp request.

`GoogleJsonResponseException` returns 400 if a parameter was incorrectly formatted and 404 if a parameter value was not found, such as a gce machine type or cluster autoscaling policy uri. For both, surface the gcp error message and return a 400.

This also fixes a case where creating vertex ai notebooks with a bad machine type or vm image family will hang for all 10 flight retries before finally failing due to the 404 being retried.

Before:
```
{
	"jobReport": {
		"id": "e73805d7-a09f-47de-a27b-450d97a71857",
		"description": "Create controlled resource CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE; id d08b97d5-217c-4221-b951-30be477a9f6f; name new-instance3",
		"status": "FAILED",
		"statusCode": 500,
		"submitted": "2023-08-25T20:38:19.627501Z",
		"completed": "2023-08-25T20:40:33.281971Z",
		"resultURL": "http://localhost:8080/api/workspaces/v1/63712477-55b9-49f2-b8db-ad127f458c83/resources/controlled/gcp/ai-notebook-instances/e73805d7-a09f-47de-a27b-450d97a71857/create-result"
	},
	"errorReport": {
		"message": "404 Not Found\nPOST https://notebooks.googleapis.com/v1/projects/terra-wsm-t-perky-corn-7923/locations/us-central1-a/instances?instanceId=sdgsdasfgasf\n{\n  \"code\": 404,\n  \"errors\": [\n    {\n      \"domain\": \"global\",\n      \"message\": \"Machine type asfafsa was not found\",\n      \"reason\": \"notFound\"\n    }\n  ],\n  \"message\": \"Machine type asfafsa was not found\",\n  \"status\": \"NOT_FOUND\"\n}",
		"statusCode": 500,
		"causes": []
	}
}
```
After:
```
{
	"jobReport": {
		"id": "479075ac-61bb-49a0-8776-14216380e20b",
		"description": "Create controlled resource CONTROLLED_GCP_AI_NOTEBOOK_INSTANCE; id 31b2aaa2-cd5c-4bda-9627-47799be83ab7; name new-instance3",
		"status": "FAILED",
		"statusCode": 400,
		"submitted": "2023-08-25T20:31:52.920250Z",
		"completed": "2023-08-25T20:32:04.519466Z",
		"resultURL": "http://localhost:8080/api/workspaces/v1/63712477-55b9-49f2-b8db-ad127f458c83/resources/controlled/gcp/ai-notebook-instances/479075ac-61bb-49a0-8776-14216380e20b/create-result"
	},
	"errorReport": {
		"message": "Machine type asfafsa was not found",
		"statusCode": 400,
		"causes": []
	}
}
```