### PR TITLE
[WOR-1586] Handle processing exception in TpsRetry

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
@@ -103,7 +103,7 @@ public class TpsRetry {
         }
       } catch (ProcessingException ws) {
         logger.info("TpsRetry: caught retry-able ProcessingException: ", ws);
-        sleepOrTimeoutBeforeRetrying(new ApiException(ws));
+        sleepOrTimeoutBeforeRetrying(ws);
       }
     }
   }
@@ -134,12 +134,12 @@ public class TpsRetry {
    * 10, 20, 30, 30, 30... seconds.
    *
    * @param previousException The error Tps threw
-   * @throws ApiException InterruptedException
+   * @throws E, InterruptedException
    */
-  private void sleepOrTimeoutBeforeRetrying(ApiException previousException)
-      throws ApiException, InterruptedException {
+  private <E extends Exception> void sleepOrTimeoutBeforeRetrying(E previousException)
+          throws E, InterruptedException {
     if (operationTimeout.minus(retryDuration).isBefore(now())) {
-      logger.error("TpsRetry: operation timed out after " + operationTimeout.toString());
+      logger.error("TpsRetry: operation timed out after " + operationTimeout);
       // If we timed out, throw the error from Tps that caused us to need to retry.
       throw previousException;
     }

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
@@ -137,7 +137,7 @@ public class TpsRetry {
    * @throws E, InterruptedException
    */
   private <E extends Exception> void sleepOrTimeoutBeforeRetrying(E previousException)
-          throws E, InterruptedException {
+      throws E, InterruptedException {
     if (operationTimeout.minus(retryDuration).isBefore(now())) {
       logger.error("TpsRetry: operation timed out after " + operationTimeout);
       // If we timed out, throw the error from Tps that caused us to need to retry.

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
@@ -104,7 +104,7 @@ public class TpsRetry {
         }
       } catch (ProcessingException ws) {
         logger.info("TpsRetry: caught retry-able ProcessingException: ", ws);
-        sleepOrTimeoutBeforeRetrying(ws);
+        sleepOrTimeoutBeforeRetrying(new ApiException(ws));
       }
     }
   }
@@ -135,10 +135,10 @@ public class TpsRetry {
    * 10, 20, 30, 30, 30... seconds.
    *
    * @param previousException The error Tps threw
-   * @throws Exception
+   * @throws ApiException InterruptedException
    */
-  private void sleepOrTimeoutBeforeRetrying(Exception previousException)
-      throws Exception {
+  private void sleepOrTimeoutBeforeRetrying(ApiException previousException)
+      throws ApiException, InterruptedException {
     if (operationTimeout.minus(retryDuration).isBefore(now())) {
       logger.error("TpsRetry: operation timed out after " + operationTimeout.toString());
       // If we timed out, throw the error from Tps that caused us to need to retry.

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
@@ -7,6 +7,8 @@ import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.ProcessingException;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,6 +102,9 @@ public class TpsRetry {
         } else {
           throw ex;
         }
+      } catch (ProcessingException ws) {
+        logger.info("TpsRetry: caught retry-able ProcessingException: ", ws);
+        sleepOrTimeoutBeforeRetrying(ws);
       }
     }
   }
@@ -130,10 +135,10 @@ public class TpsRetry {
    * 10, 20, 30, 30, 30... seconds.
    *
    * @param previousException The error Tps threw
-   * @throws ApiException InterruptedException
+   * @throws Exception
    */
-  private void sleepOrTimeoutBeforeRetrying(ApiException previousException)
-      throws ApiException, InterruptedException {
+  private void sleepOrTimeoutBeforeRetrying(Exception previousException)
+      throws Exception {
     if (operationTimeout.minus(retryDuration).isBefore(now())) {
       logger.error("TpsRetry: operation timed out after " + operationTimeout.toString());
       // If we timed out, throw the error from Tps that caused us to need to retry.

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsRetry.java
@@ -3,12 +3,11 @@ package bio.terra.workspace.service.policy;
 import static java.time.Instant.now;
 
 import bio.terra.policy.client.ApiException;
+import jakarta.ws.rs.ProcessingException;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-
-import jakarta.ws.rs.ProcessingException;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
These exceptions can occur when there are low-level IO issues (socket timeout, etc.). They bypass the retry mechanism due to the exception filter on ApiException, causing flakiness with tests (and presumably in actual usage).