### PR TITLE
[WOR-1426] Fix full integration tests and service test workflows

### DIFF
--- a/.github/workflows/full-integration-tests.yml
+++ b/.github/workflows/full-integration-tests.yml
@@ -51,8 +51,8 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Write config
-      id: config
+    - name: Write credentials
+      id: write-credentials
       uses: ./.github/actions/write-credentials
       with:
         user-delegated-sa-b64: ${{ secrets.USER_DELEGATED_SA_DEV }}
@@ -62,6 +62,22 @@ jobs:
         wsm-sa-b64: ${{ secrets.WSM_SA_DEV }}
         janitor-sa-b64: ${{ secrets.JANITOR_SA_DEV }}
         policy-client-sa-b64: ${{ secrets.POLICY_CLIENT_SA_DEV }}
+
+    # Turn on TPS for integration tests
+    # TODO remove this once WOR-1441 removes the tps-enabled feature flag
+    - name: Write config
+      id: write-config
+      run: |
+        cat << EOF > "config/local-properties.yml"
+        workspace:
+          policy:
+            base-path: https://tps.wsmtest-eng.bee.envs-terra.bio/
+          cli:
+            server-name: broad-dev
+        feature:
+          tps-enabled: true
+          temporary-grant-enabled: true
+        EOF
 
     - name: Launch local server
       uses: ./.github/actions/start-local-server

--- a/.github/workflows/full-service-tests.yml
+++ b/.github/workflows/full-service-tests.yml
@@ -59,7 +59,6 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-      # These steps aren't needed for unit tests
     - name: Get Vault token
       id: vault-token-step
       env:
@@ -78,8 +77,6 @@ jobs:
       id: config
       uses: ./.github/actions/write-config
       with:
-        # Note that unit and connected tests run with local configuration regardless of
-        # the test-env specified on the workflow-dispatch input.
         target: local
         vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
 

--- a/.github/workflows/full-service-tests.yml
+++ b/.github/workflows/full-service-tests.yml
@@ -59,17 +59,29 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+      # These steps aren't needed for unit tests
+    - name: Get Vault token
+      id: vault-token-step
+      env:
+        VAULT_ADDR: https://clotho.broadinstitute.org:8200
+      run: |
+        VAULT_TOKEN=$(docker run --rm --cap-add IPC_LOCK \
+          -e "VAULT_ADDR=${VAULT_ADDR}" \
+          vault:1.1.0 \
+          vault write -field token \
+            auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
+            secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
+        echo ::add-mask::$VAULT_TOKEN    
+        echo vault-token=$VAULT_TOKEN >> $GITHUB_OUTPUT
+
     - name: Write config
       id: config
-      uses: ./.github/actions/write-credentials
+      uses: ./.github/actions/write-config
       with:
-        user-delegated-sa-b64: ${{ secrets.USER_DELEGATED_SA_DEV }}
-        buffer-client-sa-b64: ${{ secrets.BUFFER_CLIENT_SA_DEV }}
-        testrunner-sa-b64: ${{ secrets.TESTRUNNER_SA_DEV }}
-        testrunner-k8s-sa-b64: ${{ secrets.TESTRUNNER_K8S_SA_DEV }}
-        janitor-sa-b64: ${{ secrets.JANITOR_SA_DEV }}
-        wsm-sa-b64: ${{ secrets.WSM_SA_DEV }}
-        policy-client-sa-b64: ${{ secrets.POLICY_CLIENT_SA_DEV }}
+        # Note that unit and connected tests run with local configuration regardless of
+        # the test-env specified on the workflow-dispatch input.
+        target: local
+        vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
 
       # Run tests
     - name: Run tests


### PR DESCRIPTION
The nightly full integration test run includes ITs that are not typically included in PR integration tests. One that is consistently failing requires TPS to be enabled. [WOR-1441](https://broadworkbench.atlassian.net/browse/WOR-1441) should mitigate that; until then I'm flipping the flag on by rendering a config file similar to what write-config.sh does ([here is a successful run](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/7699274333)).

The nightly full service test flow requires Azure credentials to be in place (here is a link to failing [run](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/7708081149/job/21006451627), note the failing Azure tests). This will require [WOR-1463](https://broadworkbench.atlassian.net/browse/WOR-1463) to render the azure app credentials (or perhaps use a federated identity).  I've switched this workflow back to using the old vault config until that ticket can be played. Here is a link to a [run](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/7701864752). One test on this run failed due to connectivity issues w/TPS, but note the passing Azure tests.

[WOR-1441]: https://broadworkbench.atlassian.net/browse/WOR-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WOR-1463]: https://broadworkbench.atlassian.net/browse/WOR-1463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ