### PR TITLE
[WOR-1518] Shift to READ_JOB_RESULT when verifying access to job results

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
@@ -22,6 +22,7 @@ public class SamConstants {
     public static final String WRITE = "write";
     public static final String OWN = "own";
     public static final String DELETE = "delete";
+    public static final String READ_JOB_RESULT = "read_job_result";
     public static final String READ_IAM = "read_policies";
     public static final String CREATE_CONTROLLED_USER_SHARED = "create_controlled_user_shared";
     public static final String CREATE_CONTROLLED_USER_PRIVATE = "create_controlled_user_private";

--- a/service/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/service/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -373,7 +373,7 @@ public class JobService {
       }
       flightBeanBag
           .getWorkspaceService()
-          .validateWorkspaceAndAction(userRequest, workspaceUuid, SamWorkspaceAction.READ);
+          .validateWorkspaceAndAction(userRequest, workspaceUuid, SamWorkspaceAction.READ_JOB_RESULT);
     } catch (DatabaseOperationException | InterruptedException ex) {
       throw new InternalStairwayException("Stairway exception looking up the job", ex);
     } catch (FlightNotFoundException ex) {

--- a/service/src/main/java/bio/terra/workspace/service/job/JobService.java
+++ b/service/src/main/java/bio/terra/workspace/service/job/JobService.java
@@ -373,7 +373,8 @@ public class JobService {
       }
       flightBeanBag
           .getWorkspaceService()
-          .validateWorkspaceAndAction(userRequest, workspaceUuid, SamWorkspaceAction.READ_JOB_RESULT);
+          .validateWorkspaceAndAction(
+              userRequest, workspaceUuid, SamWorkspaceAction.READ_JOB_RESULT);
     } catch (DatabaseOperationException | InterruptedException ex) {
       throw new InternalStairwayException("Stairway exception looking up the job", ex);
     } catch (FlightNotFoundException ex) {


### PR DESCRIPTION
[Related Sam PR](https://github.com/broadinstitute/sam/pull/1351)

## Context
We want to shift to using a non-auth-domain-constrainable action for the purposes of pulling job results. This is because leo polls using it's SA which will likely not be in auth domains, ever.

## Context
* Change the job service verification methods to check `read_job_result`