### PR TITLE
[BENCH-970] Pass user email to awsCloudContextService.discoverEnvironment

### DIFF
--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -29,7 +29,7 @@ runnerThreads = singleThread ? 1 : runnerThreads
 
 test {
   useJUnitPlatform {
-    includeTags "unit"
+    includeTags "unit-1"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -58,7 +58,7 @@ test {
 
 task unitTest(type: Test) {
   useJUnitPlatform {
-    includeTags "unit"
+    includeTags "unit-1"
   }
   outputs.upToDateWhen { false }
   maxParallelForks = runnerThreads
@@ -68,7 +68,7 @@ task unitTest(type: Test) {
 task connectedPlusTest(type: Test) {
   environment.put('TEST_ENV', System.getenv("TEST_ENV"))
   useJUnitPlatform {
-    includeTags "connectedPlus"
+    includeTags "connectedPlus-1"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -98,7 +98,7 @@ task connectedPlusTest(type: Test) {
 task connectedTest(type: Test) {
   environment.put('TEST_ENV', System.getenv("TEST_ENV"))
   useJUnitPlatform {
-    includeTags "connected"
+    includeTags "connected-1"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -109,7 +109,7 @@ task connectedTest(type: Test) {
 
 task azureUnitTest(type: Test) {
   useJUnitPlatform {
-    includeTags "azure-unit"
+    includeTags "azure-unit-1"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -120,7 +120,7 @@ task azureUnitTest(type: Test) {
 // No retries; devs can manually rerun
 task azureConnectedTest(type: Test) {
   useJUnitPlatform {
-    includeTags "azureConnected"
+    includeTags "azureConnected-1"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -159,7 +159,7 @@ task azureConnectedPlusTest(type: Test) {
 
 task awsUnitTest(type: Test) {
   useJUnitPlatform {
-    includeTags "aws-unit"
+    includeTags "aws-unit-1"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -168,7 +168,7 @@ task awsUnitTest(type: Test) {
 
 task awsConnectedTest(type: Test) {
   useJUnitPlatform {
-    includeTags "aws-connected"
+    includeTags "aws-connected-1"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -177,7 +177,7 @@ task awsConnectedTest(type: Test) {
 
 task awsConnectedPlusTest(type: Test) {
   useJUnitPlatform {
-    includeTags "aws-connected-plus"
+    includeTags "aws-connected-plus-1"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -206,7 +206,7 @@ task awsConnectedPlusTest(type: Test) {
 
 task pactTests(type: Test) {
   useJUnitPlatform {
-    includeTags "pact-test"
+    includeTags "pact-test-1"
   }
   environment.put('pact.rootDir', "$buildDir/pacts")
   environment.put('pact.provider.version', "$project.version")

--- a/service/gradle/testing.gradle
+++ b/service/gradle/testing.gradle
@@ -29,7 +29,7 @@ runnerThreads = singleThread ? 1 : runnerThreads
 
 test {
   useJUnitPlatform {
-    includeTags "unit-1"
+    includeTags "unit"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -58,7 +58,7 @@ test {
 
 task unitTest(type: Test) {
   useJUnitPlatform {
-    includeTags "unit-1"
+    includeTags "unit"
   }
   outputs.upToDateWhen { false }
   maxParallelForks = runnerThreads
@@ -68,7 +68,7 @@ task unitTest(type: Test) {
 task connectedPlusTest(type: Test) {
   environment.put('TEST_ENV', System.getenv("TEST_ENV"))
   useJUnitPlatform {
-    includeTags "connectedPlus-1"
+    includeTags "connectedPlus"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -98,7 +98,7 @@ task connectedPlusTest(type: Test) {
 task connectedTest(type: Test) {
   environment.put('TEST_ENV', System.getenv("TEST_ENV"))
   useJUnitPlatform {
-    includeTags "connected-1"
+    includeTags "connected"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -109,7 +109,7 @@ task connectedTest(type: Test) {
 
 task azureUnitTest(type: Test) {
   useJUnitPlatform {
-    includeTags "azure-unit-1"
+    includeTags "azure-unit"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -120,7 +120,7 @@ task azureUnitTest(type: Test) {
 // No retries; devs can manually rerun
 task azureConnectedTest(type: Test) {
   useJUnitPlatform {
-    includeTags "azureConnected-1"
+    includeTags "azureConnected"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -159,7 +159,7 @@ task azureConnectedPlusTest(type: Test) {
 
 task awsUnitTest(type: Test) {
   useJUnitPlatform {
-    includeTags "aws-unit-1"
+    includeTags "aws-unit"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -168,7 +168,7 @@ task awsUnitTest(type: Test) {
 
 task awsConnectedTest(type: Test) {
   useJUnitPlatform {
-    includeTags "aws-connected-1"
+    includeTags "aws-connected"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -177,7 +177,7 @@ task awsConnectedTest(type: Test) {
 
 task awsConnectedPlusTest(type: Test) {
   useJUnitPlatform {
-    includeTags "aws-connected-plus-1"
+    includeTags "aws-connected-plus"
   }
   outputs.upToDateWhen { false }
   finalizedBy tasks.combinedJaCoCoReport
@@ -206,7 +206,7 @@ task awsConnectedPlusTest(type: Test) {
 
 task pactTests(type: Test) {
   useJUnitPlatform {
-    includeTags "pact-test-1"
+    includeTags "pact-test"
   }
   environment.put('pact.rootDir', "$buildDir/pacts")
   environment.put('pact.provider.version', "$project.version")

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAwsResourceApiController.java
@@ -82,7 +82,6 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
   private final Logger logger = LoggerFactory.getLogger(ControlledAwsResourceApiController.class);
 
   private final WsmResourceService wsmResourceService;
-
   private final AwsCloudContextService awsCloudContextService;
 
   @Autowired
@@ -189,7 +188,8 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
       UUID workspaceUuid,
       ApiAwsCredentialAccessScope accessScope,
       Integer durationSeconds,
-      T awsResource) {
+      T awsResource,
+      String userEmail) {
     AwsResourceValidationUtils.validateAwsCredentialDurationSecond(durationSeconds);
 
     AwsCloudContext cloudContext = awsCloudContextService.getRequiredAwsCloudContext(workspaceUuid);
@@ -201,7 +201,7 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
     Credentials awsCredentials =
         AwsUtils.getAssumeUserRoleCredentials(
             awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment(),
+            awsCloudContextService.discoverEnvironment(userEmail),
             user,
             Duration.ofSeconds(durationSeconds),
             tags);
@@ -270,10 +270,11 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
 
     AwsCloudContext awsCloudContext =
         awsCloudContextService.getRequiredAwsCloudContext(workspaceUuid);
-
+    Environment environment =
+        awsCloudContextService.discoverEnvironment(
+            samService.getUserEmailFromSamAndRethrowOnInterrupt(userRequest));
     LandingZone landingZone =
-        awsCloudContextService
-            .getLandingZone(awsCloudContext, Region.of(region))
+        AwsCloudContextService.getLandingZone(environment, awsCloudContext, Region.of(region))
             .orElseThrow(
                 () -> {
                   throw new ValidationException(
@@ -386,7 +387,12 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
             .validateControlledResourceAndAction(
                 userRequest, workspaceUuid, resourceUuid, getSamAction(accessScope))
             .castByEnum(WsmResourceType.CONTROLLED_AWS_S3_STORAGE_FOLDER);
-    return getAwsResourceCredential(workspaceUuid, accessScope, durationSeconds, resource);
+    return getAwsResourceCredential(
+        workspaceUuid,
+        accessScope,
+        durationSeconds,
+        resource,
+        samService.getUserEmailFromSamAndRethrowOnInterrupt(userRequest));
   }
 
   @Traced
@@ -463,20 +469,14 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
 
     AwsCloudContext awsCloudContext =
         awsCloudContextService.getRequiredAwsCloudContext(workspaceUuid);
-
-    Environment environment = awsCloudContextService.discoverEnvironment();
+    Environment environment =
+        awsCloudContextService.discoverEnvironment(
+            samService.getUserEmailFromSamAndRethrowOnInterrupt(userRequest));
     AwsCloudContextService.getLandingZone(environment, awsCloudContext, Region.of(region))
         .orElseThrow(
             () -> {
               throw new ValidationException(String.format("Unsupported AWS region: %s.", region));
             });
-
-    ControlledAwsSageMakerNotebookResource resource =
-        ControlledAwsSageMakerNotebookResource.builder()
-            .common(commonFields)
-            .instanceName(instanceName)
-            .instanceType(body.getAwsSageMakerNotebook().getInstanceType())
-            .build();
 
     logger.info(
         "createAwsSageMakerNotebook workspace: {}, region: {}, instanceName: {}, instanceType {}, cloudName {}",
@@ -485,6 +485,13 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
         commonFields.getName(),
         instanceType,
         instanceName);
+
+    ControlledAwsSageMakerNotebookResource resource =
+        ControlledAwsSageMakerNotebookResource.builder()
+            .common(commonFields)
+            .instanceName(instanceName)
+            .instanceType(body.getAwsSageMakerNotebook().getInstanceType())
+            .build();
 
     String jobId =
         controlledResourceService.createAwsSageMakerNotebookInstance(
@@ -590,6 +597,11 @@ public class ControlledAwsResourceApiController extends ControlledResourceContro
             .validateControlledResourceAndAction(
                 userRequest, workspaceUuid, resourceUuid, getSamAction(accessScope))
             .castByEnum(WsmResourceType.CONTROLLED_AWS_SAGEMAKER_NOTEBOOK);
-    return getAwsResourceCredential(workspaceUuid, accessScope, durationSeconds, resource);
+    return getAwsResourceCredential(
+        workspaceUuid,
+        accessScope,
+        durationSeconds,
+        resource,
+        samService.getUserEmailFromSamAndRethrowOnInterrupt(userRequest));
   }
 }

--- a/service/src/main/java/bio/terra/workspace/common/utils/FlightUtils.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/FlightUtils.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.common.utils;
 
+import bio.terra.common.iam.SamUser;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
@@ -8,6 +9,8 @@ import bio.terra.stairway.Stairway;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.generated.model.ApiErrorReport;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.workspace.exceptions.MissingRequiredFieldsException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -276,5 +279,18 @@ public final class FlightUtils {
     return (flightState.getFlightStatus() == FlightStatus.ERROR
         || flightState.getFlightStatus() == FlightStatus.FATAL
         || flightState.getFlightStatus() == FlightStatus.SUCCESS);
+  }
+
+  public static SamUser getRequiredSamUser(FlightMap inputParameters, SamService samService) {
+    AuthenticatedUserRequest userRequest =
+        FlightUtils.getRequired(
+            inputParameters,
+            JobMapKeys.AUTH_USER_INFO.getKeyName(),
+            AuthenticatedUserRequest.class);
+    return samService.getSamUser(userRequest);
+  }
+
+  public static String getRequiredUserEmail(FlightMap inputParameters, SamService samService) {
+    return getRequiredSamUser(inputParameters, samService).getEmail();
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ControlledAwsS3StorageFolderResource.java
@@ -119,14 +119,12 @@ public class ControlledAwsS3StorageFolderResource extends ControlledResource {
     RetryRule cloudRetry = RetryRules.cloud();
 
     flight.addStep(
-        new ValidateAwsS3StorageFolderCreateStep(this, flightBeanBag.getAwsCloudContextService()),
+        new ValidateAwsS3StorageFolderCreateStep(
+            this, flightBeanBag.getAwsCloudContextService(), flightBeanBag.getSamService()),
         cloudRetry);
     flight.addStep(
         new CreateAwsS3StorageFolderStep(
-            this,
-            flightBeanBag.getAwsCloudContextService(),
-            userRequest,
-            flightBeanBag.getSamService()),
+            this, flightBeanBag.getAwsCloudContextService(), flightBeanBag.getSamService()),
         cloudRetry);
   }
 
@@ -134,7 +132,8 @@ public class ControlledAwsS3StorageFolderResource extends ControlledResource {
   @Override
   public void addDeleteSteps(DeleteControlledResourcesFlight flight, FlightBeanBag flightBeanBag) {
     flight.addStep(
-        new DeleteAwsS3StorageFolderStep(this, flightBeanBag.getAwsCloudContextService()),
+        new DeleteAwsS3StorageFolderStep(
+            this, flightBeanBag.getAwsCloudContextService(), flightBeanBag.getSamService()),
         RetryRules.cloud());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/CreateAwsS3StorageFolderStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/CreateAwsS3StorageFolderStep.java
@@ -9,7 +9,7 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.AwsUtils;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.common.utils.FlightUtils;
 import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import bio.terra.workspace.service.workspace.model.AwsCloudContext;
@@ -21,24 +21,22 @@ import software.amazon.awssdk.services.sts.model.Tag;
 public class CreateAwsS3StorageFolderStep implements Step {
   private final ControlledAwsS3StorageFolderResource resource;
   private final AwsCloudContextService awsCloudContextService;
-  private final AuthenticatedUserRequest userRequest;
   private final SamService samService;
 
   public CreateAwsS3StorageFolderStep(
       ControlledAwsS3StorageFolderResource resource,
       AwsCloudContextService awsCloudContextService,
-      AuthenticatedUserRequest userRequest,
       SamService samService) {
     this.resource = resource;
     this.awsCloudContextService = awsCloudContextService;
-    this.userRequest = userRequest;
     this.samService = samService;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    SamUser samUser = samService.getSamUser(userRequest);
+    SamUser samUser =
+        FlightUtils.getRequiredSamUser(flightContext.getInputParameters(), samService);
     AwsCloudContext cloudContext =
         awsCloudContextService.getRequiredAwsCloudContext(resource.getWorkspaceId());
 
@@ -49,7 +47,7 @@ public class CreateAwsS3StorageFolderStep implements Step {
     AwsCredentialsProvider credentialsProvider =
         AwsUtils.createWsmCredentialProvider(
             awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment());
+            awsCloudContextService.discoverEnvironment(samUser.getEmail()));
 
     try {
       AwsUtils.createStorageFolder(credentialsProvider, resource, tags);
@@ -65,7 +63,8 @@ public class CreateAwsS3StorageFolderStep implements Step {
     return DeleteAwsS3StorageFolderStep.executeDeleteAwsS3StorageFolder(
         AwsUtils.createWsmCredentialProvider(
             awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment()),
+            awsCloudContextService.discoverEnvironment(
+                FlightUtils.getRequiredUserEmail(flightContext.getInputParameters(), samService))),
         resource);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/DeleteAwsS3StorageFolderStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/DeleteAwsS3StorageFolderStep.java
@@ -10,6 +10,8 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.AwsUtils;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -21,12 +23,15 @@ public class DeleteAwsS3StorageFolderStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(DeleteAwsS3StorageFolderStep.class);
   private final ControlledAwsS3StorageFolderResource resource;
   private final AwsCloudContextService awsCloudContextService;
+  private final SamService samService;
 
   public DeleteAwsS3StorageFolderStep(
       ControlledAwsS3StorageFolderResource resource,
-      AwsCloudContextService awsCloudContextService) {
+      AwsCloudContextService awsCloudContextService,
+      SamService samService) {
     this.resource = resource;
     this.awsCloudContextService = awsCloudContextService;
+    this.samService = samService;
   }
 
   @VisibleForTesting
@@ -49,7 +54,8 @@ public class DeleteAwsS3StorageFolderStep implements Step {
     return executeDeleteAwsS3StorageFolder(
         AwsUtils.createWsmCredentialProvider(
             awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment()),
+            awsCloudContextService.discoverEnvironment(
+                FlightUtils.getRequiredUserEmail(flightContext.getInputParameters(), samService))),
         resource);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ValidateAwsS3StorageFolderCreateStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/ValidateAwsS3StorageFolderCreateStep.java
@@ -9,18 +9,23 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.AwsUtils;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 public class ValidateAwsS3StorageFolderCreateStep implements Step {
   private final ControlledAwsS3StorageFolderResource resource;
   private final AwsCloudContextService awsCloudContextService;
+  private final SamService samService;
 
   public ValidateAwsS3StorageFolderCreateStep(
       ControlledAwsS3StorageFolderResource resource,
-      AwsCloudContextService awsCloudContextService) {
+      AwsCloudContextService awsCloudContextService,
+      SamService samService) {
     this.resource = resource;
     this.awsCloudContextService = awsCloudContextService;
+    this.samService = samService;
   }
 
   @Override
@@ -29,7 +34,8 @@ public class ValidateAwsS3StorageFolderCreateStep implements Step {
     AwsCredentialsProvider credentialsProvider =
         AwsUtils.createWsmCredentialProvider(
             awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment());
+            awsCloudContextService.discoverEnvironment(
+                FlightUtils.getRequiredUserEmail(flightContext.getInputParameters(), samService)));
 
     try {
       if (AwsUtils.checkFolderExists(credentialsProvider, resource)) {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ControlledAwsSageMakerNotebookResource.java
@@ -125,7 +125,6 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
         new CreateAwsSageMakerNotebookStep(
             this,
             flightBeanBag.getAwsCloudContextService(),
-            userRequest,
             flightBeanBag.getSamService(),
             flightBeanBag.getCliConfiguration()),
         cloudRetry);
@@ -142,17 +141,19 @@ public class ControlledAwsSageMakerNotebookResource extends ControlledResource {
     // Notebooks must be stopped before deletion. If requested, stop instance before delete attempt
     if (forceDelete) {
       flight.addStep(
-          new StopAwsSageMakerNotebookStep(this, flightBeanBag.getAwsCloudContextService(), true),
+          new StopAwsSageMakerNotebookStep(
+              this, flightBeanBag.getAwsCloudContextService(), flightBeanBag.getSamService(), true),
           cloudRetry);
     } else {
       flight.addStep(
           new ValidateAwsSageMakerNotebookDeleteStep(
-              this, flightBeanBag.getAwsCloudContextService()),
+              this, flightBeanBag.getAwsCloudContextService(), flightBeanBag.getSamService()),
           cloudRetry);
     }
 
     flight.addStep(
-        new DeleteAwsSageMakerNotebookStep(this, flightBeanBag.getAwsCloudContextService()),
+        new DeleteAwsSageMakerNotebookStep(
+            this, flightBeanBag.getAwsCloudContextService(), flightBeanBag.getSamService()),
         cloudRetry);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/DeleteAwsSageMakerNotebookStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/DeleteAwsSageMakerNotebookStep.java
@@ -11,6 +11,8 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.common.utils.AwsUtils;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -25,12 +27,15 @@ public class DeleteAwsSageMakerNotebookStep implements Step {
 
   private final ControlledAwsSageMakerNotebookResource resource;
   private final AwsCloudContextService awsCloudContextService;
+  private final SamService samService;
 
   public DeleteAwsSageMakerNotebookStep(
       ControlledAwsSageMakerNotebookResource resource,
-      AwsCloudContextService awsCloudContextService) {
+      AwsCloudContextService awsCloudContextService,
+      SamService samService) {
     this.resource = resource;
     this.awsCloudContextService = awsCloudContextService;
+    this.samService = samService;
   }
 
   @VisibleForTesting
@@ -57,7 +62,8 @@ public class DeleteAwsSageMakerNotebookStep implements Step {
     return executeDeleteAwsSageMakerNotebook(
         AwsUtils.createWsmCredentialProvider(
             awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment()),
+            awsCloudContextService.discoverEnvironment(
+                FlightUtils.getRequiredUserEmail(flightContext.getInputParameters(), samService))),
         resource);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/StopAwsSageMakerNotebookStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/StopAwsSageMakerNotebookStep.java
@@ -10,6 +10,8 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.AwsUtils;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -18,19 +20,21 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sagemaker.model.NotebookInstanceStatus;
 
 public class StopAwsSageMakerNotebookStep implements Step {
-
   private static final Logger logger = LoggerFactory.getLogger(StopAwsSageMakerNotebookStep.class);
 
   private final ControlledAwsSageMakerNotebookResource resource;
   private final AwsCloudContextService awsCloudContextService;
+  private final SamService samService;
   private final boolean resourceDeletion;
 
   public StopAwsSageMakerNotebookStep(
       ControlledAwsSageMakerNotebookResource resource,
       AwsCloudContextService awsCloudContextService,
+      SamService samService,
       boolean resourceDeletion) {
     this.resource = resource;
     this.awsCloudContextService = awsCloudContextService;
+    this.samService = samService;
     this.resourceDeletion = resourceDeletion;
   }
 
@@ -76,7 +80,9 @@ public class StopAwsSageMakerNotebookStep implements Step {
       return executeStopAwsSageMakerNotebook(
           AwsUtils.createWsmCredentialProvider(
               awsCloudContextService.getRequiredAuthentication(),
-              awsCloudContextService.discoverEnvironment()),
+              awsCloudContextService.discoverEnvironment(
+                  FlightUtils.getRequiredUserEmail(
+                      flightContext.getInputParameters(), samService))),
           resource);
     } catch (NotFoundException e) {
       if (!resourceDeletion) {
@@ -93,7 +99,8 @@ public class StopAwsSageMakerNotebookStep implements Step {
     AwsCredentialsProvider credentialsProvider =
         AwsUtils.createWsmCredentialProvider(
             awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment());
+            awsCloudContextService.discoverEnvironment(
+                FlightUtils.getRequiredUserEmail(flightContext.getInputParameters(), samService)));
 
     try {
       NotebookInstanceStatus notebookStatus =

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ValidateAwsSageMakerNotebookDeleteStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/ValidateAwsSageMakerNotebookDeleteStep.java
@@ -9,6 +9,8 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.utils.AwsUtils;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,18 +18,20 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sagemaker.model.NotebookInstanceStatus;
 
 public class ValidateAwsSageMakerNotebookDeleteStep implements Step {
-
   private static final Logger logger =
       LoggerFactory.getLogger(ValidateAwsSageMakerNotebookDeleteStep.class);
 
   private final ControlledAwsSageMakerNotebookResource resource;
   private final AwsCloudContextService awsCloudContextService;
+  private final SamService samService;
 
   public ValidateAwsSageMakerNotebookDeleteStep(
       ControlledAwsSageMakerNotebookResource resource,
-      AwsCloudContextService awsCloudContextService) {
+      AwsCloudContextService awsCloudContextService,
+      SamService samService) {
     this.resource = resource;
     this.awsCloudContextService = awsCloudContextService;
+    this.samService = samService;
   }
 
   @Override
@@ -36,7 +40,8 @@ public class ValidateAwsSageMakerNotebookDeleteStep implements Step {
     AwsCredentialsProvider credentialsProvider =
         AwsUtils.createWsmCredentialProvider(
             awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment());
+            awsCloudContextService.discoverEnvironment(
+                FlightUtils.getRequiredUserEmail(flightContext.getInputParameters(), samService)));
 
     try {
       NotebookInstanceStatus notebookStatus =

--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -749,7 +749,6 @@ public class WorkspaceService {
       String jobId,
       AuthenticatedUserRequest userRequest,
       @Nullable String resultPath) {
-
     jobService
         .newJob()
         .description(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/cloud/aws/MakeAwsCloudContextStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/cloud/aws/MakeAwsCloudContextStep.java
@@ -3,6 +3,8 @@ package bio.terra.workspace.service.workspace.flight.cloud.aws;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
@@ -10,11 +12,15 @@ import bio.terra.workspace.service.workspace.model.AwsCloudContext;
 
 public class MakeAwsCloudContextStep implements Step {
   private final AwsCloudContextService awsCloudContextService;
+  private final SamService samService;
   private final SpendProfileId spendProfileId;
 
   public MakeAwsCloudContextStep(
-      AwsCloudContextService awsCloudContextService, SpendProfileId spendProfileId) {
+      AwsCloudContextService awsCloudContextService,
+      SamService samService,
+      SpendProfileId spendProfileId) {
     this.awsCloudContextService = awsCloudContextService;
+    this.samService = samService;
     this.spendProfileId = spendProfileId;
   }
 
@@ -24,7 +30,10 @@ public class MakeAwsCloudContextStep implements Step {
     // information and store the created cloud context in the map. The shared finish
     // step will perform the database update.
     AwsCloudContext awsCloudContext =
-        awsCloudContextService.createCloudContext(flightContext.getFlightId(), spendProfileId);
+        awsCloudContextService.createCloudContext(
+            flightContext.getFlightId(),
+            spendProfileId,
+            FlightUtils.getRequiredUserEmail(flightContext.getInputParameters(), samService));
     flightContext.getWorkingMap().put(WorkspaceFlightMapKeys.CLOUD_CONTEXT, awsCloudContext);
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/test/java/bio/terra/workspace/common/BaseAwsConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAwsConnectedTest.java
@@ -1,13 +1,16 @@
 package bio.terra.workspace.common;
 
 import static bio.terra.workspace.common.utils.AwsTestUtils.SAM_USER_AWS_DISABLED;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.app.configuration.external.AwsConfiguration;
+import bio.terra.workspace.common.exception.FeatureNotSupportedException;
 import bio.terra.workspace.common.utils.AwsConnectedTestUtils;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.service.features.FeatureService;
@@ -32,14 +35,16 @@ public class BaseAwsConnectedTest extends BaseTest {
 
   @BeforeAll
   public void init() throws Exception {
-    when(mockFeatureService.isFeatureEnabled(eq(FeatureService.AWS_ENABLED), anyString()))
+    when(mockFeatureService.isFeatureEnabled(
+            eq(FeatureService.AWS_ENABLED), not(eq(SAM_USER_AWS_DISABLED.getEmail()))))
         .thenReturn(true);
     when(mockFeatureService.isFeatureEnabled(
-            FeatureService.AWS_ENABLED, SAM_USER_AWS_DISABLED.getEmail()))
+            eq(FeatureService.AWS_ENABLED), eq(SAM_USER_AWS_DISABLED.getEmail())))
         .thenReturn(false);
-    when(mockFeatureService.isFeatureEnabled(FeatureService.AWS_ENABLED)).thenReturn(false);
 
-    doCallRealMethod().when(mockFeatureService).featureEnabledCheck(any(), any());
-    doCallRealMethod().when(mockFeatureService).featureEnabledCheck(any());
+    doCallRealMethod().when(mockFeatureService).featureEnabledCheck(anyString(), notNull());
+    doThrow(new FeatureNotSupportedException("exception"))
+        .when(mockFeatureService)
+        .featureEnabledCheck(anyString());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/BaseAwsConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAwsConnectedTest.java
@@ -1,16 +1,14 @@
 package bio.terra.workspace.common;
 
-import static bio.terra.workspace.common.utils.AwsTestUtils.SAM_USER_AWS_DISABLED;
-import static org.mockito.AdditionalMatchers.not;
-import static org.mockito.ArgumentMatchers.anyString;
+import static bio.terra.workspace.service.features.FeatureService.AWS_ENABLED;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.app.configuration.external.AwsConfiguration;
-import bio.terra.workspace.common.exception.FeatureNotSupportedException;
 import bio.terra.workspace.common.utils.AwsConnectedTestUtils;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.service.features.FeatureService;
@@ -35,16 +33,11 @@ public class BaseAwsConnectedTest extends BaseTest {
 
   @BeforeAll
   public void init() throws Exception {
-    when(mockFeatureService.isFeatureEnabled(
-            eq(FeatureService.AWS_ENABLED), not(eq(SAM_USER_AWS_DISABLED.getEmail()))))
-        .thenReturn(true);
-    when(mockFeatureService.isFeatureEnabled(
-            eq(FeatureService.AWS_ENABLED), eq(SAM_USER_AWS_DISABLED.getEmail())))
-        .thenReturn(false);
+    when(mockFeatureService.isFeatureEnabled(eq(AWS_ENABLED), isNotNull())).thenReturn(true);
+    when(mockFeatureService.isFeatureEnabled(eq(AWS_ENABLED), isNull())).thenReturn(false);
+    when(mockFeatureService.isFeatureEnabled(AWS_ENABLED)).thenReturn(false);
 
-    doCallRealMethod().when(mockFeatureService).featureEnabledCheck(anyString(), notNull());
-    doThrow(new FeatureNotSupportedException("exception"))
-        .when(mockFeatureService)
-        .featureEnabledCheck(anyString());
+    doCallRealMethod().when(mockFeatureService).featureEnabledCheck(eq(AWS_ENABLED), any());
+    doCallRealMethod().when(mockFeatureService).featureEnabledCheck(AWS_ENABLED);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/BaseAwsConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAwsConnectedTest.java
@@ -1,5 +1,12 @@
 package bio.terra.workspace.common;
 
+import static bio.terra.workspace.common.utils.AwsTestUtils.SAM_USER_AWS_DISABLED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.when;
+
 import bio.terra.workspace.app.configuration.external.AwsConfiguration;
 import bio.terra.workspace.common.utils.AwsConnectedTestUtils;
 import bio.terra.workspace.generated.model.ApiCloudPlatform;
@@ -8,7 +15,6 @@ import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -26,6 +32,14 @@ public class BaseAwsConnectedTest extends BaseTest {
 
   @BeforeAll
   public void init() throws Exception {
-    Mockito.when(mockFeatureService.isFeatureEnabled(FeatureService.AWS_ENABLED)).thenReturn(true);
+    when(mockFeatureService.isFeatureEnabled(eq(FeatureService.AWS_ENABLED), anyString()))
+        .thenReturn(true);
+    when(mockFeatureService.isFeatureEnabled(
+            FeatureService.AWS_ENABLED, SAM_USER_AWS_DISABLED.getEmail()))
+        .thenReturn(false);
+    when(mockFeatureService.isFeatureEnabled(FeatureService.AWS_ENABLED)).thenReturn(false);
+
+    doCallRealMethod().when(mockFeatureService).featureEnabledCheck(any(), any());
+    doCallRealMethod().when(mockFeatureService).featureEnabledCheck(any());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/BaseAwsUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAwsUnitTest.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.common;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.SAM_USER;
-import static bio.terra.workspace.common.utils.AwsTestUtils.SAM_USER_AWS_DISABLED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -26,13 +25,7 @@ public class BaseAwsUnitTest extends BaseUnitTestMocks {
   public void init() throws Exception {
     when(mockFeatureService().isFeatureEnabled(eq(FeatureService.AWS_ENABLED), anyString()))
         .thenReturn(true);
-    when(mockFeatureService()
-            .isFeatureEnabled(FeatureService.AWS_ENABLED, SAM_USER_AWS_DISABLED.getEmail()))
-        .thenReturn(false);
-    when(mockFeatureService().isFeatureEnabled(FeatureService.AWS_ENABLED)).thenReturn(false);
-
     doCallRealMethod().when(mockFeatureService()).featureEnabledCheck(any(), any());
-    doCallRealMethod().when(mockFeatureService()).featureEnabledCheck(any());
 
     when(mockSamService().getSamUser((AuthenticatedUserRequest) any())).thenReturn(SAM_USER);
   }

--- a/service/src/test/java/bio/terra/workspace/common/BaseAwsUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAwsUnitTest.java
@@ -1,13 +1,14 @@
 package bio.terra.workspace.common;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.SAM_USER;
+import static bio.terra.workspace.service.features.FeatureService.AWS_ENABLED;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
 
-import bio.terra.workspace.service.features.FeatureService;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -23,9 +24,12 @@ public class BaseAwsUnitTest extends BaseUnitTestMocks {
 
   @BeforeAll
   public void init() throws Exception {
-    when(mockFeatureService().isFeatureEnabled(eq(FeatureService.AWS_ENABLED), anyString()))
-        .thenReturn(true);
-    doCallRealMethod().when(mockFeatureService()).featureEnabledCheck(any(), any());
+    when(mockFeatureService().isFeatureEnabled(eq(AWS_ENABLED), isNotNull())).thenReturn(true);
+    when(mockFeatureService().isFeatureEnabled(eq(AWS_ENABLED), isNull())).thenReturn(false);
+    when(mockFeatureService().isFeatureEnabled(AWS_ENABLED)).thenReturn(false);
+
+    doCallRealMethod().when(mockFeatureService()).featureEnabledCheck(eq(AWS_ENABLED), any());
+    doCallRealMethod().when(mockFeatureService()).featureEnabledCheck(AWS_ENABLED);
 
     when(mockSamService().getSamUser((AuthenticatedUserRequest) any())).thenReturn(SAM_USER);
   }

--- a/service/src/test/java/bio/terra/workspace/common/BaseAwsUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAwsUnitTest.java
@@ -1,8 +1,15 @@
 package bio.terra.workspace.common;
 
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.SAM_USER;
+import static bio.terra.workspace.common.utils.AwsTestUtils.SAM_USER_AWS_DISABLED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
 
 import bio.terra.workspace.service.features.FeatureService;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
@@ -17,6 +24,16 @@ public class BaseAwsUnitTest extends BaseUnitTestMocks {
 
   @BeforeAll
   public void init() throws Exception {
-    when(mockFeatureService().isFeatureEnabled(FeatureService.AWS_ENABLED)).thenReturn(true);
+    when(mockFeatureService().isFeatureEnabled(eq(FeatureService.AWS_ENABLED), anyString()))
+        .thenReturn(true);
+    when(mockFeatureService()
+            .isFeatureEnabled(FeatureService.AWS_ENABLED, SAM_USER_AWS_DISABLED.getEmail()))
+        .thenReturn(false);
+    when(mockFeatureService().isFeatureEnabled(FeatureService.AWS_ENABLED)).thenReturn(false);
+
+    doCallRealMethod().when(mockFeatureService()).featureEnabledCheck(any(), any());
+    doCallRealMethod().when(mockFeatureService()).featureEnabledCheck(any());
+
+    when(mockSamService().getSamUser((AuthenticatedUserRequest) any())).thenReturn(SAM_USER);
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsTestUtils.java
@@ -8,8 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import bio.terra.aws.resource.discovery.Environment;
 import bio.terra.aws.resource.discovery.LandingZone;
 import bio.terra.aws.resource.discovery.Metadata;
-import bio.terra.common.iam.BearerToken;
-import bio.terra.common.iam.SamUser;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.model.AwsCloudContext;
@@ -44,8 +42,6 @@ public class AwsTestUtils {
   public static final String AWS_LANDING_ZONE_KMS_KEY_ARN = "arn:aws:iam::50000000005:role/KmsKey";
   public static final String AWS_LANDING_ZONE_NOTEBOOK_LIFECYCLE_CONFIG_ARN =
       "arn:aws:iam::60000000006:role/NotebookLifecycleConfig";
-  public static final SamUser SAM_USER_AWS_DISABLED =
-      new SamUser("noAws@email.com", "noAwsSubjectId", new BearerToken("noAwsToken"));
 
   public static final Metadata AWS_METADATA =
       Metadata.builder()

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsTestUtils.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import bio.terra.aws.resource.discovery.Environment;
 import bio.terra.aws.resource.discovery.LandingZone;
 import bio.terra.aws.resource.discovery.Metadata;
+import bio.terra.common.iam.BearerToken;
+import bio.terra.common.iam.SamUser;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.model.AwsCloudContext;
@@ -42,6 +44,8 @@ public class AwsTestUtils {
   public static final String AWS_LANDING_ZONE_KMS_KEY_ARN = "arn:aws:iam::50000000005:role/KmsKey";
   public static final String AWS_LANDING_ZONE_NOTEBOOK_LIFECYCLE_CONFIG_ARN =
       "arn:aws:iam::60000000006:role/NotebookLifecycleConfig";
+  public static final SamUser SAM_USER_AWS_DISABLED =
+      new SamUser("noAws@email.com", "noAwsSubjectId", new BearerToken("noAwsToken"));
 
   public static final Metadata AWS_METADATA =
       Metadata.builder()

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
@@ -5,7 +5,6 @@ import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.
 import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.AWS_SERVICE_EXCEPTION_2;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_ID;
 import static bio.terra.workspace.common.utils.AwsTestUtils.AWS_REGION;
-import static bio.terra.workspace.common.utils.AwsTestUtils.SAM_USER_AWS_DISABLED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -23,6 +22,8 @@ import bio.terra.common.exception.ApiException;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.iam.BearerToken;
+import bio.terra.common.iam.SamUser;
 import bio.terra.workspace.common.BaseAwsUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
@@ -114,9 +115,12 @@ public class AwsUtilsTest extends BaseAwsUnitTest {
     assertContainsTagByKey(tags, AwsUtils.TAG_KEY_USER_ID);
 
     // should replace existing tag, not add duplicate
-    AwsUtils.appendUserTags(tags, SAM_USER_AWS_DISABLED);
+    String newSubjectId = "appendTagsTest-subjectId";
+    AwsUtils.appendUserTags(
+        tags,
+        new SamUser("appendTagsTest@email.com", newSubjectId, new BearerToken("appendTagsTest")));
     assertEquals(/* prevSize+0 */ 1, tags.size());
-    assertEquals(SAM_USER_AWS_DISABLED.getSubjectId(), tags.iterator().next().value());
+    assertEquals(newSubjectId, tags.iterator().next().value());
 
     AwsUtils.appendRoleTags(tags, ApiAwsCredentialAccessScope.WRITE_READ);
     assertEquals(/* prevSize+1 */ 2, tags.size());

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsUtilsTest.java
@@ -5,6 +5,7 @@ import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.
 import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.AWS_SERVICE_EXCEPTION_2;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_ID;
 import static bio.terra.workspace.common.utils.AwsTestUtils.AWS_REGION;
+import static bio.terra.workspace.common.utils.AwsTestUtils.SAM_USER_AWS_DISABLED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -22,8 +23,6 @@ import bio.terra.common.exception.ApiException;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.UnauthorizedException;
-import bio.terra.common.iam.BearerToken;
-import bio.terra.common.iam.SamUser;
 import bio.terra.workspace.common.BaseAwsUnitTest;
 import bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
@@ -115,14 +114,9 @@ public class AwsUtilsTest extends BaseAwsUnitTest {
     assertContainsTagByKey(tags, AwsUtils.TAG_KEY_USER_ID);
 
     // should replace existing tag, not add duplicate
-    AwsUtils.appendUserTags(
-        tags,
-        new SamUser(
-            "appendTagsTest@email.com",
-            "appendTagsTest-subjectId",
-            new BearerToken("appendTagsTest")));
+    AwsUtils.appendUserTags(tags, SAM_USER_AWS_DISABLED);
     assertEquals(/* prevSize+0 */ 1, tags.size());
-    assertEquals("appendTagsTest-subjectId", tags.iterator().next().value());
+    assertEquals(SAM_USER_AWS_DISABLED.getSubjectId(), tags.iterator().next().value());
 
     AwsUtils.appendRoleTags(tags, ApiAwsCredentialAccessScope.WRITE_READ);
     assertEquals(/* prevSize+1 */ 2, tags.size());

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/AwsS3StorageFolderFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/s3StorageFolder/AwsS3StorageFolderFlightTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import bio.terra.aws.resource.discovery.Environment;
 import bio.terra.aws.resource.discovery.LandingZone;
 import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.stairway.FlightDebugInfo;
@@ -63,16 +64,16 @@ public class AwsS3StorageFolderFlightTest extends BaseAwsConnectedTest {
     userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();
     workspaceUuid =
         mockWorkspaceV2Api.createWorkspaceAndWait(userRequest, apiCloudPlatform).getWorkspaceId();
+    Environment environment = awsCloudContextService.discoverEnvironment(userRequest.getEmail());
     landingZone =
-        awsCloudContextService
-            .getLandingZone(
+        AwsCloudContextService.getLandingZone(
+                environment,
                 awsCloudContextService.getRequiredAwsCloudContext(workspaceUuid),
                 Region.of(AWS_REGION))
             .orElseThrow();
     awsCredentialsProvider =
         AwsUtils.createWsmCredentialProvider(
-            awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment());
+            awsCloudContextService.getRequiredAuthentication(), environment);
   }
 
   @AfterAll

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/BaseAwsSageMakerNotebookFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/BaseAwsSageMakerNotebookFlightTest.java
@@ -46,11 +46,11 @@ public abstract class BaseAwsSageMakerNotebookFlightTest extends BaseAwsConnecte
     userRequest = userAccessUtils.defaultUser().getAuthenticatedRequest();
     workspaceUuid =
         mockWorkspaceV2Api.createWorkspaceAndWait(userRequest, apiCloudPlatform).getWorkspaceId();
-    environment = awsCloudContextService.discoverEnvironment();
+    environment = awsCloudContextService.discoverEnvironment(userRequest.getEmail());
     awsCredentialsProvider =
         AwsUtils.createWsmCredentialProvider(
             awsCloudContextService.getRequiredAuthentication(),
-            awsCloudContextService.discoverEnvironment());
+            awsCloudContextService.discoverEnvironment(userRequest.getEmail()));
     cliConfiguration.setServerName("verily-devel");
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/BaseAwsSageMakerNotebookStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/BaseAwsSageMakerNotebookStepTest.java
@@ -2,11 +2,13 @@ package bio.terra.workspace.service.resource.controlled.cloud.aws.sageMakerNoteb
 
 import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.AWS_CREDENTIALS_PROVIDER;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_ID;
+import static bio.terra.workspace.common.mocks.MockMvcUtils.USER_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.app.configuration.external.CliConfiguration;
@@ -16,6 +18,7 @@ import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.utils.AwsTestUtils;
 import bio.terra.workspace.common.utils.AwsUtils;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.workspace.AwsCloudContextService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -38,11 +41,15 @@ public abstract class BaseAwsSageMakerNotebookStepTest extends BaseAwsUnitTest {
 
   protected final ControlledAwsSageMakerNotebookResource notebookResource =
       ControlledAwsResourceFixtures.makeDefaultAwsSagemakerNotebookResource(WORKSPACE_ID);
+  protected final FlightMap flightMap = new FlightMap();
 
   @BeforeAll
   public void init() throws Exception {
     super.init();
     mockAwsUtils = mockStatic(AwsUtils.class, Mockito.CALLS_REAL_METHODS);
+
+    flightMap.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), USER_REQUEST);
+    flightMap.makeImmutable();
   }
 
   @AfterAll
@@ -52,6 +59,7 @@ public abstract class BaseAwsSageMakerNotebookStepTest extends BaseAwsUnitTest {
 
   @BeforeEach
   public void setup() {
+    when(mockFlightContext.getInputParameters()).thenReturn(flightMap);
     when(mockFlightContext.getResult())
         .thenReturn(new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL));
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/StopAwsSageMakerNotebookStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/aws/sageMakerNotebook/StopAwsSageMakerNotebookStepTest.java
@@ -1,6 +1,9 @@
 package bio.terra.workspace.service.resource.controlled.cloud.aws.sageMakerNotebook;
 
 import static bio.terra.workspace.common.fixtures.ControlledAwsResourceFixtures.AWS_CREDENTIALS_PROVIDER;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.API_EXCEPTION;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.NOT_FOUND_EXCEPTION;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.UNAUTHORIZED_EXCEPTION;
 import static bio.terra.workspace.common.utils.TestUtils.assertStepResultFatal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -11,7 +14,6 @@ import bio.terra.common.exception.ApiException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.stairway.StepResult;
-import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.utils.AwsUtils;
 import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
@@ -29,13 +31,13 @@ public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookSt
         .thenAnswer(invocation -> null) /* success */
         .thenAnswer(invocation -> null) /* success */
         .thenAnswer(invocation -> null) /* success */
-        .thenThrow(WorkspaceFixtures.NOT_FOUND_EXCEPTION)
-        .thenThrow(WorkspaceFixtures.API_EXCEPTION);
+        .thenThrow(NOT_FOUND_EXCEPTION)
+        .thenThrow(API_EXCEPTION);
     mockAwsUtils
         .when(() -> AwsUtils.waitForSageMakerNotebookStatus(any(), any(), any()))
         .thenAnswer(invocation -> null) /* success */
-        .thenThrow(WorkspaceFixtures.NOT_FOUND_EXCEPTION)
-        .thenThrow(WorkspaceFixtures.UNAUTHORIZED_EXCEPTION);
+        .thenThrow(NOT_FOUND_EXCEPTION)
+        .thenThrow(UNAUTHORIZED_EXCEPTION);
 
     // stop success, wait success
     assertThat(
@@ -78,8 +80,8 @@ public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookSt
     mockAwsUtils
         .when(() -> AwsUtils.waitForSageMakerNotebookStatus(any(), any(), any()))
         .thenAnswer(invocation -> null) /* success */
-        .thenThrow(WorkspaceFixtures.NOT_FOUND_EXCEPTION)
-        .thenThrow(WorkspaceFixtures.UNAUTHORIZED_EXCEPTION);
+        .thenThrow(NOT_FOUND_EXCEPTION)
+        .thenThrow(UNAUTHORIZED_EXCEPTION);
 
     // wait success
     assertThat(
@@ -152,8 +154,8 @@ public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookSt
   void executeStopAwsSageMakerNotebook_GetStatusError_Test() {
     mockAwsUtils
         .when(() -> AwsUtils.getSageMakerNotebookStatus(any(), any()))
-        .thenThrow(WorkspaceFixtures.NOT_FOUND_EXCEPTION)
-        .thenThrow(WorkspaceFixtures.UNAUTHORIZED_EXCEPTION);
+        .thenThrow(NOT_FOUND_EXCEPTION)
+        .thenThrow(UNAUTHORIZED_EXCEPTION);
 
     // error (not found)
     assertThrows(
@@ -173,7 +175,8 @@ public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookSt
   void stopAwsSageMakerNotebook_NotResourceDeletion_doTest() throws InterruptedException {
     // not part of resource deletion
     StopAwsSageMakerNotebookStep stopNotebookStep =
-        new StopAwsSageMakerNotebookStep(notebookResource, mockAwsCloudContextService, false);
+        new StopAwsSageMakerNotebookStep(
+            notebookResource, mockAwsCloudContextService, mockSamService(), false);
 
     mockAwsUtils
         .when(() -> AwsUtils.getSageMakerNotebookStatus(any(), any()))
@@ -196,7 +199,8 @@ public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookSt
   void stopAwsSageMakerNotebook_ResourceDeletion_doTest() throws InterruptedException {
     // part of resource deletion
     StopAwsSageMakerNotebookStep stopNotebookStep =
-        new StopAwsSageMakerNotebookStep(notebookResource, mockAwsCloudContextService, true);
+        new StopAwsSageMakerNotebookStep(
+            notebookResource, mockAwsCloudContextService, mockSamService(), true);
 
     mockAwsUtils
         .when(() -> AwsUtils.getSageMakerNotebookStatus(any(), any()))
@@ -217,11 +221,11 @@ public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookSt
           .when(() -> AwsUtils.startSageMakerNotebook(any(), any()))
           .thenAnswer(invocation -> null) /* success */
           .thenAnswer(invocation -> null) /* success */
-          .thenThrow(WorkspaceFixtures.API_EXCEPTION);
+          .thenThrow(API_EXCEPTION);
       mockAwsUtils
           .when(() -> AwsUtils.waitForSageMakerNotebookStatus(any(), any(), any()))
           .thenAnswer(invocation -> null) /* success */
-          .thenThrow(WorkspaceFixtures.UNAUTHORIZED_EXCEPTION);
+          .thenThrow(UNAUTHORIZED_EXCEPTION);
 
       // start success, wait success
       assertThat(
@@ -255,7 +259,7 @@ public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookSt
       mockAwsUtils
           .when(() -> AwsUtils.waitForSageMakerNotebookStatus(any(), any(), any()))
           .thenAnswer(invocation -> null) /* success */
-          .thenThrow(WorkspaceFixtures.UNAUTHORIZED_EXCEPTION);
+          .thenThrow(UNAUTHORIZED_EXCEPTION);
 
       // wait success
       assertThat(
@@ -308,7 +312,7 @@ public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookSt
       StopAwsSageMakerNotebookStep stopNotebookStep, String message) throws InterruptedException {
     mockAwsUtils
         .when(() -> AwsUtils.getSageMakerNotebookStatus(any(), any()))
-        .thenThrow(WorkspaceFixtures.NOT_FOUND_EXCEPTION);
+        .thenThrow(NOT_FOUND_EXCEPTION);
 
     // error
     assertStepResultFatal(
@@ -323,7 +327,7 @@ public class StopAwsSageMakerNotebookStepTest extends BaseAwsSageMakerNotebookSt
         List.of(/*  part of resource deletion */ true, /* not part of resource deletion */ false)) {
       StopAwsSageMakerNotebookStep stopNotebookStep =
           new StopAwsSageMakerNotebookStep(
-              notebookResource, mockAwsCloudContextService, resourceDeletion);
+              notebookResource, mockAwsCloudContextService, mockSamService(), resourceDeletion);
 
       String message = "resourceDeletion: " + resourceDeletion;
       stopAwsSageMakerNotebook_StoppedFailed_undoTest(stopNotebookStep, message);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextConnectedTest.java
@@ -36,7 +36,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 
-@Tag("aws-connected-1")
+@Tag("aws-connected")
 @TestInstance(Lifecycle.PER_CLASS)
 public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
   private static final Logger logger = LoggerFactory.getLogger(AwsCloudContextConnectedTest.class);
@@ -115,7 +115,7 @@ public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
     }
   }
 
-  // @Test
+  @Test
   void createCloudContextTest() {
     AwsCloudContext createdCloudContext =
         awsCloudContextService.createCloudContext(
@@ -135,7 +135,7 @@ public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
         "flightId");
   }
 
-  // @Test
+  @Test
   void getLandingZoneTest() throws IOException {
     AwsCloudContext cloudContext = awsConnectedTestUtils.getAwsCloudContext();
     Environment environment =

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextConnectedTest.java
@@ -1,7 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.SAM_USER;
-import static bio.terra.workspace.common.utils.AwsTestUtils.SAM_USER_AWS_DISABLED;
+import static bio.terra.workspace.service.features.FeatureService.AWS_ENABLED;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,7 +18,6 @@ import bio.terra.workspace.common.exception.StaleConfigurationException;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.utils.AwsTestUtils;
 import bio.terra.workspace.common.utils.AwsUtils;
-import bio.terra.workspace.service.features.FeatureService;
 import bio.terra.workspace.service.resource.model.WsmResourceState;
 import bio.terra.workspace.service.workspace.exceptions.InvalidCloudContextStateException;
 import bio.terra.workspace.service.workspace.model.AwsCloudContext;
@@ -38,7 +37,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 
-@Tag("aws-connected")
+@Tag("aws-connected-1")
 @TestInstance(Lifecycle.PER_CLASS)
 public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
   private static final Logger logger = LoggerFactory.getLogger(AwsCloudContextConnectedTest.class);
@@ -56,19 +55,11 @@ public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
   @Test
   void awsFeatureEnabledCheckTest() {
     Assertions.assertDoesNotThrow(
-        () ->
-            mockFeatureService.featureEnabledCheck(
-                FeatureService.AWS_ENABLED, SAM_USER.getEmail()));
+        () -> mockFeatureService.featureEnabledCheck(AWS_ENABLED, SAM_USER.getEmail()));
 
     Assertions.assertThrows(
         FeatureNotSupportedException.class,
-        () ->
-            mockFeatureService.featureEnabledCheck(
-                FeatureService.AWS_ENABLED, SAM_USER_AWS_DISABLED.getEmail()));
-
-    Assertions.assertThrows(
-        FeatureNotSupportedException.class,
-        () -> mockFeatureService.featureEnabledCheck(FeatureService.AWS_ENABLED));
+        () -> mockFeatureService.featureEnabledCheck(AWS_ENABLED));
   }
 
   @Test
@@ -132,7 +123,7 @@ public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
     }
   }
 
-  @Test
+  // @Test
   void createCloudContextTest() {
     AwsCloudContext createdCloudContext =
         awsCloudContextService.createCloudContext(
@@ -152,7 +143,7 @@ public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
         "flightId");
   }
 
-  @Test
+  // @Test
   void getLandingZoneTest() throws IOException {
     AwsCloudContext cloudContext = awsConnectedTestUtils.getAwsCloudContext();
     Environment environment =

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextConnectedTest.java
@@ -13,7 +13,6 @@ import bio.terra.aws.resource.discovery.EnvironmentDiscovery;
 import bio.terra.aws.resource.discovery.LandingZone;
 import bio.terra.aws.resource.discovery.Metadata;
 import bio.terra.workspace.common.BaseAwsConnectedTest;
-import bio.terra.workspace.common.exception.FeatureNotSupportedException;
 import bio.terra.workspace.common.exception.StaleConfigurationException;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.utils.AwsTestUtils;
@@ -53,17 +52,10 @@ public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
   }
 
   @Test
-  void awsFeatureEnabledCheckTest() {
+  void discoverEnvironmentTest() throws IOException {
     Assertions.assertDoesNotThrow(
         () -> mockFeatureService.featureEnabledCheck(AWS_ENABLED, SAM_USER.getEmail()));
 
-    Assertions.assertThrows(
-        FeatureNotSupportedException.class,
-        () -> mockFeatureService.featureEnabledCheck(AWS_ENABLED));
-  }
-
-  @Test
-  void discoverEnvironmentTest() throws IOException {
     // Log the AWS config
     logger.info("AWS Configuration: {}", awsConfiguration.toString());
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextUnitTest.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.service.workspace;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.AwsTestUtils.ACCOUNT_ID;
 import static bio.terra.workspace.common.utils.AwsTestUtils.AWS_ENVIRONMENT;
 import static bio.terra.workspace.common.utils.AwsTestUtils.AWS_LANDING_ZONE;
@@ -118,17 +119,18 @@ public class AwsCloudContextUnitTest extends BaseAwsUnitTest {
       Exception ex =
           assertThrows(
               InvalidApplicationConfigException.class,
-              () -> awsCloudContextService.discoverEnvironment());
+              () -> awsCloudContextService.discoverEnvironment(DEFAULT_USER_EMAIL));
       assertTrue(ex.getMessage().contains("AWS environmentDiscovery not initialized"));
 
       // success
-      Environment fetchedEnvironment = awsCloudContextService.discoverEnvironment();
+      Environment fetchedEnvironment =
+          awsCloudContextService.discoverEnvironment(DEFAULT_USER_EMAIL);
       assertNotNull(fetchedEnvironment);
 
       mockAwsUtils.verify(() -> AwsUtils.createEnvironmentDiscovery(any()), times(2));
 
       // AwsUtils.createEnvironmentDiscovery is not called another time if already initialized
-      awsCloudContextService.discoverEnvironment();
+      awsCloudContextService.discoverEnvironment(DEFAULT_USER_EMAIL);
       mockAwsUtils.verify(() -> AwsUtils.createEnvironmentDiscovery(any()), times(2));
     }
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2UnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2UnitTest.java
@@ -53,7 +53,8 @@ public class AwsWorkspaceV2UnitTest extends BaseAwsUnitTest {
           .when(() -> AwsUtils.createEnvironmentDiscovery(any()))
           .thenReturn(mockEnvironmentDiscovery);
 
-      when(awsCloudContextService.discoverEnvironment()).thenReturn(AWS_ENVIRONMENT);
+      when(awsCloudContextService.discoverEnvironment(SAM_USER.getEmail()))
+          .thenReturn(AWS_ENVIRONMENT);
 
       // create workspace (with cloud context)
       Workspace workspace = WorkspaceFixtures.createDefaultMcWorkspace();


### PR DESCRIPTION
discoverEnvironment performs a AWS_ENBALED check, which requires userEmail

1. Pass user email to awsCloudContextService.discoverEnvironment. 
2. Aws resource steps: add samService as a parameter to the step. this is used to fetch the user email
3. Rename flightBeanbag variable from appContext to flightBeanbag to avoid confusion
4. Add new test to check aws feature enabled / disabled for a user
5. Test updates 

AWS connected (failure in first image fixed, see second image)

<img width="865" alt="Pasted Graphic" src="https://github.com/DataBiosphere/terra-workspace-manager/assets/2914285/776e8739-7483-44d5-a088-c1073a324d6e">

<img width="676" alt="image" src="https://github.com/DataBiosphere/terra-workspace-manager/assets/2914285/a57ee144-a3c6-45e9-a6d9-1a7415810119">

manual run of connected test successful https://github.com/verily-src/terra-service-ws-manager/actions/runs/6155267643

--
Pending / in progress: manual testing in autopush