### PR TITLE
[BENCH-822] Switch default notebook instance type to ml.t3.medium

### DIFF
--- a/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
+++ b/openapi/src/parts/controlled_aws_sagemaker_notebook.yaml
@@ -194,7 +194,7 @@ components:
         instanceType:
           description: A valid instance type per https://docs.aws.amazon.com/general/latest/gr/sageMaker.html
           type: string
-          default: "ml.t2.medium"
+          default: "ml.t3.medium"
         region:
           description: A valid SageMaker Notebook region per https://docs.aws.amazon.com/general/latest/gr/sageMaker.html.
           type: string


### PR DESCRIPTION
This is recommended by AWS support to improve notebook startup times

ml.t3.medium is of newer generation, comparison for reference - https://www.cloudzero.com/advisor/t2-vs-t3
the cost difference is 1/3 of one cent per hour ($0.0036).

note: VWB ui already using this in UI / integration tests. This may be the reason we have mostly seen the delay in WSM tests