### PR TITLE
[WOR-1099] Fix transposition of flight poll seconds vs cycles

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneAllResourcesFlightStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/AwaitCloneAllResourcesFlightStep.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.flight.clone.workspace;
 
-import static bio.terra.workspace.common.utils.FlightUtils.FLIGHT_POLL_CYCLES;
+import static bio.terra.workspace.common.utils.FlightUtils.FLIGHT_POLL_SECONDS;
 import static bio.terra.workspace.common.utils.FlightUtils.validateRequiredEntries;
 
 import bio.terra.stairway.FlightContext;
@@ -34,7 +34,7 @@ public class AwaitCloneAllResourcesFlightStep implements Step {
 
   public AwaitCloneAllResourcesFlightStep() {}
 
-  private static final int AWAIT_CLONE_RESOURCES_POLL_SECONDS = 720;
+  private static final int AWAIT_CLONE_RESOURCES_POLL_CYCLES = 720;
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
@@ -59,8 +59,8 @@ public class AwaitCloneAllResourcesFlightStep implements Step {
               .getStairway()
               .waitForFlight(
                   cloneAllResourcesFlightId,
-                  AWAIT_CLONE_RESOURCES_POLL_SECONDS,
-                  FLIGHT_POLL_CYCLES);
+                  FLIGHT_POLL_SECONDS,
+                  AWAIT_CLONE_RESOURCES_POLL_CYCLES);
       if (FlightStatus.SUCCESS != subflightState.getFlightStatus()) {
         // no point in retrying the await step
         return new StepResult(


### PR DESCRIPTION
This [PR](https://github.com/DataBiosphere/terra-workspace-manager/commits/main/) transposed the cycles and seconds arguments, so it shifted the await to a minimum of 720 seconds. The [correct](https://github.com/DataBiosphere/stairway/blob/develop/stairway/src/main/java/bio/terra/stairway/Stairway.java#L201) order is # of seconds per cycle (1), # of cycles (720).  