### PR TITLE
[WOR-1397] Move custom script installation to a separate step

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -143,10 +143,6 @@ public class ControlledAzureVmResource extends ControlledResource {
             flightBeanBag.getResourceDao()),
         cloudRetry);
     flight.addStep(
-        new InstallCustomVmExtension(
-            flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), new VmExtensionHelper()),
-        cloudRetry);
-    flight.addStep(
         new AssignManagedIdentityAzureVmStep(
             flightBeanBag.getAzureConfig(),
             flightBeanBag.getCrlService(),
@@ -161,6 +157,10 @@ public class ControlledAzureVmResource extends ControlledResource {
             flightBeanBag.getLandingZoneApiDispatch(),
             flightBeanBag.getSamService(),
             flightBeanBag.getWorkspaceService()),
+        cloudRetry);
+    flight.addStep(
+        new InstallCustomVmExtension(
+            flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), new VmExtensionHelper()),
         cloudRetry);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ControlledAzureVmResource.java
@@ -143,6 +143,10 @@ public class ControlledAzureVmResource extends ControlledResource {
             flightBeanBag.getResourceDao()),
         cloudRetry);
     flight.addStep(
+        new InstallCustomVmExtension(
+            flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), new VmExtensionHelper()),
+        cloudRetry);
+    flight.addStep(
         new AssignManagedIdentityAzureVmStep(
             flightBeanBag.getAzureConfig(),
             flightBeanBag.getCrlService(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStep.java
@@ -170,12 +170,6 @@ public class CreateAzureVmStep implements Step {
               StepStatus.STEP_RESULT_FAILURE_FATAL, new AzureManagementException(e));
         }
 
-        case AzureManagementExceptionUtils.VM_EXTENSION_PROVISIONING_ERROR -> {
-          logger.error("Error provisioning VM extension");
-          yield new StepResult(
-              StepStatus.STEP_RESULT_FAILURE_FATAL, new AzureManagementException(e));
-        }
-
         default -> new StepResult(
             AzureManagementExceptionUtils.maybeRetryStatus(e), new AzureManagementException(e));
       };
@@ -220,29 +214,6 @@ public class CreateAzureVmStep implements Step {
             .withTag("resourceId", resource.getResourceId().toString())
             .withSize(VirtualMachineSizeTypes.fromString(resource.getVmSize()));
 
-    if (creationParameters.getCustomScriptExtension() != null) {
-      var customScriptExtension =
-          vmConfigurationFinalStep
-              .defineNewExtension(creationParameters.getCustomScriptExtension().getName())
-              .withPublisher(creationParameters.getCustomScriptExtension().getPublisher())
-              .withType(creationParameters.getCustomScriptExtension().getType())
-              .withVersion(creationParameters.getCustomScriptExtension().getVersion())
-              .withPublicSettings(
-                  AzureUtils.vmSettingsFrom(
-                      creationParameters.getCustomScriptExtension().getPublicSettings()))
-              .withProtectedSettings(
-                  AzureUtils.vmSettingsFrom(
-                      creationParameters.getCustomScriptExtension().getProtectedSettings()))
-              .withTags(
-                  AzureUtils.vmTagsFrom(creationParameters.getCustomScriptExtension().getTags()));
-
-      if (creationParameters.getCustomScriptExtension().isMinorVersionAutoUpgrade()) {
-        customScriptExtension.withMinorVersionAutoUpgrade();
-      } else {
-        customScriptExtension.withoutMinorVersionAutoUpgrade();
-      }
-      customScriptExtension.attach();
-    }
     return vmConfigurationFinalStep;
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ExtensionStatus.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/ExtensionStatus.java
@@ -1,0 +1,31 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
+
+import org.apache.commons.lang3.StringUtils;
+
+enum ExtensionStatus {
+  CANCELED("Canceled"),
+  CREATING("Creating"),
+  FAILED("Failed"),
+  SUCCEEDED("Succeeded"),
+  NOT_PRESENT("NotPresent");
+
+  private final String status;
+
+  ExtensionStatus(String status) {
+    this.status = status;
+  }
+
+  public String toString() {
+    return status;
+  }
+
+  public static ExtensionStatus fromString(String status) {
+    for (ExtensionStatus extensionStatus : ExtensionStatus.values()) {
+      if (StringUtils.equalsIgnoreCase(extensionStatus.status, status)) {
+        return extensionStatus;
+      }
+    }
+    throw new IllegalArgumentException(
+        "No enum constant " + ExtensionStatus.class + " for status " + status);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/InstallCustomVmExtension.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/InstallCustomVmExtension.java
@@ -1,0 +1,91 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.utils.FlightUtils;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+
+/**
+ * Installs a custom vm extension script on a previously created Azure VM
+ *
+ * <p>Input parameter requirements:
+ *
+ * <ol>
+ *   <li>CREATION_PARAMETERS: the creation parameters for the VM
+ * </ol>
+ *
+ * <p>Working map requirements:
+ *
+ * <ol>
+ *   <li>WORKING_MAP_VM_ID: the VM ID
+ *   <li>AZURE_CLOUD_CONTEXT: the azure cloud context holding the VM
+ * </ol>
+ */
+public class InstallCustomVmExtension implements Step {
+  private final AzureConfiguration azureConfig;
+  private final CrlService crlService;
+  private final VmExtensionHelper vmExtensionHelper;
+
+  public InstallCustomVmExtension(
+      AzureConfiguration azureConfig, CrlService crlService, VmExtensionHelper vmExtensionHelper) {
+    this.azureConfig = azureConfig;
+    this.crlService = crlService;
+    this.vmExtensionHelper = vmExtensionHelper;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap inputParameters = context.getInputParameters();
+    FlightUtils.validateRequiredEntries(
+        inputParameters, WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS);
+    FlightUtils.validateRequiredEntries(
+        context.getWorkingMap(), WorkspaceFlightMapKeys.ControlledResourceKeys.AZURE_CLOUD_CONTEXT);
+    FlightUtils.validateRequiredEntries(context.getWorkingMap(), AzureVmHelper.WORKING_MAP_VM_ID);
+
+    var azureCloudContext = getCloudContextFromFlightContext(context);
+    var creationParameters = getCreationParametersFromFlightContext(context);
+    var vmId = getVmIdFromFlightContext(context);
+
+    return vmExtensionHelper.maybeInstallExtension(
+        creationParameters, vmId, crlService.getComputeManager(azureCloudContext, azureConfig));
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    var vmId = getVmIdFromFlightContext(context);
+    var creationParams = getCreationParametersFromFlightContext(context);
+    var cloudContext = getCloudContextFromFlightContext(context);
+
+    return vmExtensionHelper.maybeUninstallExtension(
+        creationParams, vmId, crlService.getComputeManager(cloudContext, azureConfig));
+  }
+
+  private String getVmIdFromFlightContext(FlightContext context) {
+    return context.getWorkingMap().get(AzureVmHelper.WORKING_MAP_VM_ID, String.class);
+  }
+
+  private ApiAzureVmCreationParameters getCreationParametersFromFlightContext(
+      FlightContext context) {
+    return context
+        .getInputParameters()
+        .get(
+            WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS,
+            ApiAzureVmCreationParameters.class);
+  }
+
+  private AzureCloudContext getCloudContextFromFlightContext(FlightContext context) {
+
+    return context
+        .getWorkingMap()
+        .get(
+            WorkspaceFlightMapKeys.ControlledResourceKeys.AZURE_CLOUD_CONTEXT,
+            AzureCloudContext.class);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelper.java
@@ -1,0 +1,192 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
+
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.common.exception.AzureManagementException;
+import bio.terra.workspace.common.exception.AzureManagementExceptionUtils;
+import bio.terra.workspace.common.utils.AzureUtils;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
+import bio.terra.workspace.generated.model.ApiAzureVmCustomScriptExtension;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.compute.ComputeManager;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Knows how to install and manage a custom script extension on a VM */
+public class VmExtensionHelper {
+  private static final Logger logger = LoggerFactory.getLogger(VmExtensionHelper.class);
+
+  /**
+   * Installs a custom script extension on a VM if the extension is configured in the supplied
+   * creation parameters
+   *
+   * @param creationParameters
+   * @param vmId
+   * @param computeManager
+   * @return
+   */
+  public StepResult maybeInstallExtension(
+      ApiAzureVmCreationParameters creationParameters, String vmId, ComputeManager computeManager) {
+    if (creationParameters == null || creationParameters.getCustomScriptExtension() == null) {
+      logger.info("No custom script extension to install on VM {}, skipping", vmId);
+      return StepResult.getStepResultSuccess();
+    }
+
+    logger.info("Checking if custom script extension is already installed on VM {}", vmId);
+    var extensionStatus =
+        this.checkExtensionInstalled(
+            vmId, creationParameters.getCustomScriptExtension(), computeManager);
+    switch (extensionStatus) {
+      case FAILED:
+      case CANCELED:
+        logger.info("Custom script extension is in state {}, uninstalling", extensionStatus);
+        this.uninstallVmExtension(
+            vmId, creationParameters.getCustomScriptExtension(), computeManager);
+        break;
+      case CREATING:
+        var msg =
+            String.format(
+                "Custom script extension is still being created in VM %s, retrying", vmId);
+        logger.info(msg);
+        return new StepResult(
+            StepStatus.STEP_RESULT_FAILURE_RETRY, new VmExtensionInstallInProgressException(msg));
+      case SUCCEEDED:
+        logger.info("Custom script extension is already installed on VM {}, skipping", vmId);
+        return StepResult.getStepResultSuccess();
+    }
+
+    logger.info("Installing custom script extension on VM {}", vmId);
+    return this.installVmExtension(
+        vmId, creationParameters.getCustomScriptExtension(), computeManager);
+  }
+
+  public StepResult maybeUninstallExtension(
+      ApiAzureVmCreationParameters creationParams, String vmId, ComputeManager computeManager) {
+    if (Objects.isNull(creationParams)
+        || Objects.isNull(creationParams.getCustomScriptExtension())) {
+      logger.info("No custom script extension to uninstall on VM {}, skipping", vmId);
+      return StepResult.getStepResultSuccess();
+    }
+
+    var state =
+        this.checkExtensionInstalled(
+            vmId, creationParams.getCustomScriptExtension(), computeManager);
+
+    switch (state) {
+      case FAILED:
+      case CANCELED:
+      case SUCCEEDED:
+        logger.info("Custom script is in state {}, performing uninstall on VM {}", state, vmId);
+        this.uninstallVmExtension(vmId, creationParams.getCustomScriptExtension(), computeManager);
+        break;
+      case CREATING:
+        logger.info(
+            "Custom script extension is still being created in VM {}, uninstallation failing but may be retried",
+            vmId);
+        return new StepResult(
+            StepStatus.STEP_RESULT_FAILURE_RETRY,
+            new RuntimeException(
+                "Custom script extension is still being created in VM " + vmId + ", retrying"));
+      case NOT_PRESENT:
+        logger.info("Custom script extension is not installed on VM {}, skipping", vmId);
+        break;
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  private ExtensionStatus checkExtensionInstalled(
+      String virtualMachineId,
+      ApiAzureVmCustomScriptExtension customScriptExtensionConfig,
+      ComputeManager computeManager) {
+    var virtualMachine = computeManager.virtualMachines().getById(virtualMachineId);
+    // handle not found
+
+    var extensions = virtualMachine.listExtensions();
+    if (extensions.containsKey(customScriptExtensionConfig.getName())) {
+      logger.info(
+          "Custom script extension already installed on VM {}, checking status",
+          virtualMachine.id());
+      var extension = extensions.get(customScriptExtensionConfig.getName());
+      // https://learn.microsoft.com/en-us/rest/api/azurestack/vm-extensions/create?view=rest-azurestack-2015-12-01-preview&tabs=HTTP#provisioningstate
+      var state = ExtensionStatus.fromString(extension.provisioningState());
+      return state;
+    } else {
+      logger.info("Custom script extension not installed on VM {}", virtualMachine.id());
+    }
+    return ExtensionStatus.NOT_PRESENT;
+  }
+
+  private void uninstallVmExtension(
+      String virtualMachineId,
+      ApiAzureVmCustomScriptExtension customScriptExtensionConfig,
+      ComputeManager computeManager) {
+    var virtualMachine = computeManager.virtualMachines().getById(virtualMachineId);
+    var extensions = virtualMachine.listExtensions();
+    if (extensions.containsKey(customScriptExtensionConfig.getName())) {
+      logger.info(
+          "Custom script extension already installed on VM {}, uninstalling", virtualMachine.id());
+      virtualMachine.update().withoutExtension(customScriptExtensionConfig.getName()).apply();
+      logger.info("Custom script extension successfully uninstalled on VM {}", virtualMachine.id());
+    } else {
+      logger.info("Custom script extension not installed on VM {}", virtualMachine.id());
+    }
+  }
+
+  /**
+   * Installs a custom script extension on a VM using the given VM information and extension
+   * configuration
+   *
+   * @param customScriptExtensionConfig Configuration for the custom script extension
+   * @return Result of the operation
+   */
+  private StepResult installVmExtension(
+      String virtualMachineId,
+      ApiAzureVmCustomScriptExtension customScriptExtensionConfig,
+      ComputeManager computeManager) {
+    var virtualMachine = computeManager.virtualMachines().getById(virtualMachineId);
+
+    try {
+      var publicSettings =
+          AzureUtils.vmSettingsFrom(customScriptExtensionConfig.getPublicSettings());
+      var protectedSettings =
+          AzureUtils.vmSettingsFrom(customScriptExtensionConfig.getProtectedSettings());
+      var tags = AzureUtils.vmTagsFrom(customScriptExtensionConfig.getTags());
+      var customScriptExtension =
+          virtualMachine
+              .update()
+              .defineNewExtension(customScriptExtensionConfig.getName())
+              .withPublisher(customScriptExtensionConfig.getPublisher())
+              .withType(customScriptExtensionConfig.getType())
+              .withVersion(customScriptExtensionConfig.getVersion())
+              .withPublicSettings(publicSettings)
+              .withProtectedSettings(protectedSettings)
+              .withTags(tags);
+
+      if (customScriptExtensionConfig.isMinorVersionAutoUpgrade()) {
+        customScriptExtension.withMinorVersionAutoUpgrade();
+      } else {
+        customScriptExtension.withoutMinorVersionAutoUpgrade();
+      }
+      customScriptExtension.attach().apply();
+      logger.info("Successfully installed custom script extension on VM {}", virtualMachine.id());
+    } catch (ManagementException e) {
+      return switch (e.getValue().getCode()) {
+        case AzureManagementExceptionUtils.VM_EXTENSION_PROVISIONING_ERROR -> {
+          logger.error("Error provisioning VM extension");
+          yield new StepResult(
+              StepStatus.STEP_RESULT_FAILURE_FATAL, new AzureManagementException(e));
+        }
+        case AzureManagementExceptionUtils.CONFLICT -> {
+          logger.info("Custom script extension already installed on VM {}", virtualMachine.id());
+          yield StepResult.getStepResultSuccess();
+        }
+        default -> new StepResult(
+            AzureManagementExceptionUtils.maybeRetryStatus(e), new AzureManagementException(e));
+      };
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelper.java
@@ -89,7 +89,7 @@ public class VmExtensionHelper {
             new VmExtensionInstallInProgressException(
                 "Custom script extension is still being created in VM " + vmId + ", retrying"));
       case NOT_PRESENT:
-        logger.info("Custom script extension is not installed on VM {}, skipping", vmId);
+        logger.info("Custom script extension is not installed on VM {}, skipping uninstallation", vmId);
         break;
     }
 
@@ -108,8 +108,7 @@ public class VmExtensionHelper {
           virtualMachine.id());
       var extension = extensions.get(customScriptExtensionConfig.getName());
       // https://learn.microsoft.com/en-us/rest/api/azurestack/vm-extensions/create?view=rest-azurestack-2015-12-01-preview&tabs=HTTP#provisioningstate
-      var state = ExtensionStatus.fromString(extension.provisioningState());
-      return state;
+      return ExtensionStatus.fromString(extension.provisioningState());
     } else {
       logger.info("Custom script extension not installed on VM {}", virtualMachine.id());
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelper.java
@@ -89,7 +89,8 @@ public class VmExtensionHelper {
             new VmExtensionInstallInProgressException(
                 "Custom script extension is still being created in VM " + vmId + ", retrying"));
       case NOT_PRESENT:
-        logger.info("Custom script extension is not installed on VM {}, skipping uninstallation", vmId);
+        logger.info(
+            "Custom script extension is not installed on VM {}, skipping uninstallation", vmId);
         break;
     }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelper.java
@@ -86,7 +86,7 @@ public class VmExtensionHelper {
             vmId);
         return new StepResult(
             StepStatus.STEP_RESULT_FAILURE_RETRY,
-            new RuntimeException(
+            new VmExtensionInstallInProgressException(
                 "Custom script extension is still being created in VM " + vmId + ", retrying"));
       case NOT_PRESENT:
         logger.info("Custom script extension is not installed on VM {}, skipping", vmId);
@@ -101,8 +101,6 @@ public class VmExtensionHelper {
       ApiAzureVmCustomScriptExtension customScriptExtensionConfig,
       ComputeManager computeManager) {
     var virtualMachine = computeManager.virtualMachines().getById(virtualMachineId);
-    // handle not found
-
     var extensions = virtualMachine.listExtensions();
     if (extensions.containsKey(customScriptExtensionConfig.getName())) {
       logger.info(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionInstallInProgressException.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionInstallInProgressException.java
@@ -1,0 +1,9 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
+
+import org.springframework.retry.RetryException;
+
+class VmExtensionInstallInProgressException extends RetryException {
+  public VmExtensionInstallInProgressException(String msg) {
+    super(msg);
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -158,7 +158,7 @@ workspace:
     sas-token-start-time-minutes-offset: 15
     sas-token-expiry-time-minutes-offset: 60
     sas-token-expiry-time-maximum-minutes-offset: 1440
-    azure-monitor-linux-agent-version: "1.22"
+    azure-monitor-linux-agent-version: "1.28"
     cors-allowed-origins:
     protected-data-landing-zone-defs: ["ProtectedDataResourcesFactory"]
     azure-database-util-image: "us.gcr.io/broad-dsp-gcr-public/azure-database-utils:${version.gitHash}"

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/CreateAzureVmStepTest.java
@@ -379,41 +379,6 @@ public class CreateAzureVmStepTest extends BaseAzureUnitTest {
   }
 
   @Test
-  void createVm_VmExtensionProvisioningError() throws InterruptedException {
-    ApiAzureVmCreationParameters creationParameters =
-        ControlledAzureResourceFixtures.getAzureVmCreationParameters();
-
-    FlightMap creationParametersFlightMap = new FlightMap();
-    creationParametersFlightMap.put(ControlledResourceKeys.CREATION_PARAMETERS, creationParameters);
-    creationParametersFlightMap.makeImmutable();
-    when(mockFlightContext.getInputParameters()).thenReturn(creationParametersFlightMap);
-
-    var createAzureVmStep =
-        new CreateAzureVmStep(
-            mockAzureConfig,
-            mockCrlService,
-            ControlledAzureResourceFixtures.getAzureVm(creationParameters),
-            mockResourceDao);
-
-    // throw a vm extension provisioning exception
-    // azure sets the HTTP status code to 200 -- we want to make sure to set that here
-    // so we don't trigger the generic 4xx retry logic
-    var mockResponse = mock(HttpResponse.class);
-    when(mockResponse.getStatusCode()).thenReturn(200);
-    var vmExtensionException =
-        new ManagementException(
-            "error",
-            mockResponse,
-            new ManagementError(
-                AzureManagementExceptionUtils.VM_EXTENSION_PROVISIONING_ERROR, "VM error"));
-    when(mockVmStage12.create(any(Context.class))).thenThrow(vmExtensionException);
-
-    StepResult stepResult = createAzureVmStep.doStep(mockFlightContext);
-
-    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
-  }
-
-  @Test
   void createVm_ResourceNotFound() throws InterruptedException {
     ApiAzureVmCreationParameters creationParameters =
         ControlledAzureResourceFixtures.getAzureVmCreationParameters();

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/InstallCustomVmExtensionTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/InstallCustomVmExtensionTest.java
@@ -1,0 +1,71 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.BaseAzureUnitTest;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
+import bio.terra.workspace.generated.model.ApiAzureVmCustomScriptExtension;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class InstallCustomVmExtensionTest extends BaseAzureUnitTest {
+
+  @Mock private AzureConfiguration azureConfig;
+  @Mock private CrlService crlService;
+  @Mock private FlightContext flightContext;
+
+  @BeforeEach
+  void setup() {
+    flightContext = spy(FlightContext.class);
+    var workingMap = new FlightMap();
+    var azureCloudContext = new AzureCloudContext(null, null);
+    workingMap.put(
+        WorkspaceFlightMapKeys.ControlledResourceKeys.AZURE_CLOUD_CONTEXT, azureCloudContext);
+    workingMap.put(AzureVmHelper.WORKING_MAP_VM_ID, "vmId");
+    var inputParameters = new FlightMap();
+    when(flightContext.getInputParameters()).thenReturn(inputParameters);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void installExtension_withExtensionConfig() throws InterruptedException {
+    var creationParams = new ApiAzureVmCreationParameters();
+    var customScriptExtension = new ApiAzureVmCustomScriptExtension();
+    creationParams.setCustomScriptExtension(customScriptExtension);
+    flightContext
+        .getInputParameters()
+        .put(WorkspaceFlightMapKeys.ControlledResourceKeys.CREATION_PARAMETERS, creationParams);
+
+    var vmExtensionHelper = mock(VmExtensionHelper.class);
+    when(vmExtensionHelper.maybeInstallExtension(eq(creationParams), any(), any()))
+        .thenReturn(StepResult.getStepResultSuccess());
+    var step = new InstallCustomVmExtension(azureConfig, crlService, vmExtensionHelper);
+
+    step.doStep(flightContext);
+
+    verify(vmExtensionHelper).maybeInstallExtension(eq(creationParams), any(), any());
+  }
+
+  @Test
+  void installExtension_undoStep() throws InterruptedException {
+    var vmExtensionHelper = mock(VmExtensionHelper.class);
+    var step = new InstallCustomVmExtension(azureConfig, crlService, vmExtensionHelper);
+
+    step.undoStep(flightContext);
+
+    verify(vmExtensionHelper).maybeUninstallExtension(any(), any(), any());
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelperTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/VmExtensionHelperTest.java
@@ -1,0 +1,296 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.common.BaseAzureUnitTest;
+import bio.terra.workspace.generated.model.ApiAzureVmCreationParameters;
+import bio.terra.workspace.generated.model.ApiAzureVmCustomScriptExtension;
+import com.azure.core.management.exception.ManagementError;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.compute.ComputeManager;
+import com.azure.resourcemanager.compute.models.VirtualMachine;
+import com.azure.resourcemanager.compute.models.VirtualMachineExtension;
+import com.azure.resourcemanager.compute.models.VirtualMachines;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class VmExtensionHelperTest extends BaseAzureUnitTest {
+
+  @Mock ComputeManager computeManager;
+  @Mock VirtualMachines virtualMachines;
+
+  @BeforeEach
+  void setup() {
+    computeManager = mock(ComputeManager.class);
+    virtualMachines = mock(com.azure.resourcemanager.compute.models.VirtualMachines.class);
+    when(computeManager.virtualMachines()).thenReturn(virtualMachines);
+  }
+
+  @Test
+  void maybeInstallExtension_doesNothingWithNoScriptExtensionInput() {
+    var computeManager = mock(ComputeManager.class);
+    var vmExtensionHelper = new VmExtensionHelper();
+    var creationParams = new ApiAzureVmCreationParameters();
+
+    vmExtensionHelper.maybeInstallExtension(creationParams, "vmId", computeManager);
+
+    verifyNoInteractions(computeManager);
+  }
+
+  @ParameterizedTest
+  @EnumSource(ExtensionStatus.class)
+  void maybeInstallExtension_installsWithExtensionConfig(ExtensionStatus extensionStatus) {
+    var creationParams = new ApiAzureVmCreationParameters();
+    var customScriptExtensionConfig = new ApiAzureVmCustomScriptExtension();
+    customScriptExtensionConfig.minorVersionAutoUpgrade(true);
+    customScriptExtensionConfig.setName("fake_extension");
+    creationParams.setCustomScriptExtension(customScriptExtensionConfig);
+
+    var virtualMachine =
+        mockVmWithExtensionState(computeManager, "fake_vmid", "fake_extension", extensionStatus);
+    var mockCustomScriptExtension =
+        mock(VirtualMachineExtension.UpdateDefinitionStages.WithAttach.class);
+    var mockUpdate = mock(VirtualMachine.Update.class);
+    when(mockCustomScriptExtension.attach()).thenReturn(mockUpdate);
+    when(virtualMachine
+            .update()
+            .defineNewExtension(nullable(String.class))
+            .withPublisher(nullable(String.class))
+            .withType(nullable(String.class))
+            .withVersion(nullable(String.class))
+            .withPublicSettings(any())
+            .withProtectedSettings(any())
+            .withTags(any()))
+        .thenReturn(mockCustomScriptExtension);
+    var vmExtensionHelper = new VmExtensionHelper();
+
+    var result =
+        vmExtensionHelper.maybeInstallExtension(creationParams, "fake_vmid", computeManager);
+
+    switch (extensionStatus) {
+      case NOT_PRESENT:
+        assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+        verify(mockUpdate).apply();
+        break;
+      case CREATING:
+        assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+        verifyNoInteractions(mockUpdate);
+        break;
+      case FAILED:
+      case CANCELED:
+        verify(virtualMachine.update().withoutExtension(anyString())).apply();
+        verify(mockUpdate).apply();
+        assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+        break;
+      case SUCCEEDED:
+        verifyNoInteractions(mockUpdate);
+        assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+        break;
+    }
+  }
+
+  @Test
+  void maybeInstallExtension_handlesConflictManagementException() {
+    var creationParams = new ApiAzureVmCreationParameters();
+    var customScriptExtensionConfig = new ApiAzureVmCustomScriptExtension();
+    customScriptExtensionConfig.minorVersionAutoUpgrade(true);
+    customScriptExtensionConfig.setName("fake");
+    creationParams.setCustomScriptExtension(customScriptExtensionConfig);
+
+    var virtualMachine = mockVmWithExtensionState(computeManager, "fake_vmid", "fake", null);
+
+    var mockUpdate = mock(VirtualMachine.Update.class);
+    var mockCustomScriptExtension =
+        mock(VirtualMachineExtension.UpdateDefinitionStages.WithAttach.class);
+    when(mockCustomScriptExtension.attach()).thenReturn(mockUpdate);
+    when(virtualMachine
+            .update()
+            .defineNewExtension(nullable(String.class))
+            .withPublisher(nullable(String.class))
+            .withType(nullable(String.class))
+            .withVersion(nullable(String.class))
+            .withPublicSettings(any())
+            .withProtectedSettings(any())
+            .withTags(any()))
+        .thenReturn(mockCustomScriptExtension);
+    var mockManagementError = mock(ManagementError.class);
+    var mockManagementException = mock(ManagementException.class);
+    when(mockManagementError.getCode()).thenReturn("Conflict");
+    when(mockManagementException.getValue()).thenReturn(mockManagementError);
+    when(mockUpdate.apply()).thenThrow(mockManagementException);
+
+    var vmExtensionHelper = new VmExtensionHelper();
+
+    var result =
+        vmExtensionHelper.maybeInstallExtension(creationParams, "fake_vmid", computeManager);
+
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void maybeInstallExtension_failsOnProvisioningError() {
+    var creationParams = new ApiAzureVmCreationParameters();
+    var customScriptExtensionConfig = new ApiAzureVmCustomScriptExtension();
+    customScriptExtensionConfig.minorVersionAutoUpgrade(true);
+    customScriptExtensionConfig.setName("fake");
+    creationParams.setCustomScriptExtension(customScriptExtensionConfig);
+
+    var virtualMachine = mockVmWithExtensionState(computeManager, "fake_vmid", "fake", null);
+
+    var mockUpdate = mock(VirtualMachine.Update.class);
+    var mockCustomScriptExtension =
+        mock(VirtualMachineExtension.UpdateDefinitionStages.WithAttach.class);
+    when(mockCustomScriptExtension.attach()).thenReturn(mockUpdate);
+    when(virtualMachine
+            .update()
+            .defineNewExtension(nullable(String.class))
+            .withPublisher(nullable(String.class))
+            .withType(nullable(String.class))
+            .withVersion(nullable(String.class))
+            .withPublicSettings(any())
+            .withProtectedSettings(any())
+            .withTags(any()))
+        .thenReturn(mockCustomScriptExtension);
+    var mockManagementError = mock(ManagementError.class);
+    var mockManagementException = mock(ManagementException.class);
+    when(mockManagementError.getCode()).thenReturn("VMExtensionProvisioningError");
+    when(mockManagementError.getMessage()).thenReturn("VMExtensionProvisioningError");
+    when(mockManagementException.getValue()).thenReturn(mockManagementError);
+    when(mockManagementException.getMessage()).thenReturn("VMExtensionProvisioningError");
+    when(mockUpdate.apply()).thenThrow(mockManagementException);
+
+    var vmExtensionHelper = new VmExtensionHelper();
+
+    var result =
+        vmExtensionHelper.maybeInstallExtension(creationParams, "fake_vmid", computeManager);
+
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void maybeInstallExtension_skipsIfExistingInstallation() {
+    var creationParams = new ApiAzureVmCreationParameters();
+    var customScriptExtensionConfig = new ApiAzureVmCustomScriptExtension();
+    customScriptExtensionConfig.minorVersionAutoUpgrade(true);
+    customScriptExtensionConfig.setName("fake");
+    creationParams.setCustomScriptExtension(customScriptExtensionConfig);
+
+    mockVmWithExtensionState(computeManager, "fake_vmid", "fake", ExtensionStatus.SUCCEEDED);
+    var vmExtensionHelper = new VmExtensionHelper();
+
+    var result =
+        vmExtensionHelper.maybeInstallExtension(creationParams, "fake_vmid", computeManager);
+
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void maybeInstallExtension_returnsRetryIfInstalling() {
+    var creationParams = new ApiAzureVmCreationParameters();
+    var customScriptExtensionConfig = new ApiAzureVmCustomScriptExtension();
+    customScriptExtensionConfig.setName("fake");
+    creationParams.setCustomScriptExtension(customScriptExtensionConfig);
+
+    mockVmWithExtensionState(computeManager, "fake_vmid", "fake", ExtensionStatus.CREATING);
+
+    var vmExtensionHelper = new VmExtensionHelper();
+
+    var result =
+        vmExtensionHelper.maybeInstallExtension(creationParams, "fake_vmid", computeManager);
+
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+
+  @Test
+  void maybeUninstallExtension_doesNothingWithNoScriptExtensionInput() {
+    var computeManager = mock(ComputeManager.class);
+    var vmExtensionHelper = new VmExtensionHelper();
+    var creationParams = new ApiAzureVmCreationParameters();
+
+    vmExtensionHelper.maybeUninstallExtension(creationParams, "vmId", computeManager);
+
+    verifyNoInteractions(computeManager);
+  }
+
+  @ParameterizedTest
+  @EnumSource(ExtensionStatus.class)
+  void maybeUninstallExtension_uninstallsExtension(ExtensionStatus extensionStatus) {
+    var computeManager = mock(ComputeManager.class);
+    var vmExtensionHelper = new VmExtensionHelper();
+    var customScriptExtensionConfig = new ApiAzureVmCustomScriptExtension();
+    customScriptExtensionConfig.setName("fake");
+    var creationParams = new ApiAzureVmCreationParameters();
+    creationParams.setCustomScriptExtension(customScriptExtensionConfig);
+    var virtualMachine =
+        mockVmWithExtensionState(computeManager, "fake_vm", "fake", extensionStatus);
+
+    var result =
+        vmExtensionHelper.maybeUninstallExtension(creationParams, "fake_vm", computeManager);
+
+    switch (extensionStatus) {
+      case FAILED:
+      case CANCELED:
+      case SUCCEEDED:
+        {
+          Mockito.verify(
+                  virtualMachine
+                      .update()
+                      .withoutExtension(ArgumentMatchers.eq(customScriptExtensionConfig.getName())))
+              .apply();
+          assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+          break;
+        }
+      case CREATING:
+        Mockito.verifyNoInteractions(
+            virtualMachine
+                .update()
+                .withoutExtension(ArgumentMatchers.eq(customScriptExtensionConfig.getName()))
+                .apply());
+        assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+        break;
+      case NOT_PRESENT:
+        Mockito.verifyNoInteractions(
+            virtualMachine
+                .update()
+                .withoutExtension(ArgumentMatchers.eq(customScriptExtensionConfig.getName()))
+                .apply());
+        assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    }
+  }
+
+  private VirtualMachine mockVmWithExtensionState(
+      ComputeManager computeManager, String vmId, String extensionName, ExtensionStatus status) {
+    var virtualMachines = mock(com.azure.resourcemanager.compute.models.VirtualMachines.class);
+    when(computeManager.virtualMachines()).thenReturn(virtualMachines);
+    var virtualMachine =
+        mock(com.azure.resourcemanager.compute.models.VirtualMachine.class, RETURNS_DEEP_STUBS);
+    when(virtualMachines.getById(vmId)).thenReturn(virtualMachine);
+
+    if (extensionName != null && status != null) {
+      var mockExtension = mock(VirtualMachineExtension.class);
+      when(virtualMachine.listExtensions())
+          .thenReturn(Collections.singletonMap(extensionName, mockExtension));
+      when(mockExtension.provisioningState()).thenReturn(status.toString());
+    } else {
+      when(virtualMachine.listExtensions()).thenReturn(Collections.emptyMap());
+    }
+
+    return virtualMachine;
+  }
+}


### PR DESCRIPTION
## Context
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1397)

VM provisioning occasionally fails due to script extension installation issues with the AzureMonitorLinuxAgent. The hypothesis is that installing the Terra custom script extension inline during VM provisioning is locking up the package manager unnecessarily, leading to downstream effects with the AzureMonitorLinuxAgent installation. 

Reproducing this issue is difficult so this is more of a speculative fix. Concurrent to this PR, I'm going through a series of tests against a BEE where I will spin up many VMs and observe the rate of success before and after this PR prior to merge.

## This PR
* Extracts the custom script installation to a separate step during the provisioning flight and adds more thorough test coverage.
