### PR TITLE
Add various fixes for dataproc cluster startup

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
@@ -232,7 +232,7 @@ cat << EOF >> "${USER_BASHRC}"
 # Set the correct java version for terra CLI
 # Note: Aliases set in ~/.bashrc are not available in jupyter notebooks.
 #       This workaround allows users to run terra CLI in terminals.
-alias terra='JAVA_HOME="${JAVA_17_HOME}" terra'
+alias terra='JAVA_HOME="${USER_HOME_LOCAL_DIR}" terra'
 
 # Prepend "${USER_HOME_LOCAL_BIN}" (if not already in the path)
 if [[ ":\${PATH}:" != *":${USER_HOME_LOCAL_BIN}:"* ]]; then
@@ -879,7 +879,7 @@ fi
   emit "Configuring Jupyter service..."
 
   # Remove the default GCSContentsManager and set jupyter file tree's root directory to the LOGIN_USER's home directory.
-  sed -i -e '/c.GCSContentsManager/d' -e '/CombinedContentsManager/d' "$JUPYTER_CONFIG"
+  sed -i -e "/c.GCSContentsManager/d" -e "/CombinedContentsManager/d" "${JUPYTER_CONFIG}"
   echo -e "c.FileContentsManager.root_dir = '${USER_HOME_DIR}'\n" | tee -a "${JUPYTER_CONFIG}"
 
   # Restart jupyter to load configurations


### PR DESCRIPTION
This change contains fixes for the following dataproc cluster issues:
- Enable sudo with no password prompt - https://verily.atlassian.net/browse/BENCH-1048
- Startup script not setting env vars such as `OWNER_EMAIL`, `PET_SA_EMAIL`, etc.
- Sets jupyter notebook file tree root to `/home/dataproc` (aligned with vertex ai notebooks, also users can access their staging bucket via `/workspace/staging-bucket-name/notebooks/jupyter/`
- "Read only-dir.." error when creating a new notebook in root dir. (no longer the case since we changed root dir)
- ggplot hail notebooks figures are not correctly rendered in cell output ( plot.ly figures being read from invalid dir path)