### PR TITLE
[NO TICKET] Try grouping dependabot updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,19 @@ updates:
   # Enable version updates for Gradle
   - package-ecosystem: "gradle"
     directory: "/"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    groups:
+      npm-major-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      npm-minor-patch-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     schedule:
       interval: "weekly"
       time: "06:00"


### PR DESCRIPTION
Let's try out the grouping feature. It seems like it will be particularly useful in this repo given that dependabot PRs currently require some hand-holding (as dependabot user doesn't have access to all the necessary secrets).