### PR TITLE
[WOR-1637] Handle not found exceptions

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package bio.terra.workspace.app.controller;
 
 import bio.terra.common.exception.ErrorReportException;
+import bio.terra.common.exception.NotFoundException;
 import bio.terra.workspace.generated.model.ApiErrorReport;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 /**
  * This module provides a top-level exception handler for controllers. All exceptions that rise
@@ -26,6 +28,13 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
   private final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+  // -- Handle both generic spring 404s and WSM specific 404s
+  @ExceptionHandler({NoResourceFoundException.class, NotFoundException.class})
+  public ResponseEntity<ApiErrorReport> noResourceFoundHandler() {
+    var report = new ApiErrorReport().message("Not found").statusCode(HttpStatus.NOT_FOUND.value());
+    return new ResponseEntity<>(report, HttpStatus.NOT_FOUND);
+  }
 
   // -- Error Report - one of our exceptions --
   @ExceptionHandler(ErrorReportException.class)


### PR DESCRIPTION
404s in WSM are not handled gracefully; they can either spawn a 500 (due to not handling the generic NoResourceFoundException exception type in the global exception handler when non-api matching requests are made like wsm_host/api/foo) or a 404 which emits a ton of unneeded logging (like when a matching URL is hit but a specific workspace resource is not found)