### PR TITLE
[WM-2398] sanitize process launcher inputs

### DIFF
--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -160,6 +160,7 @@ public class DatabaseService {
         blobFileName,
         blobContainerName);
 
+    validator.validatePgDumpCommand(commandList);
     localProcessLauncher.launchProcess(commandList, envVars);
 
     // Stream wrapping is confusing, so in English: local process output -> encryption -> base64
@@ -210,6 +211,7 @@ public class DatabaseService {
         blobFileName,
         blobContainerName);
 
+    validator.validatePgRestoreCommand(commandList);
     localProcessLauncher.launchProcess(commandList, envVars);
 
     // Stream wrapping is confusing, so in English: blob storage > base 64 decoding > decryption >

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/validation/Validator.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/validation/Validator.java
@@ -1,5 +1,6 @@
 package bio.terra.workspace.azureDatabaseUtils.validation;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
@@ -22,5 +23,32 @@ public class Validator {
 
   public void validateOidFormat(String userOid) {
     UUID.fromString(Objects.requireNonNull(userOid, "userOid must be specified"));
+  }
+
+  public void validatePgDumpCommand(List<String> commandList) {
+    var commandPath = commandList.get(0);
+    if (!commandPath.equals("pg_dump")) {
+      throw new IllegalArgumentException("commandPath must be `pg_dump`");
+    }
+    if (commandList.size() != 14) {
+      throw new IllegalArgumentException(
+          "pg_dump command list must contain exactly 14 arguments and values");
+    }
+
+    // What other validations should be used?
+
+  }
+
+  public void validatePgRestoreCommand(List<String> commandList) {
+    var commandPath = commandList.get(0);
+    if (!commandPath.equals("psql")) {
+      throw new IllegalArgumentException("commandPath must be `psql`");
+    }
+    if (commandList.size() != 11) {
+      throw new IllegalArgumentException(
+          "psql command list must contain exactly 11 arguments and values");
+    }
+
+    // What other validations should be used?
   }
 }


### PR DESCRIPTION
1. is it ok that I'm calling this just before the call to localProcessLauncher.launchProcess? the alternative is to put the validation inside the LocalProcessLauncher class, but then it'd have to be more general.
2. what kind of checks should I be doing? I can add a check for each expected item in the list of arguments... would that be sufficient?