### PR TITLE
WOR-1282 Fix error deleting old namespaces

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
@@ -46,14 +46,6 @@ public class GetWorkspaceManagedIdentityStep implements Step, GetManagedIdentity
             .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     var msiManager = crlService.getMsiManager(azureCloudContext, azureConfig);
     var managedIdentityResource = getManagedIdentityResource();
-    if (managedIdentityResource == null) {
-      return new StepResult(
-          StepStatus.STEP_RESULT_FAILURE_FATAL,
-          new BadRequestException(
-              String.format(
-                  "An Azure Managed Identity with id %s does not exist in workspace %s",
-                  managedIdentityName, workspaceId)));
-    }
     var uamiName = managedIdentityResource.getManagedIdentityName();
 
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
@@ -1,10 +1,8 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.exception.AzureManagementExceptionUtils;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
@@ -15,6 +15,7 @@ import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
 import bio.terra.workspace.common.utils.BaseMockitoStrictStubbingTest;
 import bio.terra.workspace.db.ResourceDao;
 import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.http.HttpResponse;
@@ -72,6 +73,48 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
             workspaceId,
             mockResourceDao,
             identityResource.getName());
+    assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
+
+    verify(mockWorkingMap).put(GetManagedIdentityStep.MANAGED_IDENTITY_NAME, mockIdentity.name());
+    verify(mockWorkingMap)
+        .put(GetManagedIdentityStep.MANAGED_IDENTITY_PRINCIPAL_ID, mockIdentity.principalId());
+    verify(mockWorkingMap)
+        .put(GetManagedIdentityStep.MANAGED_IDENTITY_CLIENT_ID, mockIdentity.clientId());
+  }
+
+  @Test
+  void testSuccessWithIdentityIdInsteadOfName() throws InterruptedException {
+    var workspaceId = UUID.randomUUID();
+    var creationParameters =
+        ControlledAzureResourceFixtures.getAzureManagedIdentityCreationParameters();
+    var identityResource =
+        ControlledAzureResourceFixtures.makeDefaultControlledAzureManagedIdentityResourceBuilder(
+                creationParameters, workspaceId)
+            .build();
+
+    createMockFlightContext();
+
+    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
+    when(mockMsiManager.identities()).thenReturn(mockIdentities);
+    when(mockIdentities.getByResourceGroup(
+        mockAzureCloudContext.getAzureResourceGroupId(),
+        identityResource.getManagedIdentityName()))
+        .thenReturn(mockIdentity);
+    when(mockResourceDao.getResourceByName(workspaceId, identityResource.getResourceId().toString()))
+        .thenThrow(new ResourceNotFoundException("not found"));
+    when(mockResourceDao.getResource(workspaceId, identityResource.getResourceId()))
+        .thenReturn(identityResource);
+    when(mockIdentity.name()).thenReturn(UUID.randomUUID().toString());
+    when(mockIdentity.principalId()).thenReturn(UUID.randomUUID().toString());
+    when(mockIdentity.clientId()).thenReturn(UUID.randomUUID().toString());
+
+    var step =
+        new GetWorkspaceManagedIdentityStep(
+            mockAzureConfig,
+            mockCrlService,
+            workspaceId,
+            mockResourceDao,
+            identityResource.getResourceId().toString());
     assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
 
     verify(mockWorkingMap).put(GetManagedIdentityStep.MANAGED_IDENTITY_NAME, mockIdentity.name());

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
@@ -97,10 +97,11 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
     when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
     when(mockMsiManager.identities()).thenReturn(mockIdentities);
     when(mockIdentities.getByResourceGroup(
-        mockAzureCloudContext.getAzureResourceGroupId(),
-        identityResource.getManagedIdentityName()))
+            mockAzureCloudContext.getAzureResourceGroupId(),
+            identityResource.getManagedIdentityName()))
         .thenReturn(mockIdentity);
-    when(mockResourceDao.getResourceByName(workspaceId, identityResource.getResourceId().toString()))
+    when(mockResourceDao.getResourceByName(
+            workspaceId, identityResource.getResourceId().toString()))
         .thenThrow(new ResourceNotFoundException("not found"));
     when(mockResourceDao.getResource(workspaceId, identityResource.getResourceId()))
         .thenReturn(identityResource);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1282

There are a couple dozen k8s namespaces in production that have the managed identity resource id stored in the database instead of the resource name. This change allows us to tolerate that case.