### PR TITLE
[WOR-1444] Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @DataBiosphere/broadworkspaces


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1444

This matches existing convention in BPM, LZS.  Previously, Verily's ownership of the service kept us from making this change.

We discussed in standup that we'd like to move forward with this change given a preference for consistency between services, but remain open to changing the review requirements in the future if this proves cumbersome for external contributions.  (Maybe do something similar to Terra UI, requiring one Workspaces review and one other review.)

Change flagged in Slack: https://broadinstitute.slack.com/archives/C01JVP0MLLX/p1705421646314409