### PR TITLE
[WX-1593] Update Sam Client

### DIFF
--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -35,8 +35,9 @@ dependencies {
 
   // Get stairway via TCL
   implementation("bio.terra:terra-common-lib:1.1.11-SNAPSHOT")
-  // sam is not semantically versioned so force the version here
-  implementation force: true, group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.229"
+
+  // sam
+  implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.229"
   implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.198.42-SNAPSHOT"
 
   // Cloud Resource Library

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -36,7 +36,7 @@ dependencies {
   // Get stairway via TCL
   implementation("bio.terra:terra-common-lib:1.1.11-SNAPSHOT")
   // sam is not semantically versioned so force the version here
-  implementation force: true, group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "0.1-73bc2d1"
+  implementation force: true, group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.229"
   implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.198.42-SNAPSHOT"
 
   // Cloud Resource Library

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -49,15 +49,7 @@ import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
-import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipRequest;
-import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntryV2;
-import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
-import org.broadinstitute.dsde.workbench.client.sam.model.FullyQualifiedResourceId;
-import org.broadinstitute.dsde.workbench.client.sam.model.GetOrCreatePetManagedIdentityRequest;
-import org.broadinstitute.dsde.workbench.client.sam.model.PolicyIdentifiers;
-import org.broadinstitute.dsde.workbench.client.sam.model.UserIdInfo;
-import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
-import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.broadinstitute.dsde.workbench.client.sam.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -207,10 +199,10 @@ public class SamService {
   public String getOrCreateUserManagedIdentityForUser(
       String userEmail, String subscriptionId, String tenantId, String managedResourceGroupId)
       throws InterruptedException {
-    AzureApi azureApi = samAzureApi(getWsmServiceAccountToken());
 
-    GetOrCreatePetManagedIdentityRequest request =
-        new GetOrCreatePetManagedIdentityRequest()
+    AzureApi azureApi = samAzureApi(getWsmServiceAccountToken());
+    GetOrCreateManagedIdentityRequest request =
+        new GetOrCreateManagedIdentityRequest()
             .subscriptionId(subscriptionId)
             .tenantId(tenantId)
             .managedResourceGroupName(managedResourceGroupId);


### PR DESCRIPTION
Bump the version of the Sam java client to `v0.0.229`.

Necessary to take advantage of some new endpoints (`actionManagedIdentity`) in a future branch. 