### PR TITLE
[WM-2459] DB dump & restore pod should be named based on destination resource during cloning

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStep.java
@@ -21,11 +21,13 @@ import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import java.text.SimpleDateFormat;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DumpAzureDatabaseStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(DumpAzureDatabaseStep.class);
+  private static final Integer MAX_RESOURCE_NAME_LENGTH = 63;
 
   private final ControlledAzureDatabaseResource sourceDatabase;
   private final LandingZoneApiDispatch landingZoneApiDispatch;
@@ -124,8 +126,10 @@ public class DumpAzureDatabaseStep implements Step {
     this.azureDatabaseUtilsRunner.pgDumpDatabase(
         sourceAzureContext,
         sourceDatabase.getWorkspaceId(),
-        "dump-db-%s-%s"
-            .formatted(sourceDatabase.getDatabaseName(), destinationContainer.getResourceId()),
+        StringUtils.truncate(
+            "dump-db-%s-%s"
+                .formatted(sourceDatabase.getDatabaseName(), destinationContainer.getResourceId()),
+            MAX_RESOURCE_NAME_LENGTH),
         sourceDatabase.getDatabaseName(),
         dbServerName,
         adminDbUserName,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStep.java
@@ -124,7 +124,7 @@ public class DumpAzureDatabaseStep implements Step {
     this.azureDatabaseUtilsRunner.pgDumpDatabase(
         sourceAzureContext,
         sourceDatabase.getWorkspaceId(),
-        "dump-db-" + this.sourceDatabase.getResourceId(),
+        "dump-db-" + sourceDatabase.getDatabaseName() + "-" + destinationContainer.getResourceId(),
         sourceDatabase.getDatabaseName(),
         dbServerName,
         adminDbUserName,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStep.java
@@ -124,7 +124,7 @@ public class DumpAzureDatabaseStep implements Step {
     this.azureDatabaseUtilsRunner.pgDumpDatabase(
         sourceAzureContext,
         sourceDatabase.getWorkspaceId(),
-        "dump-db-" + sourceDatabase.getDatabaseName() + "-" + destinationContainer.getResourceId(),
+        "dump-db-%s-%s".formatted(sourceDatabase.getDatabaseName(), destinationContainer.getResourceId()),
         sourceDatabase.getDatabaseName(),
         dbServerName,
         adminDbUserName,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStep.java
@@ -124,7 +124,8 @@ public class DumpAzureDatabaseStep implements Step {
     this.azureDatabaseUtilsRunner.pgDumpDatabase(
         sourceAzureContext,
         sourceDatabase.getWorkspaceId(),
-        "dump-db-%s-%s".formatted(sourceDatabase.getDatabaseName(), destinationContainer.getResourceId()),
+        "dump-db-%s-%s"
+            .formatted(sourceDatabase.getDatabaseName(), destinationContainer.getResourceId()),
         sourceDatabase.getDatabaseName(),
         dbServerName,
         adminDbUserName,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/RestoreAzureDatabaseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/RestoreAzureDatabaseStep.java
@@ -21,8 +21,10 @@ import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 
 public class RestoreAzureDatabaseStep implements Step {
+  private static final Integer MAX_RESOURCE_NAME_LENGTH = 63;
 
   private final LandingZoneApiDispatch landingZoneApiDispatch;
   private final SamService samService;
@@ -106,7 +108,11 @@ public class RestoreAzureDatabaseStep implements Step {
     this.azureDatabaseUtilsRunner.pgRestoreDatabase(
         workingMap.get(AZURE_CLOUD_CONTEXT, AzureCloudContext.class),
         destinationWorkspaceId,
-        "restore-db-" + destinationDatabase.getResourceId(),
+        StringUtils.truncate(
+            "restore-db-%s-%s"
+                .formatted(
+                    destinationDatabase.getDatabaseName(), destinationDatabase.getResourceId()),
+            MAX_RESOURCE_NAME_LENGTH),
         destinationDatabase.getDatabaseName(),
         dbServerName,
         adminDbUserName,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStepTest.java
@@ -32,6 +32,7 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.Contr
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -95,10 +96,12 @@ class DumpAzureDatabaseStepTest extends BaseMockitoStrictStubbingTest {
             eq(mockAzureCloudContext),
             eq(databaseResource.getWorkspaceId()),
             eq(
-                "dump-db-%s-%s"
-                    .formatted(
-                        databaseResource.getDatabaseName(),
-                        mockDestinationResource.getResourceId())),
+                StringUtils.truncate(
+                    "dump-db-%s-%s"
+                        .formatted(
+                            databaseResource.getDatabaseName(),
+                            mockDestinationResource.getResourceId()),
+                    63)),
             eq(databaseResource.getDatabaseName()),
             eq(databaseServerName),
             eq(databaseUserName),

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStepTest.java
@@ -71,8 +71,8 @@ class DumpAzureDatabaseStepTest extends BaseMockitoStrictStubbingTest {
               creationParameters, workspaceId, null)
           .build();
   private final String mockEncryptionKey = "mock-encryption-key-123";
-  private final ControlledResourceFields mockDestinationResource = ControlledResourceFixtures.makeDefaultControlledResourceFields(
-  mockDestinationWorkspaceId);
+  private final ControlledResourceFields mockDestinationResource =
+      ControlledResourceFixtures.makeDefaultControlledResourceFields(mockDestinationWorkspaceId);
 
   @Test
   void testSuccess() throws InterruptedException {
@@ -94,7 +94,11 @@ class DumpAzureDatabaseStepTest extends BaseMockitoStrictStubbingTest {
         .pgDumpDatabase(
             eq(mockAzureCloudContext),
             eq(databaseResource.getWorkspaceId()),
-            eq("dump-db-%s-%s".formatted(databaseResource.getDatabaseName(), mockDestinationResource.getResourceId())),
+            eq(
+                "dump-db-%s-%s"
+                    .formatted(
+                        databaseResource.getDatabaseName(),
+                        mockDestinationResource.getResourceId())),
             eq(databaseResource.getDatabaseName()),
             eq(databaseServerName),
             eq(databaseUserName),

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/DumpAzureDatabaseStepTest.java
@@ -24,6 +24,7 @@ import bio.terra.workspace.service.resource.controlled.cloud.azure.AzureStorageA
 import bio.terra.workspace.service.resource.controlled.cloud.azure.database.AzureDatabaseUtilsRunner;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.database.ControlledAzureDatabaseResource;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer.ControlledAzureStorageContainerResource;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResourceFields;
 import bio.terra.workspace.service.workspace.AzureCloudContextService;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
@@ -70,6 +71,8 @@ class DumpAzureDatabaseStepTest extends BaseMockitoStrictStubbingTest {
               creationParameters, workspaceId, null)
           .build();
   private final String mockEncryptionKey = "mock-encryption-key-123";
+  private final ControlledResourceFields mockDestinationResource = ControlledResourceFixtures.makeDefaultControlledResourceFields(
+  mockDestinationWorkspaceId);
 
   @Test
   void testSuccess() throws InterruptedException {
@@ -91,7 +94,7 @@ class DumpAzureDatabaseStepTest extends BaseMockitoStrictStubbingTest {
         .pgDumpDatabase(
             eq(mockAzureCloudContext),
             eq(databaseResource.getWorkspaceId()),
-            eq("dump-db-%s".formatted(databaseResource.getResourceId())),
+            eq("dump-db-%s-%s".formatted(databaseResource.getDatabaseName(), mockDestinationResource.getResourceId())),
             eq(databaseResource.getDatabaseName()),
             eq(databaseServerName),
             eq(databaseUserName),
@@ -128,9 +131,7 @@ class DumpAzureDatabaseStepTest extends BaseMockitoStrictStubbingTest {
             ControlledAzureStorageContainerResource.class))
         .thenReturn(
             ControlledAzureStorageContainerResource.builder()
-                .common(
-                    ControlledResourceFixtures.makeDefaultControlledResourceFields(
-                        mockDestinationWorkspaceId))
+                .common(mockDestinationResource)
                 .storageContainerName("sc-%s".formatted(mockDestinationWorkspaceId.toString()))
                 .build());
     when(mockWorkingMap.get(

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/RestoreAzureDatabaseStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/flight/clone/azure/database/RestoreAzureDatabaseStepTest.java
@@ -29,6 +29,7 @@ import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.Contr
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -74,7 +75,11 @@ class RestoreAzureDatabaseStepTest extends BaseMockitoStrictStubbingTest {
         .pgRestoreDatabase(
             mockAzureCloudContext,
             databaseResource.getWorkspaceId(),
-            "restore-db-%s".formatted(databaseResource.getResourceId()),
+            StringUtils.truncate(
+                "restore-db-%s-%s"
+                    .formatted(
+                        databaseResource.getDatabaseName(), databaseResource.getResourceId()),
+                63),
             databaseResource.getDatabaseName(),
             databaseServerName,
             databaseUserName,


### PR DESCRIPTION
Tested the changes in BEE by cloning a workspace

Before
The pod name would be (from logs)
```
INFO 2024-01-26T20:46:50.130Z Creating pod class V1Pod {.... name: dump-db-560241a2-81b4-414e-9a83-cf5765fa9050 namespace: null  …
INFO 2024-01-26T20:46:50.303Z Status = Optional[Pending] for azure database utils pod = dump-db-560241a2-81b4-414e-9a83-cf5765fa9050
INFO 2024-01-26T20:47:00.344Z Status = Optional[Succeeded] for azure database utils pod = dump-db-560241a2-81b4-414e-9a83-cf5765fa9050
```

After the changes
Pod name includes name of source database being cloned and the destination container resource ID (from logs)
```
INFO 2024-01-26T21:26:23.474Z Creating pod class V1Pod { ... name: dump-db-cbas-jkw18e-b4f91713-6f14-47f8-ad26-6a4b6633687a namespace: null …
INFO 2024-01-26T21:26:23.646Z Status = Optional[Pending] for azure database utils pod = dump-db-cbas-jkw18e-b4f91713-6f14-47f8-ad26-6a4b6633687a
INFO 2024-01-26T21:26:33.681Z Status = Optional[Succeeded] for azure database utils pod = dump-db-cbas-jkw18e-b4f91713-6f14-47f8-ad26-6a4b6633687a
```

Closes https://broadworkbench.atlassian.net/browse/WM-2459