### PR TITLE
Return resource id for subnets

### DIFF
--- a/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/amalgam/landingzone/azure/LandingZoneApiDispatch.java
@@ -247,6 +247,7 @@ public class LandingZoneApiDispatch {
           .resourceParentId(resource.resourceParentId().orElse(null)) // Only available for subnets
           .resourceName(resource.resourceName().orElse(null)) // Only available for subnets
           .resourceType(resource.resourceType())
+          .resourceId(resource.resourceId())
           .tags(resource.tags())
           .region(resource.region());
     }


### PR DESCRIPTION
TES expects the batch subnet as a full resource id.

Related PR: https://github.com/DataBiosphere/leonardo/pull/3432 is blocked until we can return the resource id. 

https://broadworkbench.atlassian.net/browse/TOAZ-335