### PR TITLE
AJ-1235: Use helmchart names for pact identifiers.

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -56,7 +56,7 @@ jobs:
 
   wsm-consumer-contract-tests:
     runs-on: ubuntu-latest
-    needs: [init-github-context]
+    needs: [ init-github-context ]
     outputs:
       pact-b64: ${{ steps.encode-pact.outputs.pact-b64 }}
 
@@ -72,7 +72,7 @@ jobs:
       - name: Output consumer contract as non-breaking base64 string
         id: encode-pact
         run: |
-          NON_BREAKING_B64=$(cat service/build/pacts/wsm-consumer-bpm-provider.json | base64 -w 0)
+          NON_BREAKING_B64=$(cat service/build/pacts/workspacemanager-bpm.json | base64 -w 0)
           echo "pact-b64=${NON_BREAKING_B64}" >> $GITHUB_OUTPUT
 
   publish-contracts:

--- a/service/src/test/java/bio/terra/workspace/pact/ProfileApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/ProfileApiTest.java
@@ -32,7 +32,7 @@ public class ProfileApiTest {
   static final String dummyAzureProfileId = "4a5afeaa-b3b2-fa51-8e4e-9dbf294b7837";
   static final String dummyGCPProfileId = "37bfb7e0-8261-4160-9ae7-882800d6464f";
 
-  @Pact(consumer = "wsm-consumer", provider = "bpm-provider")
+  @Pact(consumer = "workspacemanager", provider = "bpm")
   public RequestResponsePact existingAzureBillingProfile(PactDslWithProvider builder) {
     var billingProfileResponseShape =
         new PactDslJsonBody()
@@ -57,7 +57,7 @@ public class ProfileApiTest {
         .toPact();
   }
 
-  @Pact(consumer = "wsm-consumer", provider = "bpm-provider")
+  @Pact(consumer = "workspacemanager", provider = "bpm")
   public RequestResponsePact existingGCPBillingProfile(PactDslWithProvider builder) {
     var billingProfileResponseShape =
         new PactDslJsonBody()
@@ -77,7 +77,7 @@ public class ProfileApiTest {
         .toPact();
   }
 
-  @Pact(consumer = "wsm-consumer", provider = "bpm-provider")
+  @Pact(consumer = "workspacemanager", provider = "bpm")
   public RequestResponsePact billingProfileUnAvailable(PactDslWithProvider builder) {
     return builder
         .uponReceiving("A request to retrieve a billing profile")

--- a/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/TpsApiTest.java
@@ -110,7 +110,7 @@ public class TpsApiTest {
     dispatch = new TpsApiDispatch(featureConfig, tpsConfig);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact createPaoWithNoExistingPolicy(PactDslWithProvider builder) {
     return builder
         .uponReceiving("A request to create a policy")
@@ -134,7 +134,7 @@ public class TpsApiTest {
         TpsObjectType.WORKSPACE);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact createPaoWithAPreexistingPolicy(PactDslWithProvider builder) {
     return builder
         .given(existingPolicyState)
@@ -164,7 +164,7 @@ public class TpsApiTest {
                 TpsObjectType.WORKSPACE));
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact deletePaoThatExists(PactDslWithProvider builder) {
     return builder
         .given(existingPolicyState)
@@ -184,7 +184,7 @@ public class TpsApiTest {
     dispatch.deletePao(existingPolicyId);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact getPaoWithAnExistingPolicy(PactDslWithProvider builder) {
     var policyResponseShape =
         new PactDslJsonBody()
@@ -226,7 +226,7 @@ public class TpsApiTest {
     assertFalse(policy.getNamespace().isEmpty());
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact getPaoThatDoesNotExist(PactDslWithProvider builder) {
     return builder
         .uponReceiving("A request to retrieve a policy that doesn't exist")
@@ -243,7 +243,7 @@ public class TpsApiTest {
     assertThrows(PolicyServiceNotFoundException.class, () -> dispatch.getPao(existingPolicyId));
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact linkPaoWhenBothExist(PactDslWithProvider builder) {
     var linkRequestShape =
         new PactDslJsonBody()
@@ -280,7 +280,7 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact mergePaoWhenBothExist(PactDslWithProvider builder) {
     var linkRequestShape =
         new PactDslJsonBody()
@@ -318,7 +318,7 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact replacePaoThatExists(PactDslWithProvider builder) {
     var updateRequestShape =
         new PactDslJsonBody()
@@ -354,7 +354,7 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact updatePaoPreexistingNoConflicts(PactDslWithProvider builder) {
     var updateRequestShape =
         new PactDslJsonBody()
@@ -394,7 +394,7 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact listValidRegions(PactDslWithProvider builder) {
     return builder
         .given(existingPolicyState)
@@ -417,7 +417,7 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact listValidByPolicyInput(PactDslWithProvider builder) {
     return builder
         .given(existingPolicyState)
@@ -448,7 +448,7 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact explainingAWorkspacePolicy(PactDslWithProvider builder) {
     var explainResponse =
         new PactDslJsonBody()
@@ -494,7 +494,7 @@ public class TpsApiTest {
     assertNotNull(result.toApi());
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact getLocationInfo(PactDslWithProvider builder) {
     var locationArray =
         new PactDslJsonArray()
@@ -529,7 +529,7 @@ public class TpsApiTest {
     assertNotNull(result);
   }
 
-  @Pact(consumer = "wsm", provider = "tps")
+  @Pact(consumer = "workspacemanager", provider = "tps")
   public RequestResponsePact getLocationInfoWithNullLocation(PactDslWithProvider builder) {
     var locationArray =
         new PactDslJsonArray()


### PR DESCRIPTION
Rename the pacticipant names to the recommended convention.

* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698068076950019) discussing the `-consumer` and `-provider` suffix anti-pattern.
* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698241095600099) discussing the recommendation to use the helmchart name.
* This must be paired with corresponding changes in [BPM](https://github.com/DataBiosphere/terra-billing-profile-manager) maintain existing contract verification coverage.
* There are not currently any [TPS](https://github.com/DataBiosphere/terra-policy-service) contract verification tests, so no updates needed there.

This is prerequesite work for https://github.com/DataBiosphere/terra-workspace-manager/pull/1511, which introduces a new provider-side verification for WSM's contract with WDS, which depends on WSM's pacticipant names to be correct.