### PR TITLE
WM-2418: Wait for database table to exist before reassigning

### DIFF
--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -272,7 +272,8 @@ public class DatabaseService {
       }
     }
     localProcessLauncher.getOutputStream().flush();
-    Thread.sleep(5);
+    localProcessLauncher.getOutputStream().close();
+    localProcessLauncher.waitForTerminate();
 
     databaseDao.reassignOwner(adminUser, dbName);
   }

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -224,7 +224,8 @@ public class DatabaseService {
       String encryptionKeyBase64,
       LocalProcessLauncher localProcessLauncher)
       throws PSQLException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
-          IOException, InvalidAlgorithmParameterException, NoSuchProviderException, InterruptedException {
+          IOException, InvalidAlgorithmParameterException, NoSuchProviderException,
+          InterruptedException {
 
     // Grant the database role (dbName) to the workspace identity (adminUser).
     // In theory, we should be revoking this role after the operation is complete.

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -224,7 +224,7 @@ public class DatabaseService {
       String encryptionKeyBase64,
       LocalProcessLauncher localProcessLauncher)
       throws PSQLException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
-          IOException, InvalidAlgorithmParameterException, NoSuchProviderException {
+          IOException, InvalidAlgorithmParameterException, NoSuchProviderException, InterruptedException {
 
     // Grant the database role (dbName) to the workspace identity (adminUser).
     // In theory, we should be revoking this role after the operation is complete.
@@ -272,7 +272,7 @@ public class DatabaseService {
       }
     }
     localProcessLauncher.getOutputStream().flush();
-    localProcessLauncher.waitForTerminate();
+    Thread.sleep(5);
 
     databaseDao.reassignOwner(adminUser, dbName);
   }

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -271,7 +271,7 @@ public class DatabaseService {
         }
       }
     }
-//    localProcessLauncher.getOutputStream().flush();
+    localProcessLauncher.getOutputStream().flush();
     Thread.sleep(5);
 
     databaseDao.reassignOwner(adminUser, dbName);

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -271,7 +271,7 @@ public class DatabaseService {
         }
       }
     }
-    localProcessLauncher.getOutputStream().flush();
+//    localProcessLauncher.getOutputStream().flush();
     Thread.sleep(5);
 
     databaseDao.reassignOwner(adminUser, dbName);

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/database/DatabaseService.java
@@ -272,6 +272,7 @@ public class DatabaseService {
       }
     }
     localProcessLauncher.getOutputStream().flush();
+    localProcessLauncher.waitForTerminate();
 
     databaseDao.reassignOwner(adminUser, dbName);
   }

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/runners/PgRestoreDatabaseRunner.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/runners/PgRestoreDatabaseRunner.java
@@ -52,7 +52,7 @@ public class PgRestoreDatabaseRunner implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args)
       throws PSQLException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
-          IOException, InvalidAlgorithmParameterException, NoSuchProviderException {
+          IOException, InvalidAlgorithmParameterException, NoSuchProviderException, InterruptedException {
     LocalProcessLauncher localProcessLauncher = new LocalProcessLauncher();
     databaseService.pgRestore(
         dbName,

--- a/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/runners/PgRestoreDatabaseRunner.java
+++ b/azureDatabaseUtils/src/main/java/bio/terra/workspace/azureDatabaseUtils/runners/PgRestoreDatabaseRunner.java
@@ -52,7 +52,8 @@ public class PgRestoreDatabaseRunner implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args)
       throws PSQLException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
-          IOException, InvalidAlgorithmParameterException, NoSuchProviderException, InterruptedException {
+          IOException, InvalidAlgorithmParameterException, NoSuchProviderException,
+          InterruptedException {
     LocalProcessLauncher localProcessLauncher = new LocalProcessLauncher();
     databaseService.pgRestore(
         dbName,


### PR DESCRIPTION
Makes sure the pgrestore command finishes before we try to update table ownership.

Otherwise in the worst case (for very small dumps being restored), we can end up running the table reassignment before the table creation command has run.