### PR TITLE
[IA-4864] Don't return resourceId when creating an Azure controlled resource

### DIFF
--- a/openapi/src/common/schemas_azure.yaml
+++ b/openapi/src/common/schemas_azure.yaml
@@ -21,10 +21,6 @@ components:
     CreateControlledAzureResourceResult:
       type: object
       properties:
-        resourceId:
-          description: UUID of a newly-created resource.
-          type: string
-          format: uuid
         jobReport:
           $ref: '#/components/schemas/JobReport'
         errorReport:

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -548,11 +548,6 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     final JobApiUtils.AsyncJobResult<ControlledAzureDiskResource> jobResult =
         jobApiUtils.retrieveAsyncJobResult(jobId, ControlledAzureDiskResource.class);
 
-    ControlledAzureDiskResource resource = null;
-    if (jobResult.getJobReport().getStatus().equals(ApiJobReport.StatusEnum.SUCCEEDED)) {
-      resource = jobResult.getResult();
-    }
-
     return new ApiCreateControlledAzureResourceResult()
         .jobReport(jobResult.getJobReport())
         .errorReport(jobResult.getApiErrorReport());

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -554,7 +554,6 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     }
 
     return new ApiCreateControlledAzureResourceResult()
-        .resourceId(resource.getResourceId())
         .jobReport(jobResult.getJobReport())
         .errorReport(jobResult.getApiErrorReport());
   }

--- a/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiControllerAzureDiskTest.java
@@ -102,7 +102,6 @@ public class ControlledAzureResourceApiControllerAzureDiskTest extends BaseAzure
                         .content(objectMapper.writeValueAsString(diskRequestV2Body)),
                     USER_REQUEST)))
         .andExpect(status().is(HttpStatus.SC_OK))
-        .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists())
-        .andExpect(MockMvcResultMatchers.jsonPath("$.resourceId").exists());
+        .andExpect(MockMvcResultMatchers.jsonPath("$.jobReport").exists());
   }
 }


### PR DESCRIPTION
Change from this PR: https://github.com/DataBiosphere/terra-workspace-manager/pull/1665/files#diff-b4e1a5b143bc7b58eff41fc0a8269307d326e4bca55d8e7c66eac5904209b456L570 got reverted somehow, need to add that back in