### PR TITLE
[IA-4632] Add disk create-result

### DIFF
--- a/openapi/src/common/responses_azure.yaml
+++ b/openapi/src/common/responses_azure.yaml
@@ -9,3 +9,10 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/DeleteControlledAzureResourceResult'
+
+    CreateControlledAzureResourceResponse:
+      description: Response Payload for creating an Azure controlled resource
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateControlledAzureResourceResult'

--- a/openapi/src/common/schemas_azure.yaml
+++ b/openapi/src/common/schemas_azure.yaml
@@ -21,6 +21,10 @@ components:
     CreateControlledAzureResourceResult:
       type: object
       properties:
+        resourceId:
+          description: UUID of a newly-created resource.
+          type: string
+          format: uuid
         jobReport:
           $ref: '#/components/schemas/JobReport'
         errorReport:

--- a/openapi/src/common/schemas_azure.yaml
+++ b/openapi/src/common/schemas_azure.yaml
@@ -17,3 +17,11 @@ components:
           $ref: '#/components/schemas/JobReport'
         errorReport:
           $ref: '#/components/schemas/ErrorReport'
+
+    CreateControlledAzureResourceResult:
+      type: object
+      properties:
+        jobReport:
+          $ref: '#/components/schemas/JobReport'
+        errorReport:
+          $ref: '#/components/schemas/ErrorReport'

--- a/openapi/src/parts/controlled_azure_disk.yaml
+++ b/openapi/src/parts/controlled_azure_disk.yaml
@@ -145,8 +145,8 @@ components:
           $ref: '#/components/schemas/ControlledResourceCommonFields'
         azureDisk:
           $ref: '#/components/schemas/AzureDiskCreationParameters'
-        jobReport:
-          $ref: '#/components/schemas/JobReport'
+        jobControl:
+          $ref: '#/components/schemas/JobControl'
 
     CreatedControlledAzureDiskResult:
       description: Api result class for creating an Azure disk

--- a/openapi/src/parts/controlled_azure_disk.yaml
+++ b/openapi/src/parts/controlled_azure_disk.yaml
@@ -24,6 +24,24 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/disks/create-result/{jobId}:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/JobId'
+    get:
+      summary: Retrieve information about an Azure Disk create job.
+      operationId: getCreateAzureDiskResult
+      tags: [ ControlledAzureResource ]
+      responses:
+        '200':
+          $ref: '#/components/responses/CreateControlledAzureDiskResponse'
+        '202':
+          $ref: '#/components/responses/CreateControlledAzureDiskResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/workspaces/v1/{workspaceId}/resources/controlled/azure/disks/{resourceId}:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
@@ -127,3 +145,24 @@ components:
           $ref: '#/components/schemas/ControlledResourceCommonFields'
         azureDisk:
           $ref: '#/components/schemas/AzureDiskCreationParameters'
+
+    CreatedControlledAzureDiskResult:
+      description: Api result class for creating an Azure disk
+      type: object
+      properties:
+        azureDisk:
+          $ref: '#/components/schemas/AzureDiskResource'
+        jobReport:
+          $ref: '#/components/schemas/JobReport'
+        errorReport:
+          $ref: '#/components/schemas/ErrorReport'
+
+
+  responses:
+    CreateControlledAzureDiskResponse:
+      description: Response to create controlled Azure disk
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatedControlledAzureDiskResult'
+

--- a/openapi/src/parts/controlled_azure_disk.yaml
+++ b/openapi/src/parts/controlled_azure_disk.yaml
@@ -145,6 +145,8 @@ components:
           $ref: '#/components/schemas/ControlledResourceCommonFields'
         azureDisk:
           $ref: '#/components/schemas/AzureDiskCreationParameters'
+        jobReport:
+          $ref: '#/components/schemas/JobReport'
 
     CreatedControlledAzureDiskResult:
       description: Api result class for creating an Azure disk

--- a/openapi/src/parts/controlled_azure_disk.yaml
+++ b/openapi/src/parts/controlled_azure_disk.yaml
@@ -18,13 +18,38 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreatedControlledAzureDiskResult'
+                $ref: '#/components/schemas/CreatedControlledAzureDisk'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/disks/create-result/{jobId}:
+  /api/workspaces/v2/{workspaceId}/resources/controlled/azure/disks:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+    post:
+      summary: Create a new controlled Azure Disk
+      operationId: createAzureDiskV2
+      tags: [ ControlledAzureResource ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateControlledAzureDiskRequestV2Body'
+      responses:
+        '200':
+          description: Response to create controlled Azure disk
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateControlledAzureResourceResult'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /api/workspaces/v2/{workspaceId}/resources/controlled/azure/disks/create-result/{jobId}:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
       - $ref: '#/components/parameters/JobId'
@@ -34,9 +59,9 @@ paths:
       tags: [ ControlledAzureResource ]
       responses:
         '200':
-          $ref: '#/components/responses/CreateControlledAzureDiskResponse'
+          $ref: '#/components/responses/CreateControlledAzureResourceResponse'
         '202':
-          $ref: '#/components/responses/CreateControlledAzureDiskResponse'
+          $ref: '#/components/responses/CreateControlledAzureResourceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '500':
@@ -126,7 +151,27 @@ components:
             A valid size in GB integer representation
           type: integer
 
+    CreatedControlledAzureDisk:
+      description: Response payload for requesting a new Azure disk
+      type: object
+      properties:
+        resourceId:
+          description: UUID of a newly-created resource.
+          type: string
+          format: uuid
+        azureDisk:
+          $ref: '#/components/schemas/AzureDiskResource'
+
     CreateControlledAzureDiskRequestBody:
+      description: Payload for requesting a new controlled Azure Disk resource.
+      type: object
+      properties:
+        common:
+          $ref: '#/components/schemas/ControlledResourceCommonFields'
+        azureDisk:
+          $ref: '#/components/schemas/AzureDiskCreationParameters'
+
+    CreateControlledAzureDiskRequestV2Body:
       description: Payload for requesting a new controlled Azure Disk resource.
       type: object
       properties:
@@ -136,24 +181,3 @@ components:
           $ref: '#/components/schemas/AzureDiskCreationParameters'
         jobControl:
           $ref: '#/components/schemas/JobControl'
-
-    CreatedControlledAzureDiskResult:
-      description: Api result class for creating an Azure disk
-      type: object
-      properties:
-        azureDisk:
-          $ref: '#/components/schemas/AzureDiskResource'
-        jobReport:
-          $ref: '#/components/schemas/JobReport'
-        errorReport:
-          $ref: '#/components/schemas/ErrorReport'
-
-
-  responses:
-    CreateControlledAzureDiskResponse:
-      description: Response to create controlled Azure disk
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/CreatedControlledAzureDiskResult'
-

--- a/openapi/src/parts/controlled_azure_disk.yaml
+++ b/openapi/src/parts/controlled_azure_disk.yaml
@@ -18,7 +18,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreatedControlledAzureDisk'
+                $ref: '#/components/schemas/CreatedControlledAzureDiskResult'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '500':
@@ -125,17 +125,6 @@ components:
           description: |
             A valid size in GB integer representation
           type: integer
-
-    CreatedControlledAzureDisk:
-      description: Response payload for requesting a new Azure disk
-      type: object
-      properties:
-        resourceId:
-          description: UUID of a newly-created resource.
-          type: string
-          format: uuid
-        azureDisk:
-          $ref: '#/components/schemas/AzureDiskResource'
 
     CreateControlledAzureDiskRequestBody:
       description: Payload for requesting a new controlled Azure Disk resource.

--- a/openapi/src/parts/controlled_azure_disk.yaml
+++ b/openapi/src/parts/controlled_azure_disk.yaml
@@ -28,7 +28,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
     post:
-      summary: Create a new controlled Azure Disk
+      summary: Asynchronously create a new controlled Azure Disk
       operationId: createAzureDiskV2
       tags: [ ControlledAzureResource ]
       requestBody:
@@ -174,6 +174,7 @@ components:
     CreateControlledAzureDiskRequestV2Body:
       description: Payload for requesting a new controlled Azure Disk resource.
       type: object
+      required: [ common, azureDisk, jobControl ]
       properties:
         common:
           $ref: '#/components/schemas/ControlledResourceCommonFields'

--- a/openapi/src/parts/controlled_azure_vm.yaml
+++ b/openapi/src/parts/controlled_azure_vm.yaml
@@ -253,7 +253,7 @@ components:
           $ref: '#/components/schemas/JobControl'
 
     CreatedControlledAzureVmResult:
-      description: Api result class for creating an azure vm
+      description: Api result class for creating an Azure vm
       type: object
       properties:
         azureVm:

--- a/openapi/src/parts/controlled_azure_vm.yaml
+++ b/openapi/src/parts/controlled_azure_vm.yaml
@@ -3,7 +3,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
     post:
-      summary: Asynchronoulsy create a new controlled Azure VM
+      summary: Asynchronously create a new controlled Azure VM
       operationId: createAzureVm
       tags: [ ControlledAzureResource ]
       requestBody:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -131,7 +131,6 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             .size(body.getAzureDisk().getSize())
             .build();
 
-    // TODO: make createDisk call async once we have things working e2e
     final ControlledAzureDiskResource createdDisk =
         controlledResourceService
             .createControlledResourceSync(
@@ -152,6 +151,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     features.azureEnabledCheck();
 
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+
     ControlledResourceFields commonFields =
         toCommonFields(
             workspaceUuid,

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -125,11 +125,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
     ControlledAzureDiskResource resource =
-        ControlledAzureDiskResource.builder()
-            .common(commonFields)
-            .diskName(body.getAzureDisk().getName())
-            .size(body.getAzureDisk().getSize())
-            .build();
+        buildControlledAzureDiskResource(body.getAzureDisk(), commonFields);
 
     final ControlledAzureDiskResource createdDisk =
         controlledResourceService
@@ -166,11 +162,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
     ControlledAzureDiskResource resource =
-        ControlledAzureDiskResource.builder()
-            .common(commonFields)
-            .diskName(body.getAzureDisk().getName())
-            .size(body.getAzureDisk().getSize())
-            .build();
+        buildControlledAzureDiskResource(body.getAzureDisk(), commonFields);
 
     final String jobId =
         controlledResourceService.createControlledResourceAsync(
@@ -334,6 +326,16 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
         .vmSize(creationParameters.getVmSize())
         .vmImage(AzureUtils.getVmImageData(creationParameters.getVmImage()))
         .diskId(creationParameters.getDiskId())
+        .build();
+  }
+
+  @VisibleForTesting
+  ControlledAzureDiskResource buildControlledAzureDiskResource(
+      ApiAzureDiskCreationParameters creationParameters, ControlledResourceFields commonFields) {
+    return ControlledAzureDiskResource.builder()
+        .common(commonFields)
+        .diskName(creationParameters.getName())
+        .size(creationParameters.getSize())
         .build();
   }
 

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -148,7 +148,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
   @WithSpan
   @Override
   public ResponseEntity<ApiCreatedControlledAzureDiskResult> getCreateAzureDiskResult(
-          UUID workspaceUuid, String jobId) {
+      UUID workspaceUuid, String jobId) {
     features.azureEnabledCheck();
 
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
@@ -159,7 +159,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
 
   private ApiCreatedControlledAzureDiskResult fetchCreateControlledAzureDiskResult(String jobId) {
     final JobApiUtils.AsyncJobResult<ControlledAzureDiskResource> jobResult =
-            jobApiUtils.retrieveAsyncJobResult(jobId, ControlledAzureDiskResource.class);
+        jobApiUtils.retrieveAsyncJobResult(jobId, ControlledAzureDiskResource.class);
 
     ApiAzureDiskResource apiResource = null;
     if (jobResult.getJobReport().getStatus().equals(ApiJobReport.StatusEnum.SUCCEEDED)) {
@@ -167,9 +167,9 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
       apiResource = resource.toApiResource();
     }
     return new ApiCreatedControlledAzureDiskResult()
-            .jobReport(jobResult.getJobReport())
-            .errorReport(jobResult.getApiErrorReport())
-            .azureDisk(apiResource);
+        .jobReport(jobResult.getJobReport())
+        .errorReport(jobResult.getApiErrorReport())
+        .azureDisk(apiResource);
   }
 
   @WithSpan

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -182,7 +182,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
             getAsyncResultEndpoint(body.getJobControl().getId(), "create-result"));
 
     final ApiCreateControlledAzureResourceResult result =
-        fetchCreateControlledAzureResourceResult(jobId);
+        fetchCreateControlledAzureDiskResult(jobId);
 
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
@@ -195,7 +195,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
 
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     jobService.verifyUserAccess(jobId, userRequest, workspaceUuid);
-    ApiCreateControlledAzureResourceResult result = fetchCreateControlledAzureResourceResult(jobId);
+    ApiCreateControlledAzureResourceResult result = fetchCreateControlledAzureDiskResult(jobId);
     return new ResponseEntity<>(result, getAsyncResponseCode(result.getJobReport()));
   }
 
@@ -541,12 +541,18 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
         .azureVm(apiResource);
   }
 
-  private ApiCreateControlledAzureResourceResult fetchCreateControlledAzureResourceResult(
+  private ApiCreateControlledAzureResourceResult fetchCreateControlledAzureDiskResult(
       String jobId) {
     final JobApiUtils.AsyncJobResult<ControlledAzureDiskResource> jobResult =
         jobApiUtils.retrieveAsyncJobResult(jobId, ControlledAzureDiskResource.class);
 
+    ControlledAzureDiskResource resource = null;
+    if (jobResult.getJobReport().getStatus().equals(ApiJobReport.StatusEnum.SUCCEEDED)) {
+      resource = jobResult.getResult();
+    }
+
     return new ApiCreateControlledAzureResourceResult()
+        .resourceId(resource.getResourceId())
         .jobReport(jobResult.getJobReport())
         .errorReport(jobResult.getApiErrorReport());
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -170,6 +170,9 @@ public class ControlledAzureDiskResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureDisk.");
     }
+    if (!(getSize() > 0)) {
+      throw new InconsistentFieldsException("Disk size must be a positive non-zero integer.");
+    }
     AzureResourceValidationUtils.validateAzureDiskName(getDiskName());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/ControlledAzureDiskResource.java
@@ -170,7 +170,7 @@ public class ControlledAzureDiskResource extends ControlledResource {
       throw new MissingRequiredFieldException(
           "Missing required region field for ControlledAzureDisk.");
     }
-    if (!(getSize() > 0)) {
+    if (getSize() <= 0) {
       throw new InconsistentFieldsException("Disk size must be a positive non-zero integer.");
     }
     AzureResourceValidationUtils.validateAzureDiskName(getDiskName());

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 public class ControlledAzureResourceApiControllerAzureDiskTest extends BaseAzureUnitTest {
   @Autowired MockMvc mockMvc;
@@ -88,6 +89,8 @@ public class ControlledAzureResourceApiControllerAzureDiskTest extends BaseAzure
                     post(String.format(CREATE_CONTROLLED_AZURE_DISK_V2_PATH_FORMAT, workspaceId))
                         .content(objectMapper.writeValueAsString(diskRequestV2Body)),
                     USER_REQUEST)))
-        .andExpect(status().is(HttpStatus.SC_OK));
+        .andExpect(status().is(HttpStatus.SC_OK))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.resourceId").exists());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.mocks.MockAzureApi.*;
-import static bio.terra.workspace.common.mocks.MockMvcUtils.*;
 import static bio.terra.workspace.common.mocks.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.mocks.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.mocks.MockMvcUtils.addJsonContentType;
@@ -20,6 +19,7 @@ import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
 import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
 import com.azure.core.management.Region;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
@@ -74,10 +74,9 @@ public class ControlledAzureResourceApiControllerAzureDiskTest extends BaseAzure
             .azureDisk(params)
             .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
 
-    when(getMockJobApiUtils()
-            .retrieveAsyncJobResult(any(), eq(ApiCreateControlledAzureResourceResult.class)))
+    when(getMockJobApiUtils().retrieveAsyncJobResult(any(), eq(ControlledAzureDiskResource.class)))
         .thenReturn(
-            new JobApiUtils.AsyncJobResult<ApiCreateControlledAzureResourceResult>()
+            new JobApiUtils.AsyncJobResult<ControlledAzureDiskResource>()
                 .jobReport(new ApiJobReport().status(ApiJobReport.StatusEnum.SUCCEEDED)));
 
     setupMockLandingZoneRegion(Region.GERMANY_CENTRAL);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
@@ -20,6 +20,7 @@ import bio.terra.workspace.generated.model.ApiJobControl;
 import bio.terra.workspace.generated.model.ApiJobReport;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.disk.ControlledAzureDiskResource;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
 import com.azure.core.management.Region;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
@@ -75,9 +76,20 @@ public class ControlledAzureResourceApiControllerAzureDiskTest extends BaseAzure
             .azureDisk(params)
             .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
 
+    ControlledAzureDiskResource resource =
+        controller.buildControlledAzureDiskResource(
+            diskRequestV2Body.getAzureDisk(),
+            controller.toCommonFields(
+                workspaceId,
+                commonFields,
+                Region.US_SOUTH_CENTRAL.name(),
+                USER_REQUEST,
+                WsmResourceType.CONTROLLED_AZURE_VM));
+
     when(getMockJobApiUtils().retrieveAsyncJobResult(any(), eq(ControlledAzureDiskResource.class)))
         .thenReturn(
             new JobApiUtils.AsyncJobResult<ControlledAzureDiskResource>()
+                .result(resource)
                 .jobReport(new ApiJobReport().status(ApiJobReport.StatusEnum.SUCCEEDED)));
 
     setupMockLandingZoneRegion(Region.GERMANY_CENTRAL);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
@@ -1,0 +1,94 @@
+package bio.terra.workspace.app.controller;
+
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.mocks.MockAzureApi.*;
+import static bio.terra.workspace.common.mocks.MockMvcUtils.*;
+import static bio.terra.workspace.common.mocks.MockMvcUtils.USER_REQUEST;
+import static bio.terra.workspace.common.mocks.MockMvcUtils.addAuth;
+import static bio.terra.workspace.common.mocks.MockMvcUtils.addJsonContentType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.workspace.app.controller.shared.JobApiUtils;
+import bio.terra.workspace.common.BaseAzureUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.generated.model.*;
+import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
+import bio.terra.workspace.generated.model.ApiJobControl;
+import bio.terra.workspace.generated.model.ApiJobReport;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import com.azure.core.management.Region;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class ControlledAzureResourceApiControllerAzureDiskTest extends BaseAzureUnitTest {
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired ControlledAzureResourceApiController controller;
+
+  @BeforeEach
+  void setUp() {
+    when(mockSamService()
+            .getUserEmailFromSamAndRethrowOnInterrupt(any(AuthenticatedUserRequest.class)))
+        .thenReturn(DEFAULT_USER_EMAIL);
+  }
+
+  @Test
+  public void createAzureDisk400WithNoParameters() throws Exception {
+    UUID workspaceId = UUID.randomUUID();
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(CREATE_CONTROLLED_AZURE_DISK_V2_PATH_FORMAT, workspaceId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .content("{}"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  public void createDisk() throws Exception {
+    UUID workspaceId = UUID.randomUUID();
+    setupMockLandingZoneRegion(Region.US_SOUTH_CENTRAL);
+
+    ApiControlledResourceCommonFields commonFields =
+        ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi();
+
+    ApiAzureDiskCreationParameters params =
+        new ApiAzureDiskCreationParameters().name("disk1").size(100);
+
+    ApiCreateControlledAzureDiskRequestV2Body diskRequestV2Body =
+        new ApiCreateControlledAzureDiskRequestV2Body()
+            .common(commonFields)
+            .azureDisk(params)
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+
+    when(getMockJobApiUtils()
+            .retrieveAsyncJobResult(any(), eq(ApiCreateControlledAzureResourceResult.class)))
+        .thenReturn(
+            new JobApiUtils.AsyncJobResult<ApiCreateControlledAzureResourceResult>()
+                .jobReport(new ApiJobReport().status(ApiJobReport.StatusEnum.SUCCEEDED)));
+
+    setupMockLandingZoneRegion(Region.GERMANY_CENTRAL);
+
+    mockMvc
+        .perform(
+            addJsonContentType(
+                addAuth(
+                    post(String.format(CREATE_CONTROLLED_AZURE_DISK_V2_PATH_FORMAT, workspaceId))
+                        .content(objectMapper.writeValueAsString(diskRequestV2Body)),
+                    USER_REQUEST)))
+        .andExpect(status().is(HttpStatus.SC_OK));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockAzureApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockAzureApi.java
@@ -11,9 +11,13 @@ public class MockAzureApi {
   public static final String CONTROLLED_AZURE_DISK_PATH_FORMAT =
       CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT + "/%s";
 
+  public static final String CREATE_CONTROLLED_AZURE_DISK_V2_PATH_FORMAT =
+      "/api/workspaces/v2/%s/resources/controlled/azure/disks";
+
   // VM
   public static final String CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/vm";
+
   public static final String CONTROLLED_AZURE_VM_PATH_FORMAT =
       CREATE_CONTROLLED_AZURE_VM_PATH_FORMAT + "/%s";
 

--- a/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
@@ -128,7 +128,7 @@ public class PolicyValidatorTest extends BaseUnitTest {
     ControlledAzureStorageContainerResource azureResource =
         ControlledAzureResourceFixtures.getAzureStorageContainer("test");
     ControlledAzureDiskResource azureResourceWrongRegion =
-        ControlledAzureResourceFixtures.getAzureDisk("test", "wrongRegion", 0);
+        ControlledAzureResourceFixtures.getAzureDisk("test", "wrongRegion", 1);
     ControlledGcsBucketResource gcpResource =
         ControlledGcpResourceFixtures.getBucketResource("test");
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/ResourceValidationUtilsTest.java
@@ -565,4 +565,11 @@ public class ResourceValidationUtilsTest extends BaseUnitTest {
 
     assertEquals(1, result.size());
   }
+
+  @Test
+  void validateAzureDiskName_invalid() {
+    assertThrows(
+        InvalidReferenceException.class,
+        () -> AzureResourceValidationUtils.validateAzureDiskName("$invalidDiskName$"));
+  }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/AzureDiskValidationTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/AzureDiskValidationTest.java
@@ -1,0 +1,20 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.disk;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.common.exception.InconsistentFieldsException;
+import bio.terra.workspace.common.BaseAzureUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
+import org.junit.jupiter.api.Test;
+
+public class AzureDiskValidationTest extends BaseAzureUnitTest {
+
+  @Test
+  void validateInvalidDiskSize() {
+    assertThrows(
+        InconsistentFieldsException.class,
+        () ->
+            ControlledAzureResourceFixtures.getAzureDisk(
+                "test", ControlledAzureResourceFixtures.DEFAULT_AZURE_RESOURCE_REGION, 0));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateNamespaceRoleStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateNamespaceRoleStepTest.java
@@ -179,7 +179,7 @@ public class CreateNamespaceRoleStepTest extends BaseMockitoStrictStubbingTest {
   void testGetDatabaseResourceNotADatabase() {
     var workspaceId = UUID.randomUUID();
     var owner = UUID.randomUUID().toString();
-    var notADatabase = ControlledAzureResourceFixtures.getAzureDisk("notadatabase", "us", 0);
+    var notADatabase = ControlledAzureResourceFixtures.getAzureDisk("notadatabase", "us", 1);
 
     var creationParameters =
         ControlledAzureResourceFixtures.getAzureKubernetesNamespaceCreationParameters(


### PR DESCRIPTION
Hey all, not super familiar with WSM.

I added this code then ran then ran all gradle tasks to `generateSwagger[xxx]`, and they all succeeded and I see all the parallel constructs to what appears for other `create-result` endpoints in the generated code directories. I figure its better to post here to see if I'm missing anything obvious while attempting to verify with a locally running WSM in parallel (which is proving to be a bit of a learning curve and something I think would go smoother to pair on).

Seems a bit fishy this was so straight forward, but the resource itself already exists. There's nothing I have to do to make WSM actually track the result, does it do this already for controlled resources and just wasn't exposing it?

