### PR TITLE
[WM-2418] Use ALTER TABLE for reassigning permission in workflow cloning

### DIFF
--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -132,7 +132,7 @@ public class DatabaseDao {
     jdbcTemplate.query(
         """
         SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'
-        """.formatted(databaseName),
+        """,
         Map.of(),
         (rs, rowNum) -> rs.getString(rowNum))
         .forEach(tableName -> {
@@ -140,7 +140,7 @@ public class DatabaseDao {
           jdbcTemplate.update(
               """
               ALTER TABLE public."%s" OWNER TO "%s"
-              """.formatted(databaseName, tableName, targetRoleName),
+              """.formatted(tableName, targetRoleName),
               Map.of());
         });
 //

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -134,7 +134,7 @@ public class DatabaseDao {
         SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'
         """,
         Map.of(),
-        (rs, rowNum) -> rs.getString(rowNum))
+        (rs, rowNum) -> rs.getString(1))
         .forEach(tableName -> {
           logger.info("Updating owner of public.{} to {}", tableName, targetRoleName);
           jdbcTemplate.update(
@@ -143,45 +143,6 @@ public class DatabaseDao {
               """.formatted(tableName, targetRoleName),
               Map.of());
         });
-//
-//    jdbcTemplate.update(
-//        """
-//        ALTER TABLE %s.databasechangelog OWNER TO "%s"
-//        """
-//            .formatted(databaseName, targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE %s.databasechangeloglock OWNER TO "%s"
-//            """
-//            .formatted(databaseName, targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE %s.method OWNER TO "%s"
-//            """.formatted(databaseName, targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE %s.method_version OWNER TO "%s"
-//            """
-//            .formatted(databaseName, targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE %s.run OWNER TO "%s"
-//            """.formatted(databaseName, targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE %s.run_set OWNER TO "%s"
-//            """.formatted(databaseName, targetRoleName),
-//        Map.of());
   }
 
   public void grantAllPrivileges(String roleName, String databaseName) {

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -1,8 +1,6 @@
 package bio.terra.workspace.azureDatabaseUtils.database;
 
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -12,7 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class DatabaseDao {
   private final NamedParameterJdbcTemplate jdbcTemplate;
-  private static final Logger logger = LoggerFactory.getLogger(DatabaseDao.class);
 
   @Autowired
   public DatabaseDao(NamedParameterJdbcTemplate jdbcTemplate) {

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -122,66 +122,66 @@ public class DatabaseDao {
         """.formatted(targetRoleName, roleName), Map.of());
   }
 
-  public void reassignOwnerForCbasDatabase(String databaseName, String targetRoleName) {
+  public void reassignOwnerForCbasDatabase(String targetRoleName) {
     // Note: here we use "ALTER TABLE" command instead of "REASSIGN OWNED BY" because for 'cbas'
     // databases where the database is either empty or has 1/2 rows in each table, "REASSIGN OWNED
     // BY" wasn't reassigning permissions as expected leading to bug mentioned in
     // https://broadworkbench.atlassian.net/browse/WM-2418.
 
-//    logger.info("About to update owner of");
-//    jdbcTemplate.query(
+    logger.info("About to update owner of public schema to {}", targetRoleName);
+    jdbcTemplate.query(
+        """
+        SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'
+        """.formatted(databaseName),
+        Map.of(),
+        (rs, rowNum) -> rs.getString(rowNum))
+        .forEach(tableName -> {
+          logger.info("Updating owner of public.{} to {}", tableName, targetRoleName);
+          jdbcTemplate.update(
+              """
+              ALTER TABLE public."%s" OWNER TO "%s"
+              """.formatted(databaseName, tableName, targetRoleName),
+              Map.of());
+        });
+//
+//    jdbcTemplate.update(
 //        """
-//        SELECT table_name FROM information_schema.tables WHERE table_schema = '%s'
-//        """.formatted(databaseName),
-//        Map.of(),
-//        (rs, rowNum) -> rs.getString(rowNum))
-//        .forEach(tableName -> {
-//          logger.info("Updating owner of public.{} to {}", tableName, targetRoleName);
-//          jdbcTemplate.update(
-//              """
-//              ALTER TABLE "%s"."%s" OWNER TO "%s"
-//              """.formatted(databaseName, tableName, targetRoleName),
-//              Map.of());
-//        });
-
-    jdbcTemplate.update(
-        """
-        ALTER TABLE %s.databasechangelog OWNER TO "%s"
-        """
-            .formatted(databaseName, targetRoleName),
-        Map.of());
-
-    jdbcTemplate.update(
-        """
-            ALTER TABLE %s.databasechangeloglock OWNER TO "%s"
-            """
-            .formatted(databaseName, targetRoleName),
-        Map.of());
-
-    jdbcTemplate.update(
-        """
-            ALTER TABLE %s.method OWNER TO "%s"
-            """.formatted(databaseName, targetRoleName),
-        Map.of());
-
-    jdbcTemplate.update(
-        """
-            ALTER TABLE %s.method_version OWNER TO "%s"
-            """
-            .formatted(databaseName, targetRoleName),
-        Map.of());
-
-    jdbcTemplate.update(
-        """
-            ALTER TABLE %s.run OWNER TO "%s"
-            """.formatted(databaseName, targetRoleName),
-        Map.of());
-
-    jdbcTemplate.update(
-        """
-            ALTER TABLE %s.run_set OWNER TO "%s"
-            """.formatted(databaseName, targetRoleName),
-        Map.of());
+//        ALTER TABLE %s.databasechangelog OWNER TO "%s"
+//        """
+//            .formatted(databaseName, targetRoleName),
+//        Map.of());
+//
+//    jdbcTemplate.update(
+//        """
+//            ALTER TABLE %s.databasechangeloglock OWNER TO "%s"
+//            """
+//            .formatted(databaseName, targetRoleName),
+//        Map.of());
+//
+//    jdbcTemplate.update(
+//        """
+//            ALTER TABLE %s.method OWNER TO "%s"
+//            """.formatted(databaseName, targetRoleName),
+//        Map.of());
+//
+//    jdbcTemplate.update(
+//        """
+//            ALTER TABLE %s.method_version OWNER TO "%s"
+//            """
+//            .formatted(databaseName, targetRoleName),
+//        Map.of());
+//
+//    jdbcTemplate.update(
+//        """
+//            ALTER TABLE %s.run OWNER TO "%s"
+//            """.formatted(databaseName, targetRoleName),
+//        Map.of());
+//
+//    jdbcTemplate.update(
+//        """
+//            ALTER TABLE %s.run_set OWNER TO "%s"
+//            """.formatted(databaseName, targetRoleName),
+//        Map.of());
   }
 
   public void grantAllPrivileges(String roleName, String databaseName) {

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -121,65 +121,46 @@ public class DatabaseDao {
         """.formatted(targetRoleName, roleName), Map.of());
   }
 
-  public void reassignOwner(String roleName, String targetRoleName) {
-    logger.info(
-            "*** FIND ME *** Reassigning ownership from {} to {}",
-            roleName,
-            targetRoleName);
+  public void reassignOwnerForCbasDatabase(String targetRoleName) {
+    // Note: here we use "ALTER TABLE" command instead of "REASSIGN OWNED BY" because for 'cbas' databases
+    // where the database is either empty or has 1/2 rows in each table, "REASSIGN OWNED BY" wasn't reassigning
+    // permissions as expected leading to bug mentioned in https://broadworkbench.atlassian.net/browse/WM-2418.
 
-    int databaseChangelogUpdate = jdbcTemplate.update(
+    jdbcTemplate.update(
         """
         ALTER TABLE databasechangelog OWNER TO "%s"
         """.formatted(targetRoleName),
         Map.of());
-    logger.info(
-            "*** FIND ME *** Number of rows updated after reassigning ownership for 'databasechangelog': {}",
-            databaseChangelogUpdate);
 
-    int databaseChangelogLockUpdate = jdbcTemplate.update(
+    jdbcTemplate.update(
             """
             ALTER TABLE databasechangeloglock OWNER TO "%s"
             """.formatted(targetRoleName),
             Map.of());
-    logger.info(
-            "*** FIND ME *** Number of rows updated after reassigning ownership for 'databasechangeloglock': {}",
-            databaseChangelogLockUpdate);
 
-    int methodUpdate = jdbcTemplate.update(
+   jdbcTemplate.update(
             """
             ALTER TABLE method OWNER TO "%s"
             """.formatted(targetRoleName),
             Map.of());
-    logger.info(
-            "*** FIND ME *** Number of rows updated after reassigning ownership for 'method': {}",
-            methodUpdate);
 
-    int method_versionUpdate = jdbcTemplate.update(
+    jdbcTemplate.update(
             """
             ALTER TABLE method_version OWNER TO "%s"
             """.formatted(targetRoleName),
             Map.of());
-    logger.info(
-            "*** FIND ME *** Number of rows updated after reassigning ownership for 'method_version': {}",
-            method_versionUpdate);
 
-    int runUpdate = jdbcTemplate.update(
+   jdbcTemplate.update(
             """
             ALTER TABLE run OWNER TO "%s"
             """.formatted(targetRoleName),
             Map.of());
-    logger.info(
-            "*** FIND ME *** Number of rows updated after reassigning ownership for 'run': {}",
-            runUpdate);
 
-    int run_setUpdate = jdbcTemplate.update(
+    jdbcTemplate.update(
             """
             ALTER TABLE run_set OWNER TO "%s"
             """.formatted(targetRoleName),
             Map.of());
-    logger.info(
-            "*** FIND ME *** Number of rows updated after reassigning ownership for 'run_set': {}",
-            run_setUpdate);
   }
 
   public void grantAllPrivileges(String roleName, String databaseName) {

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -121,7 +121,7 @@ public class DatabaseDao {
         """.formatted(targetRoleName, roleName), Map.of());
   }
 
-  public void reassignOwnerForCbasDatabase(String targetRoleName) {
+  public void reassignOwnerForDatabase(String targetRoleName) {
     // Note: here we use "ALTER TABLE" command instead of "REASSIGN OWNED BY" because for 'cbas'
     // databases where the database is either empty or has 1/2 rows in each table, "REASSIGN OWNED
     // BY" wasn't reassigning permissions as expected leading to bug mentioned in

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.azureDatabaseUtils.database;
 
 import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -129,20 +128,23 @@ public class DatabaseDao {
     // https://broadworkbench.atlassian.net/browse/WM-2418.
 
     logger.info("About to update owner of public schema to {}", targetRoleName);
-    jdbcTemplate.query(
-        """
+    jdbcTemplate
+        .query(
+            """
         SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'
         """,
-        Map.of(),
-        (rs, rowNum) -> rs.getString(1))
-        .forEach(tableName -> {
-          logger.info("Updating owner of public.{} to {}", tableName, targetRoleName);
-          jdbcTemplate.update(
-              """
+            Map.of(),
+            (rs, rowNum) -> rs.getString(1))
+        .forEach(
+            tableName -> {
+              logger.info("Updating owner of public.{} to {}", tableName, targetRoleName);
+              jdbcTemplate.update(
+                  """
               ALTER TABLE public."%s" OWNER TO "%s"
-              """.formatted(tableName, targetRoleName),
-              Map.of());
-        });
+              """
+                      .formatted(tableName, targetRoleName),
+                  Map.of());
+            });
   }
 
   public void grantAllPrivileges(String roleName, String databaseName) {

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -1,6 +1,9 @@
 package bio.terra.workspace.azureDatabaseUtils.database;
 
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -10,6 +13,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class DatabaseDao {
   private final NamedParameterJdbcTemplate jdbcTemplate;
+  private static final Logger logger = LoggerFactory.getLogger(DatabaseDao.class);
 
   @Autowired
   public DatabaseDao(NamedParameterJdbcTemplate jdbcTemplate) {
@@ -118,11 +122,64 @@ public class DatabaseDao {
   }
 
   public void reassignOwner(String roleName, String targetRoleName) {
-    jdbcTemplate.update(
+    logger.info(
+            "*** FIND ME *** Reassigning ownership from {} to {}",
+            roleName,
+            targetRoleName);
+
+    int databaseChangelogUpdate = jdbcTemplate.update(
         """
-        REASSIGN OWNED BY "%s" TO "%s"
-        """.formatted(roleName, targetRoleName),
+        ALTER TABLE databasechangelog OWNER TO "%s"
+        """.formatted(targetRoleName),
         Map.of());
+    logger.info(
+            "*** FIND ME *** Number of rows updated after reassigning ownership for 'databasechangelog': {}",
+            databaseChangelogUpdate);
+
+    int databaseChangelogLockUpdate = jdbcTemplate.update(
+            """
+            ALTER TABLE databasechangeloglock OWNER TO "%s"
+            """.formatted(targetRoleName),
+            Map.of());
+    logger.info(
+            "*** FIND ME *** Number of rows updated after reassigning ownership for 'databasechangeloglock': {}",
+            databaseChangelogLockUpdate);
+
+    int methodUpdate = jdbcTemplate.update(
+            """
+            ALTER TABLE method OWNER TO "%s"
+            """.formatted(targetRoleName),
+            Map.of());
+    logger.info(
+            "*** FIND ME *** Number of rows updated after reassigning ownership for 'method': {}",
+            methodUpdate);
+
+    int method_versionUpdate = jdbcTemplate.update(
+            """
+            ALTER TABLE method_version OWNER TO "%s"
+            """.formatted(targetRoleName),
+            Map.of());
+    logger.info(
+            "*** FIND ME *** Number of rows updated after reassigning ownership for 'method_version': {}",
+            method_versionUpdate);
+
+    int runUpdate = jdbcTemplate.update(
+            """
+            ALTER TABLE run OWNER TO "%s"
+            """.formatted(targetRoleName),
+            Map.of());
+    logger.info(
+            "*** FIND ME *** Number of rows updated after reassigning ownership for 'run': {}",
+            runUpdate);
+
+    int run_setUpdate = jdbcTemplate.update(
+            """
+            ALTER TABLE run_set OWNER TO "%s"
+            """.formatted(targetRoleName),
+            Map.of());
+    logger.info(
+            "*** FIND ME *** Number of rows updated after reassigning ownership for 'run_set': {}",
+            run_setUpdate);
   }
 
   public void grantAllPrivileges(String roleName, String databaseName) {

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -128,59 +128,60 @@ public class DatabaseDao {
     // BY" wasn't reassigning permissions as expected leading to bug mentioned in
     // https://broadworkbench.atlassian.net/browse/WM-2418.
 
-    jdbcTemplate.query(
-        """
-        SELECT table_name FROM information_schema.tables WHERE table_schema = '%s'
-        """.formatted(databaseName),
-        Map.of(),
-        (rs, rowNum) -> rs.getString(1))
-        .forEach(tableName -> {
-          logger.info("Updating owner of public.{} to {}", tableName, targetRoleName);
-          jdbcTemplate.update(
-              """
-              ALTER TABLE "%s" OWNER TO "%s"
-              """.formatted(tableName, targetRoleName),
-              Map.of());
-        });
+//    logger.info("About to update owner of");
+//    jdbcTemplate.query(
+//        """
+//        SELECT table_name FROM information_schema.tables WHERE table_schema = '%s'
+//        """.formatted(databaseName),
+//        Map.of(),
+//        (rs, rowNum) -> rs.getString(rowNum))
+//        .forEach(tableName -> {
+//          logger.info("Updating owner of public.{} to {}", tableName, targetRoleName);
+//          jdbcTemplate.update(
+//              """
+//              ALTER TABLE "%s"."%s" OWNER TO "%s"
+//              """.formatted(databaseName, tableName, targetRoleName),
+//              Map.of());
+//        });
 
-//    jdbcTemplate.update(
-//        """
-//        ALTER TABLE databasechangelog OWNER TO "%s"
-//        """
-//            .formatted(targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE databasechangeloglock OWNER TO "%s"
-//            """
-//            .formatted(targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE method OWNER TO "%s"
-//            """.formatted(targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE method_version OWNER TO "%s"
-//            """
-//            .formatted(targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE run OWNER TO "%s"
-//            """.formatted(targetRoleName),
-//        Map.of());
-//
-//    jdbcTemplate.update(
-//        """
-//            ALTER TABLE run_set OWNER TO "%s"
-//            """.formatted(targetRoleName),
-//        Map.of());
+    jdbcTemplate.update(
+        """
+        ALTER TABLE %s.databasechangelog OWNER TO "%s"
+        """
+            .formatted(databaseName, targetRoleName),
+        Map.of());
+
+    jdbcTemplate.update(
+        """
+            ALTER TABLE %s.databasechangeloglock OWNER TO "%s"
+            """
+            .formatted(databaseName, targetRoleName),
+        Map.of());
+
+    jdbcTemplate.update(
+        """
+            ALTER TABLE %s.method OWNER TO "%s"
+            """.formatted(databaseName, targetRoleName),
+        Map.of());
+
+    jdbcTemplate.update(
+        """
+            ALTER TABLE %s.method_version OWNER TO "%s"
+            """
+            .formatted(databaseName, targetRoleName),
+        Map.of());
+
+    jdbcTemplate.update(
+        """
+            ALTER TABLE %s.run OWNER TO "%s"
+            """.formatted(databaseName, targetRoleName),
+        Map.of());
+
+    jdbcTemplate.update(
+        """
+            ALTER TABLE %s.run_set OWNER TO "%s"
+            """.formatted(databaseName, targetRoleName),
+        Map.of());
   }
 
   public void grantAllPrivileges(String roleName, String databaseName) {

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -131,7 +131,7 @@ public class DatabaseDao {
     jdbcTemplate.query(
         """
         SELECT table_name FROM information_schema.tables WHERE table_schema = '%s'
-        """.formatted(tableName),
+        """.formatted(databaseName),
         Map.of(),
         (rs, rowNum) -> rs.getString(1))
         .forEach(tableName -> {

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDao.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.azureDatabaseUtils.database;
 
 import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -122,45 +121,49 @@ public class DatabaseDao {
   }
 
   public void reassignOwnerForCbasDatabase(String targetRoleName) {
-    // Note: here we use "ALTER TABLE" command instead of "REASSIGN OWNED BY" because for 'cbas' databases
-    // where the database is either empty or has 1/2 rows in each table, "REASSIGN OWNED BY" wasn't reassigning
-    // permissions as expected leading to bug mentioned in https://broadworkbench.atlassian.net/browse/WM-2418.
+    // Note: here we use "ALTER TABLE" command instead of "REASSIGN OWNED BY" because for 'cbas'
+    // databases where the database is either empty or has 1/2 rows in each table, "REASSIGN OWNED
+    // BY" wasn't reassigning permissions as expected leading to bug mentioned in
+    // https://broadworkbench.atlassian.net/browse/WM-2418.
 
     jdbcTemplate.update(
         """
         ALTER TABLE databasechangelog OWNER TO "%s"
-        """.formatted(targetRoleName),
+        """
+            .formatted(targetRoleName),
         Map.of());
 
     jdbcTemplate.update(
-            """
+        """
             ALTER TABLE databasechangeloglock OWNER TO "%s"
-            """.formatted(targetRoleName),
-            Map.of());
-
-   jdbcTemplate.update(
             """
+            .formatted(targetRoleName),
+        Map.of());
+
+    jdbcTemplate.update(
+        """
             ALTER TABLE method OWNER TO "%s"
             """.formatted(targetRoleName),
-            Map.of());
+        Map.of());
 
     jdbcTemplate.update(
-            """
+        """
             ALTER TABLE method_version OWNER TO "%s"
-            """.formatted(targetRoleName),
-            Map.of());
-
-   jdbcTemplate.update(
             """
+            .formatted(targetRoleName),
+        Map.of());
+
+    jdbcTemplate.update(
+        """
             ALTER TABLE run OWNER TO "%s"
             """.formatted(targetRoleName),
-            Map.of());
+        Map.of());
 
     jdbcTemplate.update(
-            """
+        """
             ALTER TABLE run_set OWNER TO "%s"
             """.formatted(targetRoleName),
-            Map.of());
+        Map.of());
   }
 
   public void grantAllPrivileges(String roleName, String databaseName) {

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -275,7 +275,7 @@ public class DatabaseService {
 
     // This reassignment of permissions is specific to 'cbas' database for Workflows app.
     // It can be made more generalized in the future.
-    databaseDao.reassignOwnerForCbasDatabase(dbName);
+    databaseDao.reassignOwnerForCbasDatabase(dbName, dbName);
   }
 
   public List<String> generateCommandList(

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -273,9 +273,7 @@ public class DatabaseService {
     }
     localProcessLauncher.getOutputStream().flush();
 
-    // This reassignment of permissions is specific to 'cbas' database for Workflows app.
-    // It can be made more generalized in the future.
-    databaseDao.reassignOwnerForCbasDatabase(dbName);
+    databaseDao.reassignOwnerForDatabase(dbName);
   }
 
   public List<String> generateCommandList(

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -275,7 +275,7 @@ public class DatabaseService {
 
     // This reassignment of permissions is specific to 'cbas' database for Workflows app.
     // It can be made more generalized in the future.
-    databaseDao.reassignOwnerForCbasDatabase(dbName, dbName);
+    databaseDao.reassignOwnerForCbasDatabase(dbName);
   }
 
   public List<String> generateCommandList(

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -273,7 +273,9 @@ public class DatabaseService {
     }
     localProcessLauncher.getOutputStream().flush();
 
-    databaseDao.reassignOwner(adminUser, dbName);
+    // this reassignment of permissions is specific to 'cbas' database for Workflows app. This should be made more
+    // generalized in the future.
+    databaseDao.reassignOwnerForCbasDatabase(dbName);
   }
 
   public List<String> generateCommandList(

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -272,6 +272,7 @@ public class DatabaseService {
       }
     }
     localProcessLauncher.getOutputStream().flush();
+    localProcessLauncher.waitForTerminate();
 
     databaseDao.reassignOwnerForDatabase(dbName);
   }

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -273,8 +273,8 @@ public class DatabaseService {
     }
     localProcessLauncher.getOutputStream().flush();
 
-    // this reassignment of permissions is specific to 'cbas' database for Workflows app. This should be made more
-    // generalized in the future.
+    // This reassignment of permissions is specific to 'cbas' database for Workflows app.
+    // It can be made more generalized in the future.
     databaseDao.reassignOwnerForCbasDatabase(dbName);
   }
 

--- a/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
+++ b/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
@@ -117,7 +117,7 @@ public class DatabaseDaoTest extends BaseUnitTest {
     jdbcTemplate.execute("CREATE DATABASE " + testDatabaseName);
     createTestRole(testRoleName);
     createTestRole(testRoleAdminName);
-    databaseDao.reassignOwner(testRoleName, testRoleAdminName);
+    databaseDao.reassignOwnerForCbasDatabase(testRoleAdminName);
   }
 
   private void createTestRole(String testRoleName) {

--- a/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
+++ b/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
@@ -133,7 +133,7 @@ public class DatabaseDaoTest extends BaseUnitTest {
     jdbcTemplate.execute("CREATE TABLE run_set ()");
     createTestRole(testRoleName);
 
-    databaseDao.reassignOwnerForCbasDatabase(testRoleName);
+    databaseDao.reassignOwnerForCbasDatabase(testDatabaseName, testRoleName);
   }
 
   private void createTestRole(String testRoleName) {

--- a/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
+++ b/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
@@ -133,7 +133,7 @@ public class DatabaseDaoTest extends BaseUnitTest {
     jdbcTemplate.execute("CREATE TABLE run_set ()");
     createTestRole(testRoleName);
 
-    databaseDao.reassignOwnerForCbasDatabase(testRoleName);
+    databaseDao.reassignOwnerForDatabase(testRoleName);
   }
 
   private void createTestRole(String testRoleName) {

--- a/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
+++ b/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
@@ -25,6 +25,15 @@ public class DatabaseDaoTest extends BaseUnitTest {
   @AfterEach
   void cleanup() {
     jdbcTemplate.execute("DROP DATABASE IF EXISTS " + testDatabaseName);
+
+    // clean 'cbas' database
+    jdbcTemplate.execute("DROP TABLE IF EXISTS databasechangelog");
+    jdbcTemplate.execute("DROP TABLE IF EXISTS databasechangeloglock");
+    jdbcTemplate.execute("DROP TABLE IF EXISTS method");
+    jdbcTemplate.execute("DROP TABLE IF EXISTS method_version");
+    jdbcTemplate.execute("DROP TABLE IF EXISTS run");
+    jdbcTemplate.execute("DROP TABLE IF EXISTS run_set");
+
     jdbcTemplate.execute("DROP ROLE IF EXISTS \"%s\"".formatted(testRoleName));
     jdbcTemplate.execute("DROP ROLE IF EXISTS \"%s\"".formatted(testRoleAdminName));
   }
@@ -114,10 +123,17 @@ public class DatabaseDaoTest extends BaseUnitTest {
 
   @Test
   void testReassignOwner() {
+    // create mock 'cbas' database and its tables
     jdbcTemplate.execute("CREATE DATABASE " + testDatabaseName);
+    jdbcTemplate.execute("CREATE TABLE databasechangelog ()");
+    jdbcTemplate.execute("CREATE TABLE databasechangeloglock ()");
+    jdbcTemplate.execute("CREATE TABLE method ()");
+    jdbcTemplate.execute("CREATE TABLE method_version ()");
+    jdbcTemplate.execute("CREATE TABLE run ()");
+    jdbcTemplate.execute("CREATE TABLE run_set ()");
     createTestRole(testRoleName);
-    createTestRole(testRoleAdminName);
-    databaseDao.reassignOwnerForCbasDatabase(testRoleAdminName);
+
+    databaseDao.reassignOwnerForCbasDatabase(testRoleName);
   }
 
   private void createTestRole(String testRoleName) {

--- a/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
+++ b/azureDatabaseUtils/src/test/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseDaoTest.java
@@ -133,7 +133,7 @@ public class DatabaseDaoTest extends BaseUnitTest {
     jdbcTemplate.execute("CREATE TABLE run_set ()");
     createTestRole(testRoleName);
 
-    databaseDao.reassignOwnerForCbasDatabase(testDatabaseName, testRoleName);
+    databaseDao.reassignOwnerForCbasDatabase(testRoleName);
   }
 
   private void createTestRole(String testRoleName) {

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AzureCloneWorkspaceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AzureCloneWorkspaceTest.java
@@ -22,11 +22,16 @@ import bio.terra.workspace.service.resource.controlled.model.ControlledResourceF
 import bio.terra.workspace.service.resource.controlled.model.ManagedByType;
 import bio.terra.workspace.service.resource.model.CloningInstructions;
 import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -155,12 +160,18 @@ public class AzureCloneWorkspaceTest extends BaseAzureConnectedTest {
   }
 
   void assertXofResourceY(int expectedNumber, WsmResourceFamily resourceType) {
+    List<WsmResource> resources = resourceDao
+            .enumerateResources(
+                    destWorkspace.getWorkspaceId(), resourceType, StewardshipType.CONTROLLED, 0, 100);
+    String resourcesString = resources.stream().map(WsmResource::getName).collect(Collectors.joining(", "));
+
     assertEquals(
         expectedNumber,
         resourceDao
             .enumerateResources(
                 destWorkspace.getWorkspaceId(), resourceType, StewardshipType.CONTROLLED, 0, 100)
-            .size());
+            .size(),
+            String.format("Expected %d %s resources, but found %d: %s", expectedNumber, resourceType, resources.size(), resourcesString));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AzureCloneWorkspaceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AzureCloneWorkspaceTest.java
@@ -26,12 +26,10 @@ import bio.terra.workspace.service.resource.model.WsmResource;
 import bio.terra.workspace.service.resource.model.WsmResourceFamily;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -160,10 +158,11 @@ public class AzureCloneWorkspaceTest extends BaseAzureConnectedTest {
   }
 
   void assertXofResourceY(int expectedNumber, WsmResourceFamily resourceType) {
-    List<WsmResource> resources = resourceDao
-            .enumerateResources(
-                    destWorkspace.getWorkspaceId(), resourceType, StewardshipType.CONTROLLED, 0, 100);
-    String resourcesString = resources.stream().map(WsmResource::getName).collect(Collectors.joining(", "));
+    List<WsmResource> resources =
+        resourceDao.enumerateResources(
+            destWorkspace.getWorkspaceId(), resourceType, StewardshipType.CONTROLLED, 0, 100);
+    String resourcesString =
+        resources.stream().map(WsmResource::getName).collect(Collectors.joining(", "));
 
     assertEquals(
         expectedNumber,
@@ -171,7 +170,9 @@ public class AzureCloneWorkspaceTest extends BaseAzureConnectedTest {
             .enumerateResources(
                 destWorkspace.getWorkspaceId(), resourceType, StewardshipType.CONTROLLED, 0, 100)
             .size(),
-            String.format("Expected %d %s resources, but found %d: %s", expectedNumber, resourceType, resources.size(), resourcesString));
+        String.format(
+            "Expected %d %s resources, but found %d: %s",
+            expectedNumber, resourceType, resources.size(), resourcesString));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AzureCloneWorkspaceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AzureCloneWorkspaceTest.java
@@ -166,10 +166,7 @@ public class AzureCloneWorkspaceTest extends BaseAzureConnectedTest {
 
     assertEquals(
         expectedNumber,
-        resourceDao
-            .enumerateResources(
-                destWorkspace.getWorkspaceId(), resourceType, StewardshipType.CONTROLLED, 0, 100)
-            .size(),
+        resources.size(),
         String.format(
             "Expected %d %s resources, but found %d: %s",
             expectedNumber, resourceType, resources.size(), resourcesString));


### PR DESCRIPTION
Tested these changes in BEE for various cloning scenarios and they work as expected:
- cloning from a workspace with no data in workflows app
- cloning from a workspace that has 1 workflow imported in workflows app
- cloning from a workspace that has 4 workflows imported in workflows app
- WorkspaceA - no imported workflows -> Clone -> WorkspaceB -> Workflows app started successfully -> imported 1 workflow -> Clone -> WorkspaceC -> Workflows app started successfully with 1 imported workflow

Closes https://broadworkbench.atlassian.net/browse/WM-2418