### PR TITLE
[WOR-1396] Always create a landing zone during DeleteAzureCloudContextFlightTest

### DIFF
--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
@@ -44,15 +44,18 @@ public class BaseAzureConnectedTest extends BaseTest {
       WorkspaceService workspaceService, AuthenticatedUserRequest userRequest)
       throws InterruptedException {
     initSpendProfileMock();
-    Workspace workspace = azureTestUtils.createWorkspace(workspaceService);
+    createLandingZone();
 
+    Workspace workspace = azureTestUtils.createWorkspace(workspaceService);
+    azureUtils.createCloudContext(workspace.getWorkspaceId(), userRequest);
+    return workspace;
+  }
+
+  protected void createLandingZone() {
     // create quasi landing zone with no resources, tests can add any they need
     landingZoneId = UUID.fromString(landingZoneTestUtils.getDefaultLandingZoneId());
     testLandingZoneManager = new TestLandingZoneManager(landingZoneDao, azureTestUtils);
     testLandingZoneManager.createLandingZoneDbRecord(landingZoneId);
-
-    azureUtils.createCloudContext(workspace.getWorkspaceId(), userRequest);
-    return workspace;
   }
 
   /**

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/azure/DeleteAzureContextFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/azure/DeleteAzureContextFlightTest.java
@@ -13,7 +13,6 @@ import bio.terra.workspace.generated.model.ApiAccessScope;
 import bio.terra.workspace.generated.model.ApiManagedBy;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobService;
-import bio.terra.workspace.service.resource.controlled.ControlledResourceService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.model.AccessScopeType;
@@ -51,7 +50,6 @@ public class DeleteAzureContextFlightTest extends BaseAzureConnectedTest {
   private static final Duration CREATION_FLIGHT_TIMEOUT = Duration.ofMinutes(3);
 
   @Autowired private WorkspaceService workspaceService;
-  @Autowired private ControlledResourceService controlledResourceService;
   @Autowired private UserAccessUtils userAccessUtils;
   @Autowired private JobService jobService;
   @Autowired private AzureCloudContextService azureCloudContextService;
@@ -61,6 +59,8 @@ public class DeleteAzureContextFlightTest extends BaseAzureConnectedTest {
 
   @BeforeEach
   public void setup() {
+    createLandingZone();
+
     // Create a new workspace at the start of each test.
     workspaceUuid = UUID.randomUUID();
     SpendProfileId spendProfileId = initSpendProfileMock();


### PR DESCRIPTION
The `DeleteAzureContextFlightTest` test has been failing consistently the past few days. I am able to reproduce the issue locally as well:
```
bio.terra.landingzone.db.exception.LandingZoneNotFoundException: Landing Zone with billing profile 4a5afeaa-b3b2-fa51-8e4e-9dbf294b7837 not found.	
	at bio.terra.landingzone.db.LandingZoneDao.lambda$getLandingZoneByBillingProfileId$1(LandingZoneDao.java:181)	
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)	
	at bio.terra.landingzone.db.LandingZoneDao.getLandingZoneByBillingProfileId(LandingZoneDao.java:178)
```
My hunch is that these tests were only passing previously because they were running after another connected test had setup the landing zone. I've adjusted the test to always create a landing zone instead. 


[Successful run](https://scans.gradle.com/s/sadcobkowalpw/tests/task/:service:azureConnectedPlusTest/details/bio.terra.workspace.service.workspace.flight.azure.DeleteAzureContextFlightTest?top-execution=1)