### PR TITLE
TOAZ-340: Add UAE regions to LZ service

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -258,9 +258,6 @@ landingzone:
       uaenorth:
         AKS_MACHINE_TYPE: "Standard_D4as_v5"
         POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
-      uaecentral:
-        AKS_MACHINE_TYPE: "Standard_D4as_v5"
-        POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
 
 
 # Feature flags

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -255,6 +255,12 @@ landingzone:
       southafricanorth:
         AKS_MACHINE_TYPE: "Standard_D4as_v4"
         POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
+      uaenorth:
+        AKS_MACHINE_TYPE: "Standard_D4as_v5"
+        POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
+      uaecentral:
+        AKS_MACHINE_TYPE: "Standard_D4as_v5"
+        POSTGRES_SERVER_SKU: "Standard_D2ds_v5"
 
 
 # Feature flags


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-340

M42 will likely try to install the Terra managed app fairly soon. Enable both UAE regions in the LZ service.

* `UAE North` is the one they'll probably use
* ~`UAE Central` is restricted in Azure and generally just used for disaster recovery. Enabling that too though with the same settings.~

I validated on a BEE that these compute SKUs work.