### PR TITLE
[WX-1472] Batch Pool Regex Fix

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/AzureResourceValidationUtils.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/AzureResourceValidationUtils.java
@@ -107,9 +107,9 @@ public class AzureResourceValidationUtils {
 
   // Azure Batch pool
 
-  /** Batch Pool id must be -64 characters, using letters, numbers, dashes, and underscores */
+  /** Batch Pool id must be 1-64 characters, using letters, numbers, dashes, and underscores */
   private static final Pattern AZURE_BATCH_POOL_ID_VALIDATION_PATTERN =
-      Pattern.compile("^[-_a-zA-Z0-9]{0,63}$");
+      Pattern.compile("^[-_a-zA-Z0-9]{1,64}$");
 
   private static final int AZURE_MAX_BATCH_POOL_DISPLAY_NAME = 1024;
 


### PR DESCRIPTION
[WX-1472](https://broadworkbench.atlassian.net/browse/WX-1472?atlOrigin=eyJpIjoiYzA2MGI4MjRmZGVjNGFmZGJjZGQ1NTE4ZTk3YTkxYTgiLCJwIjoiaiJ9)

Changed Azure Batch Pool regex to match strings of length 1-64, rather than 0-63. This was likely the intention of the original author (judging by comments and error messages already present) and matches the [Azure Batch API](https://learn.microsoft.com/en-us/rest/api/batchservice/pool/add?view=rest-batchservice-2023-11-01&tabs=HTTP#:~:text=Description-,id,-True) requirements. 


[WX-1472]: https://broadworkbench.atlassian.net/browse/WX-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ