### PR TITLE
[NO TICKET] google-github-actions/auth doesn't support version input

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -122,7 +122,6 @@ jobs:
       if: steps.skiptest.outputs.is-bump == 'no'
       uses: google-github-actions/auth@v1
       with:
-        version: '411.0.0'
         credentials_json: ${{ secrets.GCR_PUBLISH_KEY }}
     - name: Setup gcloud
       if: steps.skiptest.outputs.is-bump == 'no'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,6 @@ jobs:
       - name: Auth to Google
         uses: google-github-actions/auth@v1
         with:
-          version: '411.0.0'
           credentials_json: ${{ secrets.GCR_PUBLISH_KEY }}
 
       - name: Setup gcloud


### PR DESCRIPTION
`version` is not a supported input to `google-github-actions/auth`:

https://github.com/google-github-actions/auth?tab=readme-ov-file#inputs

This shows up as a warning but seems to be otherwise ignored.  (I originally thought it might be causing failures in https://github.com/DataBiosphere/terra-workspace-manager/pull/1632 but that wasn't the case on further investigation).
 
Removed it anyways to clean up.