### PR TITLE
[WOR-1667] Cache Sam responses when creating SAS tokens

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -214,7 +214,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     // are determined below.
     Workspace workspace =
         sasTokenWorkspaceCache.computeIfAbsent(
-            new WorkspaceCacheKey(userRequest, workspaceUuid),
+            new WorkspaceCacheKey(userRequest.getSubjectId(), workspaceUuid),
             v ->
                 workspaceService.validateWorkspaceAndAction(
                     userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.READ));
@@ -1002,4 +1002,4 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
   }
 }
 
-record WorkspaceCacheKey(AuthenticatedUserRequest userRequest, UUID workspaceUuid) {}
+record WorkspaceCacheKey(String userSubjectId, UUID workspaceUuid) {}

--- a/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/ControlledAzureResourceApiController.java
@@ -52,8 +52,12 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +75,7 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
   private final AzureStorageAccessService azureControlledStorageResourceService;
   private final LandingZoneApiDispatch landingZoneApiDispatch;
   private final WsmResourceService wsmResourceService;
+  private final Map<WorkspaceCacheKey, Workspace> sasTokenWorkspaceCache;
 
   @Autowired
   public ControlledAzureResourceApiController(
@@ -103,6 +108,8 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     this.azureControlledStorageResourceService = azureControlledStorageResourceService;
     this.landingZoneApiDispatch = landingZoneApiDispatch;
     this.wsmResourceService = wsmResourceService;
+    this.sasTokenWorkspaceCache =
+        Collections.synchronizedMap(new PassiveExpiringMap<>(10, TimeUnit.SECONDS));
   }
 
   @WithSpan
@@ -206,8 +213,11 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     // You must have at least READ on the workspace to use this method. Actual permissions
     // are determined below.
     Workspace workspace =
-        workspaceService.validateWorkspaceAndAction(
-            userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.READ);
+        sasTokenWorkspaceCache.computeIfAbsent(
+            new WorkspaceCacheKey(userRequest, workspaceUuid),
+            v ->
+                workspaceService.validateWorkspaceAndAction(
+                    userRequest, workspaceUuid, SamConstants.SamWorkspaceAction.READ));
     workspaceService.validateWorkspaceAndContextState(workspace, CloudPlatform.AZURE);
 
     ControllerValidationUtils.validateIpAddressRange(sasIpRange);
@@ -991,3 +1001,5 @@ public class ControlledAzureResourceApiController extends ControlledResourceCont
     return workspace;
   }
 }
+
+record WorkspaceCacheKey(AuthenticatedUserRequest userRequest, UUID workspaceUuid) {}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/AzureStorageAccessService.java
@@ -65,10 +65,9 @@ public class AzureStorageAccessService {
   private final WorkspaceService workspaceService;
   private final Map<StorageAccountCoordinates, StorageData> storageAccountCache;
   private final Map<String, SamUser> samUserCache;
-  private final Map<StorageContainerResourceCacheKey, ControlledAzureStorageContainerResource>
+  private final Map<StorageContainerCacheKey, ControlledAzureStorageContainerResource>
       storageContainerResourceCache;
-  private final Map<StorageContainerPermissionsCacheKey, List<String>>
-      storageContainerPermissionsCache;
+  private final Map<StorageContainerCacheKey, List<String>> storageContainerPermissionsCache;
 
   @Autowired
   public AzureStorageAccessService(
@@ -104,9 +103,7 @@ public class AzureStorageAccessService {
       String samResourceName,
       String desiredPermissions) {
     List<String> containerActions;
-    var cacheKey =
-        new StorageContainerPermissionsCacheKey(
-            userRequest.getSubjectId(), storageContainerUuid, samResourceName);
+    var cacheKey = new StorageContainerCacheKey(userRequest.getSubjectId(), storageContainerUuid);
     if (storageContainerPermissionsCache.containsKey(cacheKey)) {
       containerActions = storageContainerPermissionsCache.get(cacheKey);
     } else {
@@ -350,8 +347,7 @@ public class AzureStorageAccessService {
     // TODO this is redundant with what we're doing for storage account keys, they should be unified
     final ControlledAzureStorageContainerResource storageContainerResource =
         storageContainerResourceCache.computeIfAbsent(
-            new StorageContainerResourceCacheKey(
-                userRequest.getSubjectId(), workspaceUuid, storageContainerUuid),
+            new StorageContainerCacheKey(userRequest.getSubjectId(), storageContainerUuid),
             v ->
                 controlledResourceMetadataManager
                     .validateControlledResourceAndAction(
@@ -402,8 +398,4 @@ public class AzureStorageAccessService {
   }
 }
 
-record StorageContainerResourceCacheKey(
-    String userSubjectId, UUID workspaceUuid, UUID storageContainerId) {}
-
-record StorageContainerPermissionsCacheKey(
-    String userSubjectId, UUID storageContainerUuid, String samResourceName) {}
+record StorageContainerCacheKey(String userSubjectId, UUID storageContainerId) {}


### PR DESCRIPTION
Ticket: [WOR-1667](https://broadworkbench.atlassian.net/browse/WOR-1667)
* The SAS token API receives heavy bursts of traffic that have brought WSM down before. This PR introduces caching for all four Sam calls in this code path to alleviate the load that these heavy bursts of traffic place on WSM and Sam.
    * A fix for this performance issue was initially attempted with https://broadworkbench.atlassian.net/browse/WOR-1335, but that was rolled back due to failures in our tests. This PR takes a more targeted approach that will have a smaller impact on upstream services.

[WOR-1667]: https://broadworkbench.atlassian.net/browse/WOR-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ