### PR TITLE
[BENCH-1270] - Dataproc startup script:  added --allow-releaseinfo-ch…

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/dataproccluster/startup.sh
@@ -216,7 +216,7 @@ ${RUN_AS_LOGIN_USER} "touch '${USER_BASHRC}'"
 emit "Resynchronizing apt package index..."
 
 # The apt package index may not be clean when we run; resynchronize
-apt-get update
+apt-get update --allow-releaseinfo-change
 
 # Create the target directories for installing into the HOME directory
 ${RUN_AS_LOGIN_USER} "mkdir -p '${USER_BASH_COMPLETION_DIR}'"


### PR DESCRIPTION
…ange to apt-get update

Adds the same flag to `apt-get update' to resolve the issue reported in [BENCH-1270](https://verily.atlassian.net/browse/BENCH-1270) when creating dataproc cluster nodes.