### PR TITLE
[WOR-1353] Update the workspace's auth domain on PAO link

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -871,15 +871,16 @@ public class WorkspaceService {
         sourcePaoId.getObjectId(),
         userRequest.getEmail());
     TpsPaoGetResult paoBeforeUpdate =
-        Rethrow.onInterrupted(() -> tpsApiDispatch.getPao(workspaceId), "getPao");
+        Rethrow.onInterrupted(
+            () ->
+                tpsApiDispatch.getOrCreatePao(
+                    workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE),
+            "getOrCreatePao");
 
     Rethrow.onInterrupted(
         () ->
             tpsApiDispatch.getOrCreatePao(
                 sourcePaoId.getObjectId(), sourcePaoId.getComponent(), sourcePaoId.getObjectType()),
-        "getOrCreatePao");
-    Rethrow.onInterrupted(
-        () -> tpsApiDispatch.getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE),
         "getOrCreatePao");
 
     TpsPaoUpdateResult dryRun =


### PR DESCRIPTION
[Related ticket](https://broadworkbench.atlassian.net/browse/WOR-1353)

We are not setting the auth domain on a workspace when a data repo snapshot is imported with a TPS group-constraint policy. This PR updates the linkPoilcies method to add the group from the constraint to the workspace's auth domain, similar to what we're doing on policy updates.