### PR TITLE
PF-2973: Get fixed PyYAML when setting up OpenAPI code gen venv.

### DIFF
--- a/openapi/tools/requirements.txt
+++ b/openapi/tools/requirements.txt
@@ -3,4 +3,4 @@ jsonschema==4.4.0
 openapi-schema-validator==0.2.3
 openapi-spec-validator==0.4.0
 pyrsistent==0.18.1
-PyYAML==6.0
+PyYAML==6.0.1


### PR DESCRIPTION
Fixes OpenAPI Python `venv` configuration, which is currently failing for fresh checkouts due to https://github.com/yaml/pyyaml/issues/736.