### PR TITLE
[WOR-1296] Azure workspace quota endpoint

### DIFF
--- a/openapi/src/parts/azure_landing_zone.yaml
+++ b/openapi/src/parts/azure_landing_zone.yaml
@@ -143,7 +143,10 @@ paths:
     parameters:
       - $ref: '#/components/parameters/LandingZoneId'
     get:
-      summary: List all Azure landing zones resources
+      deprecated: true
+      summary: |
+        List all Azure landing zones resources.
+        Deprecated in favor of the workspace-level landing zone resource endpoint.
       operationId: listAzureLandingZoneResources
       tags: [ LandingZones ]
       responses:
@@ -162,7 +165,9 @@ paths:
       - $ref: '#/components/parameters/AzureResourceId'
     get:
       deprecated: true
-      summary: Get the quota information of a resource an Azure Landing Zone
+      summary: |
+        Get the quota information of a resource an Azure Landing Zone.
+        Deprecated in favor of the workspace-level landing zone resource endpoint.
       operationId: getResourceQuotaResult
       tags: [ LandingZones ]
       responses:

--- a/openapi/src/parts/azure_landing_zone.yaml
+++ b/openapi/src/parts/azure_landing_zone.yaml
@@ -161,6 +161,7 @@ paths:
       - $ref: '#/components/parameters/LandingZoneId'
       - $ref: '#/components/parameters/AzureResourceId'
     get:
+      deprecated: true
       summary: Get the quota information of a resource an Azure Landing Zone
       operationId: getResourceQuotaResult
       tags: [ LandingZones ]

--- a/openapi/src/parts/controlled_azure_resource.yaml
+++ b/openapi/src/parts/controlled_azure_resource.yaml
@@ -1,0 +1,18 @@
+paths:
+  /api/workspaces/v1/{workspaceId}/azure/resource-quota:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/AzureResourceId'
+    get:
+      summary: Get the quota information of a resource in an Azure workspace.
+      operationId: getWorkspaceAzureResourceQuota
+      tags: [ ControlledAzureResource ]
+      responses:
+        '200':
+          $ref: '#/components/responses/ResourceQuotaResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'

--- a/openapi/src/parts/controlled_azure_resource.yaml
+++ b/openapi/src/parts/controlled_azure_resource.yaml
@@ -1,11 +1,28 @@
 paths:
-  /api/workspaces/v1/{workspaceId}/azure/resource-quota:
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/landingzone:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+    get:
+      summary: List all Azure resources in an Azure workspace's backing landing zone.
+      operationId: listWorkspaceAzureLandingZoneResources
+      tags: [ ControlledAzureResource ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AzureLandingZoneResourcesList'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/landingzone/quota:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
       - $ref: '#/components/parameters/AzureResourceId'
     get:
-      summary: Get the quota information of a resource in an Azure workspace.
-      operationId: getWorkspaceAzureResourceQuota
+      summary: Get the quota information of a resource in an Azure workspace's backing landing zone.
+      operationId: getWorkspaceAzureLandingZoneResourceQuota
       tags: [ ControlledAzureResource ]
       responses:
         '200':


### PR DESCRIPTION
## Context
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1296)
Users should be able to query resource quota for landing zone resources if they have permissions on the workspace.

## This PR
* Introduces two new endpoints:
   * ```/api/workspaces/v1/{workspaceId}/resources/controlled/azure/landingzone```
   * ```/api/workspaces/v1/{workspaceId}/resources/controlled/azure/landingzone/quota```
   * These endpoints will assert that user is a WRITER and proxy the call to the landing zone service as the WSM SA. 
 * Deprecates the old LZ versions of these endpoints.  