### PR TITLE
[BENCH-1202]  - Support installing CLI version based on environment

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -382,8 +382,26 @@ readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-serve
 # If the server environment is a verily server, use the verily download script.
 # Otherwise, install the latest DataBiosphere CLI release.
 if [[ $TERRA_SERVER == *"verily"* ]]; then
+  # Map the CLI server to the appropriate AFS service environment
+  declare -A serverMap=(
+      ["verily-devel"]="devel"
+      ["verily-autopush"]="autopush"
+      ["verily-staging"]="staging"
+      ["verily-preprod"]="preprod"
+      ["verily"]=""
+  )
+  environment="${serverMap[$TERRA_SERVER]}"
+  if [[ -z "$environment" && "$TERRA_SERVER" != "verily" ]]; then
+      >&2 echo "ERROR: $TERRA_SERVER is not a known verily server."
+      exit 1
+  fi
+  # Build AFS service path and fetch the CLI distribution path
+  afsservice="terra-${environment:+$environment-}axon.api.verily.com"
+  versionJson="$(curl -s "https://$afsservice/version")"
+  cliDistributionPath=$(echo "$versionJson" | jq -r '.cliDistributionPath')
+
   ${RUN_AS_LOGIN_USER} "\
-    curl -L https://storage.googleapis.com/devcontainerpkg/workbench-cli/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
+    curl -L https://storage.googleapis.com/${cliDistributionPath#gs://}/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
     cp terra '${TERRA_INSTALL_PATH}'"
 else
   ${RUN_AS_LOGIN_USER} "\

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -379,9 +379,17 @@ emit "Installing the Terra CLI ..."
 # Fetch the Terra CLI server environment from the metadata server to install appropriate CLI version
 readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-server")"
 
-${RUN_AS_LOGIN_USER} "\
-  curl -L https://storage.googleapis.com/devcontainerpkg/workbench-cli/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
-  cp terra '${TERRA_INSTALL_PATH}'"
+# If the server environment is a verily server, use the verily download script.
+# Otherwise, install the latest DataBiosphere CLI release.
+if [[ $TERRA_SERVER == *"verily"* ]]; then
+  ${RUN_AS_LOGIN_USER} "\
+    curl -L https://storage.googleapis.com/devcontainerpkg/workbench-cli/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
+    cp terra '${TERRA_INSTALL_PATH}'"
+else
+  ${RUN_AS_LOGIN_USER} "\
+    curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash && \
+    cp terra '${TERRA_INSTALL_PATH}'"
+fi
 
 # Set browser manual login since that's the only login supported from a Vertex AI Notebook VM
 ${RUN_AS_LOGIN_USER} "terra config set browser MANUAL"

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -376,15 +376,17 @@ ${RUN_AS_LOGIN_USER} "\
 # Install & configure the Terra CLI
 emit "Installing the Terra CLI ..."
 
+# Fetch the Terra CLI server environment from the metadata server to install appropriate CLI version
+readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-server")"
+
 ${RUN_AS_LOGIN_USER} "\
-  curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash && \
+  curl -L https://storage.googleapis.com/devcontainerpkg/workbench-cli/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
   cp terra '${TERRA_INSTALL_PATH}'"
 
 # Set browser manual login since that's the only login supported from a Vertex AI Notebook VM
 ${RUN_AS_LOGIN_USER} "terra config set browser MANUAL"
 
 # Set the CLI terra server based on the terra server that created the VM.
-readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-server")"
 if [[ -n "${TERRA_SERVER}" ]]; then
   ${RUN_AS_LOGIN_USER} "terra server set --name=${TERRA_SERVER}"
 fi

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -383,20 +383,28 @@ readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-serve
 # Otherwise, install the latest DataBiosphere CLI release.
 if [[ $TERRA_SERVER == *"verily"* ]]; then
   # Map the CLI server to the appropriate AFS service environment
-  declare -A serverMap=(
-      ["verily-devel"]="devel"
-      ["verily-autopush"]="autopush"
-      ["verily-staging"]="staging"
-      ["verily-preprod"]="preprod"
-      ["verily"]=""
-  )
-  environment="${serverMap[$TERRA_SERVER]}"
-  if [[ -z "$environment" && "$TERRA_SERVER" != "verily" ]]; then
+  case $TERRA_SERVER in
+    verily-devel)
+      afsservice=terra-devel-axon.api.verily.com
+      ;;
+    verily-autopush)
+      afsservice=terra-autopush-axon.api.verily.com
+      ;;
+    verily-staging)
+      afsservice=terra-staging-axon.api.verily.com
+      ;;
+    verily-preprod)
+      afsservice=terra-preprod-axon.api.verily.com
+      ;;
+    verily)
+      afsservice=terra-axon.api.verily.com
+      ;;
+    *)
       >&2 echo "ERROR: $TERRA_SERVER is not a known verily server."
       exit 1
-  fi
+      ;;
+  esac
   # Build AFS service path and fetch the CLI distribution path
-  afsservice="terra-${environment:+$environment-}axon.api.verily.com"
   versionJson="$(curl -s "https://$afsservice/version")"
   cliDistributionPath=$(echo "$versionJson" | jq -r '.cliDistributionPath')
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
@@ -359,20 +359,28 @@ readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-serve
 # Otherwise, install the latest DataBiosphere CLI release.
 if [[ $TERRA_SERVER == *"verily"* ]]; then
   # Map the CLI server to the appropriate AFS service environment
-  declare -A serverMap=(
-      ["verily-devel"]="devel"
-      ["verily-autopush"]="autopush"
-      ["verily-staging"]="staging"
-      ["verily-preprod"]="preprod"
-      ["verily"]=""
-  )
-  environment="${serverMap[$TERRA_SERVER]}"
-  if [[ -z "$environment" && "$TERRA_SERVER" != "verily" ]]; then
+  case $TERRA_SERVER in
+    verily-devel)
+      afsservice=terra-devel-axon.api.verily.com
+      ;;
+    verily-autopush)
+      afsservice=terra-autopush-axon.api.verily.com
+      ;;
+    verily-staging)
+      afsservice=terra-staging-axon.api.verily.com
+      ;;
+    verily-preprod)
+      afsservice=terra-preprod-axon.api.verily.com
+      ;;
+    verily)
+      afsservice=terra-axon.api.verily.com
+      ;;
+    *)
       >&2 echo "ERROR: $TERRA_SERVER is not a known verily server."
       exit 1
-  fi
+      ;;
+  esac
   # Build AFS service path and fetch the CLI distribution path
-  afsservice="terra-${environment:+$environment-}axon.api.verily.com"
   versionJson="$(curl -s "https://$afsservice/version")"
   cliDistributionPath=$(echo "$versionJson" | jq -r '.cliDistributionPath')
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
@@ -355,9 +355,17 @@ emit "Installing the Terra CLI ..."
 # Fetch the Terra CLI server environment from the metadata server to install appropriate CLI version
 readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-server")"
 
-${RUN_AS_LOGIN_USER} "\
-  curl -L https://storage.googleapis.com/devcontainerpkg/workbench-cli/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
-  cp terra '${TERRA_INSTALL_PATH}'"
+# If the server environment is a verily server, use the verily download script.
+# Otherwise, install the latest DataBiosphere CLI release.
+if [[ $TERRA_SERVER == *"verily"* ]]; then
+  ${RUN_AS_LOGIN_USER} "\
+    curl -L https://storage.googleapis.com/devcontainerpkg/workbench-cli/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
+    cp terra '${TERRA_INSTALL_PATH}'"
+else
+  ${RUN_AS_LOGIN_USER} "\
+    curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash && \
+    cp terra '${TERRA_INSTALL_PATH}'"
+fi
 
 # Set browser manual login since that's the only login supported from a Vertex AI Notebook VM
 ${RUN_AS_LOGIN_USER} "terra config set browser MANUAL"

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
@@ -352,15 +352,17 @@ ${RUN_AS_LOGIN_USER} "\
 # Install & configure the Terra CLI
 emit "Installing the Terra CLI ..."
 
+# Fetch the Terra CLI server environment from the metadata server to install appropriate CLI version
+readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-server")"
+
 ${RUN_AS_LOGIN_USER} "\
-  curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash && \
+  curl -L https://storage.googleapis.com/devcontainerpkg/workbench-cli/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
   cp terra '${TERRA_INSTALL_PATH}'"
 
 # Set browser manual login since that's the only login supported from a Vertex AI Notebook VM
 ${RUN_AS_LOGIN_USER} "terra config set browser MANUAL"
 
 # Set the CLI terra server based on the terra server that created the VM.
-readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-server")"
 if [[ -n "${TERRA_SERVER}" ]]; then
   ${RUN_AS_LOGIN_USER} "terra server set --name=${TERRA_SERVER}"
 fi
@@ -374,12 +376,11 @@ ${RUN_AS_LOGIN_USER} "terra generate-completion > '${USER_BASH_COMPLETION_DIR}/t
 # Shell and notebook environment
 ####################################
 
-# Fetch the Terra CLI server environment from the metadata server to install appropriate CLI version
-readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-server")"
-
-${RUN_AS_LOGIN_USER} "\
-  curl -L https://storage.googleapis.com/devcontainerpkg/workbench-cli/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
-  cp terra '${TERRA_INSTALL_PATH}'"
+# Set the CLI terra workspace id using the VM metadata, if set.
+readonly TERRA_WORKSPACE="$(get_metadata_value "instance/attributes/terra-workspace-id")"
+if [[ -n "${TERRA_WORKSPACE}" ]]; then
+  ${RUN_AS_LOGIN_USER} "terra workspace set --id='${TERRA_WORKSPACE}'"
+fi
 
 # Set variables into the ~/.bashrc such that they are available
 # to terminals, notebooks, and other tools

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
@@ -374,11 +374,12 @@ ${RUN_AS_LOGIN_USER} "terra generate-completion > '${USER_BASH_COMPLETION_DIR}/t
 # Shell and notebook environment
 ####################################
 
-# Set the CLI terra workspace id using the VM metadata, if set.
-readonly TERRA_WORKSPACE="$(get_metadata_value "instance/attributes/terra-workspace-id")"
-if [[ -n "${TERRA_WORKSPACE}" ]]; then
-  ${RUN_AS_LOGIN_USER} "terra workspace set --id='${TERRA_WORKSPACE}'"
-fi
+# Fetch the Terra CLI server environment from the metadata server to install appropriate CLI version
+readonly TERRA_SERVER="$(get_metadata_value "instance/attributes/terra-cli-server")"
+
+${RUN_AS_LOGIN_USER} "\
+  curl -L https://storage.googleapis.com/devcontainerpkg/workbench-cli/download-install.sh | TERRA_CLI_SERVER=${TERRA_SERVER} bash && \
+  cp terra '${TERRA_INSTALL_PATH}'"
 
 # Set variables into the ~/.bashrc such that they are available
 # to terminals, notebooks, and other tools


### PR DESCRIPTION
Read the `terra-server` metadata and install the CLI from the appropriate broad/verily distribution url. For verily, fetch the distribution path from afs, for broad, install from the open source repo.