### PR TITLE
[WOR-1336] Link workspace PAO to spend profile PAO 

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStep.java
@@ -14,6 +14,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.exception.InternalLogicException;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
+import bio.terra.workspace.service.policy.exception.PolicyServiceDuplicateException;
 import bio.terra.workspace.service.resource.exception.PolicyConflictException;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
@@ -57,7 +58,7 @@ public class LinkSpendProfilePolicyAttributesStep implements Step {
           spendProfileUUID, TpsComponent.BPM, TpsObjectType.BILLING_PROFILE);
       workspacePao =
           tpsApiDispatch.getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
-    } catch (Exception ex) {
+    } catch (PolicyServiceDuplicateException ex) {
       logger.info("Attempt to get a PAO for billing profile or workspace failed", ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStep.java
@@ -42,7 +42,14 @@ public class LinkSpendProfilePolicyAttributesStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     UUID spendProfileUUID;
     try {
-      spendProfileUUID = UUID.fromString(spendProfileId.getId());
+      if (spendProfileId != null) {
+        spendProfileUUID = UUID.fromString(spendProfileId.getId());
+      } else {
+        logger.info(
+            "no spend profile id found, skipping spend profile and workspace PAO linking. [workspaceId={}]",
+            workspaceId);
+        return StepResult.getStepResultSuccess();
+      }
     } catch (IllegalArgumentException e) {
       logger.info(
           "non-UUID spend profile id provided, skipping spend profile and workspace PAO linking. [spendProfileId={}, workspaceId={}]",

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStep.java
@@ -66,14 +66,8 @@ public class LinkSpendProfilePolicyAttributesStep implements Step {
     TpsPolicyInputs destinationAttributes = workspacePao.getAttributes();
     context.getWorkingMap().put(WorkspaceFlightMapKeys.POLICIES, destinationAttributes);
 
-    TpsPaoUpdateResult result;
-    try {
-      result =
-          tpsApiDispatch.linkPao(workspaceId, spendProfileUUID, TpsUpdateMode.FAIL_ON_CONFLICT);
-    } catch (Exception ex) {
-      logger.info("Attempt to link PAOs for billing profile and workspace failed", ex);
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
-    }
+    TpsPaoUpdateResult result =
+        tpsApiDispatch.linkPao(workspaceId, spendProfileUUID, TpsUpdateMode.FAIL_ON_CONFLICT);
 
     if (!result.isUpdateApplied()) {
       for (TpsPaoConflict conflict : result.getConflicts()) {
@@ -83,9 +77,6 @@ public class LinkSpendProfilePolicyAttributesStep implements Step {
           "Workspace policies conflict with billing profile policies", result.getConflicts());
     }
 
-    context
-        .getWorkingMap()
-        .put(WorkspaceFlightMapKeys.EFFECTIVE_POLICIES, result.getResultingPao());
     return StepResult.getStepResultSuccess();
   }
 
@@ -100,15 +91,9 @@ public class LinkSpendProfilePolicyAttributesStep implements Step {
       return StepResult.getStepResultSuccess();
     }
 
-    TpsPaoUpdateResult result;
-    try {
-      result =
-          tpsApiDispatch.replacePao(
-              workspaceId, destinationAttributes, TpsUpdateMode.FAIL_ON_CONFLICT);
-    } catch (Exception ex) {
-      logger.info("Attempt to replace PAOs for workspace failed", ex);
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
-    }
+    TpsPaoUpdateResult result =
+        tpsApiDispatch.replacePao(
+            workspaceId, destinationAttributes, TpsUpdateMode.FAIL_ON_CONFLICT);
 
     if (!result.isUpdateApplied()) {
       List<String> conflictList =

--- a/service/src/main/java/bio/terra/workspace/service/policy/flight/MergeBillingProfilePolicyAttributesStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/flight/MergeBillingProfilePolicyAttributesStep.java
@@ -1,0 +1,101 @@
+package bio.terra.workspace.service.policy.flight;
+
+import bio.terra.policy.model.TpsComponent;
+import bio.terra.policy.model.TpsObjectType;
+import bio.terra.policy.model.TpsPaoConflict;
+import bio.terra.policy.model.TpsPaoGetResult;
+import bio.terra.policy.model.TpsPaoUpdateResult;
+import bio.terra.policy.model.TpsPolicyInputs;
+import bio.terra.policy.model.TpsUpdateMode;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.exception.InternalLogicException;
+import bio.terra.workspace.service.policy.TpsApiDispatch;
+import bio.terra.workspace.service.resource.exception.PolicyConflictException;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MergeBillingProfilePolicyAttributesStep implements Step {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MergeBillingProfilePolicyAttributesStep.class);
+
+  private final UUID workspaceId;
+  private final SpendProfileId spendProfileId;
+  private final TpsApiDispatch tpsApiDispatch;
+
+  public MergeBillingProfilePolicyAttributesStep(
+      UUID workspaceId, SpendProfileId spendProfileId, TpsApiDispatch tpsApiDispatch) {
+    this.workspaceId = workspaceId;
+    this.spendProfileId = spendProfileId;
+    this.tpsApiDispatch = tpsApiDispatch;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    // Create PAOs if they don't exist; catch TPS exceptions and retry
+    TpsPaoGetResult destinationPao;
+    UUID spendProfileUUID = UUID.fromString(spendProfileId.getId());
+    try {
+      tpsApiDispatch.getOrCreatePao(
+          spendProfileUUID, TpsComponent.BPM, TpsObjectType.BILLING_PROFILE);
+      destinationPao =
+          tpsApiDispatch.getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
+    } catch (Exception ex) {
+      logger.info(
+          "Attempt to create a PAO for billing profile or destination workspace failed", ex);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+    }
+
+    // Save the destination attributes so that we can restore them if the flight fails
+    TpsPolicyInputs destinationAttributes = destinationPao.getAttributes();
+    context.getWorkingMap().put(WorkspaceFlightMapKeys.POLICIES, destinationAttributes);
+
+    TpsPaoUpdateResult result =
+        tpsApiDispatch.mergePao(workspaceId, spendProfileUUID, TpsUpdateMode.FAIL_ON_CONFLICT);
+    if (!result.isUpdateApplied()) {
+      for (TpsPaoConflict conflict : result.getConflicts()) {
+        logger.info("Policy conflict: {}", conflict);
+      }
+      throw new PolicyConflictException(
+          "Workspace policies conflict with billing profile policies", result.getConflicts());
+    }
+
+    context
+        .getWorkingMap()
+        .put(WorkspaceFlightMapKeys.EFFECTIVE_POLICIES, result.getResultingPao());
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    var destinationAttributes =
+        context.getWorkingMap().get(WorkspaceFlightMapKeys.POLICIES, TpsPolicyInputs.class);
+
+    // If the working map didn't get populated, we failed before the merge, so
+    // consider it undone.
+    if (destinationAttributes == null) {
+      return StepResult.getStepResultSuccess();
+    }
+
+    TpsPaoUpdateResult result =
+        tpsApiDispatch.replacePao(
+            workspaceId, destinationAttributes, TpsUpdateMode.FAIL_ON_CONFLICT);
+    if (!result.isUpdateApplied()) {
+      List<String> conflictList =
+          result.getConflicts().stream().map(c -> c.getNamespace() + ':' + c.getName()).toList();
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new InternalLogicException(
+              String.format("Failed to restore destination workspace policies: %s", conflictList)));
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/CreateWorkspaceV2Flight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/CreateWorkspaceV2Flight.java
@@ -11,7 +11,7 @@ import bio.terra.workspace.common.utils.MakeFlightIdsStep;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
-import bio.terra.workspace.service.policy.flight.MergeBillingProfilePolicyAttributesStep;
+import bio.terra.workspace.service.policy.flight.LinkSpendProfilePolicyAttributesStep;
 import bio.terra.workspace.service.resource.model.WsmResourceStateRule;
 import bio.terra.workspace.service.spendprofile.SpendProfile;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
@@ -62,7 +62,7 @@ public class CreateWorkspaceV2Flight extends Flight {
                   workspace, policyInputs, appContext.getTpsApiDispatch(), userRequest),
               serviceRetryRule);
           addStep(
-              new MergeBillingProfilePolicyAttributesStep(
+              new LinkSpendProfilePolicyAttributesStep(
                   workspace.workspaceId(),
                   workspace.spendProfileId(),
                   appContext.getTpsApiDispatch()),

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/CreateWorkspaceV2Flight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/CreateWorkspaceV2Flight.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.common.utils.MakeFlightIdsStep;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
+import bio.terra.workspace.service.policy.flight.MergeBillingProfilePolicyAttributesStep;
 import bio.terra.workspace.service.resource.model.WsmResourceStateRule;
 import bio.terra.workspace.service.spendprofile.SpendProfile;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
@@ -59,6 +60,12 @@ public class CreateWorkspaceV2Flight extends Flight {
           addStep(
               new CreateWorkspacePoliciesStep(
                   workspace, policyInputs, appContext.getTpsApiDispatch(), userRequest),
+              serviceRetryRule);
+          addStep(
+              new MergeBillingProfilePolicyAttributesStep(
+                  workspace.workspaceId(),
+                  workspace.spendProfileId(),
+                  appContext.getTpsApiDispatch()),
               serviceRetryRule);
         }
         addStep(

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/WorkspaceCreateFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/WorkspaceCreateFlight.java
@@ -11,7 +11,7 @@ import bio.terra.workspace.common.utils.MakeFlightIdsStep;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
-import bio.terra.workspace.service.policy.flight.MergeBillingProfilePolicyAttributesStep;
+import bio.terra.workspace.service.policy.flight.LinkSpendProfilePolicyAttributesStep;
 import bio.terra.workspace.service.policy.flight.MergePolicyAttributesStep;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceStateRule;
@@ -67,7 +67,7 @@ public class WorkspaceCreateFlight extends Flight {
               serviceRetryRule);
 
           addStep(
-              new MergeBillingProfilePolicyAttributesStep(
+              new LinkSpendProfilePolicyAttributesStep(
                   workspace.workspaceId(),
                   workspace.spendProfileId(),
                   appContext.getTpsApiDispatch()),

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/WorkspaceCreateFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/WorkspaceCreateFlight.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.common.utils.MakeFlightIdsStep;
 import bio.terra.workspace.common.utils.RetryRules;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
+import bio.terra.workspace.service.policy.flight.MergeBillingProfilePolicyAttributesStep;
 import bio.terra.workspace.service.policy.flight.MergePolicyAttributesStep;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.WsmResourceStateRule;
@@ -64,6 +65,14 @@ public class WorkspaceCreateFlight extends Flight {
               new CreateWorkspacePoliciesStep(
                   workspace, policyInputs, appContext.getTpsApiDispatch(), userRequest),
               serviceRetryRule);
+
+          addStep(
+              new MergeBillingProfilePolicyAttributesStep(
+                  workspace.workspaceId(),
+                  workspace.spendProfileId(),
+                  appContext.getTpsApiDispatch()),
+              serviceRetryRule);
+
           // If we're cloning, we need to copy the policies from the source workspace.
           // This is here instead of in the CloneWorkspaceFlight because we need to do it before
           // we create the workspace in Sam in case there are auth domains.

--- a/service/src/test/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStepTest.java
@@ -21,7 +21,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.service.policy.TpsApiDispatch;
-import bio.terra.workspace.service.policy.exception.PolicyServiceAPIException;
+import bio.terra.workspace.service.policy.exception.PolicyServiceDuplicateException;
 import bio.terra.workspace.service.resource.exception.PolicyConflictException;
 import bio.terra.workspace.service.spendprofile.SpendProfileId;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
@@ -76,14 +76,14 @@ public class LinkSpendProfilePolicyAttributesStepTest extends BaseUnitTest {
   }
 
   @Test
-  public void doStep_getPaoFailure() throws InterruptedException, RetryException {
+  public void doStep_getPaoDuplicateFailure() throws InterruptedException, RetryException {
     var workspaceId = UUID.randomUUID();
     var spendProfileId = UUID.randomUUID();
     var linkPolicyStep =
         new LinkSpendProfilePolicyAttributesStep(
             workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
 
-    doThrow(new PolicyServiceAPIException("failure"))
+    doThrow(new PolicyServiceDuplicateException("duplicate pao"))
         .when(tpsApiDispatch)
         .getOrCreatePao(any(), any(), any());
 

--- a/service/src/test/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStepTest.java
@@ -121,29 +121,6 @@ public class LinkSpendProfilePolicyAttributesStepTest extends BaseUnitTest {
   }
 
   @Test
-  public void doStep_policyLinkFailure() throws InterruptedException, RetryException {
-    var workspaceId = UUID.randomUUID();
-    var spendProfileId = UUID.randomUUID();
-    var workingMap = new FlightMap();
-    var linkPolicyStep =
-        new LinkSpendProfilePolicyAttributesStep(
-            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
-
-    when(tpsApiDispatch.getOrCreatePao(any(), any(), any()))
-        .thenReturn(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()));
-    when(flightContext.getWorkingMap()).thenReturn(workingMap);
-    doThrow(new PolicyServiceAPIException("failure"))
-        .when(tpsApiDispatch)
-        .linkPao(any(), any(), any());
-
-    var stepResult = linkPolicyStep.doStep(flightContext);
-
-    assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, stepResult.getStepStatus());
-    verify(tpsApiDispatch, times(2)).getOrCreatePao(any(), any(), any());
-    verify(tpsApiDispatch, times(1)).linkPao(any(), any(), any());
-  }
-
-  @Test
   public void undoStep_noLinkFoundSuccess() throws InterruptedException, RetryException {
     var workspaceId = UUID.randomUUID();
     var spendProfileId = UUID.randomUUID();
@@ -197,27 +174,6 @@ public class LinkSpendProfilePolicyAttributesStepTest extends BaseUnitTest {
     var stepResult = linkPolicyStep.undoStep(flightContext);
 
     assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, stepResult.getStepStatus());
-    verify(tpsApiDispatch, times(1)).replacePao(any(), any(), any());
-  }
-
-  @Test
-  public void undoStep_replacePaoFailure() throws InterruptedException, RetryException {
-    var workspaceId = UUID.randomUUID();
-    var spendProfileId = UUID.randomUUID();
-    var workingMap = new FlightMap();
-    var linkPolicyStep =
-        new LinkSpendProfilePolicyAttributesStep(
-            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
-
-    workingMap.put(WorkspaceFlightMapKeys.POLICIES, new TpsPolicyInputs());
-    when(flightContext.getWorkingMap()).thenReturn(workingMap);
-    doThrow(new PolicyServiceAPIException("failure"))
-        .when(tpsApiDispatch)
-        .replacePao(any(), any(), any());
-
-    var stepResult = linkPolicyStep.undoStep(flightContext);
-
-    assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, stepResult.getStepStatus());
     verify(tpsApiDispatch, times(1)).replacePao(any(), any(), any());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/flight/LinkSpendProfilePolicyAttributesStepTest.java
@@ -1,0 +1,223 @@
+package bio.terra.workspace.service.policy.flight;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.policy.model.TpsComponent;
+import bio.terra.policy.model.TpsObjectType;
+import bio.terra.policy.model.TpsPaoGetResult;
+import bio.terra.policy.model.TpsPaoUpdateResult;
+import bio.terra.policy.model.TpsPolicyInputs;
+import bio.terra.policy.model.TpsUpdateMode;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.common.BaseUnitTest;
+import bio.terra.workspace.service.policy.TpsApiDispatch;
+import bio.terra.workspace.service.policy.exception.PolicyServiceAPIException;
+import bio.terra.workspace.service.resource.exception.PolicyConflictException;
+import bio.terra.workspace.service.spendprofile.SpendProfileId;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class LinkSpendProfilePolicyAttributesStepTest extends BaseUnitTest {
+  @Mock private TpsApiDispatch tpsApiDispatch;
+  @Mock private FlightContext flightContext;
+
+  @Test
+  public void doStep_linkSuccess() throws InterruptedException, RetryException {
+    var workspaceId = UUID.randomUUID();
+    var spendProfileId = UUID.randomUUID();
+    var workingMap = new FlightMap();
+    var linkPolicyStep =
+        new LinkSpendProfilePolicyAttributesStep(
+            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
+
+    when(tpsApiDispatch.getOrCreatePao(any(), any(), any()))
+        .thenReturn(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()));
+    when(tpsApiDispatch.linkPao(workspaceId, spendProfileId, TpsUpdateMode.FAIL_ON_CONFLICT))
+        .thenReturn(
+            new TpsPaoUpdateResult().updateApplied(true).resultingPao(new TpsPaoGetResult()));
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+
+    var stepResult = linkPolicyStep.doStep(flightContext);
+
+    assertEquals(StepResult.getStepResultSuccess(), stepResult);
+    verify(tpsApiDispatch, times(1))
+        .getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
+    verify(tpsApiDispatch, times(1))
+        .getOrCreatePao(spendProfileId, TpsComponent.BPM, TpsObjectType.BILLING_PROFILE);
+    verify(tpsApiDispatch, times(1))
+        .linkPao(workspaceId, spendProfileId, TpsUpdateMode.FAIL_ON_CONFLICT);
+  }
+
+  @Test
+  public void doStep_nonUuidSpendProfileSuccess() throws InterruptedException, RetryException {
+    var workspaceId = UUID.randomUUID();
+    var spendProfileId = "wm-default-spend-profile";
+    var linkPolicyStep =
+        new LinkSpendProfilePolicyAttributesStep(
+            workspaceId, new SpendProfileId(spendProfileId), tpsApiDispatch);
+
+    var stepResult = linkPolicyStep.doStep(flightContext);
+
+    assertEquals(StepResult.getStepResultSuccess(), stepResult);
+    verify(tpsApiDispatch, times(0)).getOrCreatePao(any(), any(), any());
+    verify(tpsApiDispatch, times(0)).linkPao(any(), any(), any());
+  }
+
+  @Test
+  public void doStep_getPaoFailure() throws InterruptedException, RetryException {
+    var workspaceId = UUID.randomUUID();
+    var spendProfileId = UUID.randomUUID();
+    var linkPolicyStep =
+        new LinkSpendProfilePolicyAttributesStep(
+            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
+
+    doThrow(new PolicyServiceAPIException("failure"))
+        .when(tpsApiDispatch)
+        .getOrCreatePao(any(), any(), any());
+
+    var stepResult = linkPolicyStep.doStep(flightContext);
+
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, stepResult.getStepStatus());
+    verify(tpsApiDispatch, times(1)).getOrCreatePao(any(), any(), any());
+    verify(tpsApiDispatch, times(0)).linkPao(any(), any(), any());
+  }
+
+  @Test
+  public void doStep_policyLinkUnappliedFailure() throws InterruptedException, RetryException {
+    var workspaceId = UUID.randomUUID();
+    var spendProfileId = UUID.randomUUID();
+    var workingMap = new FlightMap();
+    var linkPolicyStep =
+        new LinkSpendProfilePolicyAttributesStep(
+            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
+
+    when(tpsApiDispatch.getOrCreatePao(any(), any(), any()))
+        .thenReturn(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()));
+    when(tpsApiDispatch.linkPao(workspaceId, spendProfileId, TpsUpdateMode.FAIL_ON_CONFLICT))
+        .thenReturn(
+            new TpsPaoUpdateResult().updateApplied(false).resultingPao(new TpsPaoGetResult()));
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+
+    assertThrows(PolicyConflictException.class, () -> linkPolicyStep.doStep(flightContext));
+
+    verify(tpsApiDispatch, times(1))
+        .getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE);
+    verify(tpsApiDispatch, times(1))
+        .getOrCreatePao(spendProfileId, TpsComponent.BPM, TpsObjectType.BILLING_PROFILE);
+    verify(tpsApiDispatch, times(1))
+        .linkPao(workspaceId, spendProfileId, TpsUpdateMode.FAIL_ON_CONFLICT);
+  }
+
+  @Test
+  public void doStep_policyLinkFailure() throws InterruptedException, RetryException {
+    var workspaceId = UUID.randomUUID();
+    var spendProfileId = UUID.randomUUID();
+    var workingMap = new FlightMap();
+    var linkPolicyStep =
+        new LinkSpendProfilePolicyAttributesStep(
+            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
+
+    when(tpsApiDispatch.getOrCreatePao(any(), any(), any()))
+        .thenReturn(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()));
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    doThrow(new PolicyServiceAPIException("failure"))
+        .when(tpsApiDispatch)
+        .linkPao(any(), any(), any());
+
+    var stepResult = linkPolicyStep.doStep(flightContext);
+
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, stepResult.getStepStatus());
+    verify(tpsApiDispatch, times(2)).getOrCreatePao(any(), any(), any());
+    verify(tpsApiDispatch, times(1)).linkPao(any(), any(), any());
+  }
+
+  @Test
+  public void undoStep_noLinkFoundSuccess() throws InterruptedException, RetryException {
+    var workspaceId = UUID.randomUUID();
+    var spendProfileId = UUID.randomUUID();
+    var workingMap = new FlightMap();
+    var linkPolicyStep =
+        new LinkSpendProfilePolicyAttributesStep(
+            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
+
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+
+    var stepResult = linkPolicyStep.undoStep(flightContext);
+
+    assertEquals(StepResult.getStepResultSuccess(), stepResult);
+    verify(tpsApiDispatch, times(0)).replacePao(any(), any(), any());
+  }
+
+  @Test
+  public void undoStep_replacePaoSuccess() throws InterruptedException, RetryException {
+    var workspaceId = UUID.randomUUID();
+    var spendProfileId = UUID.randomUUID();
+    var workingMap = new FlightMap();
+    var linkPolicyStep =
+        new LinkSpendProfilePolicyAttributesStep(
+            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
+
+    workingMap.put(WorkspaceFlightMapKeys.POLICIES, new TpsPolicyInputs());
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(tpsApiDispatch.replacePao(any(), any(), any()))
+        .thenReturn(new TpsPaoUpdateResult().updateApplied(true));
+
+    var stepResult = linkPolicyStep.undoStep(flightContext);
+
+    assertEquals(StepResult.getStepResultSuccess(), stepResult);
+    verify(tpsApiDispatch, times(1)).replacePao(any(), any(), any());
+  }
+
+  @Test
+  public void undoStep_replacePaoUnappliedFailure() throws InterruptedException, RetryException {
+    var workspaceId = UUID.randomUUID();
+    var spendProfileId = UUID.randomUUID();
+    var workingMap = new FlightMap();
+    var linkPolicyStep =
+        new LinkSpendProfilePolicyAttributesStep(
+            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
+
+    workingMap.put(WorkspaceFlightMapKeys.POLICIES, new TpsPolicyInputs());
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(tpsApiDispatch.replacePao(any(), any(), any()))
+        .thenReturn(new TpsPaoUpdateResult().updateApplied(false));
+
+    var stepResult = linkPolicyStep.undoStep(flightContext);
+
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, stepResult.getStepStatus());
+    verify(tpsApiDispatch, times(1)).replacePao(any(), any(), any());
+  }
+
+  @Test
+  public void undoStep_replacePaoFailure() throws InterruptedException, RetryException {
+    var workspaceId = UUID.randomUUID();
+    var spendProfileId = UUID.randomUUID();
+    var workingMap = new FlightMap();
+    var linkPolicyStep =
+        new LinkSpendProfilePolicyAttributesStep(
+            workspaceId, new SpendProfileId(spendProfileId.toString()), tpsApiDispatch);
+
+    workingMap.put(WorkspaceFlightMapKeys.POLICIES, new TpsPolicyInputs());
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    doThrow(new PolicyServiceAPIException("failure"))
+        .when(tpsApiDispatch)
+        .replacePao(any(), any(), any());
+
+    var stepResult = linkPolicyStep.undoStep(flightContext);
+
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, stepResult.getStepStatus());
+    verify(tpsApiDispatch, times(1)).replacePao(any(), any(), any());
+  }
+}


### PR DESCRIPTION
Ticket: [WOR-1336](https://broadworkbench.atlassian.net/browse/WOR-1336)
* When a workspace is created, WSM will attempt to link its PAO to its spend profile's PAO. Non-BPM spend profiles are ignored.

[WOR-1336]: https://broadworkbench.atlassian.net/browse/WOR-1336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ