### PR TITLE
Cache storage data per workspace and container

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -35,8 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import liquibase.repackaged.org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -29,7 +29,6 @@ import com.azure.storage.common.sas.SasProtocol;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -84,8 +83,7 @@ public class AzureStorageAccessService {
     this.storageAccountKeyProvider = storageAccountKeyProvider;
     this.azureConfiguration = azureConfiguration;
     this.workspaceService = workspaceService;
-    this.storageAccountCache =
-        new ConcurrentHashMap<>(new PassiveExpiringMap<>(1, TimeUnit.HOURS));
+    this.storageAccountCache = new ConcurrentHashMap<>(new PassiveExpiringMap<>(1, TimeUnit.HOURS));
   }
 
   private BlobContainerSasPermission getSasTokenPermissions(
@@ -337,7 +335,7 @@ public class AzureStorageAccessService {
             .castByEnum(WsmResourceType.CONTROLLED_AZURE_STORAGE_CONTAINER);
 
     StorageData maybeStorageData =
-            storageAccountCache.get(new StorageAccountCoordinates(workspaceUuid, storageContainerUuid));
+        storageAccountCache.get(new StorageAccountCoordinates(workspaceUuid, storageContainerUuid));
     if (maybeStorageData != null) {
       return maybeStorageData;
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -83,7 +83,7 @@ public class AzureStorageAccessService {
     this.storageAccountKeyProvider = storageAccountKeyProvider;
     this.azureConfiguration = azureConfiguration;
     this.workspaceService = workspaceService;
-    this.storageAccountCache = new ConcurrentHashMap<>(new PassiveExpiringMap<>(1, TimeUnit.HOURS));
+    this.storageAccountCache = new ConcurrentHashMap<>();
   }
 
   private BlobContainerSasPermission getSasTokenPermissions(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/StorageAccountCoordinates.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/StorageAccountCoordinates.java
@@ -1,0 +1,6 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure;
+
+import java.util.UUID;
+
+record StorageAccountCoordinates(UUID workspaceUuid, UUID storageContainerUuid) {
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/StorageAccountCoordinates.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/StorageAccountCoordinates.java
@@ -2,5 +2,4 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
 import java.util.UUID;
 
-public record StorageAccountCoordinates(UUID workspaceUuid, UUID storageContainerUuid) {
-}
+public record StorageAccountCoordinates(UUID workspaceUuid, UUID storageContainerUuid) {}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/StorageAccountCoordinates.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/StorageAccountCoordinates.java
@@ -2,5 +2,5 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure;
 
 import java.util.UUID;
 
-record StorageAccountCoordinates(UUID workspaceUuid, UUID storageContainerUuid) {
+public record StorageAccountCoordinates(UUID workspaceUuid, UUID storageContainerUuid) {
 }


### PR DESCRIPTION
We're bumping into Azure throttling under load to the getSasToken endpoint. This is because we are making a live call to Azure to get storage account information for workspaces, from which we mint a sas token locally. 

This PR introduces a basic cache keyed on workspaceId and storageContainerUuid.