### PR TITLE
[WOR-1507] Capture metrics and status for flights and steps

### DIFF
--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Builds the current WSM branch and pushes container images
+# for AzureDatabaseUtils and WSM to GCR. Useful for testing
+# on BEEs.
+
+SHA=$(git rev-parse HEAD)
+./gradlew :service:jibDockerBuild --image="gcr.io/broad-dsp-gcr-public/terra-workspace-manager:$SHA"
+docker push "gcr.io/broad-dsp-gcr-public/terra-workspace-manager:$SHA"
+./gradlew :azureDatabaseUtils:jibDockerBuild --image="us.gcr.io/broad-dsp-gcr-public/azure-database-utils:$SHA"
+docker push "us.gcr.io/broad-dsp-gcr-public/azure-database-utils:$SHA"
+
+echo "App rev pushed to GCR $SHA"

--- a/service/src/main/java/bio/terra/workspace/common/logging/FlightMetricsHook.java
+++ b/service/src/main/java/bio/terra/workspace/common/logging/FlightMetricsHook.java
@@ -1,0 +1,156 @@
+package bio.terra.workspace.common.logging;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.HookAction;
+import bio.terra.stairway.StairwayHook;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.ClassUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Captures the duration and final status of stairway flights and steps for emission to a metrics
+ * backend like prometheus
+ */
+@Component
+public class FlightMetricsHook implements StairwayHook {
+  private static final Logger logger = LoggerFactory.getLogger(FlightMetricsHook.class);
+  private static final String FLIGHT_METRICS_KEY_PREFIX = "stairway.flight";
+  private final MeterRegistry registry;
+
+  public FlightMetricsHook(MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public HookAction startStep(FlightContext context) {
+    if (isContextInvalid(context)) {
+      return HookAction.CONTINUE;
+    }
+
+    var stepMetrics = new TaskMetrics(OffsetDateTime.now());
+    context.getWorkingMap().put(getStepMetricsKey(context), stepMetrics);
+
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction endStep(FlightContext context) {
+    if (isContextInvalid(context)) {
+      return HookAction.CONTINUE;
+    }
+
+    var key = getStepMetricsKey(context);
+    var stepMetrics = context.getWorkingMap().get(key, TaskMetrics.class);
+    if (stepMetrics == null) {
+      logger.warn(
+          "No step metrics present for flightId {}, step {}",
+          context.getFlightId(),
+          context.getStepClassName());
+      return HookAction.CONTINUE;
+    }
+
+    stepMetrics.setEndTime(OffsetDateTime.now());
+    var stepStatus = context.getResult().getStepStatus();
+    var tags =
+        new ArrayList<>(
+            List.of(
+                Tag.of("status", stepStatus.toString()),
+                Tag.of("flight", ClassUtils.getShortClassName(context.getFlightClassName()))));
+
+    if (context
+        .getInputParameters()
+        .containsKey(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE)) {
+
+      var resourceType =
+          context
+              .getInputParameters()
+              .get(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE, String.class);
+      tags.add(Tag.of("resourceType", resourceType));
+    }
+    emitTimer(stepMetrics, key, tags);
+
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction startFlight(FlightContext context) {
+    if (isContextInvalid(context)) {
+      return HookAction.CONTINUE;
+    }
+
+    var flightMetrics = new TaskMetrics(OffsetDateTime.now());
+    context.getWorkingMap().put(getFlightMetricsKey(context), flightMetrics);
+
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction endFlight(FlightContext context) {
+    if (isContextInvalid(context)) {
+      return HookAction.CONTINUE;
+    }
+
+    var key = getFlightMetricsKey(context);
+    var flightMetrics = context.getWorkingMap().get(key, TaskMetrics.class);
+    if (flightMetrics == null) {
+      logger.warn("No flight metrics present for flight {}", context.getFlightId());
+      return HookAction.CONTINUE;
+    }
+
+    flightMetrics.setEndTime(OffsetDateTime.now());
+    var tags = new ArrayList<>(List.of(Tag.of("status", context.getFlightStatus().toString())));
+    if (context
+        .getInputParameters()
+        .containsKey(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE)) {
+
+      var resourceType =
+          context
+              .getInputParameters()
+              .get(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE, String.class);
+      tags.add(Tag.of("resourceType", resourceType));
+    }
+
+    emitTimer(flightMetrics, key, tags);
+    return HookAction.CONTINUE;
+  }
+
+  private void emitTimer(TaskMetrics flightMetrics, String key, List<Tag> tags) {
+    var duration = flightMetrics.getDuration();
+    if (duration == null) {
+      return;
+    }
+
+    registry.timer(key + ".duration", tags).record(duration);
+  }
+
+  @VisibleForTesting
+  String getFlightMetricsKey(FlightContext context) {
+    return String.format(
+        "%s.%s",
+        FLIGHT_METRICS_KEY_PREFIX, ClassUtils.getShortClassName(context.getFlightClassName()));
+  }
+
+  @VisibleForTesting
+  String getStepMetricsKey(FlightContext context) {
+    var flightKeyPrefix = getFlightMetricsKey(context);
+    return String.format(
+        "%s.step.%s", flightKeyPrefix, ClassUtils.getShortClassName(context.getStepClassName()));
+  }
+
+  private boolean isContextInvalid(FlightContext context) {
+    if (context == null || context.getWorkingMap() == null) {
+      logger.warn("Flight context or working map null, skipping metrics hook");
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/common/logging/TaskMetrics.java
+++ b/service/src/main/java/bio/terra/workspace/common/logging/TaskMetrics.java
@@ -1,0 +1,46 @@
+package bio.terra.workspace.common.logging;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import javax.annotation.Nullable;
+
+/** Measures the wall clock time for dispatch of a stairway task (i.e., a flight or a step) */
+public class TaskMetrics {
+  private final OffsetDateTime startTime;
+  private OffsetDateTime endTime;
+
+  public TaskMetrics(OffsetDateTime started) {
+    this.startTime = started;
+  }
+
+  @JsonCreator
+  public TaskMetrics(
+      @JsonProperty("startTime") OffsetDateTime startTime,
+      @JsonProperty("endTime") OffsetDateTime endTime) {
+    this.startTime = startTime;
+    this.endTime = endTime;
+  }
+
+  public void setEndTime(OffsetDateTime endTime) {
+    this.endTime = endTime;
+  }
+
+  public OffsetDateTime getEndTime() {
+    return this.endTime;
+  }
+
+  public OffsetDateTime getStartTime() {
+    return this.startTime;
+  }
+
+  @Nullable
+  public Duration getDuration() {
+    if (endTime == null) {
+      return null;
+    }
+
+    return Duration.between(startTime, endTime);
+  }
+}

--- a/service/src/main/java/bio/terra/workspace/service/job/StairwayInitializerService.java
+++ b/service/src/main/java/bio/terra/workspace/service/job/StairwayInitializerService.java
@@ -6,6 +6,7 @@ import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.common.stairway.StairwayLoggingHook;
 import bio.terra.stairway.StairwayMapper;
 import bio.terra.workspace.app.configuration.external.StairwayDatabaseConfiguration;
+import bio.terra.workspace.common.logging.FlightMetricsHook;
 import bio.terra.workspace.common.logging.WorkspaceActivityLogHook;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
@@ -27,6 +28,7 @@ public class StairwayInitializerService {
   private final FlightBeanBag flightBeanBag;
   private final ObjectMapper objectMapper;
   private final OpenTelemetry openTelemetry;
+  private final FlightMetricsHook flightMetricsHook;
 
   @Autowired
   public StairwayInitializerService(
@@ -36,7 +38,8 @@ public class StairwayInitializerService {
       StairwayComponent stairwayComponent,
       FlightBeanBag flightBeanBag,
       ObjectMapper objectMapper,
-      OpenTelemetry openTelemetry) {
+      OpenTelemetry openTelemetry,
+      FlightMetricsHook flightMetricsHook) {
     this.dataSourceManager = dataSourceManager;
     this.stairwayDatabaseConfiguration = stairwayDatabaseConfiguration;
     this.workspaceActivityLogHook = workspaceActivityLogHook;
@@ -44,6 +47,7 @@ public class StairwayInitializerService {
     this.flightBeanBag = flightBeanBag;
     this.objectMapper = objectMapper;
     this.openTelemetry = openTelemetry;
+    this.flightMetricsHook = flightMetricsHook;
   }
 
   /**
@@ -59,6 +63,7 @@ public class StairwayInitializerService {
             .context(flightBeanBag)
             .addHook(new StairwayLoggingHook())
             .addHook(new MonitoringHook(openTelemetry))
+            .addHook(flightMetricsHook)
             .addHook(workspaceActivityLogHook)
             .exceptionSerializer(new StairwayExceptionSerializer(objectMapper)));
   }

--- a/service/src/test/java/bio/terra/workspace/common/logging/FlightMetricsHookTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/logging/FlightMetricsHookTest.java
@@ -1,0 +1,131 @@
+package bio.terra.workspace.common.logging;
+
+import static bio.terra.workspace.service.resource.model.WsmResourceType.CONTROLLED_AZURE_VM;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import bio.terra.stairway.FlightMap;
+import bio.terra.workspace.common.annotations.BaseTest;
+import bio.terra.workspace.common.utils.TestFlightContext;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@BaseTest
+class FlightMetricsHookTest {
+
+  FlightMetricsHook flightMetricsHook;
+  MeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setup() {
+    meterRegistry = new SimpleMeterRegistry();
+    flightMetricsHook = new FlightMetricsHook(meterRegistry);
+  }
+
+  @Test
+  void startStep_success() {
+    var context =
+        new TestFlightContext()
+            .flightClassName("bio.terra.testing.flight.TestFlight")
+            .stepClassName("bio.terra.testing.StepClass");
+
+    flightMetricsHook.startStep(context);
+    var metrics =
+        context
+            .getWorkingMap()
+            .get(flightMetricsHook.getStepMetricsKey(context), TaskMetrics.class);
+
+    assertThat(metrics, notNullValue());
+    assertThat(metrics.getDuration(), nullValue());
+  }
+
+  @Test
+  void startFlight_success() {
+    var context = new TestFlightContext().flightClassName("bio.terra.testing.flight.TestFlight");
+
+    flightMetricsHook.startFlight(context);
+    var metrics =
+        context
+            .getWorkingMap()
+            .get(flightMetricsHook.getFlightMetricsKey(context), TaskMetrics.class);
+
+    assertThat(metrics, notNullValue());
+    assertThat(metrics.getDuration(), nullValue());
+  }
+
+  @Test
+  void endStep_success() {
+    var context =
+        new TestFlightContext()
+            .flightClassName("bio.terra.testing.flight.TestFlight")
+            .stepClassName("bio.terra.testing.StepClass");
+
+    flightMetricsHook.startStep(context);
+    flightMetricsHook.endStep(context);
+    var metrics =
+        context
+            .getWorkingMap()
+            .get(flightMetricsHook.getStepMetricsKey(context), TaskMetrics.class);
+
+    assertThat(metrics, notNullValue());
+    var timer =
+        meterRegistry.find(flightMetricsHook.getStepMetricsKey(context) + ".duration").timer();
+    assertThat(timer, notNullValue());
+    assertThat(
+        timer.getId().getTag("status"), equalTo(context.getResult().getStepStatus().toString()));
+  }
+
+  @Test
+  void endFlight_success() {
+    var context =
+        new TestFlightContext()
+            .flightClassName("bio.terra.testing.flight.TestFlight")
+            .stepClassName("bio.terra.testing.StepClass");
+
+    flightMetricsHook.startFlight(context);
+    flightMetricsHook.endFlight(context);
+    var metrics =
+        context
+            .getWorkingMap()
+            .get(flightMetricsHook.getFlightMetricsKey(context), TaskMetrics.class);
+
+    assertThat(metrics, notNullValue());
+    var timer =
+        meterRegistry.find(flightMetricsHook.getFlightMetricsKey(context) + ".duration").timer();
+    assertThat(timer, notNullValue());
+    assertThat(timer.getId().getTag("status"), equalTo(context.getFlightStatus().toString()));
+  }
+
+  @Test
+  void endFlight_capturesResourceTypeLabel() {
+    var inputParams = new FlightMap();
+    inputParams.put(WorkspaceFlightMapKeys.ResourceKeys.RESOURCE_TYPE, CONTROLLED_AZURE_VM);
+    var context =
+        new TestFlightContext()
+            .flightClassName("bio.terra.testing.flight.TestFlight")
+            .stepClassName("bio.terra.testing.StepClass")
+            .inputParameters(inputParams);
+
+    flightMetricsHook.startFlight(context);
+    flightMetricsHook.endFlight(context);
+
+    var metrics =
+        context
+            .getWorkingMap()
+            .get(flightMetricsHook.getFlightMetricsKey(context), TaskMetrics.class);
+
+    assertThat(metrics, notNullValue());
+    var timer =
+        meterRegistry.find(flightMetricsHook.getFlightMetricsKey(context) + ".duration").timer();
+    assertThat(timer, notNullValue());
+    assertThat(timer.getId().getTag("status"), equalTo(context.getFlightStatus().toString()));
+    assertThat(timer.getId().getTag("resourceType"), equalTo(CONTROLLED_AZURE_VM.toString()));
+  }
+}

--- a/service/src/test/java/bio/terra/workspace/common/utils/TestFlightContext.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/TestFlightContext.java
@@ -17,6 +17,7 @@ public class TestFlightContext implements FlightContext {
   private FlightStatus flightStatus = FlightStatus.QUEUED;
   private Direction direction = Direction.DO;
   private String stepClassName = TestUtils.appendRandomNumber("stepClassName");
+  private StepResult result = new StepResult(StepStatus.STEP_RESULT_SUCCESS);
 
   @Override
   public Object getApplicationContext() {
@@ -95,7 +96,12 @@ public class TestFlightContext implements FlightContext {
 
   @Override
   public StepResult getResult() {
-    return null;
+    return result;
+  }
+
+  public TestFlightContext result(StepResult result) {
+    this.result = result;
+    return this;
   }
 
   @Override

--- a/service/src/test/java/bio/terra/workspace/service/job/StairwayInitializerServiceTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/job/StairwayInitializerServiceTest.java
@@ -14,6 +14,7 @@ import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.common.stairway.StairwayLoggingHook;
 import bio.terra.workspace.app.configuration.external.StairwayDatabaseConfiguration;
 import bio.terra.workspace.common.annotations.Unit;
+import bio.terra.workspace.common.logging.FlightMetricsHook;
 import bio.terra.workspace.common.logging.WorkspaceActivityLogHook;
 import bio.terra.workspace.common.utils.FlightBeanBag;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,6 +35,8 @@ class StairwayInitializerServiceTest {
   @Mock private WorkspaceActivityLogHook workspaceActivityLogHook;
   @Mock private StairwayComponent stairwayComponent;
   @Mock private FlightBeanBag flightBeanBag;
+  @Mock private FlightMetricsHook flightMetricsHook;
+
   private StairwayInitializerService stairwayInitializerService;
 
   @BeforeEach
@@ -46,7 +49,8 @@ class StairwayInitializerServiceTest {
             stairwayComponent,
             flightBeanBag,
             mock(ObjectMapper.class),
-            OpenTelemetry.noop());
+            OpenTelemetry.noop(),
+            flightMetricsHook);
   }
 
   @Test
@@ -75,6 +79,7 @@ class StairwayInitializerServiceTest {
         contains(
             instanceOf(StairwayLoggingHook.class),
             instanceOf(MonitoringHook.class),
+            is(flightMetricsHook),
             is(workspaceActivityLogHook)));
     assertThat(
         "Stairway is initialized with exception serializer",


### PR DESCRIPTION
## Context
We want to capture the success/failure rate of flights. 

## This PR
Introduces a `FlightMetricsHook` class. This is a stairway lifecycle hook that emits a micrometer timer at the end of steps and flights. The metrics are namespaced in the following manner:

For flight-level data:
```
stairway_flight_<flight_class_name>_duration_seconds_<metric>
```
For step-level data:
```
stairway_flight_<flight_class_name>_step_<step_class_name>_duration_seconds_<metric>
```
The following tags are attached to both types of metrics:
* Status: Final status of the flight
* Resource type: Cloud resource type; this is only emitted in the case of flights with a `RESOURCE_TYPE` value in their input parameters (i.e,. `CreateControlledCloudResourceFlight`). It is omitted otherwise.

[Example](https://grafana.dsp-devops.broadinstitute.org/explore?orgId=1&left=%7B%22datasource%22:%228ZLL-_cnk%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22builder%22,%22expr%22:%22rate%28stairway_flight_WorkspaceDeleteFlight_duration_seconds_count%7Bcluster%3D%5C%22terra-qa-bees%5C%22,%20service%3D%5C%22workspacemanager-appmetrics-service%5C%22%7D%5B5m%5D%29%22,%22legendFormat%22:%22%7B%7Bstatus%7D%7D%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D)