### PR TITLE
[BENCH-999] Change notebook waiter timeout to 30 min

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/AwsResourceConstants.java
@@ -25,5 +25,5 @@ public class AwsResourceConstants {
    * observed: 45+ minutes waitUntilStopped: Stopping->Stopped typically takes 3-5 minutes
    * waitUntilDeleted: Deleting->[Deleted] typically takes 2-4 minutes
    */
-  public static final Duration SAGEMAKER_WAITER_TIMEOUT = Duration.ofMinutes(60);
+  public static final Duration SAGEMAKER_WAITER_TIMEOUT = Duration.ofMinutes(30);
 }


### PR DESCRIPTION
This helps us better monitor recent changes to the instance type