### PR TITLE
[WOR-1566] Upgrade terra-common-lib from 1.0.9 -> 1.1.0

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'terra-workspace-manager.java-conventions'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+
     // Apply the application plugin to add support for building a CLI application in Java
     id 'application'
+
     // Terra Test Runner Plugin.
     id 'bio.terra.test-runner-plugin' version '0.2.0-SNAPSHOT'
 }
@@ -64,4 +64,7 @@ dependencies {
     implementation("bio.terra:terra-common-lib:1.1.0-SNAPSHOT") {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
+    // Needed for TCL, but if we reorganize our dependencies so that the Spring Boot dependency manager
+    // is used, then we should be able to remove this (Spring Boot dependency manager pulls in opentelemetry-bom):
+    implementation 'io.opentelemetry:opentelemetry-api:1.36.0'
 }

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'terra-workspace-manager.java-conventions'
-
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
     // Apply the application plugin to add support for building a CLI application in Java
     id 'application'
-
     // Terra Test Runner Plugin.
     id 'bio.terra.test-runner-plugin' version '0.2.0-SNAPSHOT'
 }
@@ -61,7 +61,7 @@ dependencies {
     implementation "bio.terra:terra-test-runner:${testRunnerVersion}"
 
     // Use Terra Common Library on client side to retry direct Sam calls
-    implementation("bio.terra:terra-common-lib:1.0.9-SNAPSHOT") {
+    implementation("bio.terra:terra-common-lib:1.1.0-SNAPSHOT") {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 }

--- a/service/gradle/dependencies.gradle
+++ b/service/gradle/dependencies.gradle
@@ -43,14 +43,11 @@ dependencies {
   // hk2 is required to use datarepo client, but not correctly exposed by the client
   implementation group: "org.glassfish.jersey.inject", name: "jersey-hk2"
 
-  // OpenTelemetry
-  // Versioned by Spring Boot Dependency Manager via opentelemetry-bom:
-  implementation 'io.opentelemetry:opentelemetry-api'
-  // Needed for @WithSpan annotations:
+  // OpenTelemetry @WithSpan annotations:
   implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0'
 
   // Get stairway via TCL
-  implementation("bio.terra:terra-common-lib:1.0.9-SNAPSHOT")
+  implementation("bio.terra:terra-common-lib:1.1.0-SNAPSHOT")
   // sam is not semantically versioned so force the version here
   implementation force: true, group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "0.1-73bc2d1"
   implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.198.42-SNAPSHOT"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1566

This PR is a necessary follow-on to https://github.com/DataBiosphere/terra-workspace-manager/pull/1675.  It further bumps our `terra-common-lib` version to latest, 1.1.0

This now includes https://github.com/DataBiosphere/terra-common-lib/pull/146 which upgraded io.kubernetes:client-java to the same version we upgraded to in WSM -- 20.0.1.

I suspect this discrepancy was the cause of [failures to deploy the WSM k8s client upgrade to dev](https://broadinstitute.slack.com/archives/C01NLH6SHJN/p1710981666720469?thread_ts=1710980664.406049&cid=C01NLH6SHJN).  Relevant [logs](https://cloudlogging.app.goo.gl/BcY1ya1Nk2b5kt7H6):

```
java.lang.NoSuchMethodError: 'okhttp3.Call io.kubernetes.client.openapi.apis.CoreV1Api.listNamespacedPodCall(java.lang.String, java.lang.String, java.lang.Boolean, java.lang.String, java.lang.String, java.lang.String, java.lang.Integer, java.lang.String, java.lang.String, java.lang.Integer, java.lang.Boolean, io.kubernetes.client.openapi.ApiCallback)'
	at bio.terra.common.kubernetes.KubePodListener.makeWatch(KubePodListener.java:162)
	at bio.terra.common.kubernetes.KubePodListener.run(KubePodListener.java:100)
	at java.base/java.lang.Thread.run(Unknown Source)
```

**Manual Verification**

I successfully deployed an [image created from this branch](https://broadworkbench.atlassian.net/wiki/spaces/WOR/pages/2916679772/How+to+test+a+WSM+branch+on+a+BEE) to my [Bee](https://beehive.dsp-devops.broadinstitute.org/environments/okotsopo/chart-releases/workspacemanager).
<img width="534" alt="Screenshot 2024-03-21 at 10 26 25 AM" src="https://github.com/DataBiosphere/terra-workspace-manager/assets/79769153/343ad2fc-7b5e-46ff-9643-f5f37ab831af">
