### PR TITLE
update client lib to allow non-uuids in prep for allowing names

### DIFF
--- a/openapi/src/parts/controlled_azure_database.yaml
+++ b/openapi/src/parts/controlled_azure_database.yaml
@@ -90,7 +90,6 @@ components:
         owner:
           description: Resource id of an azure managed identity in this workspace to be the owner of the database, required for shared databases. For private databases, the owner will be determined from privateResourceUser.
           type: string
-          format: uuid
         k8sNamespace:
           description: The kubernetes namespace from which the database will be accessed. A database created with this specified will not be usable with a KubernetesNamespace controlled resource. Will be removed once Leonardo switches to use KubernetesNamespace controlled resources.
           type: string

--- a/openapi/src/parts/controlled_azure_kubernetes_namespace.yaml
+++ b/openapi/src/parts/controlled_azure_kubernetes_namespace.yaml
@@ -120,13 +120,11 @@ components:
         managedIdentity:
           description: The resource id of a managed identity to use for the kubernetesNamespace. Omit for private namespaces.
           type: string
-          format: uuid
         databases:
           description: The resource IDs of databases within the workspace to be used by the kubernetesNamespace. Some form of identity (managed identity or private namespace) must be used to access databases.
           type: array
           items:
             type: string
-            format: uuid
 
     CreatedControlledAzureKubernetesNamespaceResult:
       description: Response payload for requesting a new Azure kubernetesNamespace

--- a/openapi/src/resources/azure_database.yaml
+++ b/openapi/src/resources/azure_database.yaml
@@ -11,7 +11,6 @@ components:
         databaseOwner:
           description: Identity of database owner.
           type: string
-          format: uuid
         allowAccessForAllWorkspaceUsers:
           description: Whether all workspace users have access to the database.
           type: boolean

--- a/openapi/src/resources/azure_kubernetesNamespace.yaml
+++ b/openapi/src/resources/azure_kubernetesNamespace.yaml
@@ -14,13 +14,11 @@ components:
         managedIdentity:
           description: The resource id of a managed identity to use for the kubernetesNamespace. Null for private namespaces.
           type: string
-          format: uuid
         databases:
           description: The resource IDs of databases within the workspace to be used by the kubernetesNamespace.
           type: array
           items:
             type: string
-            format: uuid
 
     AzureKubernetesNamespaceResource:
       type: object

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/ControlledAzureDatabaseResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/ControlledAzureDatabaseResource.java
@@ -247,7 +247,7 @@ public class ControlledAzureDatabaseResource extends ControlledResource {
   private ApiAzureDatabaseAttributes toApiAttributes() {
     return new ApiAzureDatabaseAttributes()
         .databaseName(getDatabaseName())
-        .databaseOwner(getDatabaseOwner())
+        .databaseOwner(getDatabaseOwner().toString())
         .allowAccessForAllWorkspaceUsers(getAllowAccessForAllWorkspaceUsers());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/ControlledAzureKubernetesNamespaceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/ControlledAzureKubernetesNamespaceResource.java
@@ -316,8 +316,8 @@ public class ControlledAzureKubernetesNamespaceResource extends ControlledResour
     return new ApiAzureKubernetesNamespaceAttributes()
         .kubernetesNamespace(getKubernetesNamespace())
         .kubernetesServiceAccount(getKubernetesServiceAccount())
-        .managedIdentity(getManagedIdentity())
-        .databases(getDatabases().stream().toList());
+        .managedIdentity(getManagedIdentity().toString())
+        .databases(getDatabases().stream().map(UUID::toString).toList());
   }
 
   @Override

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAzureResourceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAzureResourceFixtures.java
@@ -44,9 +44,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /** A series of static objects useful for testing controlled resources. */
 public class ControlledAzureResourceFixtures {
@@ -412,8 +413,8 @@ public class ControlledAzureResourceFixtures {
   public static ApiAzureKubernetesNamespaceCreationParameters
       getAzureKubernetesNamespaceCreationParameters(UUID owner, List<UUID> databases) {
     return new ApiAzureKubernetesNamespaceCreationParameters()
-        .managedIdentity(owner)
-        .databases(databases)
+        .managedIdentity(Objects.toString(owner, null))
+        .databases(databases.stream().map(UUID::toString).toList())
         .namespacePrefix(uniqueAzureName(AZURE_KUBERNETES_NAMESPACE_PREFIX).substring(0, 24));
   }
 
@@ -433,8 +434,14 @@ public class ControlledAzureResourceFixtures {
                 .build())
         .kubernetesServiceAccount(namespace + "-ksa")
         .kubernetesNamespace(namespace)
-        .managedIdentity(creationParameters.getManagedIdentity())
-        .databases(new HashSet<>(creationParameters.getDatabases()));
+        .managedIdentity(
+            creationParameters.getManagedIdentity() == null
+                ? null
+                : UUID.fromString(creationParameters.getManagedIdentity()))
+        .databases(
+            creationParameters.getDatabases().stream()
+                .map(UUID::fromString)
+                .collect(Collectors.toSet()));
   }
 
   public static ControlledAzureKubernetesNamespaceResource.Builder
@@ -457,7 +464,10 @@ public class ControlledAzureResourceFixtures {
                 .build())
         .kubernetesServiceAccount(creationParameters.getNamespacePrefix() + "-ksa")
         .kubernetesNamespace(namespace)
-        .databases(new HashSet<>(creationParameters.getDatabases()));
+        .databases(
+            creationParameters.getDatabases().stream()
+                .map(UUID::fromString)
+                .collect(Collectors.toSet()));
   }
 
   public static ApiAzureDatabaseCreationParameters getAzureDatabaseCreationParameters(
@@ -465,7 +475,7 @@ public class ControlledAzureResourceFixtures {
     return new ApiAzureDatabaseCreationParameters()
         .name(uniqueAzureName(AZURE_DATABASE_NAME_PREFIX))
         .k8sNamespace(k8sNamespace)
-        .owner(owner);
+        .owner(Objects.toString(owner, null));
   }
 
   public static ControlledAzureDatabaseResource.Builder
@@ -482,7 +492,7 @@ public class ControlledAzureResourceFixtures {
                 .region(DEFAULT_AZURE_RESOURCE_REGION)
                 .build())
         .databaseName(creationParameters.getName())
-        .databaseOwner(creationParameters.getOwner())
+        .databaseOwner(UUID.fromString(creationParameters.getOwner()))
         .k8sNamespace(creationParameters.getK8sNamespace())
         .allowAccessForAllWorkspaceUsers(creationParameters.isAllowAccessForAllWorkspaceUsers());
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/ControlledAzureKubernetesNamespaceResourceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/ControlledAzureKubernetesNamespaceResourceTest.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdenti
 import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetPetManagedIdentityStep;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetWorkspaceManagedIdentityStep;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -50,8 +51,8 @@ public class ControlledAzureKubernetesNamespaceResourceTest extends BaseMockitoS
             new ApiAzureKubernetesNamespaceAttributes()
                 .kubernetesNamespace(resource.getKubernetesNamespace())
                 .kubernetesServiceAccount(resource.getKubernetesServiceAccount())
-                .managedIdentity(owner)
-                .databases(List.of(dbResource.getResourceId()))));
+                .managedIdentity(Objects.toString(owner, null))
+                .databases(List.of(dbResource.getResourceId().toString()))));
   }
 
   @Test


### PR DESCRIPTION
this is prep for https://broadworkbench.atlassian.net/browse/WOR-1250 so that we can roll out a new client lib that does not actually change anything but is forward compatible with the real change