### PR TITLE
[NO TICKET] Route failures to Workspaces test alert channel.

### DIFF
--- a/.github/workflows/full-integration-tests.yml
+++ b/.github/workflows/full-integration-tests.yml
@@ -92,7 +92,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#terra-wsm-alerts"
+        channel: "#dsp-workspace-test-alerts"
         username: "WSM full integration test"
         author_name: "${{ matrix.gradleTask }}"
         icon_emoji: ":bangbang:"

--- a/.github/workflows/full-integration-tests.yml
+++ b/.github/workflows/full-integration-tests.yml
@@ -92,7 +92,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsp-workspace-test-alerts"
+        channel: "#dsp-workspaces-test-alerts"
         username: "WSM full integration test"
         author_name: "${{ matrix.gradleTask }}"
         icon_emoji: ":bangbang:"

--- a/.github/workflows/full-service-tests.yml
+++ b/.github/workflows/full-service-tests.yml
@@ -120,7 +120,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#terra-wsm-alerts"
+        channel: "#dsp-workspace-test-alerts"
         username: "WSM full service test branch"
         author_name: "${{ matrix.gradleTask }}"
         icon_emoji: ":bangbang:"

--- a/.github/workflows/full-service-tests.yml
+++ b/.github/workflows/full-service-tests.yml
@@ -120,7 +120,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsp-workspace-test-alerts"
+        channel: "#dsp-workspaces-test-alerts"
         username: "WSM full service test branch"
         author_name: "${{ matrix.gradleTask }}"
         icon_emoji: ":bangbang:"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -192,7 +192,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          channel: "#dsp-workspace-test-alerts"
+          channel: "#dsp-workspaces-test-alerts"
           username: "WSM nightly test"
           author_name: ${{ steps.status-message.outputs.status-bold }}
           icon_emoji: ${{ steps.status-message.outputs.status-emoji }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -192,7 +192,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          channel: "#terra-wsm-alerts"
+          channel: "#dsp-workspace-test-alerts"
           username: "WSM nightly test"
           author_name: ${{ steps.status-message.outputs.status-bold }}
           icon_emoji: ${{ steps.status-message.outputs.status-emoji }}

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -112,7 +112,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsp-workspace-test-alerts"
+        channel: "#dsp-workspaces-test-alerts"
         username: "WSM push to main branch"
         author_name: "integrationTest"
         icon_emoji: ":triangular_ruler:"

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -112,7 +112,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#terra-wsm-alerts"
+        channel: "#dsp-workspace-test-alerts"
         username: "WSM push to main branch"
         author_name: "integrationTest"
         icon_emoji: ":triangular_ruler:"

--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -183,7 +183,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          channel: "#dsp-workspace-test-alerts"
+          channel: "#dsp-workspaces-test-alerts"
           username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
           author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
           fields: repo,job,workflow,commit,eventName,author,took

--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -175,6 +175,19 @@ jobs:
           author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
           fields: repo,job,workflow,commit,eventName,author,took
 
+      - name: "Notify Workspaces test failure Slack"
+        if: failure()
+        uses: broadinstitute/action-slack@v3.8.0
+        # see https://github.com/broadinstitute/action-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          channel: "#dsp-workspace-test-alerts"
+          username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
+          author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
+          fields: repo,job,workflow,commit,eventName,author,took
+
       - name: Archive WSM and TestRunner logs
         id: archive_logs
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsp-workspace-test-alerts"
+        channel: "#dsp-workspaces-test-alerts"
         username: "WSM push to main branch"
         author_name: "${{ matrix.gradleTask }}"
         icon_emoji: ":triangular_ruler:"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#terra-wsm-alerts"
+        channel: "#dsp-workspace-test-alerts"
         username: "WSM push to main branch"
         author_name: "${{ matrix.gradleTask }}"
         icon_emoji: ":triangular_ruler:"


### PR DESCRIPTION
Move notifications from #terra-wsm-alerts to the Workspaces team channel. The older Slack channel will be archived.