### PR TITLE
Do not fail out azure k8s namespace deletion when managed identity resource is not present

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/ControlledAzureKubernetesNamespaceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/ControlledAzureKubernetesNamespaceResource.java
@@ -21,6 +21,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdenti
 import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetFederatedIdentityStep;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetPetManagedIdentityStep;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetWorkspaceManagedIdentityStep;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.ManagedIdentityHelper;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.MissingIdentityBehavior;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.create.GetAzureCloudContextStep;
@@ -218,12 +219,13 @@ public class ControlledAzureKubernetesNamespaceResource extends ControlledResour
       FlightBeanBag flightBeanBag, MissingIdentityBehavior missingIdentityBehavior) {
     return switch (getAccessScope()) {
       case ACCESS_SCOPE_SHARED -> new GetWorkspaceManagedIdentityStep(
-          flightBeanBag.getAzureConfig(),
-          flightBeanBag.getCrlService(),
           getWorkspaceId(),
-          flightBeanBag.getResourceDao(),
           getManagedIdentity(),
-          missingIdentityBehavior);
+          missingIdentityBehavior,
+          new ManagedIdentityHelper(
+              flightBeanBag.getResourceDao(),
+              flightBeanBag.getCrlService(),
+              flightBeanBag.getAzureConfig()));
 
       case ACCESS_SCOPE_PRIVATE -> new GetPetManagedIdentityStep(
           flightBeanBag.getAzureConfig(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/DeleteFederatedCredentialStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/DeleteFederatedCredentialStep.java
@@ -41,7 +41,7 @@ public class DeleteFederatedCredentialStep implements Step {
     var msiManager = crlService.getMsiManager(azureCloudContext, azureConfig);
 
     // guard against the managed identity not existing from a previous deletion
-    if (!GetManagedIdentityStep.managedIdentityExists(context)
+    if (!GetManagedIdentityStep.managedIdentityExistsInFlightWorkingMap(context)
         && missingIdentityBehavior == MissingIdentityBehavior.ALLOW_MISSING) {
       logger.info("Managed identity not found, but allowed to be missing");
       return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/DeleteFederatedCredentialStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/DeleteFederatedCredentialStep.java
@@ -19,12 +19,17 @@ public class DeleteFederatedCredentialStep implements Step {
   public final String k8sNamespace;
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
+  private final MissingIdentityBehavior missingIdentityBehavior;
 
   public DeleteFederatedCredentialStep(
-      String k8sNamespace, AzureConfiguration azureConfig, CrlService crlService) {
+      String k8sNamespace,
+      AzureConfiguration azureConfig,
+      CrlService crlService,
+      MissingIdentityBehavior missingIdentityBehavior) {
     this.k8sNamespace = k8sNamespace;
     this.azureConfig = azureConfig;
     this.crlService = crlService;
+    this.missingIdentityBehavior = missingIdentityBehavior;
   }
 
   @Override
@@ -34,6 +39,13 @@ public class DeleteFederatedCredentialStep implements Step {
             .getWorkingMap()
             .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
     var msiManager = crlService.getMsiManager(azureCloudContext, azureConfig);
+
+    // guard against the managed identity not existing from a previous deletion
+    if (!GetManagedIdentityStep.managedIdentityExists(context)
+        && missingIdentityBehavior == MissingIdentityBehavior.ALLOW_MISSING) {
+      logger.info("Managed identity not found, but allowed to be missing");
+      return StepResult.getStepResultSuccess();
+    }
 
     try {
       String uamiName = GetManagedIdentityStep.getManagedIdentityName(context);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetManagedIdentityStep.java
@@ -23,7 +23,7 @@ public interface GetManagedIdentityStep {
     return FlightUtils.getRequired(context.getWorkingMap(), MANAGED_IDENTITY_NAME, String.class);
   }
 
-  static boolean managedIdentityExists(FlightContext context) {
+  static boolean managedIdentityExistsInFlightWorkingMap(FlightContext context) {
     return context.getWorkingMap().containsKey(MANAGED_IDENTITY_NAME);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
@@ -61,7 +61,7 @@ public class GetWorkspaceManagedIdentityStep implements Step, GetManagedIdentity
     var uamiName = managedIdentityResource.getManagedIdentityName();
 
     try {
-      var uami = managedIdentityHelper.getUamiName(azureCloudContext, uamiName);
+      var uami = managedIdentityHelper.getIdentity(azureCloudContext, uamiName);
       putManagedIdentityInContext(context, uami);
 
       return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStep.java
@@ -3,13 +3,10 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdent
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
-import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.exception.AzureManagementExceptionUtils;
-import bio.terra.workspace.db.ResourceDao;
-import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
-import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.management.exception.ManagementException;
@@ -22,26 +19,21 @@ import java.util.UUID;
  * may have already been deleted out of band but consuming flights want to proceed.
  */
 public class GetWorkspaceManagedIdentityStep implements Step, GetManagedIdentityStep {
-  private final AzureConfiguration azureConfig;
-  private final CrlService crlService;
   private final UUID workspaceId;
-  private final ResourceDao resourceDao;
   private final String managedIdentityName;
   private final MissingIdentityBehavior missingIdentityBehavior;
+  private final ManagedIdentityHelper managedIdentityHelper;
 
   public GetWorkspaceManagedIdentityStep(
-      AzureConfiguration azureConfig,
-      CrlService crlService,
       UUID workspaceId,
-      ResourceDao resourceDao,
       String managedIdentityName,
-      MissingIdentityBehavior failOnMissing) {
-    this.azureConfig = azureConfig;
-    this.crlService = crlService;
+      MissingIdentityBehavior failOnMissing,
+      ManagedIdentityHelper managedIdentityHelper) {
     this.workspaceId = workspaceId;
-    this.resourceDao = resourceDao;
     this.managedIdentityName = managedIdentityName;
     this.missingIdentityBehavior = failOnMissing;
+
+    this.managedIdentityHelper = managedIdentityHelper;
   }
 
   @Override
@@ -50,51 +42,31 @@ public class GetWorkspaceManagedIdentityStep implements Step, GetManagedIdentity
         context
             .getWorkingMap()
             .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
-    var msiManager = crlService.getMsiManager(azureCloudContext, azureConfig);
 
-    var managedIdentityResource = getManagedIdentityResource();
-
-    if (managedIdentityResource == null
+    var maybeManagedIdentityResource =
+        managedIdentityHelper.getManagedIdentityResource(workspaceId, managedIdentityName);
+    if (maybeManagedIdentityResource.isEmpty()
         && missingIdentityBehavior == MissingIdentityBehavior.ALLOW_MISSING) {
       return StepResult.getStepResultSuccess();
+    } else if (maybeManagedIdentityResource.isEmpty()) {
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new ResourceNotFoundException(
+              String.format(
+                  "Could not find managed identity %s in workspace %s",
+                  managedIdentityName, workspaceId)));
     }
 
+    var managedIdentityResource = maybeManagedIdentityResource.get();
     var uamiName = managedIdentityResource.getManagedIdentityName();
 
     try {
-      var uami =
-          msiManager
-              .identities()
-              .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), uamiName);
-
+      var uami = managedIdentityHelper.getUamiName(azureCloudContext, uamiName);
       putManagedIdentityInContext(context, uami);
 
       return StepResult.getStepResultSuccess();
     } catch (ManagementException e) {
       return new StepResult(AzureManagementExceptionUtils.maybeRetryStatus(e), e);
-    }
-  }
-
-  private ControlledAzureManagedIdentityResource getManagedIdentityResource() {
-    try {
-      return resourceDao
-          .getResourceByName(workspaceId, managedIdentityName)
-          .castByEnum(WsmResourceType.CONTROLLED_AZURE_MANAGED_IDENTITY);
-    } catch (ResourceNotFoundException e) {
-      // There are some older resources where the resource id was stored before we decided
-      // storing the resource name would be better. This is a fallback to support those
-      // resources. If the resource is not found by name and the name is an uuid, try by id.
-      try {
-        return resourceDao
-            .getResource(workspaceId, UUID.fromString(managedIdentityName))
-            .castByEnum(WsmResourceType.CONTROLLED_AZURE_MANAGED_IDENTITY);
-      } catch (ResourceNotFoundException | IllegalArgumentException ex) {
-        if (missingIdentityBehavior.equals(MissingIdentityBehavior.FAIL_ON_MISSING)) {
-          throw e;
-        } else {
-          return null;
-        }
-      }
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityHelper.java
@@ -44,10 +44,10 @@ public class ManagedIdentityHelper {
     }
   }
 
-  public Identity getUamiName(AzureCloudContext azureCloudContext, String uamiName) {
+  public Identity getIdentity(AzureCloudContext azureCloudContext, String identityName) {
     return crlService
         .getMsiManager(azureCloudContext, azureConfiguration)
         .identities()
-        .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), uamiName);
+        .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), identityName);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityHelper.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityHelper.java
@@ -1,0 +1,53 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.resourcemanager.msi.models.Identity;
+import java.util.Optional;
+import java.util.UUID;
+
+public class ManagedIdentityHelper {
+  private final ResourceDao resourceDao;
+  private final CrlService crlService;
+  private final AzureConfiguration azureConfiguration;
+
+  public ManagedIdentityHelper(
+      ResourceDao resourceDao, CrlService crlService, AzureConfiguration azureConfiguration) {
+    this.resourceDao = resourceDao;
+    this.crlService = crlService;
+    this.azureConfiguration = azureConfiguration;
+  }
+
+  public Optional<ControlledAzureManagedIdentityResource> getManagedIdentityResource(
+      UUID workspaceId, String managedIdentityName) {
+    try {
+      return Optional.of(
+          resourceDao
+              .getResourceByName(workspaceId, managedIdentityName)
+              .castByEnum(WsmResourceType.CONTROLLED_AZURE_MANAGED_IDENTITY));
+    } catch (ResourceNotFoundException e) {
+      // There are some older resources where the resource id was stored before we decided
+      // storing the resource name would be better. This is a fallback to support those
+      // resources. If the resource is not found by name and the name is an uuid, try by id.
+      try {
+        return Optional.of(
+            resourceDao
+                .getResource(workspaceId, UUID.fromString(managedIdentityName))
+                .castByEnum(WsmResourceType.CONTROLLED_AZURE_MANAGED_IDENTITY));
+      } catch (ResourceNotFoundException | IllegalArgumentException ex) {
+        return Optional.empty();
+      }
+    }
+  }
+
+  public Identity getUamiName(AzureCloudContext azureCloudContext, String uamiName) {
+    return crlService
+        .getMsiManager(azureCloudContext, azureConfiguration)
+        .identities()
+        .getByResourceGroup(azureCloudContext.getAzureResourceGroupId(), uamiName);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/MissingIdentityBehavior.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/MissingIdentityBehavior.java
@@ -1,0 +1,6 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+public enum MissingIdentityBehavior {
+  FAIL_ON_MISSING,
+  ALLOW_MISSING
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
@@ -68,12 +68,10 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
 
     var step =
         new GetWorkspaceManagedIdentityStep(
-            mockAzureConfig,
-            mockCrlService,
             workspaceId,
-            mockResourceDao,
             identityResource.getName(),
-            MissingIdentityBehavior.FAIL_ON_MISSING);
+            MissingIdentityBehavior.FAIL_ON_MISSING,
+            new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfig));
     assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
 
     verify(mockWorkingMap).put(GetManagedIdentityStep.MANAGED_IDENTITY_NAME, mockIdentity.name());
@@ -112,12 +110,10 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
 
     var step =
         new GetWorkspaceManagedIdentityStep(
-            mockAzureConfig,
-            mockCrlService,
             workspaceId,
-            mockResourceDao,
             identityResource.getResourceId().toString(),
-            MissingIdentityBehavior.FAIL_ON_MISSING);
+            MissingIdentityBehavior.FAIL_ON_MISSING,
+            new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfig));
     assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
 
     verify(mockWorkingMap).put(GetManagedIdentityStep.MANAGED_IDENTITY_NAME, mockIdentity.name());
@@ -152,18 +148,16 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
     when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
         .thenReturn(mockAzureCloudContext);
 
-    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
+    //    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
     when(mockResourceDao.getResourceByName(workspaceId, identityResource.getName()))
         .thenThrow(new ResourceNotFoundException("not found"));
 
     var step =
         new GetWorkspaceManagedIdentityStep(
-            mockAzureConfig,
-            mockCrlService,
             workspaceId,
-            mockResourceDao,
             identityResource.getName(),
-            MissingIdentityBehavior.ALLOW_MISSING);
+            MissingIdentityBehavior.ALLOW_MISSING,
+            new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfig));
     assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
   }
 
@@ -190,12 +184,10 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
 
     var step =
         new GetWorkspaceManagedIdentityStep(
-            mockAzureConfig,
-            mockCrlService,
             workspaceId,
-            mockResourceDao,
             identityResource.getName(),
-            MissingIdentityBehavior.FAIL_ON_MISSING);
+            MissingIdentityBehavior.FAIL_ON_MISSING,
+            new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfig));
     return step.doStep(mockFlightContext);
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetWorkspaceManagedIdentityStepTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdent
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -10,18 +9,12 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
 import bio.terra.workspace.common.utils.BaseMockitoStrictStubbingTest;
-import bio.terra.workspace.db.ResourceDao;
-import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.management.exception.ManagementException;
-import com.azure.resourcemanager.msi.MsiManager;
-import com.azure.resourcemanager.msi.models.Identities;
 import com.azure.resourcemanager.msi.models.Identity;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
@@ -34,13 +27,9 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
   @Mock private FlightContext mockFlightContext;
   @Mock private FlightMap mockWorkingMap;
   @Mock private AzureCloudContext mockAzureCloudContext;
-  @Mock private CrlService mockCrlService;
-  @Mock private MsiManager mockMsiManager;
-  @Mock private Identities mockIdentities;
-  @Mock private AzureConfiguration mockAzureConfig;
   @Mock private HttpResponse mockHttpResponse;
-  @Mock private ResourceDao mockResourceDao;
   @Mock private Identity mockIdentity;
+  @Mock private ManagedIdentityHelper managedIdentityHelper;
 
   @Test
   void testSuccess() throws InterruptedException {
@@ -54,66 +43,22 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
 
     createMockFlightContext();
 
-    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
-    when(mockMsiManager.identities()).thenReturn(mockIdentities);
-    when(mockIdentities.getByResourceGroup(
-            mockAzureCloudContext.getAzureResourceGroupId(),
-            identityResource.getManagedIdentityName()))
-        .thenReturn(mockIdentity);
-    when(mockResourceDao.getResourceByName(workspaceId, identityResource.getName()))
-        .thenReturn(identityResource);
     when(mockIdentity.name()).thenReturn(UUID.randomUUID().toString());
     when(mockIdentity.principalId()).thenReturn(UUID.randomUUID().toString());
     when(mockIdentity.clientId()).thenReturn(UUID.randomUUID().toString());
+    when(managedIdentityHelper.getManagedIdentityResource(workspaceId, identityResource.getName()))
+        .thenReturn(java.util.Optional.of(identityResource));
+    when(managedIdentityHelper.getIdentity(
+            mockAzureCloudContext, identityResource.getManagedIdentityName()))
+        .thenReturn(mockIdentity);
 
     var step =
         new GetWorkspaceManagedIdentityStep(
             workspaceId,
             identityResource.getName(),
             MissingIdentityBehavior.FAIL_ON_MISSING,
-            new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfig));
-    assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
+            managedIdentityHelper);
 
-    verify(mockWorkingMap).put(GetManagedIdentityStep.MANAGED_IDENTITY_NAME, mockIdentity.name());
-    verify(mockWorkingMap)
-        .put(GetManagedIdentityStep.MANAGED_IDENTITY_PRINCIPAL_ID, mockIdentity.principalId());
-    verify(mockWorkingMap)
-        .put(GetManagedIdentityStep.MANAGED_IDENTITY_CLIENT_ID, mockIdentity.clientId());
-  }
-
-  @Test
-  void testSuccessWithIdentityIdInsteadOfName() throws InterruptedException {
-    var workspaceId = UUID.randomUUID();
-    var creationParameters =
-        ControlledAzureResourceFixtures.getAzureManagedIdentityCreationParameters();
-    var identityResource =
-        ControlledAzureResourceFixtures.makeDefaultControlledAzureManagedIdentityResourceBuilder(
-                creationParameters, workspaceId)
-            .build();
-
-    createMockFlightContext();
-
-    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
-    when(mockMsiManager.identities()).thenReturn(mockIdentities);
-    when(mockIdentities.getByResourceGroup(
-            mockAzureCloudContext.getAzureResourceGroupId(),
-            identityResource.getManagedIdentityName()))
-        .thenReturn(mockIdentity);
-    when(mockResourceDao.getResourceByName(
-            workspaceId, identityResource.getResourceId().toString()))
-        .thenThrow(new ResourceNotFoundException("not found"));
-    when(mockResourceDao.getResource(workspaceId, identityResource.getResourceId()))
-        .thenReturn(identityResource);
-    when(mockIdentity.name()).thenReturn(UUID.randomUUID().toString());
-    when(mockIdentity.principalId()).thenReturn(UUID.randomUUID().toString());
-    when(mockIdentity.clientId()).thenReturn(UUID.randomUUID().toString());
-
-    var step =
-        new GetWorkspaceManagedIdentityStep(
-            workspaceId,
-            identityResource.getResourceId().toString(),
-            MissingIdentityBehavior.FAIL_ON_MISSING,
-            new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfig));
     assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
 
     verify(mockWorkingMap).put(GetManagedIdentityStep.MANAGED_IDENTITY_NAME, mockIdentity.name());
@@ -148,17 +93,37 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
     when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
         .thenReturn(mockAzureCloudContext);
 
-    //    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
-    when(mockResourceDao.getResourceByName(workspaceId, identityResource.getName()))
-        .thenThrow(new ResourceNotFoundException("not found"));
-
     var step =
         new GetWorkspaceManagedIdentityStep(
             workspaceId,
             identityResource.getName(),
             MissingIdentityBehavior.ALLOW_MISSING,
-            new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfig));
+            managedIdentityHelper);
     assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
+  }
+
+  @Test
+  void testFailureOnMissingResourceWhenConfigured() throws InterruptedException {
+    var workspaceId = UUID.randomUUID();
+    var creationParameters =
+        ControlledAzureResourceFixtures.getAzureManagedIdentityCreationParameters();
+    var identityResource =
+        ControlledAzureResourceFixtures.makeDefaultControlledAzureManagedIdentityResourceBuilder(
+                creationParameters, workspaceId)
+            .build();
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
+
+    var step =
+        new GetWorkspaceManagedIdentityStep(
+            workspaceId,
+            identityResource.getName(),
+            MissingIdentityBehavior.FAIL_ON_MISSING,
+            managedIdentityHelper);
+    assertThat(
+        step.doStep(mockFlightContext).getStepStatus(),
+        equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
   }
 
   private StepResult testWithError(HttpStatus httpStatus) throws InterruptedException {
@@ -172,22 +137,19 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
 
     createMockFlightContext();
 
-    when(mockCrlService.getMsiManager(any(), any())).thenReturn(mockMsiManager);
-    when(mockMsiManager.identities()).thenReturn(mockIdentities);
-    when(mockIdentities.getByResourceGroup(
-            mockAzureCloudContext.getAzureResourceGroupId(),
-            identityResource.getManagedIdentityName()))
-        .thenThrow(new ManagementException(httpStatus.name(), mockHttpResponse));
     when(mockHttpResponse.getStatusCode()).thenReturn(httpStatus.value());
-    when(mockResourceDao.getResourceByName(workspaceId, identityResource.getName()))
-        .thenReturn(identityResource);
+    when(managedIdentityHelper.getManagedIdentityResource(workspaceId, identityResource.getName()))
+        .thenReturn(java.util.Optional.of(identityResource));
+    when(managedIdentityHelper.getIdentity(
+            mockAzureCloudContext, identityResource.getManagedIdentityName()))
+        .thenThrow(new ManagementException(httpStatus.name(), mockHttpResponse));
 
     var step =
         new GetWorkspaceManagedIdentityStep(
             workspaceId,
             identityResource.getName(),
             MissingIdentityBehavior.FAIL_ON_MISSING,
-            new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfig));
+            managedIdentityHelper);
     return step.doStep(mockFlightContext);
   }
 
@@ -195,8 +157,6 @@ public class GetWorkspaceManagedIdentityStepTest extends BaseMockitoStrictStubbi
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
     when(mockWorkingMap.get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class))
         .thenReturn(mockAzureCloudContext);
-
-    when(mockAzureCloudContext.getAzureResourceGroupId()).thenReturn(UUID.randomUUID().toString());
 
     return mockFlightContext;
   }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityHelperTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/ManagedIdentityHelperTest.java
@@ -1,0 +1,123 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
+import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
+import bio.terra.workspace.common.utils.BaseMockitoStrictStubbingTest;
+import bio.terra.workspace.db.ResourceDao;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.resourcemanager.msi.MsiManager;
+import com.azure.resourcemanager.msi.models.Identities;
+import com.azure.resourcemanager.msi.models.Identity;
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@Tag("azure-unit")
+class ManagedIdentityHelperTest extends BaseMockitoStrictStubbingTest {
+
+  @Mock private ResourceDao mockResourceDao;
+  @Mock private CrlService mockCrlService;
+  @Mock private AzureConfiguration mockAzureConfiguration;
+
+  @Test
+  void getManagedIdentityResource_successWithName() {
+    var workspaceId = UUID.randomUUID();
+    var creationParameters =
+        ControlledAzureResourceFixtures.getAzureManagedIdentityCreationParameters();
+    var identityResource =
+        ControlledAzureResourceFixtures.makeDefaultControlledAzureManagedIdentityResourceBuilder(
+                creationParameters, workspaceId)
+            .build();
+    when(mockResourceDao.getResourceByName(workspaceId, identityResource.getName()))
+        .thenReturn(identityResource);
+    var managedIdentityHelper =
+        new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfiguration);
+
+    var maybeIdentityResource =
+        managedIdentityHelper.getManagedIdentityResource(workspaceId, identityResource.getName());
+
+    assertThat(maybeIdentityResource.isPresent(), equalTo(true));
+    assertThat(maybeIdentityResource.get(), equalTo(identityResource));
+  }
+
+  @Test
+  void getManagedIdentityResource_successOnFallback() {
+    var workspaceId = UUID.randomUUID();
+    var creationParameters =
+        ControlledAzureResourceFixtures.getAzureManagedIdentityCreationParameters();
+    var identityResource =
+        ControlledAzureResourceFixtures.makeDefaultControlledAzureManagedIdentityResourceBuilder(
+                creationParameters, workspaceId)
+            .build();
+    when(mockResourceDao.getResourceByName(
+            workspaceId, identityResource.getResourceId().toString()))
+        .thenThrow(new ResourceNotFoundException("not found"));
+    when(mockResourceDao.getResource(workspaceId, identityResource.getResourceId()))
+        .thenReturn(identityResource);
+
+    var managedIdentityHelper =
+        new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfiguration);
+
+    var maybeIdentityResource =
+        managedIdentityHelper.getManagedIdentityResource(
+            workspaceId, identityResource.getResourceId().toString());
+
+    assertThat(maybeIdentityResource.isPresent(), equalTo(true));
+    assertThat(maybeIdentityResource.get(), equalTo(identityResource));
+  }
+
+  @Test
+  void getManagedIdentityResource_notFound() {
+    var workspaceId = UUID.randomUUID();
+    var creationParameters =
+        ControlledAzureResourceFixtures.getAzureManagedIdentityCreationParameters();
+    var identityResource =
+        ControlledAzureResourceFixtures.makeDefaultControlledAzureManagedIdentityResourceBuilder(
+                creationParameters, workspaceId)
+            .build();
+    when(mockResourceDao.getResourceByName(
+            workspaceId, identityResource.getResourceId().toString()))
+        .thenThrow(new ResourceNotFoundException("not found"));
+    when(mockResourceDao.getResource(workspaceId, identityResource.getResourceId()))
+        .thenThrow(new ResourceNotFoundException("not found"));
+
+    var managedIdentityHelper =
+        new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfiguration);
+
+    var maybeIdentityResource =
+        managedIdentityHelper.getManagedIdentityResource(
+            workspaceId, identityResource.getResourceId().toString());
+
+    assertThat(maybeIdentityResource.isEmpty(), equalTo(true));
+  }
+
+  @Test
+  void getIdentity_success() {
+    var managedIdentityHelper =
+        new ManagedIdentityHelper(mockResourceDao, mockCrlService, mockAzureConfiguration);
+    var mockIdentity = mock(Identity.class);
+    var mockMsiManager = mock(MsiManager.class);
+    var mockIdentities = mock(Identities.class);
+    var mockAzureCloudContext = mock(AzureCloudContext.class);
+    when(mockMsiManager.identities()).thenReturn(mockIdentities);
+    when(mockIdentities.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(), "fake"))
+        .thenReturn(mockIdentity);
+    when(mockCrlService.getMsiManager(mockAzureCloudContext, mockAzureConfiguration))
+        .thenReturn(mockMsiManager);
+    when(mockMsiManager.identities()).thenReturn(mockIdentities);
+    when(mockIdentities.getByResourceGroup(mockAzureCloudContext.getAzureResourceGroupId(), "fake"))
+        .thenReturn(mockIdentity);
+
+    var identity = managedIdentityHelper.getIdentity(mockAzureCloudContext, "fake");
+
+    assertThat(identity, equalTo(mockIdentity));
+  }
+}


### PR DESCRIPTION
[Related ticket](https://broadworkbench.atlassian.net/browse/WOR-1418)

Clients can delete the managed identity an Azure kubernetes namespace uses out of band. This causes the k8s namespace deletion flight to fail as it expects the managed identity resource to be present.

This is an attempt at making the namespace deletion flight resilient to these situations.

This PR:

* Modifies the logic in the GetWorkspaceManagedIdentityStep to allow the identity resource to be missing.
* Refactors the azure logic to a separate helper to ease testability.