### PR TITLE
fix(IA-4718): delete vm extension before retrying to create it

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/EnableVmLoggingStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/EnableVmLoggingStep.java
@@ -80,27 +80,46 @@ public class EnableVmLoggingStep implements Step {
   @Traced
   private void createDataCollectionRuleAssociation(
       FlightContext context, ApiAzureLandingZoneDeployedResource dcr, String vmId) {
-    getMonitorManager(context)
-        .diagnosticSettings()
-        .manager()
-        .serviceClient()
-        .getDataCollectionRuleAssociations()
-        .createWithResponse(
+    try {
+      getMonitorManager(context)
+          .diagnosticSettings()
+          .manager()
+          .serviceClient()
+          .getDataCollectionRuleAssociations()
+          .createWithResponse(
+              vmId,
+              resource.getVmName(),
+              new DataCollectionRuleAssociationProxyOnlyResourceInner()
+                  .withDataCollectionRuleId(dcr.getResourceId()),
+              Context.NONE);
+    } catch (ManagementException e) {
+      if (e.getResponse().getStatusCode() == 409) {
+        logger.info(
+            "data collection rule association already exists for vm {} and dcr {}",
             vmId,
-            resource.getVmName(),
-            new DataCollectionRuleAssociationProxyOnlyResourceInner()
-                .withDataCollectionRuleId(dcr.getResourceId()),
-            Context.NONE);
+            dcr.getResourceId());
+      } else {
+        throw e;
+      }
+    }
   }
 
   @Traced
   private void addMonitorAgentToVm(FlightContext context, String vmId) {
     var virtualMachine = getComputeManager(context).virtualMachines().getById(vmId);
 
+    var extensionName = "AzureMonitorLinuxAgent";
+    Optional.ofNullable(virtualMachine.listExtensions().get(extensionName)).ifPresent(
+        (extension) -> {
+          logger.info("extension {} already exists on vm {}, deleting it to retry", extensionName, vmId);
+          virtualMachine.update().withoutExtension(extensionName).apply();
+        }
+    );
+
     var extension =
         virtualMachine
             .update()
-            .defineNewExtension("AzureMonitorLinuxAgent")
+            .defineNewExtension(extensionName)
             .withPublisher("Microsoft.Azure.Monitor")
             .withType("AzureMonitorLinuxAgent")
             .withVersion(azureConfig.getAzureMonitorLinuxAgentVersion())

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/EnableVmLoggingStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/EnableVmLoggingStep.java
@@ -109,12 +109,15 @@ public class EnableVmLoggingStep implements Step {
     var virtualMachine = getComputeManager(context).virtualMachines().getById(vmId);
 
     var extensionName = "AzureMonitorLinuxAgent";
-    Optional.ofNullable(virtualMachine.listExtensions().get(extensionName)).ifPresent(
-        (extension) -> {
-          logger.info("extension {} already exists on vm {}, deleting it to retry", extensionName, vmId);
-          virtualMachine.update().withoutExtension(extensionName).apply();
-        }
-    );
+    Optional.ofNullable(virtualMachine.listExtensions().get(extensionName))
+        .ifPresent(
+            (extension) -> {
+              logger.info(
+                  "extension {} already exists on vm {}, deleting it to retry",
+                  extensionName,
+                  vmId);
+              virtualMachine.update().withoutExtension(extensionName).apply();
+            });
 
     var extension =
         virtualMachine


### PR DESCRIPTION
While trying to re-try creating the Azure Monitor Agent, the re-try fails because an extension with the same name exists.

This code attempts to delete the failed extension with the same name before retrying.

Tests are coming - 😅 

https://broadworkbench.atlassian.net/browse/IA-4718