### PR TITLE
[IA-4584] Add a delete database result endpoint

### DIFF
--- a/openapi/src/parts/controlled_azure_database.yaml
+++ b/openapi/src/parts/controlled_azure_database.yaml
@@ -72,6 +72,30 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+    post:
+      summary: |
+        Delete a controlled Azure Database resource. This is async, because the 
+        operation can take a few minutes. OpenAPI does not support request body 
+        in DELETE, but async state requires it. Hence this is a POST.
+      operationId: deleteAzureDatabaseAsync
+      tags: [ ControlledAzureResource ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteControlledAzureResourceRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/DeleteControlledAzureResourceResponse'
+        '202':
+          $ref: '#/components/responses/DeleteControlledAzureResourceResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
   /api/workspaces/v1/{workspaceId}/resources/controlled/azure/databases/delete-result/{jobId}:
     parameters:
@@ -88,6 +112,8 @@ paths:
           $ref: '#/components/responses/DeleteControlledAzureResourceResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
 

--- a/openapi/src/parts/controlled_azure_database.yaml
+++ b/openapi/src/parts/controlled_azure_database.yaml
@@ -73,6 +73,24 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/workspaces/v1/{workspaceId}/resources/controlled/azure/databases/delete-result/{jobId}:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - $ref: '#/components/parameters/JobId'
+    get:
+      summary: Retrieve information about an Azure Database delete job.
+      operationId: getDeleteAzureDatabaseResult
+      tags: [ ControlledAzureResource ]
+      responses:
+        '200':
+          $ref: '#/components/responses/DeleteControlledAzureResourceResponse'
+        '202':
+          $ref: '#/components/responses/DeleteControlledAzureResourceResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
 
 components:
   schemas:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -794,6 +794,15 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
   }
 
   @Override
+  public ResponseEntity<ApiDeleteControlledAzureResourceResult> getDeleteAzureDatabaseResult(
+          UUID workspaceId, String jobId) {
+    features.azureEnabledCheck();
+    final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    jobService.verifyUserAccess(jobId, userRequest, workspaceId);
+    return getJobDeleteResult(jobId);
+  }
+
+  @Override
   public ResponseEntity<ApiCreatedControlledAzureKubernetesNamespaceResult>
       createAzureKubernetesNamespace(
           UUID workspaceId, ApiCreateControlledAzureKubernetesNamespaceRequestBody body) {

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -795,7 +795,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
 
   @Override
   public ResponseEntity<ApiDeleteControlledAzureResourceResult> getDeleteAzureDatabaseResult(
-          UUID workspaceId, String jobId) {
+      UUID workspaceId, String jobId) {
     features.azureEnabledCheck();
     final AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     jobService.verifyUserAccess(jobId, userRequest, workspaceId);

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDatabaseTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDatabaseTest.java
@@ -46,7 +46,7 @@ public class ControlledAzureResourceApiControllerAzureDatabaseTest
   }
 
   @Test
-  public void createAzureDatabaseWithNoParameters() throws Exception {
+  public void createAzureDatabase400WithNoParameters() throws Exception {
     UUID workspaceId = UUID.randomUUID();
     mockMvc
         .perform(
@@ -55,7 +55,7 @@ public class ControlledAzureResourceApiControllerAzureDatabaseTest
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON)
                     .characterEncoding("UTF-8")
-                    .content("{}"),
+                    .content(""),
                 USER_REQUEST))
         .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
   }
@@ -97,8 +97,6 @@ public class ControlledAzureResourceApiControllerAzureDatabaseTest
                 .result(resource)
                 .jobReport(new ApiJobReport().status(ApiJobReport.StatusEnum.SUCCEEDED)));
 
-    setupMockLandingZoneRegion(Region.GERMANY_CENTRAL);
-
     mockMvc
         .perform(
             addJsonContentType(
@@ -121,12 +119,10 @@ public class ControlledAzureResourceApiControllerAzureDatabaseTest
             .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
 
     when(getMockJobApiUtils()
-            .retrieveAsyncJobResult(any(), eq(ApiDeleteControlledAzureResourceResult.class)))
+            .retrieveAsyncJobResult(any(), eq(Void.class)))
         .thenReturn(
-            new JobApiUtils.AsyncJobResult<ApiDeleteControlledAzureResourceResult>()
+            new JobApiUtils.AsyncJobResult<Void>()
                 .jobReport(new ApiJobReport().status(ApiJobReport.StatusEnum.SUCCEEDED)));
-
-    setupMockLandingZoneRegion(Region.GERMANY_CENTRAL);
 
     mockMvc
         .perform(

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDatabaseTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDatabaseTest.java
@@ -118,8 +118,7 @@ public class ControlledAzureResourceApiControllerAzureDatabaseTest
         new ApiDeleteControlledAzureResourceRequest()
             .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
 
-    when(getMockJobApiUtils()
-            .retrieveAsyncJobResult(any(), eq(Void.class)))
+    when(getMockJobApiUtils().retrieveAsyncJobResult(any(), eq(Void.class)))
         .thenReturn(
             new JobApiUtils.AsyncJobResult<Void>()
                 .jobReport(new ApiJobReport().status(ApiJobReport.StatusEnum.SUCCEEDED)));

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDatabaseTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDatabaseTest.java
@@ -1,0 +1,142 @@
+package bio.terra.workspace.app.controller;
+
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
+import static bio.terra.workspace.common.mocks.MockAzureApi.*;
+import static bio.terra.workspace.common.mocks.MockMvcUtils.USER_REQUEST;
+import static bio.terra.workspace.common.mocks.MockMvcUtils.addAuth;
+import static bio.terra.workspace.common.mocks.MockMvcUtils.addJsonContentType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.workspace.app.controller.shared.JobApiUtils;
+import bio.terra.workspace.common.BaseAzureSpringBootUnitTest;
+import bio.terra.workspace.common.fixtures.ControlledResourceFixtures;
+import bio.terra.workspace.generated.model.*;
+import bio.terra.workspace.generated.model.ApiControlledResourceCommonFields;
+import bio.terra.workspace.generated.model.ApiJobControl;
+import bio.terra.workspace.generated.model.ApiJobReport;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.database.ControlledAzureDatabaseResource;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
+import com.azure.core.management.Region;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+public class ControlledAzureResourceApiControllerAzureDatabaseTest
+    extends BaseAzureSpringBootUnitTest {
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+  @Autowired ControlledAzureResourceApiController controller;
+
+  @BeforeEach
+  void setUp() {
+    when(mockSamService()
+            .getUserEmailFromSamAndRethrowOnInterrupt(any(AuthenticatedUserRequest.class)))
+        .thenReturn(DEFAULT_USER_EMAIL);
+  }
+
+  @Test
+  public void createAzureDatabaseWithNoParameters() throws Exception {
+    UUID workspaceId = UUID.randomUUID();
+    mockMvc
+        .perform(
+            addAuth(
+                post(String.format(CREATE_CONTROLLED_AZURE_DATABASE_PATH_FORMAT, workspaceId))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("UTF-8")
+                    .content("{}"),
+                USER_REQUEST))
+        .andExpect(status().is(HttpStatus.SC_BAD_REQUEST));
+  }
+
+  @Test
+  public void createDatabase() throws Exception {
+    UUID workspaceId = UUID.randomUUID();
+    setupMockLandingZoneRegion(Region.US_SOUTH_CENTRAL);
+
+    ApiControlledResourceCommonFields commonFields =
+        ControlledResourceFixtures.makeDefaultControlledResourceFieldsApi();
+
+    ApiAzureDatabaseCreationParameters params =
+        new ApiAzureDatabaseCreationParameters()
+            .name("database1")
+            .owner("owner")
+            .allowAccessForAllWorkspaceUsers(true);
+
+    ApiCreateControlledAzureDatabaseRequestBody databaseRequestBody =
+        new ApiCreateControlledAzureDatabaseRequestBody()
+            .common(commonFields)
+            .azureDatabase(params)
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+
+    ControlledAzureDatabaseResource resource =
+        controller.buildControlledAzureDatabaseResource(
+            databaseRequestBody.getAzureDatabase(),
+            controller.toCommonFields(
+                workspaceId,
+                commonFields,
+                Region.US_SOUTH_CENTRAL.name(),
+                USER_REQUEST,
+                WsmResourceType.CONTROLLED_AZURE_VM));
+
+    when(getMockJobApiUtils()
+            .retrieveAsyncJobResult(any(), eq(ControlledAzureDatabaseResource.class)))
+        .thenReturn(
+            new JobApiUtils.AsyncJobResult<ControlledAzureDatabaseResource>()
+                .result(resource)
+                .jobReport(new ApiJobReport().status(ApiJobReport.StatusEnum.SUCCEEDED)));
+
+    setupMockLandingZoneRegion(Region.GERMANY_CENTRAL);
+
+    mockMvc
+        .perform(
+            addJsonContentType(
+                addAuth(
+                    post(String.format(CREATE_CONTROLLED_AZURE_DATABASE_PATH_FORMAT, workspaceId))
+                        .content(objectMapper.writeValueAsString(databaseRequestBody)),
+                    USER_REQUEST)))
+        .andExpect(status().is(HttpStatus.SC_OK))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists());
+  }
+
+  @Test
+  public void deleteDatabase() throws Exception {
+    UUID workspaceId = UUID.randomUUID();
+    UUID resourceId = UUID.randomUUID();
+    setupMockLandingZoneRegion(Region.US_SOUTH_CENTRAL);
+
+    ApiDeleteControlledAzureResourceRequest deleteRequestBody =
+        new ApiDeleteControlledAzureResourceRequest()
+            .jobControl(new ApiJobControl().id(UUID.randomUUID().toString()));
+
+    when(getMockJobApiUtils()
+            .retrieveAsyncJobResult(any(), eq(ApiDeleteControlledAzureResourceResult.class)))
+        .thenReturn(
+            new JobApiUtils.AsyncJobResult<ApiDeleteControlledAzureResourceResult>()
+                .jobReport(new ApiJobReport().status(ApiJobReport.StatusEnum.SUCCEEDED)));
+
+    setupMockLandingZoneRegion(Region.GERMANY_CENTRAL);
+
+    mockMvc
+        .perform(
+            addJsonContentType(
+                addAuth(
+                    post(String.format(
+                            CONTROLLED_AZURE_DATABASE_PATH_FORMAT, workspaceId, resourceId))
+                        .content(objectMapper.writeValueAsString(deleteRequestBody)),
+                    USER_REQUEST)))
+        .andExpect(status().is(HttpStatus.SC_OK))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists());
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockAzureApi.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockAzureApi.java
@@ -5,6 +5,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class MockAzureApi {
 
+  // Databases
+  public static final String CREATE_CONTROLLED_AZURE_DATABASE_PATH_FORMAT =
+      "/api/workspaces/v1/%s/resources/controlled/azure/databases";
+
+  public static final String CONTROLLED_AZURE_DATABASE_PATH_FORMAT =
+      CREATE_CONTROLLED_AZURE_DATABASE_PATH_FORMAT + "/%s";
+
   // Disks
   public static final String CREATE_CONTROLLED_AZURE_DISK_PATH_FORMAT =
       "/api/workspaces/v1/%s/resources/controlled/azure/disks";


### PR DESCRIPTION
JIRA Ticket: https://broadworkbench.atlassian.net/browse/IA-4633

This PR adds the following endpoints:
- An async delete database post to rerun the job ID
- A get delete-result database endpoint to retrieve the status of the delete database job

We are doing this so that Leonardo can properly poll for the status of the database deletion job, instead of assuming that the operation is really done sync (e.g. Leo marks the database as `deleted` immediately, but something goes wrong with the deletion on the WSM side)

Tested on a BEE with the following steps:
- Create a database
- Delete the database using the new async endpoint and make sure a job id is in the response body
- Use the get delete-result endpoint with this job id until the status is `SUCCESS`