### PR TITLE
Do not ignore changes to .github when publishing

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -25,7 +25,6 @@ on:
     - main
     paths-ignore:
     - 'README.md'
-    - '.github/**'
     - 'local-dev/**'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
We need an azureDatabaseUtils image built for ITs to run successfully against a given SHA. This un-ignores changes to .github so changes to workflows in this repo always get the needed image built as we iterate on CI modifications. 