### PR TITLE
Revert "[WOR-1566] Upgrade io.kubernetes:client-java to 20.0.1 (#1675)"

### DIFF
--- a/service/gradle/dependencies.gradle
+++ b/service/gradle/dependencies.gradle
@@ -88,7 +88,7 @@ dependencies {
   implementation group: "org.springframework.retry", name: "spring-retry"
   implementation group: "org.springframework.security", name: "spring-security-oauth2-jose"
 
-  implementation group: "io.kubernetes", name: "client-java", version: "20.0.1"
+  implementation group: "io.kubernetes", name: "client-java", version: "18.0.0"
 
   implementation group: "io.micrometer", name: "micrometer-registry-prometheus"
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
@@ -440,7 +440,7 @@ public class AzureDatabaseUtilsRunner {
 
       try {
         logger.info("Creating secret: {}", secretDefinition.getMetadata());
-        aksApi.createNamespacedSecret(namespace, secretDefinition).execute();
+        aksApi.createNamespacedSecret(namespace, secretDefinition, null, null, null, null);
       } catch (ApiException e) {
         var status = Optional.ofNullable(HttpStatus.resolve(e.getCode()));
         // If the secret already exists, assume this is a retry.
@@ -458,7 +458,7 @@ public class AzureDatabaseUtilsRunner {
       CoreV1Api aksApi, Map<String, String> secretStringData, String secretName, String namespace) {
     if (!secretStringData.isEmpty()) {
       try {
-        aksApi.deleteNamespacedSecret(secretName, namespace).execute();
+        aksApi.deleteNamespacedSecret(secretName, namespace, null, null, null, null, null, null);
       } catch (ApiException e) {
         logger.warn("Failed to delete azure database utils secret", e);
       }
@@ -467,7 +467,7 @@ public class AzureDatabaseUtilsRunner {
 
   private void deleteContainer(CoreV1Api aksApi, String podName, String namespace) {
     try {
-      aksApi.deleteNamespacedPod(podName, namespace).execute();
+      aksApi.deleteNamespacedPod(podName, namespace, null, null, null, null, null, null);
     } catch (ApiException e) {
       logger.warn("Failed to delete azure database utils pod", e);
     }
@@ -494,7 +494,7 @@ public class AzureDatabaseUtilsRunner {
       CoreV1Api aksApi, String podName, Integer tailLines, UUID workspaceId, String namespace) {
     var logContext = Map.of("workspaceId", workspaceId, "podName", podName);
     try {
-      var pod = aksApi.readNamespacedPod(podName, namespace).execute();
+      var pod = aksApi.readNamespacedPod(podName, namespace, null);
       logger.info("Pod final status: {}", pod.getStatus(), logContext);
 
       try (InputStream logs =
@@ -519,7 +519,7 @@ public class AzureDatabaseUtilsRunner {
   private Optional<String> getPodStatus(CoreV1Api aksApi, String podName, String namespace) {
     try {
       var status =
-          Optional.ofNullable(aksApi.readNamespacedPod(podName, namespace).execute().getStatus())
+          Optional.ofNullable(aksApi.readNamespacedPod(podName, namespace, null).getStatus())
               .map(V1PodStatus::getPhase);
       logger.info("Status = {} for azure database utils pod = {}", status, podName);
       return status;
@@ -540,7 +540,7 @@ public class AzureDatabaseUtilsRunner {
       throws ApiException {
     try {
       logger.info("Creating pod {}", podDefinition);
-      aksApi.createNamespacedPod(namespace, podDefinition).execute();
+      aksApi.createNamespacedPod(namespace, podDefinition, null, null, null, null);
     } catch (ApiException e) {
       var status = Optional.ofNullable(HttpStatus.resolve(e.getCode()));
       // If the pod already exists, assume this is a retry, monitor the already running pod

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateKubernetesNamespaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateKubernetesNamespaceStep.java
@@ -66,9 +66,12 @@ public class CreateKubernetesNamespaceStep implements Step {
         kubernetesClientProvider.createCoreApiClient(azureCloudContext, clusterResource);
 
     try {
-      var namespace =
-          new V1Namespace().metadata(new V1ObjectMeta().name(resource.getKubernetesNamespace()));
-      coreApiClient.createNamespace(namespace).execute();
+      coreApiClient.createNamespace(
+          new V1Namespace().metadata(new V1ObjectMeta().name(resource.getKubernetesNamespace())),
+          null,
+          null,
+          null,
+          null);
     } catch (ApiException e) {
       return kubernetesClientProvider.stepResultFromException(e, HttpStatus.CONFLICT);
     }
@@ -93,7 +96,8 @@ public class CreateKubernetesNamespaceStep implements Step {
                         workspaceId.toString()));
 
     try {
-      coreApiClient.deleteNamespace(resource.getKubernetesNamespace()).execute();
+      coreApiClient.deleteNamespace(
+          resource.getKubernetesNamespace(), null, null, null, null, null, null);
     } catch (ApiException e) {
       return kubernetesClientProvider.stepResultFromException(e, HttpStatus.NOT_FOUND);
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStep.java
@@ -55,7 +55,9 @@ public class DeleteKubernetesNamespaceStep extends DeleteAzureControlledResource
 
     try {
       logger.debug("Deleting namespace {}", resource.getKubernetesNamespace());
-      coreApiClient.get().deleteNamespace(resource.getKubernetesNamespace()).execute();
+      coreApiClient
+          .get()
+          .deleteNamespace(resource.getKubernetesNamespace(), null, null, null, null, null, null);
     } catch (ApiException e) {
       return kubernetesClientProvider.stepResultFromException(e, HttpStatus.NOT_FOUND);
     }
@@ -90,7 +92,7 @@ public class DeleteKubernetesNamespaceStep extends DeleteAzureControlledResource
 
   private Optional<String> getNamespaceStatus(CoreV1Api coreApiClient) {
     try {
-      var namespace = coreApiClient.readNamespace(resource.getKubernetesNamespace()).execute();
+      var namespace = coreApiClient.readNamespace(resource.getKubernetesNamespace(), null);
       var phase = Optional.ofNullable(namespace.getStatus()).map(V1NamespaceStatus::getPhase);
       logger.info("Status = {} for azure namespace = {}", phase, resource.getKubernetesNamespace());
       return phase;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/KubernetesNamespaceGuardStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/KubernetesNamespaceGuardStep.java
@@ -40,7 +40,7 @@ public class KubernetesNamespaceGuardStep implements Step {
             .orElseThrow(() -> new RuntimeException("No shared cluster found"));
 
     try {
-      var existing = coreApiClient.readNamespace(resource.getKubernetesNamespace()).execute();
+      var existing = coreApiClient.readNamespace(resource.getKubernetesNamespace(), null);
       if (existing != null) {
         return new StepResult(
             StepStatus.STEP_RESULT_FAILURE_FATAL,

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStep.java
@@ -157,14 +157,12 @@ public class CreateFederatedIdentityStep implements Step {
                     .name(ksaName)
                     .namespace(k8sNamespace));
 
-    aksApi.createNamespacedServiceAccount(k8sNamespace, k8sServiceAccount).execute();
+    aksApi.createNamespacedServiceAccount(k8sNamespace, k8sServiceAccount, null, null, null, null);
   }
 
   private void deleteK8sServiceAccount(CoreV1Api aksApi, String k8sNamespace) throws ApiException {
-    aksApi
-        .deleteNamespacedServiceAccount(ksaName, k8sNamespace)
-        .body(new V1DeleteOptions())
-        .execute();
+    aksApi.deleteNamespacedServiceAccount(
+        ksaName, k8sNamespace, null, null, null, null, null, new V1DeleteOptions());
   }
 
   private void createOrUpdateFederatedCredentials(

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetFederatedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetFederatedIdentityStep.java
@@ -94,7 +94,7 @@ public class GetFederatedIdentityStep implements Step {
 
   private boolean k8sServiceAccountExists(String uamiName, CoreV1Api aksApi) {
     try {
-      return aksApi.readNamespacedServiceAccount(uamiName, k8sServiceAccountName).execute() != null;
+      return aksApi.readNamespacedServiceAccount(uamiName, k8sServiceAccountName, null) != null;
     } catch (ApiException e) {
       if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
         return false;

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDatabaseConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureDatabaseConnectedTest.java
@@ -229,7 +229,9 @@ public class AzureDatabaseConnectedTest extends BaseAzureConnectedTest {
     var notFound =
         assertThrows(
             ApiException.class,
-            () -> apiClient.readNamespace(namespace.getKubernetesNamespace()).execute());
+            () -> {
+              apiClient.readNamespace(namespace.getKubernetesNamespace(), null);
+            });
     assertEquals(404, notFound.getCode());
 
     var managedIdentity =

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.exception.RetryException;
@@ -197,16 +196,12 @@ public class AzureDatabaseUtilsRunnerTest extends BaseMockitoStrictStubbingTest 
             any(AzureCloudContext.class), any(UUID.class)))
         .thenReturn(Optional.of(mockCoreV1Api));
 
-    var createRequest = mock(CoreV1Api.APIcreateNamespacedPodRequest.class);
-    when(mockCoreV1Api.createNamespacedPod(any(), podCaptor.capture())).thenReturn(createRequest);
-    when(createRequest.execute()).thenReturn(new V1Pod());
-
-    var readRequest = mock(CoreV1Api.APIreadNamespacedPodRequest.class);
-    when(mockCoreV1Api.readNamespacedPod(eq(podName), any())).thenReturn(readRequest);
-    when(readRequest.execute()).thenReturn(new V1Pod().status(new V1PodStatus().phase(podPhase)));
-
-    var deleteRequest = mock(CoreV1Api.APIdeleteNamespacedPodRequest.class);
-    when(mockCoreV1Api.deleteNamespacedPod(eq(podName), any())).thenReturn(deleteRequest);
-    when(deleteRequest.execute()).thenReturn(new V1Pod());
+    when(mockCoreV1Api.createNamespacedPod(any(), podCaptor.capture(), any(), any(), any(), any()))
+        .thenReturn(new V1Pod());
+    when(mockCoreV1Api.readNamespacedPod(eq(podName), any(), any()))
+        .thenReturn(new V1Pod().status(new V1PodStatus().phase(podPhase)));
+    when(mockCoreV1Api.deleteNamespacedPod(
+            eq(podName), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(new V1Pod());
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateKubernetesNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/CreateKubernetesNamespaceStepTest.java
@@ -37,8 +37,6 @@ public class CreateKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
   @Mock private FlightContext mockFlightContext;
   @Mock private KubernetesClientProvider mockKubernetesClientProvider;
   @Mock private CoreV1Api mockCoreV1Api;
-  @Mock private CoreV1Api.APIcreateNamespaceRequest mockCreateNamespaceRequest;
-  @Mock private CoreV1Api.APIdeleteNamespaceRequest mockDeleteNamespaceRequest;
   @Mock private CrlService mockCrlService;
 
   @Test
@@ -54,8 +52,6 @@ public class CreateKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
             .build();
     var aksClusterResource =
         new ApiAzureLandingZoneDeployedResource().resourceId("path/to/aksCluster");
-    var namespace =
-        new V1Namespace().metadata(new V1ObjectMeta().name(resource.getKubernetesNamespace()));
 
     when(mockAzureCloudContext.getAzureTenantId()).thenReturn("tenant");
     when(mockAzureCloudContext.getAzureSubscriptionId()).thenReturn("sub");
@@ -65,7 +61,6 @@ public class CreateKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
     when(mockKubernetesClientProvider.createCoreApiClient(
             mockAzureCloudContext, aksClusterResource))
         .thenReturn(mockCoreV1Api);
-    when(mockCoreV1Api.createNamespace(namespace)).thenReturn(mockCreateNamespaceRequest);
 
     var result =
         new CreateKubernetesNamespaceStep(
@@ -74,7 +69,13 @@ public class CreateKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
 
     assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
 
-    verify(mockCreateNamespaceRequest).execute();
+    verify(mockCoreV1Api)
+        .createNamespace(
+            new V1Namespace().metadata(new V1ObjectMeta().name(resource.getKubernetesNamespace())),
+            null,
+            null,
+            null,
+            null);
 
     verify(mockCrlService)
         .recordAzureCleanup(
@@ -100,8 +101,6 @@ public class CreateKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
             .build();
     var aksClusterResource =
         new ApiAzureLandingZoneDeployedResource().resourceId("path/to/aksCluster");
-    var namespace =
-        new V1Namespace().metadata(new V1ObjectMeta().name(resource.getKubernetesNamespace()));
 
     when(mockAzureCloudContext.getAzureTenantId()).thenReturn("tenant");
     when(mockAzureCloudContext.getAzureSubscriptionId()).thenReturn("sub");
@@ -111,8 +110,12 @@ public class CreateKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
     when(mockKubernetesClientProvider.createCoreApiClient(
             mockAzureCloudContext, aksClusterResource))
         .thenReturn(mockCoreV1Api);
-    when(mockCoreV1Api.createNamespace(namespace)).thenReturn(mockCreateNamespaceRequest);
-    when(mockCreateNamespaceRequest.execute())
+    when(mockCoreV1Api.createNamespace(
+            new V1Namespace().metadata(new V1ObjectMeta().name(resource.getKubernetesNamespace())),
+            null,
+            null,
+            null,
+            null))
         .thenThrow(new ApiException(HttpStatus.CONFLICT.value(), "message"));
     when(mockKubernetesClientProvider.stepResultFromException(any(), any())).thenCallRealMethod();
 
@@ -148,8 +151,6 @@ public class CreateKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
-    when(mockCoreV1Api.deleteNamespace(resource.getKubernetesNamespace()))
-        .thenReturn(mockDeleteNamespaceRequest);
 
     var result =
         new CreateKubernetesNamespaceStep(
@@ -158,7 +159,8 @@ public class CreateKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
 
     assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
 
-    verify(mockDeleteNamespaceRequest).execute();
+    verify(mockCoreV1Api)
+        .deleteNamespace(resource.getKubernetesNamespace(), null, null, null, null, null, null);
   }
 
   @Test
@@ -175,9 +177,8 @@ public class CreateKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
-    when(mockCoreV1Api.deleteNamespace(resource.getKubernetesNamespace()))
-        .thenReturn(mockDeleteNamespaceRequest);
-    when(mockDeleteNamespaceRequest.execute())
+    when(mockCoreV1Api.deleteNamespace(
+            resource.getKubernetesNamespace(), null, null, null, null, null, null))
         .thenThrow(new ApiException(HttpStatus.NOT_FOUND.value(), "message"));
     when(mockKubernetesClientProvider.stepResultFromException(any(), any()))
         .thenCallRealMethod()

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStepTest.java
@@ -2,7 +2,6 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.kubernetesNa
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.stairway.FlightContext;
@@ -30,8 +29,6 @@ public class DeleteKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
   @Mock private FlightContext mockFlightContext;
   @Mock private KubernetesClientProvider mockKubernetesClientProvider;
   @Mock private CoreV1Api mockCoreV1Api;
-  @Mock private CoreV1Api.APIdeleteNamespaceRequest mockDeleteNamespaceRequest;
-  @Mock private CoreV1Api.APIreadNamespaceRequest mockReadNamespaceRequest;
 
   @Test
   void testDoStepSuccess() throws Exception {
@@ -47,18 +44,13 @@ public class DeleteKubernetesNamespaceStepTest extends BaseMockitoStrictStubbing
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
-    when(mockCoreV1Api.deleteNamespace(resource.getKubernetesNamespace()))
-        .thenReturn(mockDeleteNamespaceRequest);
-    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace()))
-        .thenReturn(mockReadNamespaceRequest);
-    when(mockReadNamespaceRequest.execute())
+    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace(), null))
         .thenThrow(new ApiException(HttpStatus.NOT_FOUND.value(), "Not found"));
 
     var result =
         new DeleteKubernetesNamespaceStep(workspaceId, mockKubernetesClientProvider, resource)
             .doStep(createMockFlightContext());
 
-    verify(mockDeleteNamespaceRequest).execute();
     assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
   }
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/KubernetesNamespaceGuardStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/KubernetesNamespaceGuardStepTest.java
@@ -31,7 +31,6 @@ public class KubernetesNamespaceGuardStepTest extends BaseMockitoStrictStubbingT
   @Mock private FlightContext mockFlightContext;
   @Mock private KubernetesClientProvider mockKubernetesClientProvider;
   @Mock private CoreV1Api mockCoreV1Api;
-  @Mock private CoreV1Api.APIreadNamespaceRequest mockReadNamespaceRequest;
 
   @Test
   void testDoStepSuccess() throws InterruptedException, ApiException {
@@ -47,9 +46,7 @@ public class KubernetesNamespaceGuardStepTest extends BaseMockitoStrictStubbingT
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
-    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace()))
-        .thenReturn(mockReadNamespaceRequest);
-    when(mockReadNamespaceRequest.execute())
+    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace(), null))
         .thenThrow(new ApiException(HttpStatus.NOT_FOUND.value(), "not found"));
     when(mockKubernetesClientProvider.stepResultFromException(any(), any())).thenCallRealMethod();
 
@@ -74,9 +71,8 @@ public class KubernetesNamespaceGuardStepTest extends BaseMockitoStrictStubbingT
 
     when(mockKubernetesClientProvider.createCoreApiClient(mockAzureCloudContext, workspaceId))
         .thenReturn(Optional.of(mockCoreV1Api));
-    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace()))
-        .thenReturn(mockReadNamespaceRequest);
-    when(mockReadNamespaceRequest.execute()).thenReturn(new V1Namespace());
+    when(mockCoreV1Api.readNamespace(resource.getKubernetesNamespace(), null))
+        .thenReturn(new V1Namespace());
 
     var result =
         new KubernetesNamespaceGuardStep(workspaceId, mockKubernetesClientProvider, resource)

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/CreateFederatedIdentityStepTest.java
@@ -3,6 +3,7 @@ package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdent
 import static bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetFederatedIdentityStep.FEDERATED_IDENTITY_EXISTS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -55,11 +56,6 @@ public class CreateFederatedIdentityStepTest extends BaseMockitoStrictStubbingTe
           .build();
   @Mock private MsiManager mockMsiManager;
   @Mock private CoreV1Api mockCoreV1Api;
-
-  @Mock
-  private CoreV1Api.APIcreateNamespacedServiceAccountRequest
-      mockCreateNamespacedServiceAccountRequest;
-
   private final String oidcIssuer = UUID.randomUUID().toString();
   private final String uamiClientId = UUID.randomUUID().toString();
   @Mock private Identities mockIdentities;
@@ -76,9 +72,8 @@ public class CreateFederatedIdentityStepTest extends BaseMockitoStrictStubbingTe
     setupMocks();
 
     when(mockCoreV1Api.createNamespacedServiceAccount(
-            eq(k8sNamespace), serviceAccountCaptor.capture()))
-        .thenReturn(mockCreateNamespacedServiceAccountRequest);
-    when(mockCreateNamespacedServiceAccountRequest.execute()).thenReturn(null);
+            eq(k8sNamespace), serviceAccountCaptor.capture(), any(), any(), any(), any()))
+        .thenReturn(null);
 
     var step =
         new CreateFederatedIdentityStep(
@@ -161,9 +156,7 @@ public class CreateFederatedIdentityStepTest extends BaseMockitoStrictStubbingTe
     setupMocks();
 
     when(mockCoreV1Api.createNamespacedServiceAccount(
-            eq(k8sNamespace), serviceAccountCaptor.capture()))
-        .thenReturn(mockCreateNamespacedServiceAccountRequest);
-    when(mockCreateNamespacedServiceAccountRequest.execute())
+            eq(k8sNamespace), serviceAccountCaptor.capture(), any(), any(), any(), any()))
         .thenThrow(new ApiException(httpStatus.value(), httpStatus.name()));
 
     var step =


### PR DESCRIPTION
This reverts commit cb970d93a4bb88ae29cea452bcaee34d483ac832 resulting from merging https://github.com/DataBiosphere/terra-workspace-manager/pull/1675.

https://github.com/DataBiosphere/terra-workspace-manager/pull/1676#issuecomment-2012861271

> Update on order of operations:
>
> **1. Revert breaking WSM k8s client upgrade**
> 2. Upgrade LZS' TCL from 0.x -> 1.0.9 (to get Stairway's native MDC support but there are some other TCL breaking changes)
> 3. Upgrade LZS' k8s client, TCL from 1.0.9 -> 1.1.0 (smaller TCL version bump)
> 4. Upgrade WSM' k8s client, TCL from 1.0.9 -> 1.1.0, LZS to latest