### PR TITLE
WOR-1519: add method to retrieve a resource of a workspace by name

### DIFF
--- a/openapi/src/parts/resource.yaml
+++ b/openapi/src/parts/resource.yaml
@@ -55,6 +55,31 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/workspaces/v1/{workspaceId}/resources/name/{name}:
+    parameters:
+    - $ref: '#/components/parameters/WorkspaceId'
+    - $ref: '#/components/parameters/Name'
+    get:
+      summary: |
+        Retrieve a resource in a workspace by the resource name.
+      operationId: getResourceByName
+      tags: [ Resource ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceDescription'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/workspaces/v1/{workspaceId}/resources/referenced/{resourceId}/access:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'

--- a/service/src/main/java/bio/terra/workspace/app/controller/ResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ResourceApiController.java
@@ -148,17 +148,10 @@ public class ResourceApiController extends ControllerBase implements ResourceApi
             throw workspaceException;
           }
         }
-        case REFERENCED -> {
-          var hasAccess =
-              referencedResourceService.checkAccess(
-                  workspaceUuid, resource.getResourceId(), userRequest);
-          if (hasAccess) {
-            return resource;
-          } else {
-            // if no access, throw original exception to avoid leaking information on resource
-            throw workspaceException;
-          }
-        }
+        // there's no valid case where the user will be able to access a referenced resource,
+        // but not the workspace itself
+        case REFERENCED -> throw workspaceException;
+        // if no access, throw original exception to avoid leaking information on resource
         default -> throw workspaceException;
       }
     }

--- a/service/src/main/java/bio/terra/workspace/app/controller/ResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ResourceApiController.java
@@ -148,10 +148,10 @@ public class ResourceApiController extends ControllerBase implements ResourceApi
             throw workspaceException;
           }
         }
-        // there's no valid case where the user will be able to access a referenced resource,
-        // but not the workspace itself
+          // there's no valid case where the user will be able to access a referenced resource,
+          // but not the workspace itself
         case REFERENCED -> throw workspaceException;
-        // if no access, throw original exception to avoid leaking information on resource
+          // if no access, throw original exception to avoid leaking information on resource
         default -> throw workspaceException;
       }
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/WsmResourceService.java
@@ -45,6 +45,10 @@ public class WsmResourceService {
     return resourceDao.getResource(workspaceUuid, resourceUuid);
   }
 
+  public WsmResource getResourceByName(UUID workspaceUuid, String resourceName) {
+    return resourceDao.getResourceByName(workspaceUuid, resourceName);
+  }
+
   public void updateResource(
       AuthenticatedUserRequest userRequest,
       WsmResource resource,

--- a/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ResourceApiControllerUnitTest.java
@@ -1,0 +1,233 @@
+package bio.terra.workspace.app.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import bio.terra.common.exception.ForbiddenException;
+import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.app.controller.shared.JobApiUtils;
+import bio.terra.workspace.common.annotations.Unit;
+import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
+import bio.terra.workspace.generated.model.ApiResourceMetadata;
+import bio.terra.workspace.service.features.FeatureService;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequestFactory;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.SamConstants;
+import bio.terra.workspace.service.job.JobService;
+import bio.terra.workspace.service.resource.WsmResourceService;
+import bio.terra.workspace.service.resource.controlled.ControlledResourceMetadataManager;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
+import bio.terra.workspace.service.resource.model.StewardshipType;
+import bio.terra.workspace.service.resource.model.WsmResource;
+import bio.terra.workspace.service.resource.referenced.ReferencedResourceService;
+import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatusCode;
+
+@Unit
+@ExtendWith(MockitoExtension.class)
+public class ResourceApiControllerUnitTest {
+
+  @Mock AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @Mock HttpServletRequest request;
+  @Mock SamService samService;
+  @Mock FeatureConfiguration features;
+  @Mock FeatureService featureService;
+  @Mock JobService jobService;
+  @Mock JobApiUtils jobApiUtils;
+  @Mock WsmResourceService resourceService;
+  @Mock WorkspaceService workspaceService;
+  @Mock ReferencedResourceService referencedResourceService;
+  @Mock ControlledResourceMetadataManager controlledResourceMetadataManager;
+  @Mock AuthenticatedUserRequest userRequest;
+
+  @BeforeEach
+  void setup() {
+    when(authenticatedUserRequestFactory.from(request)).thenReturn(userRequest);
+  }
+
+  ResourceApiController getApiController() {
+    return new ResourceApiController(
+        authenticatedUserRequestFactory,
+        request,
+        samService,
+        features,
+        featureService,
+        jobService,
+        jobApiUtils,
+        resourceService,
+        workspaceService,
+        referencedResourceService,
+        controlledResourceMetadataManager);
+  }
+
+  @Test
+  void getResourceByName_returnsResourceIfUserCanAccessEntireWorkspace() {
+    var workspaceId = UUID.randomUUID();
+    Workspace workspace = mock();
+    WsmResource resource = mock();
+    when(workspaceService.validateWorkspaceAndAction(
+            userRequest, workspaceId, SamConstants.SamControlledResourceActions.READ_ACTION))
+        .thenReturn(workspace);
+    var resourceName = "test-resource-name";
+    when(resourceService.getResourceByName(workspaceId, resourceName)).thenReturn(resource);
+    ApiResourceMetadata resourceMetadata = mock();
+    when(resource.toApiMetadata()).thenReturn(resourceMetadata);
+    ApiResourceAttributesUnion resourceAttributes = mock();
+    when(resource.toApiAttributesUnion()).thenReturn(resourceAttributes);
+
+    // methods to check access on resources aren't set up here,
+    // so any calls to them should just throw an incomplete stubbing exception
+    var api = getApiController();
+    var apiResponse = api.getResourceByName(workspaceId, resourceName);
+
+    assertEquals(HttpStatusCode.valueOf(200), apiResponse.getStatusCode());
+    var resourceDesciption = apiResponse.getBody();
+    assertEquals(resourceAttributes, resourceDesciption.getResourceAttributes());
+    assertEquals(resourceMetadata, resourceDesciption.getMetadata());
+  }
+
+  @Test
+  void getResourceByName_returnsControlledResourceForNoWorkspaceAccessButHasResourceAccess() {
+    var workspaceId = UUID.randomUUID();
+    ControlledResource resource = mock();
+    var wsAccessException = new ForbiddenException("no workspace access");
+    doThrow(wsAccessException)
+        .when(workspaceService)
+        .validateWorkspaceAndAction(
+            userRequest, workspaceId, SamConstants.SamControlledResourceActions.READ_ACTION);
+
+    var resourceName = "test-resource-name";
+    when(resourceService.getResourceByName(workspaceId, resourceName)).thenReturn(resource);
+    var resourceId = UUID.randomUUID();
+    when(resource.getResourceId()).thenReturn(resourceId);
+    when(resource.getStewardshipType()).thenReturn(StewardshipType.CONTROLLED);
+    when(controlledResourceMetadataManager.validateControlledResourceAndAction(
+            userRequest,
+            workspaceId,
+            resourceId,
+            SamConstants.SamControlledResourceActions.READ_ACTION))
+        .thenReturn(resource);
+
+    ApiResourceMetadata resourceMetadata = mock();
+    when(resource.toApiMetadata()).thenReturn(resourceMetadata);
+    ApiResourceAttributesUnion resourceAttributes = mock();
+    when(resource.toApiAttributesUnion()).thenReturn(resourceAttributes);
+
+    var api = getApiController();
+    var apiResponse = api.getResourceByName(workspaceId, resourceName);
+
+    assertEquals(HttpStatusCode.valueOf(200), apiResponse.getStatusCode());
+    var resourceDesciption = apiResponse.getBody();
+    assertEquals(resourceAttributes, resourceDesciption.getResourceAttributes());
+    assertEquals(resourceMetadata, resourceDesciption.getMetadata());
+    verify(controlledResourceMetadataManager)
+        .validateControlledResourceAndAction(
+            userRequest,
+            workspaceId,
+            resourceId,
+            SamConstants.SamControlledResourceActions.READ_ACTION);
+  }
+
+  @Test
+  void getResourceByName_throwsOriginalWorkspaceExceptionForNoAccessToControlledResource() {
+    var workspaceId = UUID.randomUUID();
+    ControlledResource resource = mock();
+    var wsAccessException = new ForbiddenException("no workspace access");
+    doThrow(wsAccessException)
+        .when(workspaceService)
+        .validateWorkspaceAndAction(
+            userRequest, workspaceId, SamConstants.SamControlledResourceActions.READ_ACTION);
+    var resourceName = "test-resource-name";
+    when(resourceService.getResourceByName(workspaceId, resourceName)).thenReturn(resource);
+    var resourceId = UUID.randomUUID();
+    when(resource.getResourceId()).thenReturn(resourceId);
+    when(resource.getStewardshipType()).thenReturn(StewardshipType.CONTROLLED);
+    var resourceException = new ForbiddenException("no resource access");
+    doThrow(resourceException)
+        .when(controlledResourceMetadataManager)
+        .validateControlledResourceAndAction(
+            userRequest,
+            workspaceId,
+            resourceId,
+            SamConstants.SamControlledResourceActions.READ_ACTION);
+
+    var api = getApiController();
+    var thrownException =
+        assertThrows(
+            ForbiddenException.class, () -> api.getResourceByName(workspaceId, resourceName));
+
+    assertEquals(wsAccessException, thrownException);
+    verify(controlledResourceMetadataManager)
+        .validateControlledResourceAndAction(
+            userRequest,
+            workspaceId,
+            resourceId,
+            SamConstants.SamControlledResourceActions.READ_ACTION);
+  }
+
+  @Test
+  void getResourceByName_returnsReferencedResourceForNoWorkspaceAccessButHasResourceAccess() {
+    var workspaceId = UUID.randomUUID();
+    WsmResource resource = mock();
+    var wsAccessException = new ForbiddenException("no workspace access");
+    doThrow(wsAccessException)
+        .when(workspaceService)
+        .validateWorkspaceAndAction(
+            userRequest, workspaceId, SamConstants.SamControlledResourceActions.READ_ACTION);
+    var resourceName = "test-resource-name";
+    when(resourceService.getResourceByName(workspaceId, resourceName)).thenReturn(resource);
+    var resourceId = UUID.randomUUID();
+    when(resource.getResourceId()).thenReturn(resourceId);
+    when(resource.getStewardshipType()).thenReturn(StewardshipType.REFERENCED);
+    when(referencedResourceService.checkAccess(workspaceId, resourceId, userRequest))
+        .thenReturn(true);
+    ApiResourceMetadata resourceMetadata = mock();
+    when(resource.toApiMetadata()).thenReturn(resourceMetadata);
+    ApiResourceAttributesUnion resourceAttributes = mock();
+    when(resource.toApiAttributesUnion()).thenReturn(resourceAttributes);
+
+    var api = getApiController();
+    var apiResponse = api.getResourceByName(workspaceId, resourceName);
+
+    assertEquals(HttpStatusCode.valueOf(200), apiResponse.getStatusCode());
+    var resourceDesciption = apiResponse.getBody();
+    assertEquals(resourceAttributes, resourceDesciption.getResourceAttributes());
+    assertEquals(resourceMetadata, resourceDesciption.getMetadata());
+    verify(referencedResourceService).checkAccess(workspaceId, resourceId, userRequest);
+  }
+
+  @Test
+  void getResourceByName_throwsOriginalWorkspaceExceptionForNoAccessToReferencedResource() {
+    var workspaceId = UUID.randomUUID();
+    WsmResource resource = mock();
+    var wsAccessException = new ForbiddenException("no workspace access");
+    doThrow(wsAccessException)
+        .when(workspaceService)
+        .validateWorkspaceAndAction(
+            userRequest, workspaceId, SamConstants.SamControlledResourceActions.READ_ACTION);
+    var resourceName = "test-resource-name";
+    when(resourceService.getResourceByName(workspaceId, resourceName)).thenReturn(resource);
+    var resourceId = UUID.randomUUID();
+    when(resource.getResourceId()).thenReturn(resourceId);
+    when(resource.getStewardshipType()).thenReturn(StewardshipType.REFERENCED);
+    when(referencedResourceService.checkAccess(workspaceId, resourceId, userRequest))
+        .thenReturn(false);
+
+    var api = getApiController();
+    var thrownException =
+        assertThrows(
+            ForbiddenException.class, () -> api.getResourceByName(workspaceId, resourceName));
+
+    assertEquals(wsAccessException, thrownException);
+    verify(referencedResourceService).checkAccess(workspaceId, resourceId, userRequest);
+  }
+}


### PR DESCRIPTION
[WOR-1519](https://broadworkbench.atlassian.net/browse/WOR-1519)

Adds an endpoint to look up reasources by name, instead of enumerating all the resources in a workspace.
If the user does not have access to the entire workspace, access is checked for the specific resource instead.

Using the new endpoint, I was able to get leo to create apps a workspace with an auth domain, in a BEE.
With the first attempt, the app creation still failed, because of a new call to retrieve the workspace description. After pushing a version that didn't have that call, leo was able to successfully create the apps.
Fixing that call will require a separate solution.


[WOR-1519]: https://broadworkbench.atlassian.net/browse/WOR-1519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ