### PR TITLE
[BENCH-1016] Populate operation state on workspace description

### DIFF
--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -784,7 +784,7 @@ components:
 
     WorkspaceDescription:
       type: object
-      required: [id, userFacingId, highestRole, createdBy, lastUpdatedBy, createdDate, lastUpdatedDate, operationState]
+      required: [id, userFacingId, highestRole, createdBy, lastUpdatedBy, createdDate, lastUpdatedDate]
       properties:
         id:
           description: The ID of the workspace. Immutable.

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -784,7 +784,7 @@ components:
 
     WorkspaceDescription:
       type: object
-      required: [id, userFacingId, highestRole, createdBy, lastUpdatedBy, createdDate, lastUpdatedDate]
+      required: [id, userFacingId, highestRole, createdBy, lastUpdatedBy, createdDate, lastUpdatedDate, operationState]
       properties:
         id:
           description: The ID of the workspace. Immutable.

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/ControllerUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/ControllerUtils.java
@@ -1,6 +1,11 @@
 package bio.terra.workspace.app.controller.shared;
 
+import bio.terra.common.exception.ErrorReportException;
+import bio.terra.workspace.generated.model.ApiErrorReport;
 import bio.terra.workspace.generated.model.ApiJobReport;
+import bio.terra.workspace.generated.model.ApiOperationState;
+import bio.terra.workspace.service.resource.model.WsmResourceState;
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 
@@ -43,5 +48,26 @@ public class ControllerUtils {
     return jobReport.getStatus() == ApiJobReport.StatusEnum.RUNNING
         ? HttpStatus.ACCEPTED
         : HttpStatus.OK;
+  }
+
+  /**
+   * Generate an ApiOperation state from the internal ingredients
+   *
+   * @param flightId flight id
+   * @param state state
+   * @param error nullable exception
+   * @return ApiOperationState object
+   */
+  public static ApiOperationState toApiOperationState(
+      String flightId, WsmResourceState state, @Nullable ErrorReportException error) {
+    var opstate = new ApiOperationState().jobId(flightId).state(state.toApi());
+    if (error != null) {
+      opstate.errorReport(
+          new ApiErrorReport()
+              .message(error.getMessage())
+              .statusCode(error.getStatusCode().value())
+              .causes(error.getCauses()));
+    }
+    return opstate;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/ControllerUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/ControllerUtils.java
@@ -52,21 +52,26 @@ public class ControllerUtils {
 
   /**
    * Generate an ApiOperation state from the internal ingredients
+   * State can be null if we have stripped data from the workspace
+   * description for a discoverer.
    *
    * @param flightId flight id
-   * @param state state
+   * @param state if null, then we return null for the operation state
    * @param error nullable exception
    * @return ApiOperationState object
    */
-  public static ApiOperationState toApiOperationState(
-      String flightId, WsmResourceState state, @Nullable ErrorReportException error) {
-    var opstate = new ApiOperationState().jobId(flightId).state(state.toApi());
-    if (error != null) {
-      opstate.errorReport(
+  public static @Nullable ApiOperationState toApiOperationState(
+      String flightId, @Nullable WsmResourceState state, @Nullable ErrorReportException error) {
+    ApiOperationState opstate = null;
+    if (state != null) {
+      opstate = new ApiOperationState().jobId(flightId).state(state.toApi());
+      if (error != null) {
+        opstate.errorReport(
           new ApiErrorReport()
-              .message(error.getMessage())
-              .statusCode(error.getStatusCode().value())
-              .causes(error.getCauses()));
+            .message(error.getMessage())
+            .statusCode(error.getStatusCode().value())
+            .causes(error.getCauses()));
+      }
     }
     return opstate;
   }

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/ControllerUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/ControllerUtils.java
@@ -51,9 +51,8 @@ public class ControllerUtils {
   }
 
   /**
-   * Generate an ApiOperation state from the internal ingredients
-   * State can be null if we have stripped data from the workspace
-   * description for a discoverer.
+   * Generate an ApiOperation state from the internal ingredients State can be null if we have
+   * stripped data from the workspace description for a discoverer.
    *
    * @param flightId flight id
    * @param state if null, then we return null for the operation state
@@ -67,10 +66,10 @@ public class ControllerUtils {
       opstate = new ApiOperationState().jobId(flightId).state(state.toApi());
       if (error != null) {
         opstate.errorReport(
-          new ApiErrorReport()
-            .message(error.getMessage())
-            .statusCode(error.getStatusCode().value())
-            .causes(error.getCauses()));
+            new ApiErrorReport()
+                .message(error.getMessage())
+                .statusCode(error.getStatusCode().value())
+                .causes(error.getCauses()));
       }
     }
     return opstate;

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -158,6 +158,9 @@ public class WorkspaceApiUtils {
         .policies(
             TpsApiConversionUtils.apiEffectivePolicyListFromTpsPao(
                 workspaceDescriptions.workspacePolicies()))
-        .missingAuthDomains(workspaceDescriptions.missingAuthDomains());
+        .missingAuthDomains(workspaceDescriptions.missingAuthDomains())
+        .operationState(
+            ControllerUtils.toApiOperationState(
+                workspace.flightId(), workspace.state(), workspace.error()));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextCommonFields.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/model/CloudContextCommonFields.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.workspace.model;
 
 import bio.terra.common.exception.ErrorReportException;
-import bio.terra.workspace.generated.model.ApiErrorReport;
+import bio.terra.workspace.app.controller.shared.ControllerUtils;
 import bio.terra.workspace.generated.model.ApiOperationState;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
@@ -13,14 +13,6 @@ public record CloudContextCommonFields(
     ErrorReportException error) {
 
   public ApiOperationState toApi() {
-    var opstate = new ApiOperationState().jobId(flightId).state(state.toApi());
-    if (error != null) {
-      opstate.errorReport(
-          new ApiErrorReport()
-              .message(error().getMessage())
-              .statusCode(error().getStatusCode().value())
-              .causes(error().getCauses()));
-    }
-    return opstate;
+    return ControllerUtils.toApiOperationState(flightId, state, error);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceV2ApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/WorkspaceV2ApiTest.java
@@ -1,11 +1,16 @@
 package bio.terra.workspace.service.workspace;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import bio.terra.workspace.common.BaseConnectedTest;
 import bio.terra.workspace.common.mocks.MockMvcUtils;
+import bio.terra.workspace.common.mocks.MockWorkspaceV1Api;
 import bio.terra.workspace.common.mocks.MockWorkspaceV2Api;
 import bio.terra.workspace.connected.UserAccessUtils;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiCreateWorkspaceV2Result;
+import bio.terra.workspace.generated.model.ApiState;
+import bio.terra.workspace.generated.model.ApiWorkspaceDescription;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
@@ -16,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Tag("connected")
 public class WorkspaceV2ApiTest extends BaseConnectedTest {
   @Autowired MockMvcUtils mockMvcUtils;
+  @Autowired MockWorkspaceV1Api mockWorkspaceV1Api;
   @Autowired MockWorkspaceV2Api mockWorkspaceV2Api;
   @Autowired UserAccessUtils userAccessUtils;
 
@@ -36,6 +42,10 @@ public class WorkspaceV2ApiTest extends BaseConnectedTest {
     ApiCreateWorkspaceV2Result result =
         mockWorkspaceV2Api.createWorkspaceAndWait(defaultUserRequest, cloudPlatform);
     UUID workspaceUuid = result.getWorkspaceId();
+
+    ApiWorkspaceDescription workspaceDescription =
+        mockWorkspaceV1Api.getWorkspace(defaultUserRequest, workspaceUuid);
+    assertEquals(ApiState.READY, workspaceDescription.getOperationState().getState());
 
     mockWorkspaceV2Api.deleteWorkspaceAndWait(defaultUserRequest, workspaceUuid);
   }


### PR DESCRIPTION
The operation state was populated in the internal workspace structure, but not in the API return.
