### PR TITLE
[WOR-1499] Increase job polling timeout when awaiting a clone of all workspace resources

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneAllResourcesFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneAllResourcesFlightStep.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.workspace;
 
 import static bio.terra.workspace.common.utils.FlightUtils.FLIGHT_POLL_CYCLES;
-import static bio.terra.workspace.common.utils.FlightUtils.FLIGHT_POLL_SECONDS;
 import static bio.terra.workspace.common.utils.FlightUtils.validateRequiredEntries;
 
 import bio.terra.stairway.FlightContext;
@@ -58,7 +57,10 @@ public class AwaitCloneAllResourcesFlightStep implements Step {
       FlightState subflightState =
           context
               .getStairway()
-              .waitForFlight(cloneAllResourcesFlightId, AWAIT_CLONE_RESOURCES_POLL_SECONDS, FLIGHT_POLL_CYCLES);
+              .waitForFlight(
+                  cloneAllResourcesFlightId,
+                  AWAIT_CLONE_RESOURCES_POLL_SECONDS,
+                  FLIGHT_POLL_CYCLES);
       if (FlightStatus.SUCCESS != subflightState.getFlightStatus()) {
         // no point in retrying the await step
         return new StepResult(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneAllResourcesFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneAllResourcesFlightStep.java
@@ -35,6 +35,8 @@ public class AwaitCloneAllResourcesFlightStep implements Step {
 
   public AwaitCloneAllResourcesFlightStep() {}
 
+  private static final int AWAIT_CLONE_RESOURCES_POLL_SECONDS = 720;
+
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     validateRequiredEntries(
@@ -56,7 +58,7 @@ public class AwaitCloneAllResourcesFlightStep implements Step {
       FlightState subflightState =
           context
               .getStairway()
-              .waitForFlight(cloneAllResourcesFlightId, FLIGHT_POLL_SECONDS, FLIGHT_POLL_CYCLES);
+              .waitForFlight(cloneAllResourcesFlightId, AWAIT_CLONE_RESOURCES_POLL_SECONDS, FLIGHT_POLL_CYCLES);
       if (FlightStatus.SUCCESS != subflightState.getFlightStatus()) {
         // no point in retrying the await step
         return new StepResult(


### PR DESCRIPTION
An Azure workspace clone can take > 6 minutes due to AKS pod creation and postgres dumps + restores. This PR is bumping the timeout by 2x to 12 minutes.