### PR TITLE
Switch provider name

### DIFF
--- a/service/src/test/java/bio/terra/workspace/pact/landingzones/LzJobsApiPactTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/landingzones/LzJobsApiPactTest.java
@@ -91,7 +91,7 @@ class LzJobsApiPactTest {
           .stringType("value")
           .closeArray();
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact startCreateLandingZone_running(PactDslWithProvider builder) {
     return builder
         .uponReceiving("A request to create a landing zone")
@@ -105,7 +105,7 @@ class LzJobsApiPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact startCreateLandingZone_failed(PactDslWithProvider builder) {
     return builder
         .uponReceiving("A request to create a landing zone")
@@ -120,7 +120,7 @@ class LzJobsApiPactTest {
   }
 
   // Reenable when we are able to publish a full-size pact payload via GHA
-  //  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  //  @Pact(consumer = "workspacemanager", provider = "landingzone")
   //  public RequestResponsePact startCreateLandingZone_notAuthorized(PactDslWithProvider builder) {
   //    return builder
   //        .uponReceiving("An unauthorized request to create a landing zone")
@@ -133,7 +133,7 @@ class LzJobsApiPactTest {
   //        .toPact();
   //  }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact getCreateLandingZoneResult(PactDslWithProvider builder) {
     var createResultResponseShape =
         new PactDslJsonBody()
@@ -162,7 +162,7 @@ class LzJobsApiPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact getCreateLandingZoneResult_notAuthorized(PactDslWithProvider builder) {
     return builder
         .given(
@@ -178,7 +178,7 @@ class LzJobsApiPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact startDeleteLandingZone_running(PactDslWithProvider builder) {
     var deleteRequestShape =
         new PactDslJsonBody().object("jobControl").stringType("id").closeObject();
@@ -203,7 +203,7 @@ class LzJobsApiPactTest {
   }
 
   // Reenable when we are able to publish a full-size pact payload via GHA
-  //  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  //  @Pact(consumer = "workspacemanager", provider = "landingzone")
   //  public RequestResponsePact startDeleteLandingZone_notAuthorized(PactDslWithProvider builder) {
   //    var deleteRequestShape = new PactDslJsonBody().object("jobControl", jobControlShape);
   //
@@ -220,7 +220,7 @@ class LzJobsApiPactTest {
   //        .toPact();
   //  }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact getDeleteLandingZoneResult_success(PactDslWithProvider builder) {
     var deleteResultResponseShape =
         new PactDslJsonBody()
@@ -246,7 +246,7 @@ class LzJobsApiPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact getDeleteLandingZoneResult_failed(PactDslWithProvider builder) {
     var deleteResultResponseShape =
         new PactDslJsonBody()
@@ -272,7 +272,7 @@ class LzJobsApiPactTest {
         .toPact();
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact getDeleteLandingZoneResult_notAuthorized(PactDslWithProvider builder) {
     return builder
         .given(

--- a/service/src/test/java/bio/terra/workspace/pact/landingzones/LzReadApiTest.java
+++ b/service/src/test/java/bio/terra/workspace/pact/landingzones/LzReadApiTest.java
@@ -72,7 +72,7 @@ class LzReadApiTest {
     landingZoneService = new HttpLandingZoneService(OpenTelemetry.noop(), config);
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact getLandingZone(PactDslWithProvider builder) {
     var getResultResponseShape =
         new PactDslJsonBody()
@@ -97,7 +97,7 @@ class LzReadApiTest {
   }
 
   // TODO Reenable when we are able to publish a full-size pact payload via GHA
-  //  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  //  @Pact(consumer = "workspacemanager", provider = "landingzone")
   //  public RequestResponsePact getLandingZone_notFound(PactDslWithProvider builder) {
   //    return builder
   //        .uponReceiving("A request for a non-existent landing zone")
@@ -108,7 +108,7 @@ class LzReadApiTest {
   //        .toPact();
   //  }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact listLandingZonesForBillingProfile(PactDslWithProvider builder) {
     var listResponseShape =
         new PactDslJsonBody()
@@ -133,7 +133,7 @@ class LzReadApiTest {
         .toPact();
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact listLandingZones(PactDslWithProvider builder) {
     var listResponseShape =
         new PactDslJsonBody()
@@ -156,7 +156,7 @@ class LzReadApiTest {
         .toPact();
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact listLandingZoneDefinitions(PactDslWithProvider builder) {
     var definitionsResponseShape =
         new PactDslJsonBody()
@@ -176,7 +176,7 @@ class LzReadApiTest {
         .toPact();
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact listAzureLandingZoneResources(PactDslWithProvider builder) {
     var resourcesResponseShape =
         new PactDslJsonBody().uuid("id").eachLike("resources", resourcesByTypeShape);
@@ -195,7 +195,7 @@ class LzReadApiTest {
         .toPact();
   }
 
-  @Pact(consumer = "workspacemanager", provider = "terra-landing-zone-service")
+  @Pact(consumer = "workspacemanager", provider = "landingzone")
   public RequestResponsePact getResourceQuota(PactDslWithProvider builder) {
     var quotaResponseShape =
         new PactDslJsonBody()


### PR DESCRIPTION
Webhooks firing into LZS on can-i-deploy are failing. My current hypothesis is that this is related to the provider name being different in lzs and terra-helmfile ("terra-landing-zone-service" vs "landingzone"). I've deleted the pact in the broker so can-i-deploy should pass and updated the provider here. Next step is to update the provider name in LZS and publish a new pact. 