### PR TITLE
[DDO-3710] Make janitor ttl configurable

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/CrlConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/CrlConfiguration.java
@@ -33,6 +33,9 @@ public class CrlConfiguration {
   /** pubsub topic id to publish track resource to Janitor */
   private String janitorTrackResourceTopicId;
 
+  /** Number of hours before Janitor cleans up a tracked resource */
+  private int janitorTtlHours = 1;
+
   public boolean getUseCrl() {
     return useCrl;
   }
@@ -57,6 +60,10 @@ public class CrlConfiguration {
     return janitorTrackResourceTopicId;
   }
 
+  public int getJanitorTtlHours() {
+    return janitorTtlHours;
+  }
+
   public void setUseJanitor(boolean useJanitor) {
     this.useJanitor = useJanitor;
   }
@@ -71,5 +78,9 @@ public class CrlConfiguration {
 
   public void setJanitorTrackResourceTopicId(String janitorTrackResourceTopicId) {
     this.janitorTrackResourceTopicId = janitorTrackResourceTopicId;
+  }
+
+  public void setJanitorTtlHours(int janitorTtlHours) {
+    this.janitorTtlHours = janitorTtlHours;
   }
 }

--- a/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/workspace/service/crl/CrlService.java
@@ -70,9 +70,6 @@ public class CrlService {
   /** The client name required by CRL. */
   private static final String CLIENT_NAME = "workspace";
 
-  /** How long to keep the resource before Janitor does the cleanup. */
-  private static final Duration TEST_RESOURCE_TIME_TO_LIVE = Duration.ofHours(1);
-
   @Value("${azure.customer.usage-attribute:}")
   private String azureCustomerUsageAttribute;
 
@@ -554,7 +551,7 @@ public class CrlService {
       builder.setCleanupConfig(
           CleanupConfig.builder()
               .setCleanupId(CLIENT_NAME + "-test")
-              .setTimeToLive(TEST_RESOURCE_TIME_TO_LIVE)
+              .setTimeToLive(Duration.ofHours(crlConfig.getJanitorTtlHours()))
               .setJanitorProjectId(crlConfig.getJanitorTrackResourceProjectId())
               .setJanitorTopicName(crlConfig.getJanitorTrackResourceTopicId())
               .setCredentials(getJanitorCredentials(crlConfig.getJanitorClientCredentialFilePath()))


### PR DESCRIPTION
Friends with: https://github.com/broadinstitute/terra-helmfile/pull/5586/

Make the Janitor resource TTL configurable, instead of hard-coded to 1 hour. We want the ability to have different cleanup TTLs in different BEE environments.