### PR TITLE
[AJ-1705] Fix enumerate snapshots response for WDS Pact

### DIFF
--- a/service/src/test/java/bio/terra/workspace/pact/WdsContractVerificationTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/WdsContractVerificationTest.java
@@ -52,7 +52,6 @@ import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
 import bio.terra.workspace.service.workspace.model.WorkspaceStage;
 import com.azure.core.management.Region;
-import com.google.common.collect.ImmutableMap;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.List;
@@ -288,11 +287,7 @@ public class WdsContractVerificationTest extends BaseSpringBootUnitTestMocks {
                                     .workspaceUuid(workspaceUuid)
                                     .name("snapshotName")
                                     .cloningInstructions(CloningInstructions.COPY_REFERENCE)
-                                    .properties(
-                                        new ImmutableMap.Builder<String, String>()
-                                            .put("key", "purpose")
-                                            .put("value", "policy")
-                                            .build())
+                                    .properties(Map.of("purpose", "policy"))
                                     .createdByEmail("snapshot.creator@e.mail")
                                     .build())
                             .build())


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1705

Trying to get the WDS / WSM Pact verified...

We're seeing errors like:
```
      "mismatches": [
        {
          "attribute": "body",
          "description": "Expected [{\"key\":\"key\",\"value\":\"purpose\"}, {\"key\":\"value\",\"value\":\"policy\"}] to have maximum 1",
          "diff": null,
          "identifier": "$.resources.0.metadata.properties"
        },
        {
          "attribute": "body",
          "description": "Expected [{\"key\":\"key\",\"value\":\"purpose\"}, {\"key\":\"value\",\"value\":\"policy\"}] to have maximum 1",
          "diff": null,
          "identifier": "$.resources.1.metadata.properties"
        },
        {
          "attribute": "body",
          "description": "Expected [{\"key\":\"key\",\"value\":\"purpose\"}, {\"key\":\"value\",\"value\":\"policy\"}] to have maximum 1",
          "diff": null,
          "identifier": "$.resources.2.metadata.properties"
        }
      ],
```

It looks like that's originating from this mock response.

The current properties value looks like it was the result of confusion due to properties being serialized as an array of key/value objects in the API response.