### PR TITLE
AJ-1705: Adjust verification to match latest pact.

### DIFF
--- a/service/src/test/java/bio/terra/workspace/pact/WdsContractVerificationTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/WdsContractVerificationTest.java
@@ -52,6 +52,7 @@ import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.azure.core.management.Region;
+import com.google.common.collect.ImmutableMap;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.List;
@@ -287,6 +288,11 @@ public class WdsContractVerificationTest extends BaseSpringBootUnitTestMocks {
                                     .workspaceUuid(workspaceUuid)
                                     .name("snapshotName")
                                     .cloningInstructions(CloningInstructions.COPY_REFERENCE)
+                                    .properties(
+                                        new ImmutableMap.Builder<String, String>()
+                                            .put("key", "purpose")
+                                            .put("value", "policy")
+                                            .build())
                                     .createdByEmail("snapshot.creator@e.mail")
                                     .build())
                             .build())


### PR DESCRIPTION
Adjusts the pact setup to produce a response that matches the latest pact changes made in https://github.com/DataBiosphere/terra-workspace-data-service/pull/696