### PR TITLE
[DDO-3470] Use Sherlock v3 in GitHub Actions

### DIFF
--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -42,9 +42,9 @@ jobs:
       # until testrunner can be configured to talk to it.
       #
 
-      # Set up workload-identity so we can auth to Sherlock
+      # Set up auth to Sherlock
       - name: "Authenticate to GCP"
-        id: 'auth'
+        id: 'iap_auth'
         uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
@@ -54,6 +54,11 @@ jobs:
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false
+      - name: "Generate GHA OIDC Token"
+        id: 'gha_auth'
+        uses: actions/github-script@v7
+        with:
+          script: core.setOutput('id_token', await core.getIDToken())
 
       # Generate versions file
       - name: terra-helmfile-shim
@@ -77,7 +82,8 @@ jobs:
           # call the chart-releases endpoint to get a list of chart-releases in the target env
           #
           curl --fail \
-            -H 'Authorization: Bearer ${{ steps.auth.outputs.id_token }}' \
+            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
+            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
             "${SHERLOCK_URL}/api/chart-releases/v3?environment=${ENV}" \
             > /tmp/.chart-releases.json
 

--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -78,7 +78,7 @@ jobs:
           #
           curl --fail \
             -H 'Authorization: Bearer ${{ steps.auth.outputs.id_token }}' \
-            "${SHERLOCK_URL}/api/v2/chart-releases?environment=${ENV}" \
+            "${SHERLOCK_URL}/api/chart-releases/v3?environment=${ENV}" \
             > /tmp/.chart-releases.json
 
           #


### PR DESCRIPTION
Sherlock's v2 endpoints are deprecated in favor of the v3 ones. For the purposes of this repo's workflows, they're equivalent (they have `chart`, `appVersionExact` and `chartVersionExact` in the same structure).

This PR also passes the GHA workflow's OIDC token to Sherlock, which is a best practice that allows Sherlock to understand more about the call (it can log what workflow the request came from, for example). For more examples of this, see any of the client-* reusable workflows in Sherlock's own repository ([example](https://github.com/broadinstitute/sherlock/blob/main/.github/workflows/client-report-app-version.yaml#L253)).