### PR TITLE
[BENCH-992] Incorrect categorization of flight states

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/JobApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/JobApiUtils.java
@@ -150,6 +150,10 @@ public class JobApiUtils {
   private ApiJobReport.StatusEnum mapFlightStatusToApi(FlightStatus flightStatus) {
     switch (flightStatus) {
       case RUNNING:
+      case QUEUED:
+      case WAITING:
+      case READY:
+      case READY_TO_RESTART:
         return ApiJobReport.StatusEnum.RUNNING;
       case SUCCESS:
         return ApiJobReport.StatusEnum.SUCCEEDED;


### PR DESCRIPTION
A small piece of code that mapped Stairway flight status to async job state had a bug. It was categorizing 
QUEUED, WAITING, READY, and READY_TO_RESTART as FAILED states. Those are actually RUNNING states - the flight is not complete so wouldn't have a complete time.

In this particular case, the flight enters the QUEUED state. In this case, I think the QUEUED state happened because the Stairway thread pool had too many pending flights in its queue. At that point, Stairway pushes flights to its pubsub queue for other pods to deal with. Even though we don't have that properly configured, the state changes still happen.
