### PR TITLE
WOR-1242 fix too long pod names

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStep.java
@@ -54,7 +54,7 @@ public class CreateAzureDatabaseStep implements Step {
   }
 
   private String getPodName() {
-    return "create-" + this.resource.getDatabaseName();
+    return "create-" + this.resource.getResourceId();
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateNamespaceRoleStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateNamespaceRoleStep.java
@@ -40,11 +40,11 @@ public class CreateNamespaceRoleStep implements Step {
   }
 
   private String getCreatePodName() {
-    return "create-namespace-role-" + this.resource.getKubernetesServiceAccount();
+    return "create-namespace-role-" + this.resource.getResourceId();
   }
 
   private String getUndoPodName() {
-    return "undo-create-namespace-role-" + this.resource.getKubernetesServiceAccount();
+    return "undo-create-namespace-role-" + this.resource.getResourceId();
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteNamespaceRoleStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteNamespaceRoleStep.java
@@ -26,7 +26,7 @@ public class DeleteNamespaceRoleStep implements Step {
   }
 
   private String getDeletePodName() {
-    return "delete-namespace-role-" + this.resource.getKubernetesServiceAccount();
+    return "delete-namespace-role-" + this.resource.getResourceId();
   }
 
   @Override

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAzureResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAzureResourceFixtures.java
@@ -431,7 +431,7 @@ public class ControlledAzureResourceFixtures {
                 .managedBy(ManagedByType.fromApi(ApiManagedBy.USER))
                 .region(DEFAULT_AZURE_RESOURCE_REGION)
                 .build())
-        .kubernetesServiceAccount(creationParameters.getNamespacePrefix() + "-ksa")
+        .kubernetesServiceAccount(namespace + "-ksa")
         .kubernetesNamespace(namespace)
         .managedIdentity(creationParameters.getManagedIdentity())
         .databases(new HashSet<>(creationParameters.getDatabases()));

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/CreateAzureDatabaseStepTest.java
@@ -72,7 +72,7 @@ public class CreateAzureDatabaseStepTest extends BaseMockitoStrictStubbingTest {
         .createDatabase(
             mockAzureCloudContext,
             workspaceId,
-            "create-" + databaseResource.getDatabaseName(),
+            "create-" + databaseResource.getResourceId(),
             uamiName,
             uamiPrincipalId,
             databaseResource.getDatabaseName());
@@ -86,7 +86,7 @@ public class CreateAzureDatabaseStepTest extends BaseMockitoStrictStubbingTest {
         .createDatabaseWithDbRole(
             mockAzureCloudContext,
             workspaceId,
-            "create-" + databaseResource.getDatabaseName(),
+            "create-" + databaseResource.getResourceId(),
             databaseResource.getDatabaseName());
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateNamespaceRoleStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateNamespaceRoleStepTest.java
@@ -74,7 +74,7 @@ public class CreateNamespaceRoleStepTest extends BaseMockitoStrictStubbingTest {
         .createNamespaceRole(
             mockAzureCloudContext,
             workspaceId,
-            "create-namespace-role-" + resource.getKubernetesServiceAccount(),
+            "create-namespace-role-" + resource.getResourceId(),
             resource.getKubernetesServiceAccount(),
             principalId,
             dbResources.stream()
@@ -113,7 +113,7 @@ public class CreateNamespaceRoleStepTest extends BaseMockitoStrictStubbingTest {
         .deleteNamespaceRole(
             mockAzureCloudContext,
             workspaceId,
-            "undo-create-namespace-role-" + resource.getKubernetesServiceAccount(),
+            "undo-create-namespace-role-" + resource.getResourceId(),
             resource.getKubernetesServiceAccount());
   }
 


### PR DESCRIPTION
I was using more human readable values for pod names that execute db commands but those are too long. This switches to just use the resource id.

https://broadworkbench.atlassian.net/browse/WOR-1242