### PR TITLE
[WOR-1294] Add tag permissions to the get SAS token API

### DIFF
--- a/openapi/src/common/parameters.yaml
+++ b/openapi/src/common/parameters.yaml
@@ -128,6 +128,7 @@ components:
         |`w`         | Write       |
         |`d`         | Delete      |
         |`l`         | List        |
+        |`t`         | Tags        |
 
         For example:
           * To construct a SAS with permissions limited to read, write and list the caller would supply the string

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -101,7 +101,7 @@ public class AzureStorageAccessService {
       if (action.equals(SamConstants.SamControlledResourceActions.READ_ACTION)) {
         possiblePermissions += "rl";
       } else if (action.equals(SamConstants.SamControlledResourceActions.WRITE_ACTION)) {
-        possiblePermissions += "acwd";
+        possiblePermissions += "acwdt";
       }
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/SasPermissionsHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/SasPermissionsHelper.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 
 public class SasPermissionsHelper {
   private static final Set<Character> ALLOWED_SAS_PERMISSIONS =
-      Set.of('r', 'l', 'a', 'c', 'w', 'd');
+      Set.of('r', 'l', 'a', 'c', 'w', 'd', 't');
 
   public static Set<Character> permissionStringToCharSet(String permissions) {
     return permissions.chars().mapToObj(c -> (char) c).collect(Collectors.toSet());

--- a/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/CreateAzureStorageContainerSasTokenTest.java
@@ -218,7 +218,7 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
 
   @Test
   void createSASTokenBlobPermissionsSuccess() throws Exception {
-    String permissions = "rwcd";
+    String permissions = "rwcdt";
     mockMvc
         .perform(
             addAuth(
@@ -241,7 +241,7 @@ public class CreateAzureStorageContainerSasTokenTest extends BaseAzureUnitTest {
 
   @Test
   void createSASTokenBlobPermissionsInvalidPerms() throws Exception {
-    String permissions = "tfi";
+    String permissions = "fi";
     mockMvc
         .perform(
             addAuth(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessServiceUnitTest.java
@@ -191,7 +191,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             userRequest,
             new SasTokenOptions(null, startTime, expiryTime, null, null));
 
-    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), false);
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdlt"), false);
     verify(mockSamService())
         .listResourceActions(
             ArgumentMatchers.eq(userRequest),
@@ -256,7 +256,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             userRequest,
             new SasTokenOptions(null, startTime, expiryTime, null, null));
 
-    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), false);
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdlt"), false);
 
     verify(mockSamService())
         .listResourceActions(
@@ -290,7 +290,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             userRequest,
             new SasTokenOptions(null, startTime, expiryTime, "testing/blob-path", null));
 
-    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), true);
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdlt"), true);
   }
 
   @Test
@@ -402,7 +402,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             userRequest,
             new SasTokenOptions(null, startTime, expiryTime, blobName, null));
 
-    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), true);
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdlt"), true);
     assertTrue(
         result
             .sasUrl()
@@ -437,7 +437,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
             userRequest,
             new SasTokenOptions(ipRange, startTime, expiryTime, null, null));
 
-    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdl"), false);
+    assertValidToken(result.sasToken(), BlobContainerSasPermission.parse("racwdlt"), false);
     assertTrue(
         result.sasToken().contains("sip=" + ipRange),
         "the SignedIP was added to the query parameters");
@@ -489,7 +489,7 @@ public class AzureStorageAccessServiceUnitTest extends BaseAzureUnitTest {
                 null));
 
     assertEquals(
-        "AA2137EFE8AC6FE96478DDAA844D917A4472005E3DE3984BF0C6FF641D293AB3", result.sha256());
+        "CFB533C099640123124FA52E02EF82C97CD28CE7AD7ACF94532982569F98F920", result.sha256());
   }
 
   @Test


### PR DESCRIPTION
In this PR:
- Added the `t` (tag) permission to the API that generates SAS tokens.
- The `t` permission is allowed when the user has write access to the workspace.
