### PR TITLE
[WOR-1463] Remove vault dependency from staging promotion workflow

### DIFF
--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -140,25 +140,17 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Get Vault token
-        id: vault-token-step
-        env:
-          VAULT_ADDR: https://clotho.broadinstitute.org:8200
+      - id: setup-env-var-names
+        name: 'Setup env var names'
         run: |
-          VAULT_TOKEN=$(docker run --rm --cap-add IPC_LOCK \
-            -e "VAULT_ADDR=${VAULT_ADDR}" \
-            vault:1.1.0 \
-            vault write -field token \
-              auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
-              secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
-          echo ::add-mask::$VAULT_TOKEN    
-          echo vault-token=$VAULT_TOKEN >> $GITHUB_OUTPUT
+          echo "USER_DELEGATED_SA_VAR=USER_DELEGATED_SA_${{ steps.set-env-step.outputs.test-env }}" >> ${GITHUB_OUTPUT}
+        shell: bash
 
-      - name: Write configuration
-        uses: ./.github/actions/write-config
+      - name: Write config
+        id: config
+        uses: ./.github/actions/write-credentials
         with:
-          target: ${{ steps.set-env-step.outputs.test-env }}
-          vault-token: ${{ steps.vault-token-step.outputs.vault-token }}
+          user-delegated-sa-b64: ${{ secrets[steps.setup-env-var-names.outputs.USER_DELEGATED_SA_VAR] }}
 
       - name: Run the integration test suite
         id: integration-test
@@ -168,31 +160,31 @@ jobs:
           test-server: ${{ steps.set-config-files-step.outputs.test-server }}
           test: ${{ steps.set-config-files-step.outputs.test }}
 
-      - name: "Notify QA Slack"
-        if: always() && (steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging')
-        uses: broadinstitute/action-slack@v3.8.0
-        # see https://github.com/broadinstitute/action-slack
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#dsde-qa"
-          username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
-          author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
-          fields: repo,job,workflow,commit,eventName,author,took
+#      - name: "Notify QA Slack"
+#        if: always() && (steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging')
+#        uses: broadinstitute/action-slack@v3.8.0
+#        # see https://github.com/broadinstitute/action-slack
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#        with:
+#          status: ${{ job.status }}
+#          channel: "#dsde-qa"
+#          username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
+#          author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
+#          fields: repo,job,workflow,commit,eventName,author,took
 
-      - name: "Notify Workspaces test failure Slack"
-        if: failure()
-        uses: broadinstitute/action-slack@v3.8.0
-        # see https://github.com/broadinstitute/action-slack
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#dsp-workspaces-test-alerts"
-          username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
-          author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
-          fields: repo,job,workflow,commit,eventName,author,took
+#      - name: "Notify Workspaces test failure Slack"
+#        if: failure()
+#        uses: broadinstitute/action-slack@v3.8.0
+#        # see https://github.com/broadinstitute/action-slack
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#        with:
+#          status: ${{ job.status }}
+#          channel: "#dsp-workspaces-test-alerts"
+#          username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
+#          author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
+#          fields: repo,job,workflow,commit,eventName,author,took
 
       - name: Archive WSM and TestRunner logs
         id: archive_logs

--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -160,31 +160,31 @@ jobs:
           test-server: ${{ steps.set-config-files-step.outputs.test-server }}
           test: ${{ steps.set-config-files-step.outputs.test }}
 
-#      - name: "Notify QA Slack"
-#        if: always() && (steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging')
-#        uses: broadinstitute/action-slack@v3.8.0
-#        # see https://github.com/broadinstitute/action-slack
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#        with:
-#          status: ${{ job.status }}
-#          channel: "#dsde-qa"
-#          username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
-#          author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
-#          fields: repo,job,workflow,commit,eventName,author,took
+      - name: "Notify QA Slack"
+        if: always() && (steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging')
+        uses: broadinstitute/action-slack@v3.8.0
+        # see https://github.com/broadinstitute/action-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          channel: "#dsde-qa"
+          username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
+          author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
+          fields: repo,job,workflow,commit,eventName,author,took
 
-#      - name: "Notify Workspaces test failure Slack"
-#        if: failure()
-#        uses: broadinstitute/action-slack@v3.8.0
-#        # see https://github.com/broadinstitute/action-slack
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#        with:
-#          status: ${{ job.status }}
-#          channel: "#dsp-workspaces-test-alerts"
-#          username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
-#          author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
-#          fields: repo,job,workflow,commit,eventName,author,took
+      - name: "Notify Workspaces test failure Slack"
+        if: failure()
+        uses: broadinstitute/action-slack@v3.8.0
+        # see https://github.com/broadinstitute/action-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          channel: "#dsp-workspaces-test-alerts"
+          username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
+          author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
+          fields: repo,job,workflow,commit,eventName,author,took
 
       - name: Archive WSM and TestRunner logs
         id: archive_logs

--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -1,14 +1,10 @@
-# This workflow will build a Java project with Gradle
+# This workflow will build a Java project with Gradle on promotion of WSM to the terra staging environment
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: Release Promotion Tests
 
 on:
-  workflow_dispatch:
-    inputs:
-      testEnv:
-        description: 'Environment in which tests should be run. Currently runs on alpha and staging'
-        required: true
+  workflow_dispatch: {}
 
 jobs:
   release-promotion-tests:
@@ -32,7 +28,7 @@ jobs:
             echo ::error ::${{ github.event_name }} not supported for this workflow
             exit 1
           fi
-          echo test-env=$ENV >> $GITHUB_OUTPUT
+          echo test-env=staging >> $GITHUB_OUTPUT
 
       #
       #
@@ -65,7 +61,7 @@ jobs:
         run: |
           set -exo pipefail
           
-          ENV="${{ steps.set-env-step.outputs.test-env }}"
+          ENV="staging"
           SHERLOCK_URL="https://sherlock.dsp-devops.broadinstitute.org"
 
           OLD_TERRA_HELMFILE_DIR="integration/terra-helmfile"
@@ -106,19 +102,9 @@ jobs:
       - name: Set config files
         id: set-config-files-step
         run: |
-          if ${{ steps.set-env-step.outputs.test-env == 'dev' }}; then
-            TEST_SERVER=workspace-dev.json
-            TEST=suites/dev/FullIntegration.json
-          elif ${{ steps.set-env-step.outputs.test-env == 'alpha' }}; then
-            TEST_SERVER=workspace-alpha.json
-            TEST=suites/alpha/FullIntegration.json
-          elif ${{ steps.set-env-step.outputs.test-env == 'staging' }}; then
-            TEST_SERVER=workspace-staging.json
-            TEST=suites/staging/FullIntegration.json
-          else
-            echo ::error ::${{ steps.set-env-step.outputs.test-env }} environment not supported for this workflow
-            exit 1
-          fi
+          TEST_SERVER=workspace-staging.json
+          TEST=suites/staging/FullIntegration.json
+        
           echo test-server=$TEST_SERVER >> $GITHUB_OUTPUT
           echo test=$TEST >> $GITHUB_OUTPUT
 
@@ -140,17 +126,11 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - id: setup-env-var-names
-        name: 'Setup env var names'
-        run: |
-          echo "USER_DELEGATED_SA_VAR=USER_DELEGATED_SA_${{ steps.set-env-step.outputs.test-env }}" >> ${GITHUB_OUTPUT}
-        shell: bash
-
       - name: Write config
         id: config
         uses: ./.github/actions/write-credentials
         with:
-          user-delegated-sa-b64: ${{ secrets[steps.setup-env-var-names.outputs.USER_DELEGATED_SA_VAR] }}
+          user-delegated-sa-b64: ${{ secrets.USER_DELEGATED_SA_STAGING }}
 
       - name: Run the integration test suite
         id: integration-test


### PR DESCRIPTION
The `Release promotion tests` workflow still has a vault dependency. This needs to be shifted to using github secrets. In my testing, I observed that this flow runs only in the staging environment so I've removed the parameterization as well. We should reflect on the need and contents of these promo tests going forward, but this is not that PR.

[Successful run](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/8142150720/job/22251055856)