### PR TITLE
[IA-4592] fix NPE

### DIFF
--- a/openapi/src/common/schemas_azure.yaml
+++ b/openapi/src/common/schemas_azure.yaml
@@ -21,10 +21,6 @@ components:
     CreateControlledAzureResourceResult:
       type: object
       properties:
-        resourceId:
-          description: UUID of a newly-created resource.
-          type: string
-          format: uuid
         jobReport:
           $ref: '#/components/schemas/JobReport'
         errorReport:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -156,10 +156,9 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
                 userRequest, workspaceService.getWorkspace(workspaceUuid)),
             userRequest,
             WsmResourceType.CONTROLLED_AZURE_DISK);
-    Workspace workspace =
-        workspaceService.validateMcWorkspaceAndAction(
-            userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
-    workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
+    workspaceService.validateMcWorkspaceAndAction(
+        userRequest, workspaceUuid, ControllerValidationUtils.samCreateAction(commonFields));
+    workspaceService.validateWorkspaceAndContextState(workspaceUuid, CloudPlatform.AZURE);
 
     ControlledAzureDiskResource resource =
         buildControlledAzureDiskResource(body.getAzureDisk(), commonFields);
@@ -561,13 +560,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     final JobApiUtils.AsyncJobResult<ControlledAzureDiskResource> jobResult =
         jobApiUtils.retrieveAsyncJobResult(jobId, ControlledAzureDiskResource.class);
 
-    ControlledAzureDiskResource resource = null;
-    if (jobResult.getJobReport().getStatus().equals(ApiJobReport.StatusEnum.SUCCEEDED)) {
-      resource = jobResult.getResult();
-    }
-
     return new ApiCreateControlledAzureResourceResult()
-        .resourceId(resource.getResourceId())
         .jobReport(jobResult.getJobReport())
         .errorReport(jobResult.getApiErrorReport());
   }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
@@ -102,7 +102,6 @@ public class ControlledAzureResourceApiControllerAzureDiskTest extends BaseAzure
                         .content(objectMapper.writeValueAsString(diskRequestV2Body)),
                     USER_REQUEST)))
         .andExpect(status().is(HttpStatus.SC_OK))
-        .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists())
-        .andExpect(MockMvcResultMatchers.jsonPath("$.resourceId").exists());
+        .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists());
   }
 }


### PR DESCRIPTION
I copied code inappropriately here, and the if statement was causing `resource` to be null on the initial create call. 

We need to delete resourceId from the payload that can be returned from a `-result` API here, since there is no way to retrieve a `resourceId` from a `jobId` if the job is not completed, only the `jobReport`.