### PR TITLE
DC-839: Move references back to datarepo-client; Upgrade to latest

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation "com.google.cloud:google-cloud-storage"
 
     // Data Repo client library
-    implementation "bio.terra:datarepo-jakarta-client:1.557.0-SNAPSHOT"
+    implementation "bio.terra:datarepo-client:2.13.0-SNAPSHOT"
     implementation gradle.librarySwaggerAnnotations
 
     // Workspace Manager client library

--- a/service/gradle/dependencies.gradle
+++ b/service/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ dependencies {
   implementation 'software.amazon.awssdk:sts'
 
   // Terra deps
-  implementation group: "bio.terra", name: "datarepo-jakarta-client", version: "1.557.0-SNAPSHOT"
+  implementation group: "bio.terra", name: "datarepo-client", version: "2.13.0-SNAPSHOT"
   implementation group: "bio.terra", name:"billing-profile-manager-client", version: "0.1.237-SNAPSHOT"
   implementation group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT"
   implementation group: "bio.terra", name:"terra-aws-resource-discovery", version:"v0.6.2-SNAPSHOT"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-839
___
With the [Spring boot upgrade](https://github.com/DataBiosphere/jade-data-repo/pull/1581) for data repo, we're switching back to only publishing to one Jakarta backed client. This PR moves your references to the jakarta client back to the main data repo client and bumps to the latest version. This is an effort to alleviate any confusion around upgrading past the last supported datarepo-jakarta-client version. 
