### PR TITLE
[WOR-1566] Upgrade io.kubernetes:client-java to 20.0.1

### DIFF
--- a/service/gradle/dependencies.gradle
+++ b/service/gradle/dependencies.gradle
@@ -88,7 +88,7 @@ dependencies {
   implementation group: "org.springframework.retry", name: "spring-retry"
   implementation group: "org.springframework.security", name: "spring-security-oauth2-jose"
 
-  implementation group: "io.kubernetes", name: "client-java", version: "18.0.0"
+  implementation group: "io.kubernetes", name: "client-java", version: "20.0.1"
 
   implementation group: "io.micrometer", name: "micrometer-registry-prometheus"
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
@@ -440,7 +440,7 @@ public class AzureDatabaseUtilsRunner {
 
       try {
         logger.info("Creating secret: {}", secretDefinition.getMetadata());
-        aksApi.createNamespacedSecret(namespace, secretDefinition, null, null, null, null);
+        aksApi.createNamespacedSecret(namespace, secretDefinition).execute();
       } catch (ApiException e) {
         var status = Optional.ofNullable(HttpStatus.resolve(e.getCode()));
         // If the secret already exists, assume this is a retry.
@@ -458,7 +458,7 @@ public class AzureDatabaseUtilsRunner {
       CoreV1Api aksApi, Map<String, String> secretStringData, String secretName, String namespace) {
     if (!secretStringData.isEmpty()) {
       try {
-        aksApi.deleteNamespacedSecret(secretName, namespace, null, null, null, null, null, null);
+        aksApi.deleteNamespacedSecret(secretName, namespace).execute();
       } catch (ApiException e) {
         logger.warn("Failed to delete azure database utils secret", e);
       }
@@ -467,7 +467,7 @@ public class AzureDatabaseUtilsRunner {
 
   private void deleteContainer(CoreV1Api aksApi, String podName, String namespace) {
     try {
-      aksApi.deleteNamespacedPod(podName, namespace, null, null, null, null, null, null);
+      aksApi.deleteNamespacedPod(podName, namespace).execute();
     } catch (ApiException e) {
       logger.warn("Failed to delete azure database utils pod", e);
     }
@@ -494,7 +494,7 @@ public class AzureDatabaseUtilsRunner {
       CoreV1Api aksApi, String podName, Integer tailLines, UUID workspaceId, String namespace) {
     var logContext = Map.of("workspaceId", workspaceId, "podName", podName);
     try {
-      var pod = aksApi.readNamespacedPod(podName, namespace, null);
+      var pod = aksApi.readNamespacedPod(podName, namespace).execute();
       logger.info("Pod final status: {}", pod.getStatus(), logContext);
 
       try (InputStream logs =
@@ -519,7 +519,7 @@ public class AzureDatabaseUtilsRunner {
   private Optional<String> getPodStatus(CoreV1Api aksApi, String podName, String namespace) {
     try {
       var status =
-          Optional.ofNullable(aksApi.readNamespacedPod(podName, namespace, null).getStatus())
+          Optional.ofNullable(aksApi.readNamespacedPod(podName, namespace).execute().getStatus())
               .map(V1PodStatus::getPhase);
       logger.info("Status = {} for azure database utils pod = {}", status, podName);
       return status;
@@ -540,7 +540,7 @@ public class AzureDatabaseUtilsRunner {
       throws ApiException {
     try {
       logger.info("Creating pod {}", podDefinition);
-      aksApi.createNamespacedPod(namespace, podDefinition, null, null, null, null);
+      aksApi.createNamespacedPod(namespace, podDefinition).execute();
     } catch (ApiException e) {
       var status = Optional.ofNullable(HttpStatus.resolve(e.getCode()));
       // If the pod already exists, assume this is a retry, monitor the already running pod

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateKubernetesNamespaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateKubernetesNamespaceStep.java
@@ -66,12 +66,9 @@ public class CreateKubernetesNamespaceStep implements Step {
         kubernetesClientProvider.createCoreApiClient(azureCloudContext, clusterResource);
 
     try {
-      coreApiClient.createNamespace(
-          new V1Namespace().metadata(new V1ObjectMeta().name(resource.getKubernetesNamespace())),
-          null,
-          null,
-          null,
-          null);
+      var namespace =
+          new V1Namespace().metadata(new V1ObjectMeta().name(resource.getKubernetesNamespace()));
+      coreApiClient.createNamespace(namespace).execute();
     } catch (ApiException e) {
       return kubernetesClientProvider.stepResultFromException(e, HttpStatus.CONFLICT);
     }
@@ -96,8 +93,7 @@ public class CreateKubernetesNamespaceStep implements Step {
                         workspaceId.toString()));
 
     try {
-      coreApiClient.deleteNamespace(
-          resource.getKubernetesNamespace(), null, null, null, null, null, null);
+      coreApiClient.deleteNamespace(resource.getKubernetesNamespace()).execute();
     } catch (ApiException e) {
       return kubernetesClientProvider.stepResultFromException(e, HttpStatus.NOT_FOUND);
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStep.java
@@ -55,9 +55,7 @@ public class DeleteKubernetesNamespaceStep extends DeleteAzureControlledResource
 
     try {
       logger.debug("Deleting namespace {}", resource.getKubernetesNamespace());
-      coreApiClient
-          .get()
-          .deleteNamespace(resource.getKubernetesNamespace(), null, null, null, null, null, null);
+      coreApiClient.get().deleteNamespace(resource.getKubernetesNamespace()).execute();
     } catch (ApiException e) {
       return kubernetesClientProvider.stepResultFromException(e, HttpStatus.NOT_FOUND);
     }
@@ -92,7 +90,7 @@ public class DeleteKubernetesNamespaceStep extends DeleteAzureControlledResource
 
   private Optional<String> getNamespaceStatus(CoreV1Api coreApiClient) {
     try {
-      var namespace = coreApiClient.readNamespace(resource.getKubernetesNamespace(), null);
+      var namespace = coreApiClient.readNamespace(resource.getKubernetesNamespace()).execute();
       var phase = Optional.ofNullable(namespace.getStatus()).map(V1NamespaceStatus::getPhase);
       logger.info("Status = {} for azure namespace = {}", phase, resource.getKubernetesNamespace());
       return phase;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/KubernetesNamespaceGuardStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/KubernetesNamespaceGuardStep.java
@@ -40,7 +40,7 @@ public class KubernetesNamespaceGuardStep implements Step {
             .orElseThrow(() -> new RuntimeException("No shared cluster found"));
 
     try {
-      var existing = coreApiClient.readNamespace(resource.getKubernetesNamespace(), null);
+      var existing = coreApiClient.readNamespace(resource.getKubernetesNamespace()).execute();
       if (existing != null) {
         return new StepResult(
             StepStatus.STEP_RESULT_FAILURE_FATAL,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStep.java
@@ -23,7 +23,6 @@ import com.azure.resourcemanager.msi.fluent.models.FederatedIdentityCredentialIn
 import com.google.common.annotations.VisibleForTesting;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ServiceAccount;
 import java.util.List;
@@ -157,12 +156,11 @@ public class CreateFederatedIdentityStep implements Step {
                     .name(ksaName)
                     .namespace(k8sNamespace));
 
-    aksApi.createNamespacedServiceAccount(k8sNamespace, k8sServiceAccount, null, null, null, null);
+    aksApi.createNamespacedServiceAccount(k8sNamespace, k8sServiceAccount).execute();
   }
 
   private void deleteK8sServiceAccount(CoreV1Api aksApi, String k8sNamespace) throws ApiException {
-    aksApi.deleteNamespacedServiceAccount(
-        ksaName, k8sNamespace, null, null, null, null, null, new V1DeleteOptions());
+    aksApi.deleteNamespacedServiceAccount(ksaName, k8sNamespace).execute();
   }
 
   private void createOrUpdateFederatedCredentials(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStep.java
@@ -23,6 +23,7 @@ import com.azure.resourcemanager.msi.fluent.models.FederatedIdentityCredentialIn
 import com.google.common.annotations.VisibleForTesting;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ServiceAccount;
 import java.util.List;
@@ -160,7 +161,10 @@ public class CreateFederatedIdentityStep implements Step {
   }
 
   private void deleteK8sServiceAccount(CoreV1Api aksApi, String k8sNamespace) throws ApiException {
-    aksApi.deleteNamespacedServiceAccount(ksaName, k8sNamespace).execute();
+    aksApi
+        .deleteNamespacedServiceAccount(ksaName, k8sNamespace)
+        .body(new V1DeleteOptions())
+        .execute();
   }
 
   private void createOrUpdateFederatedCredentials(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetFederatedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetFederatedIdentityStep.java
@@ -94,7 +94,7 @@ public class GetFederatedIdentityStep implements Step {
 
   private boolean k8sServiceAccountExists(String uamiName, CoreV1Api aksApi) {
     try {
-      return aksApi.readNamespacedServiceAccount(uamiName, k8sServiceAccountName, null) != null;
+      return aksApi.readNamespacedServiceAccount(uamiName, k8sServiceAccountName).execute() != null;
     } catch (ApiException e) {
       if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
         return false;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDatabaseConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDatabaseConnectedTest.java
@@ -229,9 +229,7 @@ public class AzureDatabaseConnectedTest extends BaseAzureConnectedTest {
     var notFound =
         assertThrows(
             ApiException.class,
-            () -> {
-              apiClient.readNamespace(namespace.getKubernetesNamespace(), null);
-            });
+            () -> apiClient.readNamespace(namespace.getKubernetesNamespace()).execute());
     assertEquals(404, notFound.getCode());
 
     var managedIdentity =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.exception.RetryException;
@@ -196,12 +197,16 @@ public class AzureDatabaseUtilsRunnerTest extends BaseMockitoStrictStubbingTest 
             any(AzureCloudContext.class), any(UUID.class)))
         .thenReturn(Optional.of(mockCoreV1Api));
 
-    when(mockCoreV1Api.createNamespacedPod(any(), podCaptor.capture(), any(), any(), any(), any()))
-        .thenReturn(new V1Pod());
-    when(mockCoreV1Api.readNamespacedPod(eq(podName), any(), any()))
-        .thenReturn(new V1Pod().status(new V1PodStatus().phase(podPhase)));
-    when(mockCoreV1Api.deleteNamespacedPod(
-            eq(podName), any(), any(), any(), any(), any(), any(), any()))
-        .thenReturn(new V1Pod());
+    var createRequest = mock(CoreV1Api.APIcreateNamespacedPodRequest.class);
+    when(mockCoreV1Api.createNamespacedPod(any(), podCaptor.capture())).thenReturn(createRequest);
+    when(createRequest.execute()).thenReturn(new V1Pod());
+
+    var readRequest = mock(CoreV1Api.APIreadNamespacedPodRequest.class);
+    when(mockCoreV1Api.readNamespacedPod(eq(podName), any())).thenReturn(readRequest);
+    when(readRequest.execute()).thenReturn(new V1Pod().status(new V1PodStatus().phase(podPhase)));
+
+    var deleteRequest = mock(CoreV1Api.APIdeleteNamespacedPodRequest.class);
+    when(mockCoreV1Api.deleteNamespacedPod(eq(podName), any())).thenReturn(deleteRequest);
+    when(deleteRequest.execute()).thenReturn(new V1Pod());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStepTest.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.kubernetesNa
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.FlightContext;
@@ -29,6 +30,7 @@ public class DeleteKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
   @Mock private FlightContext mockFlightContext;
   @Mock private KubernetesClientProvider mockKubernetesClientProvider;
   @Mock private CoreV1Api mockCoreV1Api;
+  @Mock private CoreV1Api.APIdeleteNamespaceRequest mockDeleteNamespaceRequest;
   @Mock private CoreV1Api.APIreadNamespaceRequest mockReadNamespaceRequest;
 
   @Test
@@ -45,6 +47,7 @@ public class DeleteKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
+    when(mockCoreV1Api.deleteNamespace(resource.getKubernetesNamespace())).thenReturn(mockDeleteNamespaceRequest);
     when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace()))
         .thenReturn(mockReadNamespaceRequest);
     when(mockReadNamespaceRequest.execute())
@@ -54,6 +57,7 @@ public class DeleteKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
         new DeleteKubernetesNamespaceStep(workspaceId, mockKubernetesClientProvider, resource)
             .doStep(createMockFlightContext());
 
+    verify(mockDeleteNamespaceRequest).execute();
     assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStepTest.java
@@ -29,6 +29,7 @@ public class DeleteKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
   @Mock private FlightContext mockFlightContext;
   @Mock private KubernetesClientProvider mockKubernetesClientProvider;
   @Mock private CoreV1Api mockCoreV1Api;
+  @Mock private CoreV1Api.APIreadNamespaceRequest mockReadNamespaceRequest;
 
   @Test
   void testDoStepSuccess() throws Exception {
@@ -44,7 +45,9 @@ public class DeleteKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
-    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace(), null))
+    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace()))
+        .thenReturn(mockReadNamespaceRequest);
+    when(mockReadNamespaceRequest.execute())
         .thenThrow(new ApiException(HttpStatus.NOT_FOUND.value(), "Not found"));
 
     var result =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStepTest.java
@@ -47,7 +47,8 @@ public class DeleteKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
-    when(mockCoreV1Api.deleteNamespace(resource.getKubernetesNamespace())).thenReturn(mockDeleteNamespaceRequest);
+    when(mockCoreV1Api.deleteNamespace(resource.getKubernetesNamespace()))
+        .thenReturn(mockDeleteNamespaceRequest);
     when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace()))
         .thenReturn(mockReadNamespaceRequest);
     when(mockReadNamespaceRequest.execute())

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/KubernetesNamespaceGuardStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/KubernetesNamespaceGuardStepTest.java
@@ -31,6 +31,7 @@ public class KubernetesNamespaceGuardStepTest extends BaseMockitoStrictStubbingT
   @Mock private FlightContext mockFlightContext;
   @Mock private KubernetesClientProvider mockKubernetesClientProvider;
   @Mock private CoreV1Api mockCoreV1Api;
+  @Mock private CoreV1Api.APIreadNamespaceRequest mockReadNamespaceRequest;
 
   @Test
   void testDoStepSuccess() throws InterruptedException, ApiException {
@@ -46,7 +47,9 @@ public class KubernetesNamespaceGuardStepTest extends BaseMockitoStrictStubbingT
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
-    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace(), null))
+    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace()))
+        .thenReturn(mockReadNamespaceRequest);
+    when(mockReadNamespaceRequest.execute())
         .thenThrow(new ApiException(HttpStatus.NOT_FOUND.value(), "not found"));
     when(mockKubernetesClientProvider.stepResultFromException(any(), any())).thenCallRealMethod();
 
@@ -71,8 +74,9 @@ public class KubernetesNamespaceGuardStepTest extends BaseMockitoStrictStubbingT
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
-    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace(), null))
-        .thenReturn(new V1Namespace());
+    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace()))
+        .thenReturn(mockReadNamespaceRequest);
+    when(mockReadNamespaceRequest.execute()).thenReturn(new V1Namespace());
 
     var result =
         new KubernetesNamespaceGuardStep(workspaceId, mockKubernetesClientProvider, resource)

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
@@ -3,7 +3,6 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdent
 import static bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetFederatedIdentityStep.FEDERATED_IDENTITY_EXISTS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -56,6 +55,11 @@ public class CreateFederatedIdentityStepTest extends BaseMockitoStrictStubbingTe
           .build();
   @Mock private MsiManager mockMsiManager;
   @Mock private CoreV1Api mockCoreV1Api;
+
+  @Mock
+  private CoreV1Api.APIcreateNamespacedServiceAccountRequest
+      mockCreateNamespacedServiceAccountRequest;
+
   private final String oidcIssuer = UUID.randomUUID().toString();
   private final String uamiClientId = UUID.randomUUID().toString();
   @Mock private Identities mockIdentities;
@@ -72,8 +76,9 @@ public class CreateFederatedIdentityStepTest extends BaseMockitoStrictStubbingTe
     setupMocks();
 
     when(mockCoreV1Api.createNamespacedServiceAccount(
-            eq(k8sNamespace), serviceAccountCaptor.capture(), any(), any(), any(), any()))
-        .thenReturn(null);
+            eq(k8sNamespace), serviceAccountCaptor.capture()))
+        .thenReturn(mockCreateNamespacedServiceAccountRequest);
+    when(mockCreateNamespacedServiceAccountRequest.execute()).thenReturn(null);
 
     var step =
         new CreateFederatedIdentityStep(
@@ -156,7 +161,9 @@ public class CreateFederatedIdentityStepTest extends BaseMockitoStrictStubbingTe
     setupMocks();
 
     when(mockCoreV1Api.createNamespacedServiceAccount(
-            eq(k8sNamespace), serviceAccountCaptor.capture(), any(), any(), any(), any()))
+            eq(k8sNamespace), serviceAccountCaptor.capture()))
+        .thenReturn(mockCreateNamespacedServiceAccountRequest);
+    when(mockCreateNamespacedServiceAccountRequest.execute())
         .thenThrow(new ApiException(httpStatus.value(), httpStatus.name()));
 
     var step =


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1566

This change was motivated by a desire to address a security vulnerability with jose4j, a transitive dependency of the Kubernetes client. Upgrading the client brought this dependency past its vulnerability without needing to explicitly pin it.

Breaking changes were introduced in v20.0.0: optional parameters are now consolidated into a single object, and we must explicitly execute our requests (the client now supports different flavors of execution such as async).