### PR TITLE
[DDO-3622] Use new IAP and Sherlock URL

### DIFF
--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -44,9 +44,9 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
           token_format: 'id_token'
-          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false
@@ -62,7 +62,7 @@ jobs:
           set -exo pipefail
           
           ENV="staging"
-          SHERLOCK_URL="https://sherlock.dsp-devops.broadinstitute.org"
+          SHERLOCK_URL="https://sherlock.dsp-devops-prod.broadinstitute.org"
 
           OLD_TERRA_HELMFILE_DIR="integration/terra-helmfile"
           VERSIONS_FILE="${OLD_TERRA_HELMFILE_DIR}/versions/app/${ENV}.yaml"


### PR DESCRIPTION
Unfortunately another instance of this workflow failing (it was also impacted by the Sherlock v3 migration not too long ago) -- this seems to be one of the only IAP/Sherlock-accessors that DevOps doesn't have direct control over. My bad for not preparing a PR here in advance, I always forget that this exists until I'm trying to clean-up after off-hours maintenance. (It seems this repo's automation has automatically @'ed people for review off-hours -- sorry!)

I had a successful run [here](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/8871845520/job/24355698223) (at least, it got past the IAP change). The first attempt did fail, I tweaked config on our end and re-ran.