### PR TITLE
[WOR-1279] Bump default AzureMonitorLinuxAgent extension version to latest

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -168,7 +168,7 @@ workspace:
     sas-token-start-time-minutes-offset: 15
     sas-token-expiry-time-minutes-offset: 60
     sas-token-expiry-time-maximum-minutes-offset: 1440
-    azure-monitor-linux-agent-version: "1.28"
+    azure-monitor-linux-agent-version: "1.31"
     cors-allowed-origins:
     protected-data-landing-zone-defs: ["ProtectedDataResourcesFactory"]
     azure-database-util-image: "us.gcr.io/broad-dsp-gcr-public/azure-database-utils:${version.gitHash}"


### PR DESCRIPTION
We should be up to date with the latest version of the Azure linux monitor [extension](https://learn.microsoft.com/en-us/azure/azure-monitor/agents/azure-monitor-agent-extension-versions). 