### PR TITLE
WOR-1594: Ensure that PHI workspaces can only be created in protected-data landing zones

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
@@ -52,6 +52,7 @@ public class PolicyValidator {
         validateWorkspaceConformsToProtectedDataPolicy(workspace, policies, userRequest));
     validationErrors.addAll(
         validateWorkspaceConformsToGroupPolicy(workspace, policies, userRequest));
+    validationErrors.addAll(validateRequiredPoliciesForDataTracking(policies));
 
     if (!validationErrors.isEmpty()) {
       throw new PolicyConflictException(validationErrors);
@@ -104,6 +105,17 @@ public class PolicyValidator {
           default -> validationErrors.add("Protected data policy only supported on Azure");
         }
       }
+    }
+    return validationErrors;
+  }
+
+
+  public List<String> validateRequiredPoliciesForDataTracking(TpsPaoGetResult policies){
+    var validationErrors = new ArrayList<String>();
+    var hasTrackedDataPolicy = TpsUtilities.containsDataTrackingPolicy(policies.getEffectiveAttributes());
+    var hasProtectedDataPolicy = TpsUtilities.containsProtectedDataPolicy(policies.getEffectiveAttributes());
+    if (hasTrackedDataPolicy && !hasProtectedDataPolicy) {
+      validationErrors.add("Data tracking requires a protected data policy");
     }
     return validationErrors;
   }

--- a/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/PolicyValidator.java
@@ -109,11 +109,12 @@ public class PolicyValidator {
     return validationErrors;
   }
 
-
-  public List<String> validateRequiredPoliciesForDataTracking(TpsPaoGetResult policies){
+  public List<String> validateRequiredPoliciesForDataTracking(TpsPaoGetResult policies) {
     var validationErrors = new ArrayList<String>();
-    var hasTrackedDataPolicy = TpsUtilities.containsDataTrackingPolicy(policies.getEffectiveAttributes());
-    var hasProtectedDataPolicy = TpsUtilities.containsProtectedDataPolicy(policies.getEffectiveAttributes());
+    var hasTrackedDataPolicy =
+        TpsUtilities.containsDataTrackingPolicy(policies.getEffectiveAttributes());
+    var hasProtectedDataPolicy =
+        TpsUtilities.containsProtectedDataPolicy(policies.getEffectiveAttributes());
     if (hasTrackedDataPolicy && !hasProtectedDataPolicy) {
       validationErrors.add("Data tracking requires a protected data policy");
     }

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsUtilities.java
@@ -11,6 +11,7 @@ public class TpsUtilities {
   public static final String GROUP_CONSTRAINT = "group-constraint";
   public static final String GROUP_KEY = "group";
   public static final String PROTECTED_DATA_POLICY_NAME = "protected-data";
+  public static final String DATA_TRACKING_POLICY_NAME = "data-tracking";
 
   public static List<String> getGroupConstraintsFromInputs(TpsPolicyInputs inputs) {
     List<String> result = new ArrayList<>();
@@ -80,5 +81,14 @@ public class TpsUtilities {
             input ->
                 input.getNamespace().equals(TERRA_NAMESPACE)
                     && input.getName().equals(PROTECTED_DATA_POLICY_NAME));
+  }
+
+  public static boolean containsDataTrackingPolicy(TpsPolicyInputs inputs) {
+    if (inputs == null) return false;
+    return inputs.getInputs().stream()
+        .anyMatch(
+            input ->
+                input.getNamespace().equals(TERRA_NAMESPACE)
+                    && input.getName().equals(DATA_TRACKING_POLICY_NAME));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
@@ -35,13 +35,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 
 @Unit
 @ExtendWith(MockitoExtension.class)
@@ -56,13 +54,13 @@ public class PolicyValidatorTest {
 
   @BeforeEach
   void setup() {
-    policyValidator = new PolicyValidator(
-        mockTpsApiDispatch,
-        mockLandingZoneApiDispatch,
-        mockAzureConfiguration,
-        mockResourceDao,
-        mockWorkspaceDao
-    );
+    policyValidator =
+        new PolicyValidator(
+            mockTpsApiDispatch,
+            mockLandingZoneApiDispatch,
+            mockAzureConfiguration,
+            mockResourceDao,
+            mockWorkspaceDao);
   }
 
   private static final AuthenticatedUserRequest userRequest =
@@ -276,39 +274,35 @@ public class PolicyValidatorTest {
   }
 
   @Test
-  void validateRequiredPoliciesForDataTracking_noErrorsWhenNoPolicy(){
+  void validateRequiredPoliciesForDataTracking_noErrorsWhenNoPolicy() {
     TpsPaoGetResult emptyPolicies = createPao();
-    PolicyValidator policyValidator = new PolicyValidator(mock(),mock(),mock(),mock(),mock());
     var errors = policyValidator.validateRequiredPoliciesForDataTracking(emptyPolicies);
     assertTrue(errors.isEmpty());
   }
-  
 
   @Test
-  void validateRequiredPoliciesForDataTracking_noErrorsWhenTrackedDataAndProtectedDataPolicies(){
-    TpsPaoGetResult policies = createPao(
+  void validateRequiredPoliciesForDataTracking_noErrorsWhenTrackedDataAndProtectedDataPolicies() {
+    TpsPaoGetResult policies =
+        createPao(
             new TpsPolicyInput()
                 .namespace(TpsUtilities.TERRA_NAMESPACE)
                 .name(TpsUtilities.PROTECTED_DATA_POLICY_NAME),
             new TpsPolicyInput()
                 .namespace(TpsUtilities.TERRA_NAMESPACE)
-                .name(TpsUtilities.DATA_TRACKING_POLICY_NAME)
-            );
-
-    PolicyValidator policyValidator = new PolicyValidator(mock(),mock(),mock(),mock(),mock());
+                .name(TpsUtilities.DATA_TRACKING_POLICY_NAME));
     var errors = policyValidator.validateRequiredPoliciesForDataTracking(policies);
     assertTrue(errors.isEmpty());
   }
 
   @Test
-  void validateRequiredPoliciesForDataTracking_reportsErrorForTrackingPolicyWithoutProtectedData(){
+  void validateRequiredPoliciesForDataTracking_reportsErrorForTrackingPolicyWithoutProtectedData() {
     TpsPaoGetResult trackedDataPolicy =
         createPao(
             new TpsPolicyInput()
                 .namespace(TpsUtilities.TERRA_NAMESPACE)
                 .name(TpsUtilities.DATA_TRACKING_POLICY_NAME));
 
-    PolicyValidator policyValidator = new PolicyValidator(mock(),mock(),mock(),mock(),mock());
+    PolicyValidator policyValidator = new PolicyValidator(mock(), mock(), mock(), mock(), mock());
     var errors = policyValidator.validateRequiredPoliciesForDataTracking(trackedDataPolicy);
     assertEquals(1, errors.size());
   }

--- a/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
@@ -274,7 +274,44 @@ public class PolicyValidatorTest {
             workspace, protectedDataPolicy, userRequest);
     assertTrue(results.isEmpty());
   }
+
+  @Test
+  void validateRequiredPoliciesForDataTracking_noErrorsWhenNoPolicy(){
+    TpsPaoGetResult emptyPolicies = createPao();
+    PolicyValidator policyValidator = new PolicyValidator(mock(),mock(),mock(),mock(),mock());
+    var errors = policyValidator.validateRequiredPoliciesForDataTracking(emptyPolicies);
+    assertTrue(errors.isEmpty());
+  }
   
+
+  @Test
+  void validateRequiredPoliciesForDataTracking_noErrorsWhenTrackedDataAndProtectedDataPolicies(){
+    TpsPaoGetResult policies = createPao(
+            new TpsPolicyInput()
+                .namespace(TpsUtilities.TERRA_NAMESPACE)
+                .name(TpsUtilities.PROTECTED_DATA_POLICY_NAME),
+            new TpsPolicyInput()
+                .namespace(TpsUtilities.TERRA_NAMESPACE)
+                .name(TpsUtilities.DATA_TRACKING_POLICY_NAME)
+            );
+
+    PolicyValidator policyValidator = new PolicyValidator(mock(),mock(),mock(),mock(),mock());
+    var errors = policyValidator.validateRequiredPoliciesForDataTracking(policies);
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void validateRequiredPoliciesForDataTracking_reportsErrorForTrackingPolicyWithoutProtectedData(){
+    TpsPaoGetResult trackedDataPolicy =
+        createPao(
+            new TpsPolicyInput()
+                .namespace(TpsUtilities.TERRA_NAMESPACE)
+                .name(TpsUtilities.DATA_TRACKING_POLICY_NAME));
+
+    PolicyValidator policyValidator = new PolicyValidator(mock(),mock(),mock(),mock(),mock());
+    var errors = policyValidator.validateRequiredPoliciesForDataTracking(trackedDataPolicy);
+    assertEquals(1, errors.size());
+  }
 
   private static TpsPaoGetResult createPao(TpsPolicyInput... inputs) {
     TpsPolicyInputs tpsPolicyInputs = new TpsPolicyInputs().inputs(Arrays.stream(inputs).toList());

--- a/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
@@ -6,9 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import bio.terra.policy.model.TpsComponent;
 import bio.terra.policy.model.TpsObjectType;
@@ -17,7 +15,7 @@ import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
-import bio.terra.workspace.common.BaseSpringBootUnitTest;
+import bio.terra.workspace.common.annotations.Unit;
 import bio.terra.workspace.common.fixtures.ControlledAzureResourceFixtures;
 import bio.terra.workspace.common.fixtures.ControlledGcpResourceFixtures;
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
@@ -37,17 +35,35 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class PolicyValidatorTest extends BaseSpringBootUnitTest {
-  @Autowired private PolicyValidator policyValidator;
 
-  @MockBean private ResourceDao mockResourceDao;
-  @MockBean private LandingZoneApiDispatch mockLandingZoneApiDispatch;
-  @MockBean private WorkspaceDao mockWorkspaceDao;
-  @MockBean private AzureConfiguration mockAzureConfiguration;
+@Unit
+@ExtendWith(MockitoExtension.class)
+public class PolicyValidatorTest {
+
+  @Mock private ResourceDao mockResourceDao;
+  @Mock private LandingZoneApiDispatch mockLandingZoneApiDispatch;
+  @Mock private WorkspaceDao mockWorkspaceDao;
+  @Mock private AzureConfiguration mockAzureConfiguration;
+  @Mock private TpsApiDispatch mockTpsApiDispatch;
+  private PolicyValidator policyValidator;
+
+  @BeforeEach
+  void setup() {
+    policyValidator = new PolicyValidator(
+        mockTpsApiDispatch,
+        mockLandingZoneApiDispatch,
+        mockAzureConfiguration,
+        mockResourceDao,
+        mockWorkspaceDao
+    );
+  }
 
   private static final AuthenticatedUserRequest userRequest =
       new AuthenticatedUserRequest("email", "id", Optional.of("token"));
@@ -102,13 +118,13 @@ public class PolicyValidatorTest extends BaseSpringBootUnitTest {
 
     when(mockWorkspaceDao.listCloudPlatforms(workspace.workspaceId()))
         .thenReturn(List.of(CloudPlatform.AZURE, CloudPlatform.GCP));
-    when(mockTpsApiDispatch().listValidRegionsForPao(any(), eq(CloudPlatform.GCP)))
+    when(mockTpsApiDispatch.listValidRegionsForPao(any(), eq(CloudPlatform.GCP)))
         .thenReturn(List.of(gcpResource.getRegion()));
     when(mockResourceDao.listControlledResources(workspace.workspaceId(), CloudPlatform.GCP))
         .thenReturn(List.of(gcpResource));
     when(mockLandingZoneApiDispatch.getLandingZoneRegionForWorkspaceUsingWsmToken(workspace))
         .thenReturn(azureResource.getRegion());
-    when(mockTpsApiDispatch().listValidRegionsForPao(any(), eq(CloudPlatform.AZURE)))
+    when(mockTpsApiDispatch.listValidRegionsForPao(any(), eq(CloudPlatform.AZURE)))
         .thenReturn(List.of(azureResource.getRegion()));
     when(mockResourceDao.listControlledResources(workspace.workspaceId(), CloudPlatform.AZURE))
         .thenReturn(List.of(azureResource));
@@ -133,13 +149,13 @@ public class PolicyValidatorTest extends BaseSpringBootUnitTest {
 
     when(mockWorkspaceDao.listCloudPlatforms(workspace.workspaceId()))
         .thenReturn(List.of(CloudPlatform.AZURE, CloudPlatform.GCP));
-    when(mockTpsApiDispatch().listValidRegionsForPao(any(), eq(CloudPlatform.GCP)))
+    when(mockTpsApiDispatch.listValidRegionsForPao(any(), eq(CloudPlatform.GCP)))
         .thenReturn(List.of(gcpResource.getRegion()));
     when(mockResourceDao.listControlledResources(workspace.workspaceId(), CloudPlatform.GCP))
         .thenReturn(List.of(gcpResource));
     when(mockLandingZoneApiDispatch.getLandingZoneRegionForWorkspaceUsingWsmToken(workspace))
         .thenReturn(azureResource.getRegion());
-    when(mockTpsApiDispatch().listValidRegionsForPao(any(), eq(CloudPlatform.AZURE)))
+    when(mockTpsApiDispatch.listValidRegionsForPao(any(), eq(CloudPlatform.AZURE)))
         .thenReturn(List.of(azureResource.getRegion()));
     when(mockResourceDao.listControlledResources(workspace.workspaceId(), CloudPlatform.AZURE))
         .thenReturn(List.of(azureResource, azureResourceWrongRegion));
@@ -160,7 +176,7 @@ public class PolicyValidatorTest extends BaseSpringBootUnitTest {
         .thenReturn(List.of(CloudPlatform.AZURE));
     when(mockLandingZoneApiDispatch.getLandingZoneRegionForWorkspaceUsingWsmToken(workspace))
         .thenReturn("wrongRegion");
-    when(mockTpsApiDispatch().listValidRegionsForPao(any(), eq(CloudPlatform.AZURE)))
+    when(mockTpsApiDispatch.listValidRegionsForPao(any(), eq(CloudPlatform.AZURE)))
         .thenReturn(List.of("rightRegion"));
 
     List<String> results =
@@ -258,6 +274,7 @@ public class PolicyValidatorTest extends BaseSpringBootUnitTest {
             workspace, protectedDataPolicy, userRequest);
     assertTrue(results.isEmpty());
   }
+  
 
   private static TpsPaoGetResult createPao(TpsPolicyInput... inputs) {
     TpsPolicyInputs tpsPolicyInputs = new TpsPolicyInputs().inputs(Arrays.stream(inputs).toList());

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/azure/ValidateLandingZoneAgainstPolicyStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/azure/ValidateLandingZoneAgainstPolicyStepTest.java
@@ -1,0 +1,170 @@
+package bio.terra.workspace.service.workspace.flight.azure;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.policy.model.*;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
+import bio.terra.workspace.common.annotations.Unit;
+import bio.terra.workspace.generated.model.ApiAzureLandingZone;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.policy.PolicyValidator;
+import bio.terra.workspace.service.policy.TpsApiDispatch;
+import bio.terra.workspace.service.policy.TpsUtilities;
+import bio.terra.workspace.service.resource.controlled.exception.RegionNotAllowedException;
+import bio.terra.workspace.service.resource.exception.PolicyConflictException;
+import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.flight.cloud.azure.ValidateLandingZoneAgainstPolicyStep;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Unit
+@ExtendWith(MockitoExtension.class)
+public class ValidateLandingZoneAgainstPolicyStepTest {
+
+  @Mock LandingZoneApiDispatch landingZoneApiDispatch;
+  @Mock AuthenticatedUserRequest userRequest;
+  @Mock TpsApiDispatch tpsApiDispatch;
+  UUID workspaceId = UUID.randomUUID();
+  @Mock WorkspaceService workspaceService;
+  @Mock PolicyValidator policyValidator;
+  ValidateLandingZoneAgainstPolicyStep step;
+  final String token = "test-token";
+
+  @BeforeEach
+  void setup() {
+    when(userRequest.getRequiredToken()).thenReturn(token);
+    step =
+        new ValidateLandingZoneAgainstPolicyStep(
+            landingZoneApiDispatch,
+            userRequest,
+            tpsApiDispatch,
+            workspaceId,
+            workspaceService,
+            policyValidator);
+  }
+
+  @Test
+  void doStep_happyPathNoDataPolicies() throws Exception {
+    var landingZoneId = UUID.randomUUID();
+    Workspace workspace = mock();
+    when(workspaceService.getWorkspace(workspaceId)).thenReturn(workspace);
+    when(landingZoneApiDispatch.getLandingZoneId(new BearerToken(token), workspace))
+        .thenReturn(landingZoneId);
+    // region validation is done with a static method that makes the external api calls, so we can't
+    // mock it directly
+    when(landingZoneApiDispatch.getLandingZoneRegionUsingWsmToken(landingZoneId))
+        .thenReturn("test-region");
+    when(tpsApiDispatch.listValidRegions(workspaceId, CloudPlatform.AZURE))
+        .thenReturn(Arrays.asList("test-region"));
+    var workspacePao = createPao();
+    when(tpsApiDispatch.getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE))
+        .thenReturn(workspacePao);
+    when(tpsApiDispatch.getPao(workspaceId)).thenReturn(workspacePao);
+    var result = step.doStep(mock());
+    assertEquals(StepResult.getStepResultSuccess(), result);
+  }
+
+  @Test
+  void doStep_NoMatchingRegion() throws Exception {
+    var landingZoneId = UUID.randomUUID();
+    Workspace workspace = mock();
+    when(workspaceService.getWorkspace(workspaceId)).thenReturn(workspace);
+    when(landingZoneApiDispatch.getLandingZoneId(new BearerToken(token), workspace))
+        .thenReturn(landingZoneId);
+    when(landingZoneApiDispatch.getLandingZoneRegionUsingWsmToken(landingZoneId))
+        .thenReturn("test-region");
+    when(tpsApiDispatch.listValidRegions(workspaceId, CloudPlatform.AZURE))
+        .thenReturn(Arrays.asList("different-test-region"));
+    var workspacePao = createPao();
+    when(tpsApiDispatch.getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE))
+        .thenReturn(workspacePao);
+    assertThrows(RegionNotAllowedException.class, () -> step.doStep(mock()));
+  }
+
+  @Test
+  void doStep_validatesProtectedDataLandingZone() throws Exception {
+    var landingZoneId = UUID.randomUUID();
+    Workspace workspace = mock();
+
+    when(workspaceService.getWorkspace(workspaceId)).thenReturn(workspace);
+    when(landingZoneApiDispatch.getLandingZoneId(new BearerToken(token), workspace))
+        .thenReturn(landingZoneId);
+    when(landingZoneApiDispatch.getLandingZoneRegionUsingWsmToken(landingZoneId))
+        .thenReturn("test-region");
+    when(tpsApiDispatch.listValidRegions(workspaceId, CloudPlatform.AZURE))
+        .thenReturn(Arrays.asList("test-region"));
+    var workspacePao =
+        createPao(
+            new TpsPolicyInput()
+                .namespace(TpsUtilities.TERRA_NAMESPACE)
+                .name(TpsUtilities.PROTECTED_DATA_POLICY_NAME));
+    when(tpsApiDispatch.getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE))
+        .thenReturn(workspacePao);
+    when(tpsApiDispatch.getPao(workspaceId)).thenReturn(workspacePao);
+    ApiAzureLandingZone landingZone = mock();
+    when(landingZoneApiDispatch.getAzureLandingZone(new BearerToken(token), landingZoneId))
+        .thenReturn(landingZone);
+    when(policyValidator.validateLandingZoneSupportsProtectedData(landingZone))
+        .thenReturn(List.of());
+
+    var result = step.doStep(mock());
+    assertEquals(StepResult.getStepResultSuccess(), result);
+  }
+
+  @Test
+  void doStep_failsOnLZIncompatibleWithPolicy() throws Exception {
+    var landingZoneId = UUID.randomUUID();
+    Workspace workspace = mock();
+    when(workspaceService.getWorkspace(workspaceId)).thenReturn(workspace);
+    when(landingZoneApiDispatch.getLandingZoneId(new BearerToken(token), workspace))
+        .thenReturn(landingZoneId);
+    when(landingZoneApiDispatch.getLandingZoneRegionUsingWsmToken(landingZoneId))
+        .thenReturn("test-region");
+    when(tpsApiDispatch.listValidRegions(workspaceId, CloudPlatform.AZURE))
+        .thenReturn(Arrays.asList("test-region"));
+    var workspacePao =
+        createPao(
+            new TpsPolicyInput()
+                .namespace(TpsUtilities.TERRA_NAMESPACE)
+                .name(TpsUtilities.PROTECTED_DATA_POLICY_NAME));
+    when(tpsApiDispatch.getOrCreatePao(workspaceId, TpsComponent.WSM, TpsObjectType.WORKSPACE))
+        .thenReturn(workspacePao);
+    when(tpsApiDispatch.getPao(workspaceId)).thenReturn(workspacePao);
+    ApiAzureLandingZone landingZone = mock();
+    when(landingZoneApiDispatch.getAzureLandingZone(new BearerToken(token), landingZoneId))
+        .thenReturn(landingZone);
+    var validationErrors = List.of("invalid policy");
+    when(policyValidator.validateLandingZoneSupportsProtectedData(landingZone))
+        .thenReturn(validationErrors);
+
+    var result = step.doStep(mock());
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+    assertTrue(result.getException().isPresent());
+    assertInstanceOf(PolicyConflictException.class, result.getException().get());
+  }
+
+  private TpsPaoGetResult createPao(TpsPolicyInput... inputs) {
+    TpsPolicyInputs tpsPolicyInputs = new TpsPolicyInputs().inputs(Arrays.stream(inputs).toList());
+    return new TpsPaoGetResult()
+        .component(TpsComponent.WSM)
+        .objectType(TpsObjectType.WORKSPACE)
+        .objectId(workspaceId)
+        .sourcesObjectIds(Collections.emptyList())
+        .attributes(tpsPolicyInputs)
+        .effectiveAttributes(tpsPolicyInputs);
+  }
+}


### PR DESCRIPTION
[WOR-1594](https://broadworkbench.atlassian.net/browse/WOR-1594)

* Adds a check to require a `protected-data` if the `data-tracking` policy is present.
* Adds unit tests for step that previously had none
* Change existing spring-boot test suite to normal unit test 

[WOR-1594]: https://broadworkbench.atlassian.net/browse/WOR-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ