### PR TITLE
[WOR-1454] Populate MDC for Stairway flight and its steps

### DIFF
--- a/service/src/main/java/bio/terra/workspace/common/utils/MdcHook.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/MdcHook.java
@@ -102,7 +102,7 @@ public class MdcHook implements StairwayHook {
         flightContext.getStepClassName(),
         flightContext.getStepIndex(),
         flightContext.getDirection().name());
-    removeStepContextFromMdc();
+    removeStepContextFromMdc(flightContext);
     return HookAction.CONTINUE;
   }
 
@@ -169,15 +169,18 @@ public class MdcHook implements StairwayHook {
     MDC.put(FLIGHT_CLASS_KEY, context.getFlightClassName());
   }
 
-  private void addStepContextToMdc(FlightContext context) {
-    MDC.put(FLIGHT_STEP_CLASS_KEY, context.getStepClassName());
-    MDC.put(FLIGHT_STEP_DIRECTION_KEY, context.getDirection().toString());
-    MDC.put(FLIGHT_STEP_NUMBER_KEY, Integer.toString(context.getStepIndex()));
+  private Map<String, String> stepContext(FlightContext context) {
+    return Map.of(
+        FLIGHT_STEP_CLASS_KEY, context.getStepClassName(),
+        FLIGHT_STEP_DIRECTION_KEY, context.getDirection().toString(),
+        FLIGHT_STEP_NUMBER_KEY, Integer.toString(context.getStepIndex()));
   }
 
-  private void removeStepContextFromMdc() {
-    MDC.remove(FLIGHT_STEP_CLASS_KEY);
-    MDC.remove(FLIGHT_STEP_DIRECTION_KEY);
-    MDC.remove(FLIGHT_STEP_NUMBER_KEY);
+  private void addStepContextToMdc(FlightContext context) {
+    stepContext(context).forEach(MDC::put);
+  }
+
+  private void removeStepContextFromMdc(FlightContext context) {
+    stepContext(context).keySet().forEach(MDC::remove);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/common/utils/MdcHook.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/MdcHook.java
@@ -55,6 +55,9 @@ public class MdcHook implements StairwayHook {
 
   @Override
   public HookAction startStep(FlightContext flightContext) {
+    String serializedMdc = flightContext.getInputParameters().get(MDC_FLIGHT_MAP_KEY, String.class);
+    // Note that this destroys any previous context on this thread.
+    MDC.setContextMap(deserializeMdc(serializedMdc));
     logger.info(
         STEP_LOG_FORMAT,
         "startStep",
@@ -63,9 +66,6 @@ public class MdcHook implements StairwayHook {
         flightContext.getStepClassName(),
         flightContext.getStepIndex(),
         flightContext.getDirection().name());
-    String serializedMdc = flightContext.getInputParameters().get(MDC_FLIGHT_MAP_KEY, String.class);
-    // Note that this destroys any previous context on this thread.
-    MDC.setContextMap(deserializeMdc(serializedMdc));
     return HookAction.CONTINUE;
   }
 
@@ -130,7 +130,7 @@ public class MdcHook implements StairwayHook {
   }
 
   @Override
-  public HookAction stateTransition(FlightContext context) throws InterruptedException {
+  public HookAction stateTransition(FlightContext context) {
     logger.info(
         "Flight ID {} changed status to {}.", context.getFlightId(), context.getFlightStatus());
     return HookAction.CONTINUE;

--- a/service/src/main/java/bio/terra/workspace/common/utils/MdcHook.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/MdcHook.java
@@ -55,9 +55,6 @@ public class MdcHook implements StairwayHook {
 
   @Override
   public HookAction startStep(FlightContext flightContext) {
-    String serializedMdc = flightContext.getInputParameters().get(MDC_FLIGHT_MAP_KEY, String.class);
-    // Note that this destroys any previous context on this thread.
-    MDC.setContextMap(deserializeMdc(serializedMdc));
     logger.info(
         STEP_LOG_FORMAT,
         "startStep",
@@ -79,12 +76,14 @@ public class MdcHook implements StairwayHook {
         flightContext.getStepClassName(),
         flightContext.getStepIndex(),
         flightContext.getDirection().name());
-    MDC.clear();
     return HookAction.CONTINUE;
   }
 
   @Override
   public HookAction startFlight(FlightContext flightContext) {
+    String serializedMdc = flightContext.getInputParameters().get(MDC_FLIGHT_MAP_KEY, String.class);
+    // Note that this destroys any previous context on this thread.
+    MDC.setContextMap(deserializeMdc(serializedMdc));
     logger.info(
         FLIGHT_LOG_FORMAT,
         "startFlight",
@@ -100,6 +99,7 @@ public class MdcHook implements StairwayHook {
         "endFlight",
         flightContext.getFlightClassName(),
         flightContext.getFlightId());
+    MDC.clear();
     return HookAction.CONTINUE;
   }
 

--- a/service/src/main/java/bio/terra/workspace/common/utils/MdcHook.java
+++ b/service/src/main/java/bio/terra/workspace/common/utils/MdcHook.java
@@ -20,14 +20,19 @@ import org.springframework.stereotype.Component;
 /**
  * A {@link StairwayHook} which does the following:
  *
- * <li>Propagates flight-specific mapped diagnostic context (MDC) across a Stairway flight's thread(s) for the duration
- *    of the flight.  This includes context provided by the caller in the input {@link FlightMap}, intended to store the
- *    MDC from the calling thread to preserve context across the duration of a request.
- * <li>Propagates step-specific MDC across a Stairway flight's thread(s) for the duration of each step.
- * <li>Supplements logging at notable flight state transitions.
+ * <ol>
+ *   <li>Propagates flight-specific mapped diagnostic context (MDC) across a Stairway flight's
+ *       thread(s) for the duration of the flight. This includes context provided by the caller in
+ *       the input {@link FlightMap}, intended to store the MDC from the calling thread to preserve
+ *       context across the duration of a request.
+ *   <li>Propagates step-specific MDC across a Stairway flight's thread(s) for the duration of each
+ *       step.
+ *   <li>Supplements logging at notable flight state transitions.
+ * </ol>
  *
- * <p><b>Note for developers:</b> Any modifications to the MDC directly within flight or step code may not have their
- * intended effect and are not recommended (e.g. a flight may restart on a different thread due to failover-recovery).
+ * <p><b>Note for developers:</b> Any modifications to the MDC directly within flight or step code
+ * may not have their intended effect and are not recommended (e.g. a flight may restart on a
+ * different thread due to failover-recovery).
  */
 @Component
 public class MdcHook implements StairwayHook {
@@ -38,14 +43,19 @@ public class MdcHook implements StairwayHook {
 
   /** The key to use in the input {@link FlightMap} for storing the MDC context. */
   public static final String MDC_FLIGHT_MAP_KEY = "mdcKey";
+
   /** ID of the flight */
   public static final String FLIGHT_ID_KEY = "flightId";
+
   /** Class of the flight */
   public static final String FLIGHT_CLASS_KEY = "flightClass";
+
   /** Class of the flight step */
   public static final String FLIGHT_STEP_CLASS_KEY = "flightStepClass";
+
   /** Direction of the step (START, DO, SWITCH, or UNDO) */
   public static final String FLIGHT_STEP_DIRECTION_KEY = "flightStepDirection";
+
   /** The step's execution order */
   public static final String FLIGHT_STEP_NUMBER_KEY = "flightStepNumber";
 

--- a/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
@@ -8,13 +8,12 @@ import bio.terra.stairway.*;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.service.job.JobService;
 import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.time.Duration;
-import java.util.Map;
 
 class MdcHookTest extends BaseUnitTest {
   @Autowired private MdcHook mdcHook;
@@ -40,10 +39,11 @@ class MdcHookTest extends BaseUnitTest {
     flightMap.put(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext());
 
     assertEquals(
-            FlightStatus.SUCCESS,
-            submitAndWait(MdcFooBarTestFlight.class).getFlightStatus(),
-            "Input context, flight context, and step context propagated");
-    assertEquals(FOO_BAR, MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
+        FlightStatus.SUCCESS,
+        submitAndWait(MdcFooBarTestFlight.class).getFlightStatus(),
+        "Input context, flight context, and step context propagated");
+    assertEquals(
+        FOO_BAR, MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
   }
 
   @Test
@@ -56,16 +56,17 @@ class MdcHookTest extends BaseUnitTest {
     // ErrorStep causes the undo to happen and the flight to end as ERROR.
     var flightState = submitAndWait(MdcFooBarUndoTestFlight.class);
     assertEquals(
-            FlightStatus.ERROR,
-            flightState.getFlightStatus(),
-            "Flight fails but all steps can be walked back");
+        FlightStatus.ERROR,
+        flightState.getFlightStatus(),
+        "Flight fails but all steps can be walked back");
     var maybeFlightException = flightState.getException();
     assertTrue(maybeFlightException.isPresent());
     assertEquals(
-            ErrorStep.EXPECTED_EXCEPTION.getMessage(),
-            maybeFlightException.get().getMessage(),
-            "Flight fails due to ErrorStep");
-    assertEquals(FOO_BAR, MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
+        ErrorStep.EXPECTED_EXCEPTION.getMessage(),
+        maybeFlightException.get().getMessage(),
+        "Flight fails due to ErrorStep");
+    assertEquals(
+        FOO_BAR, MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
   }
 
   @Test
@@ -73,18 +74,18 @@ class MdcHookTest extends BaseUnitTest {
     flightMap.put(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext());
 
     assertEquals(
-            FlightStatus.SUCCESS,
-            submitAndWait(MdcNoInputContextTestFlight.class).getFlightStatus(),
-            "Flight succeeds when empty input context provided");
+        FlightStatus.SUCCESS,
+        submitAndWait(MdcNoInputContextTestFlight.class).getFlightStatus(),
+        "Flight succeeds when empty input context provided");
     assertNull(MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
   }
 
   @Test
   void inputParametersNotSetOk() throws Exception {
     assertEquals(
-            FlightStatus.SUCCESS,
-            submitAndWait(MdcNoInputContextTestFlight.class).getFlightStatus(),
-            "Flight succeeds when no input context provided");
+        FlightStatus.SUCCESS,
+        submitAndWait(MdcNoInputContextTestFlight.class).getFlightStatus(),
+        "Flight succeeds when no input context provided");
     assertNull(MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
   }
 
@@ -94,9 +95,9 @@ class MdcHookTest extends BaseUnitTest {
     // Don't set the MDC_FLIGHT_MAP_KEY on the input FlightMap, but expect "foo": "bar"
     // The CheckMdc step will fail during do & undo, causing a FATAL flight failure.
     assertEquals(
-            FlightStatus.FATAL,
-            submitAndWait(MdcFooBarTestFlight.class).getFlightStatus(),
-            "Flight fails fatally without expected input context");
+        FlightStatus.FATAL,
+        submitAndWait(MdcFooBarTestFlight.class).getFlightStatus(),
+        "Flight fails fatally without expected input context");
     assertNull(MDC.getCopyOfContextMap(), "calling thread's context is preserved after flight");
   }
 
@@ -105,11 +106,11 @@ class MdcHookTest extends BaseUnitTest {
     public MdcFooBarTestFlight(FlightMap inputParameters, Object applicationContext) {
       super(inputParameters, applicationContext);
       var expectedFlightContext =
-              ImmutableMap.<String, String>builder()
-                      .putAll(FOO_BAR)
-                      .put(MdcHook.FLIGHT_ID_KEY, inputParameters.get(MdcHook.FLIGHT_ID_KEY, String.class))
-                      .put(MdcHook.FLIGHT_CLASS_KEY, getClass().getName())
-                      .build();
+          ImmutableMap.<String, String>builder()
+              .putAll(FOO_BAR)
+              .put(MdcHook.FLIGHT_ID_KEY, inputParameters.get(MdcHook.FLIGHT_ID_KEY, String.class))
+              .put(MdcHook.FLIGHT_CLASS_KEY, getClass().getName())
+              .build();
       addStep(new CheckMdc(expectedFlightContext, 0, Direction.SWITCH));
     }
   }
@@ -119,25 +120,28 @@ class MdcHookTest extends BaseUnitTest {
     public MdcFooBarUndoTestFlight(FlightMap inputParameters, Object applicationContext) {
       super(inputParameters, applicationContext);
       var expectedFlightContext =
-              ImmutableMap.<String, String>builder()
-                      .putAll(FOO_BAR)
-                      .put(MdcHook.FLIGHT_ID_KEY, inputParameters.get(MdcHook.FLIGHT_ID_KEY, String.class))
-                      .put(MdcHook.FLIGHT_CLASS_KEY, getClass().getName())
-                      .build();
+          ImmutableMap.<String, String>builder()
+              .putAll(FOO_BAR)
+              .put(MdcHook.FLIGHT_ID_KEY, inputParameters.get(MdcHook.FLIGHT_ID_KEY, String.class))
+              .put(MdcHook.FLIGHT_CLASS_KEY, getClass().getName())
+              .build();
       addStep(new CheckMdc(expectedFlightContext, 0, Direction.UNDO));
       addStep(new ErrorStep(expectedFlightContext, 1, Direction.SWITCH));
     }
   }
 
-  /** Flight to check Stairway MDC context modifications when no initial context was provided as a flight input. */
+  /**
+   * Flight to check Stairway MDC context modifications when no initial context was provided as a
+   * flight input.
+   */
   public static class MdcNoInputContextTestFlight extends Flight {
     public MdcNoInputContextTestFlight(FlightMap inputParameters, Object applicationContext) {
       super(inputParameters, applicationContext);
       var expectedFlightContext =
-              ImmutableMap.<String, String>builder()
-                      .put(MdcHook.FLIGHT_ID_KEY, inputParameters.get(MdcHook.FLIGHT_ID_KEY, String.class))
-                      .put(MdcHook.FLIGHT_CLASS_KEY, getClass().getName())
-                      .build();
+          ImmutableMap.<String, String>builder()
+              .put(MdcHook.FLIGHT_ID_KEY, inputParameters.get(MdcHook.FLIGHT_ID_KEY, String.class))
+              .put(MdcHook.FLIGHT_CLASS_KEY, getClass().getName())
+              .build();
       addStep(new CheckMdc(expectedFlightContext, 0, Direction.SWITCH));
     }
   }
@@ -146,9 +150,9 @@ class MdcHookTest extends BaseUnitTest {
   public static class CheckMdc extends MdcAssertionStep {
 
     public CheckMdc(
-            Map<String, String> expectedFlightContext,
-            Integer expectedStepNumber,
-            Direction expectedUndoDirection) {
+        Map<String, String> expectedFlightContext,
+        Integer expectedStepNumber,
+        Direction expectedUndoDirection) {
       super(expectedFlightContext, expectedStepNumber, expectedUndoDirection);
     }
 
@@ -168,12 +172,13 @@ class MdcHookTest extends BaseUnitTest {
   /** A {@link Step} that always fails in a non-retryable way. */
   public static class ErrorStep extends MdcAssertionStep {
 
-    public static final Exception EXPECTED_EXCEPTION = new RuntimeException("Expected exception on ErrorStep.doStep");
+    public static final Exception EXPECTED_EXCEPTION =
+        new RuntimeException("Expected exception on ErrorStep.doStep");
 
     public ErrorStep(
-            Map<String, String> expectedFlightContext,
-            Integer expectedStepNumber,
-            Direction expectedUndoDirection) {
+        Map<String, String> expectedFlightContext,
+        Integer expectedStepNumber,
+        Direction expectedUndoDirection) {
       super(expectedFlightContext, expectedStepNumber, expectedUndoDirection);
     }
 
@@ -190,30 +195,30 @@ class MdcHookTest extends BaseUnitTest {
     }
   }
 
-  private static abstract class MdcAssertionStep implements Step {
+  private abstract static class MdcAssertionStep implements Step {
     private final Map<String, String> expectedContextBase;
     final Direction expectedUndoDirection;
 
     MdcAssertionStep(
-            Map<String, String> expectedFlightContext,
-            Integer expectedStepNumber,
-            Direction expectedUndoDirection) {
+        Map<String, String> expectedFlightContext,
+        Integer expectedStepNumber,
+        Direction expectedUndoDirection) {
       this.expectedContextBase =
-              ImmutableMap.<String, String>builder()
-                      .putAll(expectedFlightContext)
-                      .put(MdcHook.FLIGHT_STEP_CLASS_KEY, getClass().getName())
-                      .put(MdcHook.FLIGHT_STEP_NUMBER_KEY, expectedStepNumber.toString())
-                      .build();
+          ImmutableMap.<String, String>builder()
+              .putAll(expectedFlightContext)
+              .put(MdcHook.FLIGHT_STEP_CLASS_KEY, getClass().getName())
+              .put(MdcHook.FLIGHT_STEP_NUMBER_KEY, expectedStepNumber.toString())
+              .build();
       this.expectedUndoDirection = expectedUndoDirection;
     }
 
     void assertMatchesExpectedContext(Direction flightStepDirection) {
       try {
         var expectedContext =
-                ImmutableMap.<String, String>builder()
-                        .putAll(expectedContextBase)
-                        .put(MdcHook.FLIGHT_STEP_DIRECTION_KEY, flightStepDirection.name())
-                        .build();
+            ImmutableMap.<String, String>builder()
+                .putAll(expectedContextBase)
+                .put(MdcHook.FLIGHT_STEP_DIRECTION_KEY, flightStepDirection.name())
+                .build();
         assertEquals(expectedContext, MDC.getCopyOfContextMap());
       } catch (AssertionError error) {
         // Rethrow an AssertionError as an Exception so that Stairway can handle it
@@ -224,11 +229,18 @@ class MdcHookTest extends BaseUnitTest {
 
   /**
    * Submits the flight and polls every 100 ms for its completion, up to 3 seconds.
+   *
    * @param flightClass to submit with flightId and flightMap instance variables
    * @return FlightState of the completed flight
    */
   private FlightState submitAndWait(Class<? extends Flight> flightClass) throws Exception {
     stairway.submit(flightId, flightClass, flightMap);
-    return FlightUtils.waitForFlightCompletion(stairway, flightId, Duration.ofSeconds(3), Duration.ofMillis(100), 0, Duration.ofMillis(100));
+    return FlightUtils.waitForFlightCompletion(
+        stairway,
+        flightId,
+        Duration.ofSeconds(3),
+        Duration.ofMillis(100),
+        0,
+        Duration.ofMillis(100));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
@@ -1,100 +1,116 @@
 package bio.terra.workspace.common.utils;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import bio.terra.stairway.*;
 import bio.terra.workspace.common.BaseUnitTest;
 import bio.terra.workspace.service.job.JobService;
 import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Duration;
+import java.util.Map;
 
 class MdcHookTest extends BaseUnitTest {
   @Autowired private MdcHook mdcHook;
   @Autowired private JobService jobService;
 
-  @Test
-  void initialContextPropagated_Do() throws Exception {
-    Stairway stairway = jobService.getStairway();
+  private static final Map<String, String> FOO_BAR = Map.of("foo", "bar");
+  private Stairway stairway;
+  private String flightId;
+  private FlightMap flightMap;
 
+  @BeforeEach
+  void beforeEach() {
     MDC.clear();
-    MDC.put("foo", "bar");
-    FlightMap flightMap = new FlightMap();
-    flightMap.put(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext());
-
-    String flightId = stairway.createFlightId();
-    stairway.submit(flightId, MdcFooBarTestFlight.class, flightMap);
-    Thread.sleep(3000);
-
-    assertEquals(FlightStatus.SUCCESS, stairway.getFlightState(flightId).getFlightStatus());
+    stairway = jobService.getStairway();
+    flightId = stairway.createFlightId();
+    flightMap = new FlightMap();
+    flightMap.put(MdcHook.FLIGHT_ID_KEY, flightId);
   }
 
   @Test
-  void initialContextPropagated_Undo() throws Exception {
-    Stairway stairway = jobService.getStairway();
-
-    MDC.clear();
-    MDC.put("foo", "bar");
-    FlightMap flightMap = new FlightMap();
+  void inputContextPropagated_Do() throws Exception {
+    MDC.setContextMap(FOO_BAR);
     flightMap.put(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext());
 
-    String flightId = stairway.createFlightId();
-    // Use a flight that always errors to check the MDC context on undo.
-    stairway.submit(flightId, MdcFooBarUndoTestFlight.class, flightMap);
-    Thread.sleep(3000);
+    assertEquals(
+            FlightStatus.SUCCESS,
+            submitAndWait(MdcFooBarTestFlight.class).getFlightStatus(),
+            "Input context, flight context, and step context propagated");
+    assertEquals(FOO_BAR, MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
+  }
 
+  @Test
+  void inputContextPropagated_Undo() throws Exception {
+    MDC.setContextMap(FOO_BAR);
+    flightMap.put(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext());
+
+    // Use a flight that always errors to check the MDC context on undo.
     // CheckMDC passes on do & undo, otherwise the flight would end with FlightStatus.FATAL. The
     // ErrorStep causes the undo to happen and the flight to end as ERROR.
-    assertEquals(FlightStatus.ERROR, stairway.getFlightState(flightId).getFlightStatus());
+    var flightState = submitAndWait(MdcFooBarUndoTestFlight.class);
+    assertEquals(
+            FlightStatus.ERROR,
+            flightState.getFlightStatus(),
+            "Flight fails but all steps can be walked back");
+    var maybeFlightException = flightState.getException();
+    assertTrue(maybeFlightException.isPresent());
+    assertEquals(
+            ErrorStep.EXPECTED_EXCEPTION.getMessage(),
+            maybeFlightException.get().getMessage(),
+            "Flight fails due to ErrorStep");
+    assertEquals(FOO_BAR, MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
   }
 
   @Test
-  void noInitialContextOk() throws Exception {
-    Stairway stairway = jobService.getStairway();
-
-    MDC.clear();
-    FlightMap flightMap = new FlightMap();
+  void emptyInputContextOk() throws Exception {
     flightMap.put(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext());
 
-    String flightId = stairway.createFlightId();
-    stairway.submit(flightId, MdcNoContextTestFlight.class, flightMap);
-    Thread.sleep(3000);
-
-    assertEquals(FlightStatus.SUCCESS, stairway.getFlightState(flightId).getFlightStatus());
+    assertEquals(
+            FlightStatus.SUCCESS,
+            submitAndWait(MdcNoInputContextTestFlight.class).getFlightStatus(),
+            "Flight succeeds when empty input context provided");
+    assertNull(MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
   }
 
   @Test
   void inputParametersNotSetOk() throws Exception {
-    Stairway stairway = jobService.getStairway();
-
-    String flightId = stairway.createFlightId();
-    // Don't set the MDC_FLIGHT_MAP_KEY on the input FlightMap.
-    stairway.submit(flightId, MdcNoContextTestFlight.class, new FlightMap());
-    Thread.sleep(3000);
-
-    assertEquals(FlightStatus.SUCCESS, stairway.getFlightState(flightId).getFlightStatus());
+    assertEquals(
+            FlightStatus.SUCCESS,
+            submitAndWait(MdcNoInputContextTestFlight.class).getFlightStatus(),
+            "Flight succeeds when no input context provided");
+    assertNull(MDC.getCopyOfContextMap(), "Calling thread's context is preserved after flight");
   }
 
   /** Test that the CheckMdc Step will fail the flight as expected by the rest of the tests. */
   @Test
   void testCheckMdc() throws Exception {
-    Stairway stairway = jobService.getStairway();
-
-    String flightId = stairway.createFlightId();
     // Don't set the MDC_FLIGHT_MAP_KEY on the input FlightMap, but expect "foo": "bar"
-    stairway.submit(flightId, MdcFooBarTestFlight.class, new FlightMap());
-    Thread.sleep(3000);
-
     // The CheckMdc step will fail during do & undo, causing a FATAL flight failure.
-    assertEquals(FlightStatus.FATAL, stairway.getFlightState(flightId).getFlightStatus());
+    assertEquals(
+            FlightStatus.FATAL,
+            submitAndWait(MdcFooBarTestFlight.class).getFlightStatus(),
+            "Flight fails fatally without expected input context");
+    assertNull(MDC.getCopyOfContextMap(), "calling thread's context is preserved after flight");
   }
 
   /** Flight to check that "foo": "bar" is in the MDC context. */
   public static class MdcFooBarTestFlight extends Flight {
     public MdcFooBarTestFlight(FlightMap inputParameters, Object applicationContext) {
       super(inputParameters, applicationContext);
-      addStep(new CheckMdc(ImmutableMap.of("foo", "bar")));
+      var expectedFlightContext =
+              ImmutableMap.<String, String>builder()
+                      .putAll(FOO_BAR)
+                      .put(MdcHook.FLIGHT_ID_KEY, inputParameters.get(MdcHook.FLIGHT_ID_KEY, String.class))
+                      .put(MdcHook.FLIGHT_CLASS_KEY, getClass().getName())
+                      .build();
+      addStep(new CheckMdc(expectedFlightContext, 0, Direction.SWITCH));
     }
   }
 
@@ -102,41 +118,102 @@ class MdcHookTest extends BaseUnitTest {
   public static class MdcFooBarUndoTestFlight extends Flight {
     public MdcFooBarUndoTestFlight(FlightMap inputParameters, Object applicationContext) {
       super(inputParameters, applicationContext);
-      addStep(new CheckMdc(ImmutableMap.of("foo", "bar")));
-      addStep(new ErrorStep());
+      var expectedFlightContext =
+              ImmutableMap.<String, String>builder()
+                      .putAll(FOO_BAR)
+                      .put(MdcHook.FLIGHT_ID_KEY, inputParameters.get(MdcHook.FLIGHT_ID_KEY, String.class))
+                      .put(MdcHook.FLIGHT_CLASS_KEY, getClass().getName())
+                      .build();
+      addStep(new CheckMdc(expectedFlightContext, 0, Direction.UNDO));
+      addStep(new ErrorStep(expectedFlightContext, 1, Direction.SWITCH));
     }
   }
 
-  /** Flight to check that the MDC context has no values. */
-  public static class MdcNoContextTestFlight extends Flight {
-    public MdcNoContextTestFlight(FlightMap inputParameters, Object applicationContext) {
+  /** Flight to check Stairway MDC context modifications when no initial context was provided as a flight input. */
+  public static class MdcNoInputContextTestFlight extends Flight {
+    public MdcNoInputContextTestFlight(FlightMap inputParameters, Object applicationContext) {
       super(inputParameters, applicationContext);
-      addStep(new CheckMdc(ImmutableMap.of()));
+      var expectedFlightContext =
+              ImmutableMap.<String, String>builder()
+                      .put(MdcHook.FLIGHT_ID_KEY, inputParameters.get(MdcHook.FLIGHT_ID_KEY, String.class))
+                      .put(MdcHook.FLIGHT_CLASS_KEY, getClass().getName())
+                      .build();
+      addStep(new CheckMdc(expectedFlightContext, 0, Direction.SWITCH));
     }
   }
 
   /** A step that asserts the MDC context is what's expected on do and undo. */
-  public static class CheckMdc implements Step {
-    private final ImmutableMap<String, String> expectedContext;
+  public static class CheckMdc extends MdcAssertionStep {
 
-    public CheckMdc(ImmutableMap<String, String> expectedContext) {
-      this.expectedContext = expectedContext;
+    public CheckMdc(
+            Map<String, String> expectedFlightContext,
+            Integer expectedStepNumber,
+            Direction expectedUndoDirection) {
+      super(expectedFlightContext, expectedStepNumber, expectedUndoDirection);
     }
 
     @Override
     public StepResult doStep(FlightContext flightContext) {
-      assertMatchesExpectedContext();
+      assertMatchesExpectedContext(Direction.DO);
       return StepResult.getStepResultSuccess();
     }
 
     @Override
     public StepResult undoStep(FlightContext flightContext) {
-      assertMatchesExpectedContext();
+      assertMatchesExpectedContext(expectedUndoDirection);
       return StepResult.getStepResultSuccess();
     }
+  }
 
-    private void assertMatchesExpectedContext() {
+  /** A {@link Step} that always fails in a non-retryable way. */
+  public static class ErrorStep extends MdcAssertionStep {
+
+    public static final Exception EXPECTED_EXCEPTION = new RuntimeException("Expected exception on ErrorStep.doStep");
+
+    public ErrorStep(
+            Map<String, String> expectedFlightContext,
+            Integer expectedStepNumber,
+            Direction expectedUndoDirection) {
+      super(expectedFlightContext, expectedStepNumber, expectedUndoDirection);
+    }
+
+    @Override
+    public StepResult doStep(FlightContext flightContext) {
+      assertMatchesExpectedContext(Direction.DO);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, EXPECTED_EXCEPTION);
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext flightContext) {
+      assertMatchesExpectedContext(expectedUndoDirection);
+      return StepResult.getStepResultSuccess();
+    }
+  }
+
+  private static abstract class MdcAssertionStep implements Step {
+    private final Map<String, String> expectedContextBase;
+    final Direction expectedUndoDirection;
+
+    MdcAssertionStep(
+            Map<String, String> expectedFlightContext,
+            Integer expectedStepNumber,
+            Direction expectedUndoDirection) {
+      this.expectedContextBase =
+              ImmutableMap.<String, String>builder()
+                      .putAll(expectedFlightContext)
+                      .put(MdcHook.FLIGHT_STEP_CLASS_KEY, getClass().getName())
+                      .put(MdcHook.FLIGHT_STEP_NUMBER_KEY, expectedStepNumber.toString())
+                      .build();
+      this.expectedUndoDirection = expectedUndoDirection;
+    }
+
+    void assertMatchesExpectedContext(Direction flightStepDirection) {
       try {
+        var expectedContext =
+                ImmutableMap.<String, String>builder()
+                        .putAll(expectedContextBase)
+                        .put(MdcHook.FLIGHT_STEP_DIRECTION_KEY, flightStepDirection.name())
+                        .build();
         assertEquals(expectedContext, MDC.getCopyOfContextMap());
       } catch (AssertionError error) {
         // Rethrow an AssertionError as an Exception so that Stairway can handle it
@@ -145,16 +222,13 @@ class MdcHookTest extends BaseUnitTest {
     }
   }
 
-  /** A {@link Step} that always fails in a non-retryable way. */
-  public static class ErrorStep implements Step {
-    @Override
-    public StepResult doStep(FlightContext flightContext) {
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL);
-    }
-
-    @Override
-    public StepResult undoStep(FlightContext flightContext) {
-      return StepResult.getStepResultSuccess();
-    }
+  /**
+   * Submits the flight and polls every 100 ms for its completion, up to 3 seconds.
+   * @param flightClass to submit with flightId and flightMap instance variables
+   * @return FlightState of the completed flight
+   */
+  private FlightState submitAndWait(Class<? extends Flight> flightClass) throws Exception {
+    stairway.submit(flightId, flightClass, flightMap);
+    return FlightUtils.waitForFlightCompletion(stairway, flightId, Duration.ofSeconds(3), Duration.ofMillis(100), 0, Duration.ofMillis(100));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
@@ -10,7 +10,6 @@ import bio.terra.workspace.service.job.JobService;
 import com.google.common.collect.ImmutableMap;
 import java.time.Duration;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;

--- a/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/MdcHookTest.java
@@ -1,8 +1,8 @@
 package bio.terra.workspace.common.utils;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.stairway.*;
 import bio.terra.workspace.common.BaseUnitTest;
@@ -10,6 +10,7 @@ import bio.terra.workspace.service.job.JobService;
 import com.google.common.collect.ImmutableMap;
 import java.time.Duration;
 import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1454

**Problem**

We've had a hard time debugging the dismal failures of our services' Stairway flights when [alerts](https://console.cloud.google.com/monitoring/alerting/incidents/0.n8b4q18pyjgu?channelType=slack&project=broad-dsde-staging) are emitted to #dsp-workspaces-alerts.  We'd resort to searching across fields for the flight ID, roughly around the time of the failure, which is a fuzzy process liable to miss relevant logs.

Previously, we tried to propagate the calling thread's MDC to each Stairway step.  At present, this only contains the `requestId` set via TCL's [RequestIdFilter](https://github.com/DataBiosphere/terra-common-lib/blob/develop/src/main/java/bio/terra/common/logging/RequestIdFilter.java).

But this left a few gaps in context:
- When starting the step, we logged before setting the MDC: we want to set the MDC before logging for it to be useful.
- Stairway flight execution outside of the steps themselves, notably when handling dismal failures.

**Changes**

MdcHooks now does the following:
- Propagates flight-specific mapped diagnostic context (MDC) across a Stairway flight's thread(s) for the duration of the flight. This includes context provided by the caller in the input map, intended to store the MDC from the calling thread to preserve context across the duration of a request.
- Propagates step-specific MDC across a Stairway flight's thread(s) for the duration of each step.

Updated unit tests.

**Concrete example**

My [Bee](https://beehive.dsp-devops.broadinstitute.org/environments/okotsopo/chart-releases/workspacemanager) is up to date with these changes.

I modified the workspace creation flight to fail dismally.  Here are the [logs for the duration of such a request](https://cloudlogging.app.goo.gl/kvvx7Krn6hLSrzx67).

I've exposed some of the new MDC additions in the log summary lines to help visualize the lifespan of each piece of context:
- `jsonPayload.requestId` - available from the calling thread's MDC via TCL's [RequestIdFilter](https://github.com/DataBiosphere/terra-common-lib/blob/develop/src/main/java/bio/terra/common/logging/RequestIdFilter.java)
- `jsonPayload.flightId` - available on the Stairway thread(s) for the duration of the flight
- `jsonPayload.flightStepClass` - available on the Stairway thread(s) for the duration of the step
- `jsonPayload.flightStepDirection` - available on the Stairway thread(s) for the duration of the step's execution in the specified direction

<img width="1713" alt="Screenshot 2024-02-02 at 12 12 35 PM" src="https://github.com/DataBiosphere/terra-workspace-manager/assets/79769153/c8a2f184-6658-4f1b-95ec-ae701e31a4f2">

If this had been a dismal failure that we were tasked with debugging, we could have easily restricted our logs by `requestId` or `flightId`.  Both are set on the log which triggers the alert.

**Future opportunities**
- Discuss centralizing MDC propagation to Stairway threads in `terra-common-library` or `stairway` with Saga Transactions working group.  This PR borrows from [TDR's own hook](https://github.com/DataBiosphere/jade-data-repo/blob/develop/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java), but nothing about it is specific to either service and would likely be broadly useful.
- Update [dismal failure debugging documentation](https://broadworkbench.atlassian.net/wiki/spaces/WOR/pages/2438037505/Operations+Playbook#%3CENV%3E:-Dismal-Stairway-Failure)
- If needed, supplement MDC further to make debugging WSM dismal failures easier.  A straightforward way to do this would be to supplement the MDC before submitting the job: it would then be picked up as part of existing calling thread context propagation.
- Audit MDC propagation to Stairway threads in other Workspaces services (BPM, LZS).  It would be preferable to have these services benefit from centralized MDC propagation rather than needing to copy this over.