### PR TITLE
Fix dataproc integration test flake

### DIFF
--- a/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
+++ b/integration/src/main/java/scripts/testscripts/CloneWorkspace.java
@@ -71,6 +71,7 @@ import scripts.utils.CloudContextMaker;
 import scripts.utils.FlexResourceUtils;
 import scripts.utils.GcsBucketObjectUtils;
 import scripts.utils.GcsBucketUtils;
+import scripts.utils.RetryUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
@@ -125,7 +126,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
     // Retry because in rare cases, it can take a while for bigquery.jobs.create to propagate
     // TODO(PF-2335): Delete retry after PF-2335 is fixed
     final TableResult listTablesResult =
-        ClientTestUtils.getWithRetryOnException(() -> bigQueryClient.query(listTablesQuery));
+        RetryUtils.getWithRetryOnException(() -> bigQueryClient.query(listTablesQuery));
     final long numRows =
         StreamSupport.stream(listTablesResult.getValues().spliterator(), false).count();
     assertEquals(0, numRows, "Expected zero tables for COPY_DEFINITION dataset");
@@ -394,7 +395,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
         cloneResult.getWorkspace().getSourceWorkspaceId(),
         "Source workspace ID reported accurately.");
     Properties sourceProperties =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () ->
                 sourceOwnerWorkspaceApi
                     .getWorkspace(getWorkspaceId(), /*minimumHighestRole=*/ null)
@@ -464,7 +465,7 @@ public class CloneWorkspace extends WorkspaceAllocateTestScriptBase {
         cloningUserResourceApi.getBucket(
             destinationWorkspaceId, sharedBucketCloneDetails.getDestinationResourceId());
     logger.info("Cloned Shared Bucket: {}", clonedSharedBucket);
-    ClientTestUtils.getWithRetryOnException(
+    RetryUtils.getWithRetryOnException(
         () ->
             GcsBucketObjectUtils.retrieveBucketFile(
                 clonedSharedBucket.getAttributes().getBucketName(),

--- a/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -137,7 +137,7 @@ public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScr
     // This is the reader's first use of cloud APIs after being added to the workspace, so we
     // retry this operation until cloud IAM has properly synced.
     var readTable =
-        ClientTestUtils.getWithRetryOnException(() -> readerBqClient.getTable(table.getTableId()));
+        RetryUtils.getWithRetryOnException(() -> readerBqClient.getTable(table.getTableId()));
     assertEquals(table, readTable);
     logger.info("Read table {} as workspace reader", tableName);
 

--- a/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ControlledBigQueryDatasetLifecycle.java
@@ -50,6 +50,7 @@ import scripts.utils.BqDatasetUtils;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.GcpWorkspaceCloneTestScriptBase;
 import scripts.utils.MultiResourcesUtils;
+import scripts.utils.RetryUtils;
 import scripts.utils.SamClientUtils;
 
 // TODO: This test no longer clones. Extend WorkspaceAllocateTestScriptBase instead of
@@ -159,14 +160,13 @@ public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScr
     // This is the writer's first use of cloud APIs after being added to the workspace, so we
     // retry this operation until cloud IAM has properly synced.
     var writerReadTable =
-        ClientTestUtils.getWithRetryOnException(() -> writerBqClient.getTable(table.getTableId()));
+        RetryUtils.getWithRetryOnException(() -> writerBqClient.getTable(table.getTableId()));
     assertEquals(table, writerReadTable);
     logger.info("Read table {} as workspace writer", tableName);
 
     // In contrast, a workspace writer can write data to tables
     String columnValue = "this value lives in a table";
-    ClientTestUtils.getWithRetryOnException(
-        () -> insertValueIntoTable(writerBqClient, columnValue));
+    RetryUtils.getWithRetryOnException(() -> insertValueIntoTable(writerBqClient, columnValue));
     logger.info("Workspace writer wrote a row to table {}", tableName);
 
     // Create a dataset to hold query results in the destination project.
@@ -190,7 +190,7 @@ public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScr
     String newDescription = "Another new table description";
     Table writerUpdatedTable = table.toBuilder().setDescription(newDescription).build();
     Table updatedTable =
-        ClientTestUtils.getWithRetryOnException(() -> writerBqClient.update(writerUpdatedTable));
+        RetryUtils.getWithRetryOnException(() -> writerBqClient.update(writerUpdatedTable));
     assertEquals(newDescription, updatedTable.getDescription());
     logger.info("Workspace writer modified table {} metadata", tableName);
 
@@ -299,7 +299,7 @@ public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScr
     var tableInfo = TableInfo.of(tableId, tableDefinition);
 
     logger.info("Creating table {} in dataset {}", TABLE_NAME, DATASET_RESOURCE_NAME);
-    return ClientTestUtils.getWithRetryOnException(() -> bigQueryClient.create(tableInfo));
+    return RetryUtils.getWithRetryOnException(() -> bigQueryClient.create(tableInfo));
   }
 
   /** Insert a single String value into the column/table/dataset specified by constant values. */
@@ -335,7 +335,7 @@ public class ControlledBigQueryDatasetLifecycle extends GcpWorkspaceCloneTestScr
     JobId jobId = JobId.of(UUID.randomUUID().toString());
     // Retry because bigquery.jobs.create can take time to propagate
     Job queryJob =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () -> bigQueryClient.create(JobInfo.newBuilder(jobConfig).setJobId(jobId).build()));
     Job completedJob = queryJob.waitFor();
 

--- a/integration/src/main/java/scripts/testscripts/EnablePet.java
+++ b/integration/src/main/java/scripts/testscripts/EnablePet.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
+import scripts.utils.RetryUtils;
 import scripts.utils.SamClientUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
@@ -85,7 +86,7 @@ public class EnablePet extends WorkspaceAllocateTestScriptBase {
     // pet.
     userWorkspaceApi.removeRole(getWorkspaceId(), IamRole.READER, secondUser.userEmail);
     assertTrue(
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () -> assertCannotImpersonateSa(secondUserIamClient, secondUserPetSaEmail)));
   }
 

--- a/integration/src/main/java/scripts/testscripts/EnumerateResources.java
+++ b/integration/src/main/java/scripts/testscripts/EnumerateResources.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
 import scripts.utils.MultiResourcesUtils;
+import scripts.utils.RetryUtils;
 import scripts.utils.TestUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
@@ -107,7 +108,7 @@ public class EnumerateResources extends WorkspaceAllocateTestScriptBase {
     // As this is the first operation after modifying workspace IAM groups, retry here to compensate
     // for the delay in GCP IAM propagation.
     ResourceList readerEnumList =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () ->
                 readerResourceApi.enumerateResources(
                     getWorkspaceId(), 0, RESOURCE_COUNT, null, null));

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstancePostStartup.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledAiNotebookInstancePostStartup.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.StringUtils;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.CloudContextMaker;
 import scripts.utils.NotebookUtils;
+import scripts.utils.RetryUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
 public class PrivateControlledAiNotebookInstancePostStartup
@@ -66,7 +67,7 @@ public class PrivateControlledAiNotebookInstancePostStartup
     assertEquals(
         resource.getMetadata().getName(), metadata.get("terra-gcp-notebook-resource-name"));
     var testResultValue =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () -> {
               String result =
                   userNotebooks

--- a/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/PrivateControlledGcsBucketLifecycle.java
@@ -40,6 +40,7 @@ import scripts.utils.CommonResourceFieldsUtil;
 import scripts.utils.GcsBucketAccessTester;
 import scripts.utils.GcsBucketUtils;
 import scripts.utils.MultiResourcesUtils;
+import scripts.utils.RetryUtils;
 import scripts.utils.TestUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
 
@@ -90,7 +91,7 @@ public class PrivateControlledGcsBucketLifecycle extends WorkspaceAllocateTestSc
     // Cloud IAM permissions may take several minutes to sync, so we retry this operation until
     // it succeeds.
     CreatedControlledGcpGcsBucket bucket =
-        ClientTestUtils.getWithRetryOnException(() -> createPrivateBucket(privateUserResourceApi));
+        RetryUtils.getWithRetryOnException(() -> createPrivateBucket(privateUserResourceApi));
     UUID resourceId = bucket.getResourceId();
     assertEquals(
         CommonResourceFieldsUtil.getResourceDefaultProperties(),

--- a/integration/src/main/java/scripts/testscripts/ReferencedTerraWorkspaceLifecycle.java
+++ b/integration/src/main/java/scripts/testscripts/ReferencedTerraWorkspaceLifecycle.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scripts.utils.ClientTestUtils;
 import scripts.utils.GcpWorkspaceCloneTestScriptBase;
+import scripts.utils.RetryUtils;
 import scripts.utils.TestUtils;
 
 // Subclass GcpWorkspaceCloneTestScriptBase because that creates 2 workspaces. In this test, we
@@ -57,7 +58,7 @@ public class ReferencedTerraWorkspaceLifecycle extends GcpWorkspaceCloneTestScri
             .referencedWorkspace(
                 new TerraWorkspaceAttributes().referencedWorkspaceId(getReferencedWorkspaceId()));
     TerraWorkspaceResource createdResource =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () -> referencedGcpResourceApi.createTerraWorkspaceReference(body, getWorkspaceId()));
     logger.info(
         "In workspace {}, created reference to workspace {}",
@@ -66,7 +67,7 @@ public class ReferencedTerraWorkspaceLifecycle extends GcpWorkspaceCloneTestScri
 
     // Get resource by resource id
     TerraWorkspaceResource gotResource =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () ->
                 referencedGcpResourceApi.getTerraWorkspaceReference(
                     getWorkspaceId(), createdResource.getMetadata().getResourceId()));
@@ -74,7 +75,7 @@ public class ReferencedTerraWorkspaceLifecycle extends GcpWorkspaceCloneTestScri
 
     // Get resource by resource name
     gotResource =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () ->
                 referencedGcpResourceApi.getTerraWorkspaceReferenceByName(
                     getWorkspaceId(), createdResource.getMetadata().getName()));
@@ -106,7 +107,7 @@ public class ReferencedTerraWorkspaceLifecycle extends GcpWorkspaceCloneTestScri
   private void testDelete(ReferencedGcpResourceApi referencedGcpResourceApi, UUID createdResourceId)
       throws Exception {
     // Delete resource
-    ClientTestUtils.runWithRetryOnException(
+    RetryUtils.runWithRetryOnException(
         () -> {
           try {
             referencedGcpResourceApi.deleteTerraWorkspaceReference(

--- a/integration/src/main/java/scripts/testscripts/RemoveUser.java
+++ b/integration/src/main/java/scripts/testscripts/RemoveUser.java
@@ -34,6 +34,7 @@ import scripts.utils.CloudContextMaker;
 import scripts.utils.GcsBucketObjectUtils;
 import scripts.utils.GcsBucketUtils;
 import scripts.utils.NotebookUtils;
+import scripts.utils.RetryUtils;
 import scripts.utils.SamClientUtils;
 import scripts.utils.TestUtils;
 import scripts.utils.WorkspaceAllocateTestScriptBase;
@@ -138,11 +139,11 @@ public class RemoveUser extends WorkspaceAllocateTestScriptBase {
     String sharedBucketName = sharedBucket.getGcpBucket().getAttributes().getBucketName();
     String privateBucketName = privateBucket.getGcpBucket().getAttributes().getBucketName();
     // Validate that setup ran correctly and users have appropriate resource access.
-    ClientTestUtils.getWithRetryOnException(
+    RetryUtils.getWithRetryOnException(
         () ->
             GcsBucketObjectUtils.retrieveBucketFile(
                 sharedBucketName, projectId, sharedResourceUser));
-    ClientTestUtils.getWithRetryOnException(
+    RetryUtils.getWithRetryOnException(
         () ->
             GcsBucketObjectUtils.retrieveBucketFile(
                 privateBucketName, projectId, privateResourceUser));
@@ -160,7 +161,7 @@ public class RemoveUser extends WorkspaceAllocateTestScriptBase {
 
     // Validate that sharedResourceUser can no longer read resources in the workspace.
     // This requires syncing google groups, so there is often a delay that we need to wait for.
-    ClientTestUtils.runWithRetryOnException(
+    RetryUtils.runWithRetryOnException(
         () -> assertUserCannotReadBucket(sharedBucketName, sharedResourceUser));
 
     // privateResource user can still read the shared bucket.
@@ -189,13 +190,13 @@ public class RemoveUser extends WorkspaceAllocateTestScriptBase {
     assertTrue(revokeReaderSucceeded);
 
     // Validate privateResourceWriter no longer has access to any private resources.
-    ClientTestUtils.runWithRetryOnException(
+    RetryUtils.runWithRetryOnException(
         () -> assertUserCannotReadBucket(sharedBucketName, privateResourceUser));
-    ClientTestUtils.runWithRetryOnException(
+    RetryUtils.runWithRetryOnException(
         () -> assertUserCannotReadBucket(privateBucketName, privateResourceUser));
-    ClientTestUtils.runWithRetryOnException(
+    RetryUtils.runWithRetryOnException(
         () -> assertUserCannotReadDataset(privateDataset, privateResourceUser));
-    ClientTestUtils.runWithRetryOnException(
+    RetryUtils.runWithRetryOnException(
         () -> assertUserCannotAccessNotebook(privateNotebook, privateResourceUser));
   }
 

--- a/integration/src/main/java/scripts/utils/BqDatasetUtils.java
+++ b/integration/src/main/java/scripts/utils/BqDatasetUtils.java
@@ -85,7 +85,7 @@ public class BqDatasetUtils {
             .dataset(dataset);
 
     GcpBigQueryDatasetResource result =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () -> resourceApi.createBigQueryDatasetReference(body, workspaceUuid));
     logger.info(
         "Created BigQuery Dataset Reference {} project {} resource ID {} workspace {}",
@@ -155,7 +155,7 @@ public class BqDatasetUtils {
             .metadata(makeReferencedResourceCommonFields(name, cloningInstructions))
             .dataTable(dataTable);
 
-    return ClientTestUtils.getWithRetryOnException(
+    return RetryUtils.getWithRetryOnException(
         () -> resourceApi.createBigQueryDataTableReference(body, workspaceUuid));
   }
 
@@ -275,11 +275,11 @@ public class BqDatasetUtils {
 
     // Wrap operations in a wait to allow the IAM permissions to propagate
     final Table createdEmployeeTable =
-        ClientTestUtils.getWithRetryOnException(() -> bigQueryClient.create(employeeTableInfo));
+        RetryUtils.getWithRetryOnException(() -> bigQueryClient.create(employeeTableInfo));
     logger.info("Created Employee Table: {}", createdEmployeeTable);
 
     final Table createdDepartmentTable =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () ->
                 bigQueryClient.create(
                     TableInfo.newBuilder(
@@ -303,7 +303,7 @@ public class BqDatasetUtils {
 
     // Stream insert one row to check the error handling/warning. This row may not be copied. (If
     // the stream happens after the DDL insert, sometimes it gets copied).
-    ClientTestUtils.getWithRetryOnException(
+    RetryUtils.getWithRetryOnException(
         () ->
             bigQueryClient.insertAll(
                 InsertAllRequest.newBuilder(employeeTableInfo)
@@ -314,7 +314,7 @@ public class BqDatasetUtils {
     // be in the streaming buffer where it's un-copyable for up to 90 minutes.
     // Retry because if project was created recently, it may take time for bigquery.jobs.create to
     // propagate
-    ClientTestUtils.getWithRetryOnException(
+    RetryUtils.getWithRetryOnException(
         () ->
             bigQueryClient.query(
                 QueryJobConfiguration.newBuilder(
@@ -328,7 +328,7 @@ public class BqDatasetUtils {
                             + "101, 'Aquaman'), (102, 'Superman');")
                     .build()));
 
-    ClientTestUtils.getWithRetryOnException(
+    RetryUtils.getWithRetryOnException(
         () ->
             bigQueryClient.query(
                 QueryJobConfiguration.newBuilder(
@@ -342,7 +342,7 @@ public class BqDatasetUtils {
 
     // double-check the rows are there
     TableResult employeeTableResult =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () ->
                 bigQueryClient.query(
                     QueryJobConfiguration.newBuilder(

--- a/integration/src/main/java/scripts/utils/ClientTestUtils.java
+++ b/integration/src/main/java/scripts/utils/ClientTestUtils.java
@@ -43,23 +43,15 @@ import com.google.common.base.Strings;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ClientTestUtils {
-  // Retry default parameters
-  // The total allowed duration is a guess. It may be too long, but we have no guidance.
-  // The sleep duration is based on guidance for the fastest we should consider polling.
-  public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(20);
-  public static final Duration DEFAULT_SLEEP_DURATION = Duration.ofSeconds(30);
-
   public static final String RESOURCE_NAME_PREFIX = "terratest";
   // We may want this to be a test parameter. It has to match what is in the config or in the helm
   public static final String TEST_WSM_APP = "TestWsmApp";
@@ -280,89 +272,6 @@ public class ClientTestUtils {
   }
 
   /**
-   * Get a result from a call that might throw an exception. Treat the exception as retry-able. This
-   * structure is useful for situations where we are waiting on a cloud IAM permission change to
-   * take effect.
-   *
-   * @param supplier - code returning the result or throwing an exception
-   * @param <T> - type of result
-   * @return - result from supplier, the first time it doesn't throw, or null if all tries have been
-   *     exhausted
-   * @throws InterruptedException if the sleep is interrupted
-   */
-  public static @Nullable <T> T getWithRetryOnException(SupplierWithException<T> supplier)
-      throws Exception {
-    return getWithRetryOnException(
-        supplier, DEFAULT_RETRY_TOTAL_DURATION, DEFAULT_SLEEP_DURATION, null);
-  }
-
-  public static void runWithRetryOnException(Runnable fn) throws Exception {
-    getWithRetryOnException(
-        () -> {
-          fn.run();
-          return null;
-        });
-  }
-
-  /**
-   * Get a result from a call that might throw an exception. If the supplier finishes, the result is
-   * returned. If the supplier continues to throw, when totalDuration has elapsed, this method will
-   * throw that exception.
-   *
-   * @param supplier - code returning the result or throwing an exception
-   * @param totalDuration - total amount of time to retry
-   * @param sleepDuration - amount of time to sleep between retries
-   * @param retryExceptionList - nullable; a list of exception classes. If null, any exception is
-   *     retried
-   * @param <T> - type of result
-   * @return - result from supplier, if no exception
-   * @throws InterruptedException if the sleep is interrupted
-   */
-  public static <T> T getWithRetryOnException(
-      SupplierWithException<T> supplier,
-      Duration totalDuration,
-      Duration sleepDuration,
-      @Nullable List<Class<? extends Exception>> retryExceptionList)
-      throws Exception {
-
-    T result;
-    Instant endTime = Instant.now().plus(totalDuration);
-
-    while (true) {
-      try {
-        result = supplier.get();
-        break;
-      } catch (Exception e) {
-        // If we are out of time or the exception is not retryable
-        if (Instant.now().isAfter(endTime) || !isRetryable(e, retryExceptionList)) {
-          throw e;
-        }
-        logger.info(
-            "Exception \"{}\". Waiting {} seconds. End time is {}",
-            e.getMessage(),
-            sleepDuration.toSeconds(),
-            endTime);
-        TimeUnit.MILLISECONDS.sleep(sleepDuration.toMillis());
-      }
-    }
-    return result;
-  }
-
-  private static boolean isRetryable(
-      Exception e, @Nullable List<Class<? extends Exception>> retryExceptionList) {
-    // If we didn't get a list, then all exceptions are considered retryable
-    if (retryExceptionList == null) {
-      return true;
-    }
-    for (Class<? extends Exception> clazz : retryExceptionList) {
-      if (clazz.isInstance(e)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Polls a workspace API operation as long as the job is running.
    *
    * @param <T> the result type of the async operation.
@@ -479,7 +388,7 @@ public class ClientTestUtils {
 
     // Wait for the grantee to have storage.bucket.list permission,
     // indicating that the grant has been propagated to the project.
-    getWithRetryOnException(granteeStorage::list);
+    RetryUtils.getWithRetryOnException(granteeStorage::list);
   }
 
   /**
@@ -509,7 +418,7 @@ public class ClientTestUtils {
 
     // Wait for the testUser to lose storage.bucket.list permission,
     // indicating that the revoke has been propagated to the project.
-    return getWithRetryOnException(() -> testForbiddenStorageList(storage, testUser));
+    return RetryUtils.getWithRetryOnException(() -> testForbiddenStorageList(storage, testUser));
   }
 
   private static boolean testForbiddenStorageList(Storage storage, TestUserSpecification testUser)

--- a/integration/src/main/java/scripts/utils/GcsBucketAccessTester.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketAccessTester.java
@@ -255,7 +255,7 @@ public class GcsBucketAccessTester implements AutoCloseable {
 
   private boolean doWait(TestFunction function) throws Exception {
     try {
-      ClientTestUtils.getWithRetryOnException(function::apply);
+      RetryUtils.getWithRetryOnException(function::apply);
       return true;
     } catch (StorageException e) {
       if (e.getCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {

--- a/integration/src/main/java/scripts/utils/GcsBucketObjectUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketObjectUtils.java
@@ -60,7 +60,7 @@ public class GcsBucketObjectUtils {
             .file(file);
 
     logger.info("Making reference to a gcs bucket file");
-    return ClientTestUtils.getWithRetryOnException(
+    return RetryUtils.getWithRetryOnException(
         () -> resourceApi.createGcsObjectReference(body, workspaceUuid));
   }
 

--- a/integration/src/main/java/scripts/utils/GcsBucketUtils.java
+++ b/integration/src/main/java/scripts/utils/GcsBucketUtils.java
@@ -245,7 +245,7 @@ public class GcsBucketUtils {
             .bucket(bucket);
 
     GcpGcsBucketResource result =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () -> resourceApi.createBucketReference(body, workspaceUuid));
     logger.info(
         "Created reference to GCS bucket {} resourceID {} workspaceID {}",
@@ -354,7 +354,7 @@ public class GcsBucketUtils {
 
     // There can be IAM propagation delays, so be a patient with the creation
     Blob result =
-        ClientTestUtils.getWithRetryOnException(
+        RetryUtils.getWithRetryOnException(
             () ->
                 sourceOwnerStorageClient.create(
                     blobInfo, GCS_BLOB_CONTENT.getBytes(StandardCharsets.UTF_8)));

--- a/integration/src/main/java/scripts/utils/GitRepoUtils.java
+++ b/integration/src/main/java/scripts/utils/GitRepoUtils.java
@@ -60,7 +60,7 @@ public class GitRepoUtils {
             .metadata(makeReferencedResourceCommonFields(name, CloningInstructionsEnum.REFERENCE))
             .gitrepo(new GitRepoAttributes().gitRepoUrl(attributes.getGitRepoUrl()));
     logger.info("Making git repo reference of {} with name {}", attributes.getGitRepoUrl(), name);
-    return ClientTestUtils.getWithRetryOnException(
+    return RetryUtils.getWithRetryOnException(
         () -> resourceApi.createGitRepoReference(body, workspaceUuid));
   }
 }

--- a/integration/src/main/java/scripts/utils/RetryUtils.java
+++ b/integration/src/main/java/scripts/utils/RetryUtils.java
@@ -2,15 +2,25 @@ package scripts.utils;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scripts.utils.ClientTestUtils.SupplierWithException;
 
 /** RetryUtils provides static methods for waiting and retrying. */
 public class RetryUtils {
-  public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(10);
-  public static final Duration DEFAULT_RETRY_SLEEP_DURATION = Duration.ofSeconds(15);
+  // Retry default parameters
+  // The total allowed duration is a guess. It may be too long, but we have no guidance.
+  // The sleep duration is based on guidance for the fastest we should consider polling.
+  public static final Duration DEFAULT_RETRY_TOTAL_DURATION = Duration.ofMinutes(20);
+  public static final Duration DEFAULT_RETRY_SLEEP_DURATION = Duration.ofSeconds(30);
   public static final double DEFAULT_RETRY_FACTOR_INCREASE = 0.0;
   public static final Duration DEFAULT_RETRY_SLEEP_DURATION_MAX = Duration.ofMinutes(3);
+  private static final Logger logger = LoggerFactory.getLogger(ClientTestUtils.class);
+
   /**
    * Get a result from a call that might throw an exception. If the supplier finishes, the result is
    * returned. If the supplier continues to throw, when totalDuration has elapsed, this method will
@@ -85,6 +95,89 @@ public class RetryUtils {
         DEFAULT_RETRY_FACTOR_INCREASE,
         DEFAULT_RETRY_SLEEP_DURATION_MAX,
         exceptionMessage);
+  }
+
+  /**
+   * Get a result from a call that might throw an exception. Treat the exception as retry-able. This
+   * structure is useful for situations where we are waiting on a cloud IAM permission change to
+   * take effect.
+   *
+   * @param supplier - code returning the result or throwing an exception
+   * @param <T> - type of result
+   * @return - result from supplier, the first time it doesn't throw, or null if all tries have been
+   *     exhausted
+   * @throws InterruptedException if the sleep is interrupted
+   */
+  public static @Nullable <T> T getWithRetryOnException(SupplierWithException<T> supplier)
+      throws Exception {
+    return getWithRetryOnException(
+        supplier, DEFAULT_RETRY_TOTAL_DURATION, DEFAULT_RETRY_SLEEP_DURATION, null);
+  }
+
+  public static void runWithRetryOnException(Runnable fn) throws Exception {
+    getWithRetryOnException(
+        () -> {
+          fn.run();
+          return null;
+        });
+  }
+
+  /**
+   * Get a result from a call that might throw an exception. If the supplier finishes, the result is
+   * returned. If the supplier continues to throw, when totalDuration has elapsed, this method will
+   * throw that exception.
+   *
+   * @param supplier - code returning the result or throwing an exception
+   * @param totalDuration - total amount of time to retry
+   * @param sleepDuration - amount of time to sleep between retries
+   * @param retryExceptionList - nullable; a list of exception classes. If null, any exception is
+   *     retried
+   * @param <T> - type of result
+   * @return - result from supplier, if no exception
+   * @throws InterruptedException if the sleep is interrupted
+   */
+  public static <T> T getWithRetryOnException(
+      SupplierWithException<T> supplier,
+      Duration totalDuration,
+      Duration sleepDuration,
+      @Nullable List<Class<? extends Exception>> retryExceptionList)
+      throws Exception {
+
+    T result;
+    Instant endTime = Instant.now().plus(totalDuration);
+
+    while (true) {
+      try {
+        result = supplier.get();
+        break;
+      } catch (Exception e) {
+        // If we are out of time or the exception is not retryable
+        if (Instant.now().isAfter(endTime) || !isRetryable(e, retryExceptionList)) {
+          throw e;
+        }
+        logger.info(
+            "Exception \"{}\". Waiting {} seconds. End time is {}",
+            e.getMessage(),
+            sleepDuration.toSeconds(),
+            endTime);
+        TimeUnit.MILLISECONDS.sleep(sleepDuration.toMillis());
+      }
+    }
+    return result;
+  }
+
+  private static boolean isRetryable(
+      Exception e, @Nullable List<Class<? extends Exception>> retryExceptionList) {
+    // If we didn't get a list, then all exceptions are considered retryable
+    if (retryExceptionList == null) {
+      return true;
+    }
+    for (Class<? extends Exception> clazz : retryExceptionList) {
+      if (clazz.isInstance(e)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
This change:
- Add a check that the dataproc resource user has access to the created cluster before directly querying it. This catches the occaisonal `Not authorized for requested resource` permission flake.
- Wraps `userHasProxyAccess()` with retry to address the integration test sometimes failing at that step.
- Adds logic to properly test stop / start.
- Move `getWithRetryOnException` from `ClientTestUtils` to `RetryUtils`.

Note: The dataproc integration test suite not enabled in the broad environment (this repo's test config). This only applies to the downstream verily integration test suite.