### PR TITLE
[BENCH-1270] - Added --allow-releaseinfo-change to apt-get update

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh
@@ -225,7 +225,7 @@ fi
 emit "Resynchronizing apt package index..."
 
 # The apt package index may not be clean when we run; resynchronize
-apt-get update
+apt-get update --allow-releaseinfo-change
 
 # Create the target directories for installing into the HOME directory
 ${RUN_AS_LOGIN_USER} "mkdir -p '${USER_BASH_COMPLETION_DIR}'"


### PR DESCRIPTION
Resolves error when running `post-startup.sh` on newly created environments in dev:

```
E: Repository 'http://packages.cloud.google.com/apt gcsfuse-buster InRelease' changed its 'Origin' value from 'gcsfuse-jessie' to 'namespaces/gcs-fuse-prod/repositories/gcsfuse-buster'
E: Repository 'http://packages.cloud.google.com/apt gcsfuse-buster InRelease' changed its 'Label' value from 'gcsfuse-jessie' to 'namespaces/gcs-fuse-prod/repositories/gcsfuse-buster'
```