### PR TITLE
DDO-3198 Add Metadata Yaml File to to ingest WSM into DSP backstage

### DIFF
--- a/foundation.yaml
+++ b/foundation.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terra-workspace-manager
+  description: |
+    WSM provides workspaces; contexts for holding the work of individuals and teams.
+  tags:
+    - java
+    - dsp
+    - terra
+    - springboot
+    - broadworkspaces
+  annotations:
+    github.com/project-slug: databiosphere/terra-workspace-manager
+spec:
+  type: service
+  lifecycle: production
+  owner: broadworkspaces
+  system: terra
+  dependsOn:
+    - component:sam
+    - component:terra-landing-zone-service
+    - component:terra-resource-buffer
+    - component:jade-data-repo
+  providesApis:
+    - terra-workspace-manager-api
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: terra-workspace-manager-api
+  description: |
+    Placeholder API description...
+  tags:
+    - java
+    - dsp
+    - terra
+    - springboot
+    - broadworkspaces
+  annotations:
+    github.com/project-slug: databiosphere/terra-workspace-manager
+spec:
+  type: openapi
+  lifecycle: production
+  system: terra
+  owner: broadworkspaces
+  definition:
+    $text: ./openapi/src/openapi_main.yaml
+---

--- a/foundation.yaml
+++ b/foundation.yaml
@@ -23,6 +23,8 @@ spec:
     - component:terra-landing-zone-service
     - component:terra-resource-buffer
     - component:jade-data-repo
+    - component:terra-billing-profile-manager
+    - component:terra-policy-service
   providesApis:
     - terra-workspace-manager-api
 ---


### PR DESCRIPTION
This is a functional no-op PR that just adds a metadata file to the WSM repo that is used to ingest bpm into [DSP's backstage instance](https://backstage.dsp-devops.broadinstitute.org/catalog?filters%5Bkind%5D=component&filters%5Buser%5D=owned). Backstage is an internal platform tool that can be used for a lot of SDLC processes and improving Dev experience. DevOps is just starting to experiment with this as a means to make getting a new service stood up in the terra environments and through the prod readiness checklist easier.

But we also want all our existing services to be in the system so they can get any benefits.