### PR TITLE
[AJ-1849] Apply auth domain updates before policy updates

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
+++ b/service/src/main/java/bio/terra/workspace/service/workspace/WorkspaceService.java
@@ -937,6 +937,10 @@ public class WorkspaceService {
     if (tpsUpdateMode == TpsUpdateMode.DRY_RUN) {
       return dryRun;
     } else {
+      // Any necessary auth domain updates must be successfully applied *before* recording policies
+      // in TPS.
+      patchWorkspaceAuthDomain(workspaceId, userRequest, paoBeforeUpdate, dryRun);
+
       var updateResult =
           Rethrow.onInterrupted(
               () -> tpsApiDispatch.linkPao(workspaceId, sourcePaoId.getObjectId(), tpsUpdateMode),
@@ -960,8 +964,6 @@ public class WorkspaceService {
             sourcePaoId.getObjectId(),
             userRequest.getEmail());
       }
-
-      patchWorkspaceAuthDomain(workspaceId, userRequest, paoBeforeUpdate, dryRun);
 
       return updateResult;
     }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1849

Currently, it's possible to get a workspace into a state where it has a group constraint policy but no matching auth domain. This means that the group constraint policy is not enforced and potentially allows controlled access data to be viewed by users that shouldn't have access.

Steps to reproduce:

- Attempt to import a TDR snapshot that has a data access control (group constraint policy / auth domain) into a workspace in which you only have writer permission.

- The import should fail with an error like:

> Error processing data import: 403 FORBIDDEN "403 Forbidden: "{"causes":[],"exceptionClass":"bio.terra.workspace.client.ApiException","message":"{\"message\":\"Error adding group to auth domain in Sam: You may not perform any of [UPDATE_AUTH_DOMAIN] on workspace/8d8bf7e2-894e-410b-aae1-6a45e71642f3\",\"statusCode\":403,\"causes\":[]}","source":"rawls","stackTrace":[]}""

At this point, the workspace has a group constraint policy but no matching auth domain.

> Retry the import.

The import succeeds. The workspace now contains controlled access data but it has no access controls.



The problem here is that Workspace Manager links the snapshot and workspace policies before it applies auth domain updates to the workspace. Thus, it may end up applying a policy that cannot be enforced.

This switches those two operations, so that if the auth domain update fails, the policy is not applied.