### PR TITLE
[NO TICKET] Fix bumper.

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -66,7 +66,9 @@ jobs:
       # The 'ref' parameter ensures that the consumer version is postfixed with the HEAD commit of the PR branch,
       # facilitating cross-referencing of a pact between Pact Broker and GitHub.
       ref: ${{ github.head_ref || '' }}
-      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      # The 'dry-run' parameter prevents the new tag from being dispatched.
+      dry-run: true
+      release-branches: main
     secrets: inherit
 
   init-github-context:

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -76,7 +76,7 @@ jobs:
         event-name: ${{ github.event_name }}
     - name: Bump the tag to a new version
       if: steps.skiptest.outputs.is-bump == 'no'
-      uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
+      uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
       id: tag
       env:
         DEFAULT_BUMP: patch

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -47,7 +47,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,6 +18,11 @@ on:
         default: true
         required: false
         type: string
+      release-branches:
+        description: "Default branch (main, develop, etc)"
+        default: 'main'
+        required: false
+        type: string
     outputs:
       tag:
         description: "The value of the latest tag after running this action"
@@ -54,7 +59,7 @@ jobs:
           HOTFIX_BRANCHES: hotfix.*
           DEFAULT_BUMP: patch
           DRY_RUN: ${{ inputs.dry-run }}
-          RELEASE_BRANCHES: main
+          RELEASE_BRANCHES: ${{ inputs.release-branches }}
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.wsmVersion\\s*=\\s*\".*\""
           VERSION_SUFFIX: SNAPSHOT

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -96,8 +96,8 @@ jobs:
       # facilitating cross-referencing of a pact between Pact Broker and GitHub.
       ref: ${{ github.head_ref || '' }}
       # The 'dry-run' parameter prevents the new tag from being dispatched.
-      # We only need to dispatch a tag once if this is a PR merge.
-      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      dry-run: true
+      release-branches: main
     secrets: inherit
 
   verify-consumer-pact:


### PR DESCRIPTION
No ticket needed because this does not impact any production code (github workflows only).

This is to fix the problem that dependabot PRs trigger a new version to be created.