### PR TITLE
[WX-1593] Assign Action Managed Identities to Batch Pool

### DIFF
--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -37,7 +37,7 @@ dependencies {
   implementation("bio.terra:terra-common-lib:1.1.11-SNAPSHOT")
 
   // sam
-  implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.229"
+  implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.234"
   implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.198.42-SNAPSHOT"
 
   // Cloud Resource Library

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -224,8 +224,8 @@ public class SamService {
    *     resourceID is equivalent to the billingProfileID (a.k.a. SpendProfileId).
    * @param request The request from user asking for the identity. Used to impersonate the user when
    *     querying Sam.
-   * @return Display name of the Action Identity, if one exists. Might look something like
-   *     "586d120b-c4c-pull_image"
+   * @return Fully qualified name of the identity. Might look something like
+   *     /subscriptions/62b22893-6bc1-46d9-8a90-806bb3cce3c9/resourcegroups/mrg-terra-dev-previ-20240104102401/providers/Microsoft.ManagedIdentity/userAssignedIdentities/586d120b-c4c-pull_image
    */
   public Optional<String> getActionIdentityForUser(
       String samResourceType,

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -241,10 +241,19 @@ public class SamService {
       ActionManagedIdentityResponse resp =
           SamRetry.retry(
               () -> azureApi.getActionManagedIdentity(samResourceType, samResourceId, samAction));
-      return Optional.ofNullable(resp.getDisplayName());
+      return Optional.ofNullable(resp.getObjectId());
     } catch (ApiException apiException) {
+      String infoStringTemplate = "Billing Profile: %s, Resource Type: %s, Action: %s";
+      if (apiException.getCode() == 404) {
+        logger.info(
+            "Action identity not found in Sam for "
+                + String.format(infoStringTemplate, samResourceId, samResourceType, samAction));
+        return Optional.empty();
+      }
       throw SamExceptionFactory.create(
-          "Error fetching action managed identity from Sam.", apiException);
+          "Error fetching action managed identity from Sam."
+              + String.format(infoStringTemplate, samResourceId, samResourceType, samAction),
+          apiException);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -238,9 +238,9 @@ public class SamService {
           SamRetry.retry(
               () ->
                   azureApi.getActionManagedIdentity(
-                      SamConstants.SamActionManagedIdentity.RESOURCE_TYPE,
+                      SamConstants.SamResource.PRIVATE_AZURE_CONTAINER_REGISTRY,
                       billingProfileId,
-                      SamConstants.SamActionManagedIdentity.ACTION));
+                      SamConstants.SamPrivateAzureContainerRegistryAction.PULL_IMAGE));
       return Optional.ofNullable(resp.getDisplayName());
     } catch (ApiException apiException) {
       throw SamExceptionFactory.create(

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -228,23 +228,23 @@ public class SamService {
    *     "586d120b-c4c-pull_image"
    */
   public Optional<String> getActionIdentityForUser(
-          String billingProfileId, AuthenticatedUserRequest request) throws InterruptedException {
+      String billingProfileId, AuthenticatedUserRequest request) throws InterruptedException {
 
     String token = getSamUser(request).getBearerToken().getToken();
     AzureApi azureApi = samAzureApi(token);
 
     try {
       ActionManagedIdentityResponse resp =
-              SamRetry.retry(
-                      () ->
-                              azureApi.getActionManagedIdentity(
-                                      SamConstants.SamActionManagedIdentity.RESOURCE_TYPE,
-                                      billingProfileId,
-                                      SamConstants.SamActionManagedIdentity.ACTION));
+          SamRetry.retry(
+              () ->
+                  azureApi.getActionManagedIdentity(
+                      SamConstants.SamActionManagedIdentity.RESOURCE_TYPE,
+                      billingProfileId,
+                      SamConstants.SamActionManagedIdentity.ACTION));
       return Optional.ofNullable(resp.getDisplayName());
     } catch (ApiException apiException) {
       throw SamExceptionFactory.create(
-              "Error fetching action managed identity from Sam.", apiException);
+          "Error fetching action managed identity from Sam.", apiException);
     }
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
@@ -12,6 +12,8 @@ public class SamConstants {
     public static final String CONTROLLED_APPLICATION_PRIVATE =
         "controlled-application-private-workspace-resource";
     public static final String SPEND_PROFILE = "spend-profile";
+    public static final String PRIVATE_AZURE_CONTAINER_REGISTRY =
+        "private_azure_container_registry";
 
     private SamResource() {}
   }
@@ -52,10 +54,9 @@ public class SamConstants {
     private SamSpendProfileAction() {}
   }
 
-  public static class SamActionManagedIdentity {
-    public static final String RESOURCE_TYPE = "private_azure_container_registry";
-    public static final String ACTION = "pull_image";
+  public static class SamPrivateAzureContainerRegistryAction {
+    public static final String PULL_IMAGE = "pull_image";
 
-    private SamActionManagedIdentity() {}
+    private SamPrivateAzureContainerRegistryAction() {}
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/model/SamConstants.java
@@ -51,4 +51,11 @@ public class SamConstants {
 
     private SamSpendProfileAction() {}
   }
+
+  public static class SamActionManagedIdentity {
+    public static final String RESOURCE_TYPE = "private_azure_container_registry";
+    public static final String ACTION = "pull_image";
+
+    private SamActionManagedIdentity() {}
+  }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
@@ -11,7 +11,7 @@ import bio.terra.workspace.generated.model.ApiAzureBatchPoolResource;
 import bio.terra.workspace.generated.model.ApiResourceAttributesUnion;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.resource.AzureResourceValidationUtils;
-import bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool.model.BatchPoolUserAssignedManagedIdentity;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetActionManagedIdentityStep;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetPetManagedIdentityStep;
 import bio.terra.workspace.service.resource.controlled.flight.create.CreateControlledResourceFlight;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceStep;
@@ -189,6 +189,13 @@ public class ControlledAzureBatchPoolResource extends ControlledResource {
             userRequest),
         RetryRules.cloud());
     flight.addStep(
+        new GetActionManagedIdentityStep(
+            flightBeanBag.getSamService(),
+            flightBeanBag.getWorkspaceService(),
+            getWorkspaceId(),
+            userRequest),
+        RetryRules.cloud());
+    flight.addStep(
         new CreateAzureBatchPoolStep(
             flightBeanBag.getAzureConfig(), flightBeanBag.getCrlService(), this),
         RetryRules.cloud());
@@ -266,7 +273,6 @@ public class ControlledAzureBatchPoolResource extends ControlledResource {
     private String vmSize;
     private String displayName;
     private DeploymentConfiguration deploymentConfiguration;
-    private List<BatchPoolUserAssignedManagedIdentity> userAssignedIdentities;
     private ScaleSettings scaleSettings;
     private StartTask startTask;
     private List<ApplicationPackageReference> applicationPackages;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/CreateAzureBatchPoolStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/CreateAzureBatchPoolStep.java
@@ -90,12 +90,19 @@ public class CreateAzureBatchPoolStep implements Step {
     if (maybeActionIdentity != null) {
       // This UAMI may/may not exist (and that's OK). It allows the user to pull images from a
       // private azure container repository.
-      logger.info("Assigning action managed identity {} to batch pool", maybeActionIdentity);
+      logger.info(
+          "Assigning action managed identity {} to batch pool resource {} in workspace '{}'",
+          maybeActionIdentity,
+          resource.getId(),
+          resource.getWsmResourceFields().getWorkspaceId().toString());
       uamiForBatchPool.add(
           new BatchPoolUserAssignedManagedIdentity(
               azureCloudContext.getAzureResourceGroupId(), maybeActionIdentity, null));
     } else {
-      logger.info("Skipping assigning any action managed identities to batch pool.");
+      logger.info(
+          "Skipping assigning any action managed identities to batch pool resource {} in workspace {}",
+          resource.getId(),
+          resource.getWsmResourceFields().getWorkspaceId().toString());
     }
 
     try {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/CreateAzureBatchPoolStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/CreateAzureBatchPoolStep.java
@@ -13,6 +13,7 @@ import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.common.exception.AzureManagementExceptionUtils;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.batchpool.model.BatchPoolUserAssignedManagedIdentity;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetActionManagedIdentityStep;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity.GetManagedIdentityStep;
 import bio.terra.workspace.service.resource.controlled.exception.UserAssignedManagedIdentityNotFoundException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
@@ -75,11 +76,27 @@ public class CreateAzureBatchPoolStep implements Step {
     logger.info(
         String.format(PET_UAMI_FOUND, GetManagedIdentityStep.getManagedIdentityName(context)));
 
-    final BatchPoolUserAssignedManagedIdentity userAssignedManagedIdentity =
+    List<BatchPoolUserAssignedManagedIdentity> uamiForBatchPool = new ArrayList<>();
+
+    // This UAMI is required. It is the user's pet and allows them to run compute.
+    uamiForBatchPool.add(
         new BatchPoolUserAssignedManagedIdentity(
             azureCloudContext.getAzureResourceGroupId(),
             GetManagedIdentityStep.getManagedIdentityName(context),
-            null);
+            null));
+
+    String maybeActionIdentity =
+        context.getWorkingMap().get(GetActionManagedIdentityStep.ACTION_IDENTITY, String.class);
+    if (maybeActionIdentity != null) {
+      // This UAMI may/may not exist (and that's OK). It allows the user to pull images from a
+      // private azure container repository.
+      logger.info("Assigning action managed identity {} to batch pool", maybeActionIdentity);
+      uamiForBatchPool.add(
+          new BatchPoolUserAssignedManagedIdentity(
+              azureCloudContext.getAzureResourceGroupId(), maybeActionIdentity, null));
+    } else {
+      logger.info("Skipping assigning any action managed identities to batch pool.");
+    }
 
     try {
       var batchPoolDefinition =
@@ -93,11 +110,7 @@ public class CreateAzureBatchPoolStep implements Step {
 
       batchPoolDefinition =
           configureBatchPool(
-              msiManager,
-              batchPoolDefinition,
-              resource,
-              azureCloudContext,
-              List.of(userAssignedManagedIdentity));
+              msiManager, batchPoolDefinition, resource, azureCloudContext, uamiForBatchPool);
       batchPoolDefinition.create(
           Defaults.buildContext(
               CreateBatchPoolRequestData.builder()

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
@@ -1,0 +1,67 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.workspace.WorkspaceService;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gets an Azure Managed Identity for a user's 'action managed identity', which may be used to grant
+ * users access to private ACRs. This step will insert a fetched action identity into the flight
+ * context if one can be obtained from Sam.
+ */
+public class GetActionManagedIdentityStep implements Step {
+
+  public static final String ACTION_IDENTITY = "ACTION_IDENTITY";
+  private final SamService samService;
+  private final WorkspaceService workspaceService;
+  private final AuthenticatedUserRequest userRequest;
+  private final UUID workspaceId;
+  private final Logger logger = LoggerFactory.getLogger(GetActionManagedIdentityStep.class);
+
+  public GetActionManagedIdentityStep(
+      SamService samService,
+      WorkspaceService workspaceService,
+      UUID workspaceId,
+      AuthenticatedUserRequest userRequest) {
+    this.samService = samService;
+    this.workspaceService = workspaceService;
+    this.workspaceId = workspaceId;
+    this.userRequest = userRequest;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    String billingProfileId = workspaceService.getWorkspace(workspaceId).spendProfileId().getId();
+    logger.info(
+        "Querying Sam for action identity using billing profile id: '{}'", billingProfileId);
+
+    Optional<String> actionIdentity =
+        samService.getActionIdentityForUser(billingProfileId, userRequest);
+    if (actionIdentity.isPresent()) {
+      logger.info("Fetched action managed identity '{}' from sam.", actionIdentity.get());
+      putActionIdentityInContext(context, actionIdentity.get());
+    } else {
+      // NB: It is not an error if we fail to find an action identity,
+      // it just means that the user doesn't have access to any private ACRs.
+      logger.info("No action identities found to assign to batch pool.");
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+
+  private void putActionIdentityInContext(FlightContext context, String actionIdentity) {
+    context.getWorkingMap().put(ACTION_IDENTITY, actionIdentity);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
@@ -59,7 +59,7 @@ public class GetActionManagedIdentityStep implements Step {
           "Fetched action managed identity '{}' from sam for workspace '{}'.",
           actionIdentity.get(),
           workspaceId);
-      putActionIdentityInContext(context, actionIdentity.get());
+      putActionIdentityNameInContext(context, actionIdentity.get());
     } else {
       // NB: It is not an error if we fail to find an action identity,
       // it just means that the user doesn't have access to any private ACRs.
@@ -74,7 +74,12 @@ public class GetActionManagedIdentityStep implements Step {
     return StepResult.getStepResultSuccess();
   }
 
-  private void putActionIdentityInContext(FlightContext context, String actionIdentity) {
-    context.getWorkingMap().put(ACTION_IDENTITY, actionIdentity);
+  private void putActionIdentityNameInContext(FlightContext context, String actionIdentity) {
+    String identityName = actionIdentity;
+    int lastSlashIndex = actionIdentity.lastIndexOf('/');
+    if (lastSlashIndex != -1 || lastSlashIndex != identityName.length() - 1) {
+      identityName = identityName.substring(lastSlashIndex + 1);
+    }
+    context.getWorkingMap().put(ACTION_IDENTITY, identityName);
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
@@ -40,6 +40,7 @@ public class GetActionManagedIdentityStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+
     String billingProfileId = workspaceService.getWorkspace(workspaceId).spendProfileId().getId();
     logger.info(
         "Querying Sam for action identity using billing profile id '{}' in workspace '{}'",
@@ -52,6 +53,7 @@ public class GetActionManagedIdentityStep implements Step {
             SamConstants.SamPrivateAzureContainerRegistryAction.PULL_IMAGE,
             billingProfileId,
             userRequest);
+
     if (actionIdentity.isPresent()) {
       logger.info(
           "Fetched action managed identity '{}' from sam for workspace '{}'.",

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
@@ -41,17 +41,23 @@ public class GetActionManagedIdentityStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     String billingProfileId = workspaceService.getWorkspace(workspaceId).spendProfileId().getId();
     logger.info(
-        "Querying Sam for action identity using billing profile id: '{}'", billingProfileId);
+        "Querying Sam for action identity using billing profile id '{}' in workspace '{}'",
+        billingProfileId,
+        workspaceId);
 
     Optional<String> actionIdentity =
         samService.getActionIdentityForUser(billingProfileId, userRequest);
     if (actionIdentity.isPresent()) {
-      logger.info("Fetched action managed identity '{}' from sam.", actionIdentity.get());
+      logger.info(
+          "Fetched action managed identity '{}' from sam for workspace '{}'.",
+          actionIdentity.get(),
+          workspaceId);
       putActionIdentityInContext(context, actionIdentity.get());
     } else {
       // NB: It is not an error if we fail to find an action identity,
       // it just means that the user doesn't have access to any private ACRs.
-      logger.info("No action identities found to assign to batch pool.");
+      logger.info(
+          "No action identities found to assign to batch pool in workspace '{}'", workspaceId);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStep.java
@@ -6,6 +6,7 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.SamConstants;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import java.util.Optional;
 import java.util.UUID;
@@ -46,7 +47,11 @@ public class GetActionManagedIdentityStep implements Step {
         workspaceId);
 
     Optional<String> actionIdentity =
-        samService.getActionIdentityForUser(billingProfileId, userRequest);
+        samService.getActionIdentityForUser(
+            SamConstants.SamResource.PRIVATE_AZURE_CONTAINER_REGISTRY,
+            SamConstants.SamPrivateAzureContainerRegistryAction.PULL_IMAGE,
+            billingProfileId,
+            userRequest);
     if (actionIdentity.isPresent()) {
       logger.info(
           "Fetched action managed identity '{}' from sam for workspace '{}'.",

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStepTest.java
@@ -37,7 +37,8 @@ public class GetActionManagedIdentityStepTest extends BaseMockitoStrictStubbingT
   @Test
   void testSuccess() throws InterruptedException {
     when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
-    Optional<String> fetchedIdentity = Optional.of("actionIdentity-1234");
+    Optional<String> fetchedIdentity = Optional.of("this/is/an/actionIdentity-1234");
+    String expectedIdentityNameInContext = "actionIdentity-1234";
     when(mockSamService.getActionIdentityForUser(
             SamConstants.SamResource.PRIVATE_AZURE_CONTAINER_REGISTRY,
             SamConstants.SamPrivateAzureContainerRegistryAction.PULL_IMAGE,
@@ -53,7 +54,8 @@ public class GetActionManagedIdentityStepTest extends BaseMockitoStrictStubbingT
 
     assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
 
-    verify(mockWorkingMap).put(GetActionManagedIdentityStep.ACTION_IDENTITY, fetchedIdentity.get());
+    verify(mockWorkingMap)
+        .put(GetActionManagedIdentityStep.ACTION_IDENTITY, expectedIdentityNameInContext);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/GetActionManagedIdentityStepTest.java
@@ -1,0 +1,79 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.managedIdentity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.workspace.common.utils.BaseMockitoStrictStubbingTest;
+import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.iam.model.SamConstants;
+import bio.terra.workspace.service.spendprofile.model.SpendProfileId;
+import bio.terra.workspace.service.workspace.WorkspaceService;
+import bio.terra.workspace.service.workspace.model.Workspace;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@Tag("azure-unit")
+public class GetActionManagedIdentityStepTest extends BaseMockitoStrictStubbingTest {
+  @Mock private FlightContext mockFlightContext;
+  @Mock private FlightMap mockWorkingMap;
+  @Mock private SamService mockSamService;
+  @Mock private WorkspaceService mockWorkspaceService;
+  private final UUID testWorkspaceId = UUID.randomUUID();
+  private final String testBillingProfileId = "testBillingProfile";
+  private final SpendProfileId testSpendProfile = new SpendProfileId(testBillingProfileId);
+  @Mock private AuthenticatedUserRequest mockAuthenticatedUserRequest;
+
+  @Mock private Workspace mockWorkspace;
+
+  @Test
+  void testSuccess() throws InterruptedException {
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
+    Optional<String> fetchedIdentity = Optional.of("actionIdentity-1234");
+    when(mockSamService.getActionIdentityForUser(
+            SamConstants.SamResource.PRIVATE_AZURE_CONTAINER_REGISTRY,
+            SamConstants.SamPrivateAzureContainerRegistryAction.PULL_IMAGE,
+            testBillingProfileId,
+            mockAuthenticatedUserRequest))
+        .thenReturn(fetchedIdentity);
+    when(mockWorkspace.spendProfileId()).thenReturn(testSpendProfile);
+    when(mockWorkspaceService.getWorkspace(testWorkspaceId)).thenReturn(mockWorkspace);
+
+    var step =
+        new GetActionManagedIdentityStep(
+            mockSamService, mockWorkspaceService, testWorkspaceId, mockAuthenticatedUserRequest);
+
+    assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
+
+    verify(mockWorkingMap).put(GetActionManagedIdentityStep.ACTION_IDENTITY, fetchedIdentity.get());
+  }
+
+  @Test
+  void testNoIdentityFound() throws InterruptedException {
+    Optional<String> fetchedIdentity = Optional.empty();
+    when(mockSamService.getActionIdentityForUser(
+            SamConstants.SamResource.PRIVATE_AZURE_CONTAINER_REGISTRY,
+            SamConstants.SamPrivateAzureContainerRegistryAction.PULL_IMAGE,
+            testBillingProfileId,
+            mockAuthenticatedUserRequest))
+        .thenReturn(fetchedIdentity);
+    when(mockWorkspace.spendProfileId()).thenReturn(testSpendProfile);
+    when(mockWorkspaceService.getWorkspace(testWorkspaceId)).thenReturn(mockWorkspace);
+    var step =
+        new GetActionManagedIdentityStep(
+            mockSamService, mockWorkspaceService, testWorkspaceId, mockAuthenticatedUserRequest);
+
+    // Step should succeed, but nothing should have been inserted into flight context
+    assertThat(step.doStep(mockFlightContext), equalTo(StepResult.getStepResultSuccess()));
+    verify(mockWorkingMap, never())
+        .put(eq(GetActionManagedIdentityStep.ACTION_IDENTITY), any(String.class));
+  }
+}


### PR DESCRIPTION
When creating a batch pool, WSM will check Sam if the user has access to an 'Action Managed Identity'. If they do, it will be assigned to the Batch Pool. This enables users to pull images from private Azure Container Repositories. 