### PR TITLE
[WOR-1561] Modifications to cloneWorkspace to support Rawls stage workspaces

### DIFF
--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -546,8 +546,6 @@ components:
         Request body for cloning an entire workspace. Cloning instructions
         are taken from individual resources.
       type: object
-      required:
-        - spendProfile
       properties:
         destinationWorkspaceId:
           description: |

--- a/openapi/src/parts/workspace.yaml
+++ b/openapi/src/parts/workspace.yaml
@@ -561,7 +561,9 @@ components:
           description: A description of the cloned workspace
           type: string
         spendProfile:
-          description: ID of provided spend profile
+          description: >-
+            ID of provided spend profile. If not present, source workspace spend profile will be used. 
+            If source workspace spend profile is also not present, destination workspace will have no spend profile
           type: string
         location:
           description: >-

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
@@ -180,6 +180,11 @@ public class TpsApiDispatch {
   }
 
   @WithSpan
+  /**
+   * Despite the documentation in TpsApi and the naming of the parameters, mergePao will try to
+   * merge the workspaceUuid Pao into the sourceObjectId Pao. This means any policies on the
+   * workspaceUuid Pao will be transferred to the sourceObjectId Pao depending on the updateMode.
+   */
   public TpsPaoUpdateResult mergePao(
       UUID workspaceUuid, UUID sourceObjectId, TpsUpdateMode updateMode)
       throws InterruptedException {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneWorkspaceFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/flight/clone/workspace/CloneWorkspaceFlight.java
@@ -48,8 +48,7 @@ public class CloneWorkspaceFlight extends Flight {
             WorkspaceFlightMapKeys.ControlledResourceKeys.SOURCE_WORKSPACE_ID,
             UUID.class);
     var spendProfile =
-        FlightUtils.getRequired(
-            inputParameters, WorkspaceFlightMapKeys.SPEND_PROFILE, SpendProfile.class);
+        inputParameters.get(WorkspaceFlightMapKeys.SPEND_PROFILE, SpendProfile.class);
 
     addStep(
         new CloneAllFoldersStep(flightBeanBag.getSamService(), flightBeanBag.getFolderDao()),

--- a/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/WorkspaceCreateFlight.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/workspace/WorkspaceCreateFlight.java
@@ -61,60 +61,47 @@ public class WorkspaceCreateFlight extends Flight {
           new CreateWorkspacePoliciesStep(
               workspace, policyInputs, appContext.getTpsApiDispatch(), userRequest),
           serviceRetryRule);
+
+      if (workspace.spendProfileId() != null) {
+        addStep(
+            new LinkSpendProfilePolicyAttributesStep(
+                workspace.workspaceId(),
+                workspace.spendProfileId(),
+                appContext.getTpsApiDispatch()),
+            serviceRetryRule);
+      }
+
+      // If we're cloning, we need to copy the policies from the source workspace.
+      // This is here instead of in the CloneWorkspaceFlight because we need to do it before
+      // we create the workspace in Sam in case there are auth domains.
+      // COPY_NOTHING is used when not cloning
+      if (cloningInstructions != CloningInstructions.COPY_NOTHING) {
+        addStep(
+            new MergePolicyAttributesStep(
+                sourceWorkspaceUuid,
+                workspace.workspaceId(),
+                cloningInstructions,
+                appContext.getTpsApiDispatch()),
+            serviceRetryRule);
+      }
     }
     // Workspace authz is handled differently depending on whether WSM owns the underlying Sam
     // resource or not, as indicated by the workspace stage enum.
     switch (workspace.getWorkspaceStage()) {
-      case MC_WORKSPACE -> {
-        if (appContext.getFeatureConfiguration().isTpsEnabled()) {
+      case MC_WORKSPACE ->
           addStep(
-              new LinkSpendProfilePolicyAttributesStep(
-                  workspace.workspaceId(),
-                  workspace.spendProfileId(),
-                  appContext.getTpsApiDispatch()),
+              new CreateWorkspaceAuthzStep(
+                  workspace,
+                  appContext.getSamService(),
+                  appContext.getTpsApiDispatch(),
+                  appContext.getFeatureConfiguration(),
+                  userRequest,
+                  projectOwnerGroupId),
               serviceRetryRule);
-
-          // If we're cloning, we need to copy the policies from the source workspace.
-          // This is here instead of in the CloneWorkspaceFlight because we need to do it before
-          // we create the workspace in Sam in case there are auth domains.
-          // COPY_NOTHING is used when not cloning
-          if (cloningInstructions != CloningInstructions.COPY_NOTHING) {
-            addStep(
-                new MergePolicyAttributesStep(
-                    sourceWorkspaceUuid,
-                    workspace.workspaceId(),
-                    cloningInstructions,
-                    appContext.getTpsApiDispatch()),
-                serviceRetryRule);
-          }
-        }
-        addStep(
-            new CreateWorkspaceAuthzStep(
-                workspace,
-                appContext.getSamService(),
-                appContext.getTpsApiDispatch(),
-                appContext.getFeatureConfiguration(),
-                userRequest,
-                projectOwnerGroupId),
-            serviceRetryRule);
-      }
-      case RAWLS_WORKSPACE -> {
-        if (appContext.getFeatureConfiguration().isTpsEnabled()) {
-          if (cloningInstructions != CloningInstructions.COPY_NOTHING) {
-            addStep(
-                new MergePolicyAttributesStep(
-                    sourceWorkspaceUuid,
-                    workspace.workspaceId(),
-                    cloningInstructions,
-                    appContext.getTpsApiDispatch()),
-                serviceRetryRule);
-          }
-        }
-
-        addStep(
-            new CheckSamWorkspaceAuthzStep(workspace, appContext.getSamService(), userRequest),
-            serviceRetryRule);
-      }
+      case RAWLS_WORKSPACE ->
+          addStep(
+              new CheckSamWorkspaceAuthzStep(workspace, appContext.getSamService(), userRequest),
+              serviceRetryRule);
       default ->
           throw new InternalLogicException(
               "Unknown workspace stage during creation: " + workspace.getWorkspaceStage().name());

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -369,11 +369,7 @@ public class WorkspaceApiControllerTest extends BaseSpringBootUnitTestMockDataRe
 
     ApiCloneWorkspaceResult cloneWorkspace =
         mockWorkspaceV1Api.cloneWorkspace(
-            USER_REQUEST,
-            sourceWorkspaceId,
-            DEFAULT_SPEND_PROFILE_NAME,
-            null,
-            destinationWorkspaceId);
+            USER_REQUEST, sourceWorkspaceId, null, null, destinationWorkspaceId);
 
     List<ApiResourceCloneDetails> cloneDetails = cloneWorkspace.getWorkspace().getResources();
     assertEquals(3, cloneDetails.size());

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -30,6 +31,7 @@ import bio.terra.policy.model.TpsPaoUpdateResult;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.policy.model.TpsPolicyPair;
+import bio.terra.policy.model.TpsUpdateMode;
 import bio.terra.workspace.common.BaseSpringBootUnitTestMockDataRepoService;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.common.logging.model.ActivityLogChangeDetails;
@@ -395,6 +397,9 @@ public class WorkspaceApiControllerTest extends BaseSpringBootUnitTestMockDataRe
         assertNotNull(cloneDetail.getDestinationResourceId());
       }
     }
+
+    verify(mockTpsApiDispatch())
+        .mergePao(sourceWorkspaceId, destinationWorkspaceId, TpsUpdateMode.FAIL_ON_CONFLICT);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -336,6 +336,11 @@ public class WorkspaceApiControllerTest extends BaseSpringBootUnitTestMockDataRe
 
     when(mockTpsApiDispatch().linkPao(any(), any(), any()))
         .thenReturn(new TpsPaoUpdateResult().resultingPao(emptyWorkspacePao()).updateApplied(true));
+    when(mockTpsApiDispatch().mergePao(any(), any(), any()))
+        .thenReturn(new TpsPaoUpdateResult().resultingPao(emptyWorkspacePao()).updateApplied(true));
+    when(mockTpsApiDispatch()
+            .getOrCreatePao(any(), eq(TpsComponent.WSM), eq(TpsObjectType.WORKSPACE)))
+        .thenReturn(emptyWorkspacePao());
 
     // Create some data repo references
     ApiDataRepoSnapshotResource snap1 =


### PR DESCRIPTION
Ticket: [WOR-1561](https://broadworkbench.atlassian.net/browse/WOR-1561)
- make spend profile id an optional parameter when cloning a workspace
- move policy-specific steps in `CreateWorkspaceFlight` out of `MC_WORKSPACE` case so cloned Rawls stage workspaces will inherit policy from their source workspace

[WOR-1561]: https://broadworkbench.atlassian.net/browse/WOR-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ