### PR TITLE
[WOR-1416] Update gradle, jib, and two other libraries required by JShell.

### DIFF
--- a/azureDatabaseUtils/build.gradle
+++ b/azureDatabaseUtils/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     id 'terra-workspace-manager.java-conventions'
     id "com.github.ben-manes.versions" version "0.50.0"
-    id "com.google.cloud.tools.jib" version "3.0.0"
+    id "com.google.cloud.tools.jib" version "3.4.0"
     id "de.undercouch.download" version "4.1.1"
     id "org.springframework.boot"
     id "io.spring.dependency-management"

--- a/azureDatabaseUtils/gradle/deploy.gradle
+++ b/azureDatabaseUtils/gradle/deploy.gradle
@@ -11,7 +11,6 @@ jib {
 }
 
 tasks.register('buildBaseImage', Exec) {
-
   workingDir "$projectDir"
   commandLine "docker", "build", "-t", "azure-database-utils-base:latest", "."
 }

--- a/azureDatabaseUtils/gradle/deploy.gradle
+++ b/azureDatabaseUtils/gradle/deploy.gradle
@@ -1,5 +1,3 @@
-import java.time.ZonedDateTime
-
 // Deploy config
 jib {
   from {
@@ -7,11 +5,13 @@ jib {
     image = "docker://azure-database-utils-base:latest"
   }
   extraDirectories {
+    mkdir jibExtraDirectory
     paths = [file(jibExtraDirectory)]
   }
 }
 
 tasks.register('buildBaseImage', Exec) {
+
   workingDir "$projectDir"
   commandLine "docker", "build", "-t", "azure-database-utils-base:latest", "."
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
 
     // For JShell support
     // https://gitlab.com/barfuin/gradle-taskinfo
-    id 'org.barfuin.gradle.taskinfo' version '1.1.1'
-    id "com.github.mrsarm.jshell.plugin" version "1.1.0"
+    id 'org.barfuin.gradle.taskinfo' version '2.1.0'
+    id 'com.github.mrsarm.jshell.plugin' version '1.2.1'
 }
 
 def artifactory_repo_key = System.getenv("ARTIFACTORY_REPO_KEY") != null ? System.getenv("ARTIFACTORY_REPO_KEY") : 'libs-snapshot-local'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     id 'terra-workspace-manager.java-conventions'
     id "com.github.ben-manes.versions" version "0.50.0"
-    id "com.google.cloud.tools.jib" version "3.0.0"
+    id "com.google.cloud.tools.jib" version "3.4.0"
     id "de.undercouch.download" version "4.1.1"
     id "org.hidetake.swagger.generator" version "2.19.2"
     id "org.springframework.boot"

--- a/service/gradle/deploy.gradle
+++ b/service/gradle/deploy.gradle
@@ -8,6 +8,7 @@ jib {
     image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian"
   }
   extraDirectories {
+    mkdir jibExtraDirectory
     paths = [file(jibExtraDirectory)]
   }
   container {


### PR DESCRIPTION
Originally https://github.com/DataBiosphere/terra-workspace-manager/pull/1560.