### PR TITLE
AJ-1308 do not allow protected data into unprotected gcp workspace

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
@@ -90,7 +90,11 @@ public class PolicyValidator {
       Workspace workspace, TpsPaoGetResult policies, AuthenticatedUserRequest userRequest) {
     var validationErrors = new ArrayList<String>();
     if (TpsUtilities.containsProtectedDataPolicy(policies.getEffectiveAttributes())) {
-      for (var cloudPlatform : workspaceDao.listCloudPlatforms(workspace.workspaceId())) {
+      List<CloudPlatform> cloudPlatforms = workspaceDao.listCloudPlatforms(workspace.workspaceId());
+      if (cloudPlatforms.isEmpty()) {
+        validationErrors.add("Unable to import protected snapshot into unprotected workspace");
+      }
+      for (var cloudPlatform : cloudPlatforms) {
         switch (cloudPlatform) {
           case AZURE -> {
             var landingZone = landingZoneApiDispatch.getLandingZone(userRequest, workspace);

--- a/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
@@ -262,6 +262,28 @@ public class PolicyValidatorTest extends BaseUnitTest {
     assertTrue(results.isEmpty());
   }
 
+  @Test
+  void validateWorkspaceConformsToProtectedDataPolicy_noCloudPlatform() {
+    Workspace workspace =
+            WorkspaceFixtures.defaultWorkspaceBuilder(UUID.randomUUID())
+                    .spendProfileId(SPEND_PROFILE_ID)
+                    .build();
+
+    TpsPaoGetResult protectedDataPolicy =
+            createPao(
+                    new TpsPolicyInput()
+                            .namespace(TpsUtilities.TERRA_NAMESPACE)
+                            .name(TpsUtilities.PROTECTED_DATA_POLICY_NAME));
+
+    when(mockWorkspaceDao.listCloudPlatforms(workspace.workspaceId()))
+            .thenReturn(List.of());
+
+    List<String> results =
+            policyValidator.validateWorkspaceConformsToProtectedDataPolicy(
+                    workspace, protectedDataPolicy, userRequest);
+    assertEquals(1, results.size());
+  }
+
   private static TpsPaoGetResult createPao(TpsPolicyInput... inputs) {
     TpsPolicyInputs tpsPolicyInputs = new TpsPolicyInputs().inputs(Arrays.stream(inputs).toList());
     return new TpsPaoGetResult()

--- a/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
@@ -265,22 +265,21 @@ public class PolicyValidatorTest extends BaseUnitTest {
   @Test
   void validateWorkspaceConformsToProtectedDataPolicy_noCloudPlatform() {
     Workspace workspace =
-            WorkspaceFixtures.defaultWorkspaceBuilder(UUID.randomUUID())
-                    .spendProfileId(SPEND_PROFILE_ID)
-                    .build();
+        WorkspaceFixtures.defaultWorkspaceBuilder(UUID.randomUUID())
+            .spendProfileId(SPEND_PROFILE_ID)
+            .build();
 
     TpsPaoGetResult protectedDataPolicy =
-            createPao(
-                    new TpsPolicyInput()
-                            .namespace(TpsUtilities.TERRA_NAMESPACE)
-                            .name(TpsUtilities.PROTECTED_DATA_POLICY_NAME));
+        createPao(
+            new TpsPolicyInput()
+                .namespace(TpsUtilities.TERRA_NAMESPACE)
+                .name(TpsUtilities.PROTECTED_DATA_POLICY_NAME));
 
-    when(mockWorkspaceDao.listCloudPlatforms(workspace.workspaceId()))
-            .thenReturn(List.of());
+    when(mockWorkspaceDao.listCloudPlatforms(workspace.workspaceId())).thenReturn(List.of());
 
     List<String> results =
-            policyValidator.validateWorkspaceConformsToProtectedDataPolicy(
-                    workspace, protectedDataPolicy, userRequest);
+        policyValidator.validateWorkspaceConformsToProtectedDataPolicy(
+            workspace, protectedDataPolicy, userRequest);
     assertEquals(1, results.size());
   }
 


### PR DESCRIPTION
[AJ-1308](https://broadworkbench.atlassian.net/browse/AJ-1308)

Protected snapshots-by-reference should not be allowed in unprotected workspaces, but currently attempts to import them into unprotected GCP workspaces erroneously succeeds.  This change should detect that a workspace is not associated with a security policy and fail.

[AJ-1308]: https://broadworkbench.atlassian.net/browse/AJ-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ