### PR TITLE
BENCH-1063: Remove spark monitor

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
@@ -733,8 +733,9 @@ if [[ "${SOFTWARE_FRAMEWORK}" == "HAIL" ]]; then
   # Create the Hail install script. The script is based off of Hail's init_notebook.py
   # script that is executed by 'hailctl dataproc start'. This modified script omits
   # the following steps:
-  # - Configuring and enabling hail's spark monitor nbextension
   # - Configuring and starting a custom jupyter systemd service
+  # - Configuring and enabling hail's spark monitor nbextension.
+  # TODO: BENCH-1094: Consider whether we need spark monitor
   cat << EOF >"${HAIL_SCRIPT_PATH}"
 #!${RUN_PYTHON}
 # This modified Hail installation script installs the necessary Hail packages and jupyter extensions,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
@@ -851,8 +851,7 @@ kernel = {
     'language': 'python',
     'env': {
         **env_to_set,
-        'HAIL_SPARK_MONITOR': '1',
-        'SPARK_MONITOR_UI': 'http://localhost:8088/proxy/%APP_ID%',
+# REMOVED SPARK MONITOR ENVS
     }
 }
 
@@ -861,18 +860,10 @@ mkdir_if_not_exists('/opt/conda/default/share/jupyter/kernels/hail/')
 with open('/opt/conda/default/share/jupyter/kernels/hail/kernel.json', 'w') as f:
     json.dump(kernel, f)
 
-print('copying spark monitor')
-spark_monitor_gs = 'gs://hail-common/sparkmonitor-3b2bc8c22921f5c920fc7370f3a160d820db1f51/sparkmonitor-0.0.11-py3-none-any.whl'
-spark_monitor_wheel = '/home/hail/' + spark_monitor_gs.split('/')[-1]
-safe_call('gsutil', 'cp', spark_monitor_gs, spark_monitor_wheel)
-safe_call('${RUN_PIP}', 'install', spark_monitor_wheel)
+# REMOVED SPARK MONITOR INSTALLATION
 
 # setup jupyter-spark extension
-safe_call('${RUN_JUPYTER}', 'serverextension', 'enable', '--user', '--py', 'sparkmonitor')
-safe_call('${RUN_JUPYTER}', 'nbextension', 'install', '--user', '--py', 'sparkmonitor')
-safe_call('${RUN_JUPYTER}', 'nbextension', 'enable', '--user', '--py', 'sparkmonitor')
 safe_call('${RUN_JUPYTER}', 'nbextension', 'enable', '--user', '--py', 'widgetsnbextension')
-safe_call("""${RUN_IPYTHON} profile create && echo "c.InteractiveShellApp.extensions.append('sparkmonitor.kernelextension')" >> $(${RUN_IPYTHON} profile locate default)/ipython_kernel_config.py""", shell=True)
 
 print("hail installed successfully.")
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
@@ -731,8 +731,10 @@ if [[ "${SOFTWARE_FRAMEWORK}" == "HAIL" ]]; then
   emit "Installing Hail..."
 
   # Create the Hail install script. The script is based off of Hail's init_notebook.py
-  # script that is executed by 'hailctl dataproc start'. This modified script excludes
-  # the step of starting a jupyter service.
+  # script that is executed by 'hailctl dataproc start'. This modified script omits
+  # the following steps:
+  # - Configuring and enabling hail's spark monitor nbextension
+  # - Configuring and starting a custom jupyter systemd service
   cat << EOF >"${HAIL_SCRIPT_PATH}"
 #!${RUN_PYTHON}
 # This modified Hail installation script installs the necessary Hail packages and jupyter extensions,


### PR DESCRIPTION
Due to package version incompatibilities with jupyter, [hail's spark monitor](https://github.com/hail-is/sparkmonitor) doesn't work out of the box. This change remove the default hail installation script installs the `sparkmonitor` nbextension.  For now, we expect users rely on the inline text based spark job output logs rendered in cell output. Users can further monitor larger jobs in cloud console.

Removing spark monitor fixes also fixes the spark monitor initialization error with `hl.init()` when using the hail kernel.