### PR TITLE
AJ-1869 WIP Add limits to spend profile and workspace description

### DIFF
--- a/openapi/src/parts/workspace_cloudcontext.yaml
+++ b/openapi/src/parts/workspace_cloudcontext.yaml
@@ -151,6 +151,11 @@ components:
           type: string
         operationState:
           $ref: '#/components/schemas/OperationState'
+        limits:
+          description: compute or other limits imposed on workspace from billing profile
+          type: object
+          additionalProperties:
+            type: string
 
     AwsContext:
       type: object

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -23,7 +23,7 @@ dependencies {
 
   // Terra deps
   implementation group: "bio.terra", name: "datarepo-client", version: "2.13.0-SNAPSHOT"
-  implementation group: "bio.terra", name:"billing-profile-manager-client", version: "0.1.536-SNAPSHOT"
+  implementation group: "bio.terra", name:"billing-profile-manager-client", version: "0.1.548-SNAPSHOT"
   implementation group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT"
   implementation group: "bio.terra", name:"terra-aws-resource-discovery", version:"v0.6.3-SNAPSHOT"
 

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
@@ -52,9 +52,6 @@ public class SpendProfileConfiguration {
 
     private Map<String, String> limits;
     private CloudPlatform cloudPlatform;
-    private UUID tenantId;
-    private UUID subscriptionId;
-    private String managedResourceGroupId;
 
     public String getId() {
       return id;
@@ -86,30 +83,6 @@ public class SpendProfileConfiguration {
 
     public void setCloudPlatform(CloudPlatform cloudPlatform) {
       this.cloudPlatform = cloudPlatform;
-    }
-
-    public UUID getTenantId() {
-      return tenantId;
-    }
-
-    public void setTenantId(UUID tenantId) {
-      this.tenantId = tenantId;
-    }
-
-    public UUID getSubscriptionId() {
-      return subscriptionId;
-    }
-
-    public void setSubscriptionId(UUID subscriptionId) {
-      this.subscriptionId = subscriptionId;
-    }
-
-    public String getManagedResourceGroupId() {
-      return managedResourceGroupId;
-    }
-
-    public void setManagedResourceGroupId(String managedResourceGroupId) {
-      this.managedResourceGroupId = managedResourceGroupId;
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
@@ -6,12 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-
-import javax.annotation.Nullable;
 
 /**
  * Configuration for Spend Profiles.

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
@@ -1,14 +1,18 @@
 package bio.terra.workspace.app.configuration.external;
 
-import bio.terra.workspace.service.spendprofile.model.SpendProfile;
+import bio.terra.workspace.service.spendprofile.model.SpendProfileOrganization;
+import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.Nullable;
 
 /**
  * Configuration for Spend Profiles.
@@ -21,16 +25,16 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "workspace.spend")
 public class SpendProfileConfiguration {
   /** The Spend Profiles known to Workspace Manager. */
-  private List<SpendProfile> spendProfiles = new ArrayList<>();
+  private List<SpendProfileModel> spendProfiles = new ArrayList<>();
 
   /** URL of the billing profile manager instance */
   private String basePath;
 
-  public List<SpendProfile> getSpendProfiles() {
+  public List<SpendProfileModel> getSpendProfiles() {
     return ImmutableList.copyOf(spendProfiles);
   }
 
-  public void setSpendProfiles(List<SpendProfile> spendProfiles) {
+  public void setSpendProfiles(List<SpendProfileModel> spendProfiles) {
     this.spendProfiles = spendProfiles;
   }
 
@@ -51,6 +55,10 @@ public class SpendProfileConfiguration {
     private String billingAccountId;
 
     private Map<String, String> limits;
+    private CloudPlatform cloudPlatform;
+    private UUID tenantId;
+    private UUID subscriptionId;
+    private String managedResourceGroupId;
 
     public String getId() {
       return id;
@@ -68,12 +76,44 @@ public class SpendProfileConfiguration {
       this.billingAccountId = billingAccountId;
     }
 
-    public Map<String, String>  getLimits(){
+    public Map<String, String> getLimits() {
       return limits;
     }
 
-    public void setLimits(Map<String, String> limits){
+    public void setLimits(Map<String, String> limits) {
       this.limits = limits;
+    }
+
+    public CloudPlatform getCloudPlatform() {
+      return cloudPlatform;
+    }
+
+    public void setCloudPlatform(CloudPlatform cloudPlatform) {
+      this.cloudPlatform = cloudPlatform;
+    }
+
+    public UUID getTenantId() {
+      return tenantId;
+    }
+
+    public void setTenantId(UUID tenantId) {
+      this.tenantId = tenantId;
+    }
+
+    public UUID getSubscriptionId() {
+      return subscriptionId;
+    }
+
+    public void setSubscriptionId(UUID subscriptionId) {
+      this.subscriptionId = subscriptionId;
+    }
+
+    public String getManagedResourceGroupId() {
+      return managedResourceGroupId;
+    }
+
+    public void setManagedResourceGroupId(String managedResourceGroupId) {
+      this.managedResourceGroupId = managedResourceGroupId;
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
@@ -1,6 +1,5 @@
 package bio.terra.workspace.app.configuration.external;
 
-import bio.terra.workspace.service.spendprofile.model.SpendProfileOrganization;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
@@ -1,8 +1,11 @@
 package bio.terra.workspace.app.configuration.external;
 
+import bio.terra.workspace.service.spendprofile.model.SpendProfile;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -18,16 +21,16 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "workspace.spend")
 public class SpendProfileConfiguration {
   /** The Spend Profiles known to Workspace Manager. */
-  private List<SpendProfileModel> spendProfiles = new ArrayList<>();
+  private List<SpendProfile> spendProfiles = new ArrayList<>();
 
   /** URL of the billing profile manager instance */
   private String basePath;
 
-  public List<SpendProfileModel> getSpendProfiles() {
+  public List<SpendProfile> getSpendProfiles() {
     return ImmutableList.copyOf(spendProfiles);
   }
 
-  public void setSpendProfiles(List<SpendProfileModel> spendProfiles) {
+  public void setSpendProfiles(List<SpendProfile> spendProfiles) {
     this.spendProfiles = spendProfiles;
   }
 
@@ -47,6 +50,8 @@ public class SpendProfileConfiguration {
     /** The id of the Google Billing Account associated with the Spend Profile. */
     private String billingAccountId;
 
+    private Map<String, String> limits;
+
     public String getId() {
       return id;
     }
@@ -61,6 +66,14 @@ public class SpendProfileConfiguration {
 
     public void setBillingAccountId(String billingAccountId) {
       this.billingAccountId = billingAccountId;
+    }
+
+    public Map<String, String>  getLimits(){
+      return limits;
+    }
+
+    public void setLimits(Map<String, String> limits){
+      this.limits = limits;
     }
   }
 }

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/SpendProfileConfiguration.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -4,6 +4,7 @@ import static bio.terra.workspace.app.controller.shared.PropertiesUtils.convertM
 
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
+import bio.terra.workspace.app.configuration.external.SpendProfileConfiguration;
 import bio.terra.workspace.common.exception.FeatureNotSupportedException;
 import bio.terra.workspace.generated.model.ApiAzureContext;
 import bio.terra.workspace.generated.model.ApiProperties;
@@ -162,9 +163,9 @@ public class WorkspaceApiUtils {
         Optional.ofNullable(workspaceDescription.azureCloudContext())
             .map(AzureCloudContext::toApi)
             .orElse(null);
-    SpendProfile maybeSpendProfile = spendProfileService.getSpendProfileById(spendProfileId);
-    if (context != null && maybeSpendProfile != null && maybeSpendProfile.organization() != null) {
-      context.setLimits(maybeSpendProfile.organization().limits());
+    SpendProfileConfiguration.SpendProfileModel maybeSpendProfile = spendProfileService.getSpendProfileById(spendProfileId);
+    if (context != null && maybeSpendProfile != null && maybeSpendProfile.getLimits() != null) {
+      context.setLimits(maybeSpendProfile.getLimits());
     }
     return context;
   }

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -133,8 +133,7 @@ public class WorkspaceApiUtils {
             Optional.ofNullable(workspaceDescriptions.gcpCloudContext())
                 .map(GcpCloudContext::toApi)
                 .orElse(null))
-        .azureContext(
-                buildAzureContext(workspaceDescriptions, workspace.getSpendProfileId().get()))
+        .azureContext(buildAzureContext(workspaceDescriptions, workspace.getSpendProfileId().get()))
         .awsContext(
             Optional.ofNullable(workspaceDescriptions.awsCloudContext())
                 .map(AwsCloudContext::toApi)
@@ -156,13 +155,15 @@ public class WorkspaceApiUtils {
                 workspace.flightId(), workspace.state(), workspace.error()));
   }
 
-  private ApiAzureContext buildAzureContext(WorkspaceDescription workspaceDescription, SpendProfileId spendProfileId){
-    ApiAzureContext context = Optional.ofNullable(workspaceDescription.azureCloudContext())
+  private ApiAzureContext buildAzureContext(
+      WorkspaceDescription workspaceDescription, SpendProfileId spendProfileId) {
+    ApiAzureContext context =
+        Optional.ofNullable(workspaceDescription.azureCloudContext())
             .map(AzureCloudContext::toApi)
             .orElse(null);
     SpendProfile maybeSpendProfile = spendProfileService.getSpendProfileById(spendProfileId);
-    if (maybeSpendProfile != null){
-      if (maybeSpendProfile.organization() != null){
+    if (maybeSpendProfile != null) {
+      if (maybeSpendProfile.organization() != null) {
         context.setLimits(maybeSpendProfile.organization().limits());
       }
     }

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -133,7 +133,7 @@ public class WorkspaceApiUtils {
             Optional.ofNullable(workspaceDescriptions.gcpCloudContext())
                 .map(GcpCloudContext::toApi)
                 .orElse(null))
-        .azureContext(buildAzureContext(workspaceDescriptions, workspace.getSpendProfileId().get()))
+        .azureContext(buildAzureContext(workspaceDescriptions, workspace.getSpendProfileId().orElse(null)))
         .awsContext(
             Optional.ofNullable(workspaceDescriptions.awsCloudContext())
                 .map(AwsCloudContext::toApi)

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -133,7 +133,8 @@ public class WorkspaceApiUtils {
             Optional.ofNullable(workspaceDescriptions.gcpCloudContext())
                 .map(GcpCloudContext::toApi)
                 .orElse(null))
-        .azureContext(buildAzureContext(workspaceDescriptions, workspace.getSpendProfileId().orElse(null)))
+        .azureContext(
+            buildAzureContext(workspaceDescriptions, workspace.getSpendProfileId().orElse(null)))
         .awsContext(
             Optional.ofNullable(workspaceDescriptions.awsCloudContext())
                 .map(AwsCloudContext::toApi)

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -163,7 +163,8 @@ public class WorkspaceApiUtils {
         Optional.ofNullable(workspaceDescription.azureCloudContext())
             .map(AzureCloudContext::toApi)
             .orElse(null);
-    SpendProfileConfiguration.SpendProfileModel maybeSpendProfile = spendProfileService.getSpendProfileById(spendProfileId);
+    SpendProfileConfiguration.SpendProfileModel maybeSpendProfile =
+        spendProfileService.getSpendProfileById(spendProfileId);
     if (context != null && maybeSpendProfile != null && maybeSpendProfile.getLimits() != null) {
       context.setLimits(maybeSpendProfile.getLimits());
     }

--- a/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
+++ b/service/src/main/java/bio/terra/workspace/app/controller/shared/WorkspaceApiUtils.java
@@ -162,10 +162,8 @@ public class WorkspaceApiUtils {
             .map(AzureCloudContext::toApi)
             .orElse(null);
     SpendProfile maybeSpendProfile = spendProfileService.getSpendProfileById(spendProfileId);
-    if (maybeSpendProfile != null) {
-      if (maybeSpendProfile.organization() != null) {
-        context.setLimits(maybeSpendProfile.organization().limits());
-      }
+    if (context != null && maybeSpendProfile != null && maybeSpendProfile.organization() != null) {
+      context.setLimits(maybeSpendProfile.organization().limits());
     }
     return context;
   }

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -133,28 +133,29 @@ public class SpendProfileService {
     return spendModels.stream()
         .filter(
             // filter out empty profiles
-            spendModel -> !Strings.isNullOrEmpty(spendModel.getId()))
-        .map(SpendProfileService::mapModelToSpendProfile)
+            spendModel -> !Strings.isNullOrEmpty(spendModel.getBillingAccountId())
+                    && !Strings.isNullOrEmpty(spendModel.getId()))
+            .map(
+                    spendModel ->
+                            new SpendProfile(
+                                    new SpendProfileId(spendModel.getId()),
+                                    CloudPlatform.GCP,
+                                    spendModel.getBillingAccountId(),
+                                    null,
+                                    null,
+                                    null,
+                                    null))
         .collect(Collectors.toList());
   }
 
-  private static SpendProfile mapModelToSpendProfile(
-      SpendProfileConfiguration.SpendProfileModel spendModel) {
-    return new SpendProfile(
-        new SpendProfileId(spendModel.getId()),
-        spendModel.getCloudPlatform(),
-        spendModel.getBillingAccountId(),
-        spendModel.getTenantId(),
-        spendModel.getSubscriptionId(),
-        spendModel.getManagedResourceGroupId(),
-        spendModel.getCloudPlatform() == CloudPlatform.AZURE
-            ? new SpendProfileOrganization(false, spendModel.getLimits())
-            : null);
-  }
-
-  public SpendProfile getSpendProfileById(SpendProfileId spendProfileId) {
-    return spendProfiles.getOrDefault(spendProfileId, null);
-  }
+  public SpendProfileConfiguration.SpendProfileModel getSpendProfileById(SpendProfileId spendProfileId) {
+    if (spendProfileId == null) {
+      return null;
+    }
+    return spendProfileConfiguration.getSpendProfiles().stream()
+            .filter(spendModel -> spendModel.getId().equals(spendProfileId.getId()))
+            .findFirst()
+            .orElse(null);  }
 
   @WithSpan
   private SpendProfile getSpendProfileFromBpm(

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -57,8 +57,8 @@ public class SpendProfileService {
       OpenTelemetry openTelemetry) {
     this(
         samService,
-//        adaptConfigurationModels(spendProfileConfiguration.getSpendProfiles()),
-            spendProfileConfiguration.getSpendProfiles(),
+        adaptConfigurationModels(spendProfileConfiguration.getSpendProfiles()),
+//            spendProfileConfiguration.getSpendProfiles(),
         spendProfileConfiguration,
         openTelemetry);
   }
@@ -141,15 +141,24 @@ public class SpendProfileService {
 //                    && !Strings.isNullOrEmpty(spendModel.getId()))
     .map(
             spendModel ->
-                new SpendProfile(
-                    new SpendProfileId(spendModel.getId()),
-                    CloudPlatform.GCP,
-                    spendModel.getBillingAccountId(),
-                    null,
-                    null,
-                    null,
-                    null))
+                    mapModelToSpendProfile(spendModel)
+                   )
         .collect(Collectors.toList());
+  }
+
+  private static SpendProfile mapModelToSpendProfile(SpendProfileConfiguration.SpendProfileModel spendModel){
+    return new SpendProfile(
+            new SpendProfileId(spendModel.getId()),
+            spendModel.getCloudPlatform(),
+            spendModel.getBillingAccountId(),
+            spendModel.getTenantId(),
+            spendModel.getSubscriptionId(),
+            spendModel.getManagedResourceGroupId(),
+            spendModel.getCloudPlatform() == CloudPlatform.AZURE ? new SpendProfileOrganization(false, spendModel.getLimits()) : null);
+  }
+
+  public SpendProfile getSpendProfileById(SpendProfileId spendProfileId){
+    return spendProfiles.getOrDefault(spendProfileId, null);
   }
 
   @WithSpan

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -133,29 +133,32 @@ public class SpendProfileService {
     return spendModels.stream()
         .filter(
             // filter out empty profiles
-            spendModel -> !Strings.isNullOrEmpty(spendModel.getBillingAccountId())
+            spendModel ->
+                !Strings.isNullOrEmpty(spendModel.getBillingAccountId())
                     && !Strings.isNullOrEmpty(spendModel.getId()))
-            .map(
-                    spendModel ->
-                            new SpendProfile(
-                                    new SpendProfileId(spendModel.getId()),
-                                    CloudPlatform.GCP,
-                                    spendModel.getBillingAccountId(),
-                                    null,
-                                    null,
-                                    null,
-                                    null))
+        .map(
+            spendModel ->
+                new SpendProfile(
+                    new SpendProfileId(spendModel.getId()),
+                    CloudPlatform.GCP,
+                    spendModel.getBillingAccountId(),
+                    null,
+                    null,
+                    null,
+                    null))
         .collect(Collectors.toList());
   }
 
-  public SpendProfileConfiguration.SpendProfileModel getSpendProfileById(SpendProfileId spendProfileId) {
+  public SpendProfileConfiguration.SpendProfileModel getSpendProfileById(
+      SpendProfileId spendProfileId) {
     if (spendProfileId == null) {
       return null;
     }
     return spendProfileConfiguration.getSpendProfiles().stream()
-            .filter(spendModel -> spendModel.getId().equals(spendProfileId.getId()))
-            .findFirst()
-            .orElse(null);  }
+        .filter(spendModel -> spendModel.getId().equals(spendProfileId.getId()))
+        .findFirst()
+        .orElse(null);
+  }
 
   @WithSpan
   private SpendProfile getSpendProfileFromBpm(

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -58,7 +58,6 @@ public class SpendProfileService {
     this(
         samService,
         adaptConfigurationModels(spendProfileConfiguration.getSpendProfiles()),
-//            spendProfileConfiguration.getSpendProfiles(),
         spendProfileConfiguration,
         openTelemetry);
   }
@@ -134,30 +133,26 @@ public class SpendProfileService {
     return spendModels.stream()
         .filter(
             // filter out empty profiles
-            spendModel ->
-                !Strings.isNullOrEmpty(spendModel.getId()))
-//    spendModel ->
-//            !Strings.isNullOrEmpty(spendModel.getBillingAccountId())
-//                    && !Strings.isNullOrEmpty(spendModel.getId()))
-    .map(
-            spendModel ->
-                    mapModelToSpendProfile(spendModel)
-                   )
+            spendModel -> !Strings.isNullOrEmpty(spendModel.getId()))
+        .map(spendModel -> mapModelToSpendProfile(spendModel))
         .collect(Collectors.toList());
   }
 
-  private static SpendProfile mapModelToSpendProfile(SpendProfileConfiguration.SpendProfileModel spendModel){
+  private static SpendProfile mapModelToSpendProfile(
+      SpendProfileConfiguration.SpendProfileModel spendModel) {
     return new SpendProfile(
-            new SpendProfileId(spendModel.getId()),
-            spendModel.getCloudPlatform(),
-            spendModel.getBillingAccountId(),
-            spendModel.getTenantId(),
-            spendModel.getSubscriptionId(),
-            spendModel.getManagedResourceGroupId(),
-            spendModel.getCloudPlatform() == CloudPlatform.AZURE ? new SpendProfileOrganization(false, spendModel.getLimits()) : null);
+        new SpendProfileId(spendModel.getId()),
+        spendModel.getCloudPlatform(),
+        spendModel.getBillingAccountId(),
+        spendModel.getTenantId(),
+        spendModel.getSubscriptionId(),
+        spendModel.getManagedResourceGroupId(),
+        spendModel.getCloudPlatform() == CloudPlatform.AZURE
+            ? new SpendProfileOrganization(false, spendModel.getLimits())
+            : null);
   }
 
-  public SpendProfile getSpendProfileById(SpendProfileId spendProfileId){
+  public SpendProfile getSpendProfileById(SpendProfileId spendProfileId) {
     return spendProfiles.getOrDefault(spendProfileId, null);
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -57,7 +57,8 @@ public class SpendProfileService {
       OpenTelemetry openTelemetry) {
     this(
         samService,
-        adaptConfigurationModels(spendProfileConfiguration.getSpendProfiles()),
+//        adaptConfigurationModels(spendProfileConfiguration.getSpendProfiles()),
+            spendProfileConfiguration.getSpendProfiles(),
         spendProfileConfiguration,
         openTelemetry);
   }
@@ -134,9 +135,11 @@ public class SpendProfileService {
         .filter(
             // filter out empty profiles
             spendModel ->
-                !Strings.isNullOrEmpty(spendModel.getBillingAccountId())
-                    && !Strings.isNullOrEmpty(spendModel.getId()))
-        .map(
+                !Strings.isNullOrEmpty(spendModel.getId()))
+//    spendModel ->
+//            !Strings.isNullOrEmpty(spendModel.getBillingAccountId())
+//                    && !Strings.isNullOrEmpty(spendModel.getId()))
+    .map(
             spendModel ->
                 new SpendProfile(
                     new SpendProfileId(spendModel.getId()),

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -134,7 +134,7 @@ public class SpendProfileService {
         .filter(
             // filter out empty profiles
             spendModel -> !Strings.isNullOrEmpty(spendModel.getId()))
-        .map(spendModel -> mapModelToSpendProfile(spendModel))
+        .map(SpendProfileService::mapModelToSpendProfile)
         .collect(Collectors.toList());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/model/SpendProfileOrganization.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/model/SpendProfileOrganization.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.service.spendprofile.model;
 
 import bio.terra.profile.model.Organization;
-
 import java.util.Map;
 
 public record SpendProfileOrganization(boolean enterprise, Map<String, String> limits) {

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/model/SpendProfileOrganization.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/model/SpendProfileOrganization.java
@@ -2,8 +2,10 @@ package bio.terra.workspace.service.spendprofile.model;
 
 import bio.terra.profile.model.Organization;
 
-public record SpendProfileOrganization(boolean enterprise) {
+import java.util.Map;
+
+public record SpendProfileOrganization(boolean enterprise, Map<String, String> limits) {
   public SpendProfileOrganization(Organization organization) {
-    this(organization.isEnterprise());
+    this(organization.isEnterprise(), organization.getLimits());
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -152,6 +152,17 @@ workspace:
       id: wm-default-spend-profile
       # The billing account workspace-dev has access to.
       billing-account-id: 01A82E-CA8A14-367457
+      cloud-platform: GCP
+    - id: facade00-0000-4000-a000-000000000000
+      tenant-id: decade00-0000-4000-a000-000000000000
+      subscription-id: 5ca1ab1e-0000-4000-a000-000000000000
+      managed-resource-group-id: default-MRG
+      cloud-platform: AZURE
+      organization:
+        enterprise: false
+        limits:
+          persistent-disk: 32
+
 
   landing-zone:
     base-path: ${env.urls.lzs}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -152,15 +152,6 @@ workspace:
       id: wm-default-spend-profile
       # The billing account workspace-dev has access to.
       billing-account-id: 01A82E-CA8A14-367457
-      cloud-platform: GCP
-    - id: 840153fc-4fe0-43c3-84c9-608259d3d590
-      tenant-id: decade00-0000-4000-a000-000000000000
-      subscription-id: 5ca1ab1e-0000-4000-a000-000000000000
-      managed-resource-group-id: default-MRG
-      cloud-platform: AZURE
-      limits:
-        persistent-disk: 32
-
 
   landing-zone:
     base-path: ${env.urls.lzs}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -153,15 +153,13 @@ workspace:
       # The billing account workspace-dev has access to.
       billing-account-id: 01A82E-CA8A14-367457
       cloud-platform: GCP
-    - id: facade00-0000-4000-a000-000000000000
+    - id: 840153fc-4fe0-43c3-84c9-608259d3d590
       tenant-id: decade00-0000-4000-a000-000000000000
       subscription-id: 5ca1ab1e-0000-4000-a000-000000000000
       managed-resource-group-id: default-MRG
       cloud-platform: AZURE
-      organization:
-        enterprise: false
-        limits:
-          persistent-disk: 32
+      limits:
+        persistent-disk: 32
 
 
   landing-zone:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -154,9 +154,6 @@ workspace:
       billing-account-id: 01A82E-CA8A14-367457
       cloud-platform: GCP
     - id: facade00-0000-4000-a000-000000000000
-      tenant-id: decade00-0000-4000-a000-000000000000
-      subscription-id: 5ca1ab1e-0000-4000-a000-000000000000
-      managed-resource-group-id: default-MRG
       cloud-platform: AZURE
       limits:
         persistent-disk: 32

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -152,6 +152,14 @@ workspace:
       id: wm-default-spend-profile
       # The billing account workspace-dev has access to.
       billing-account-id: 01A82E-CA8A14-367457
+      cloud-platform: GCP
+    - id: facade00-0000-4000-a000-000000000000
+      tenant-id: decade00-0000-4000-a000-000000000000
+      subscription-id: 5ca1ab1e-0000-4000-a000-000000000000
+      managed-resource-group-id: default-MRG
+      cloud-platform: AZURE
+      limits:
+        persistent-disk: 32
 
   landing-zone:
     base-path: ${env.urls.lzs}

--- a/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/ReferencedResourceCloneConnectedTest.java
@@ -2,7 +2,7 @@ package bio.terra.workspace.app.controller;
 
 import static bio.terra.workspace.common.fixtures.ControlledResourceFixtures.RESOURCE_DESCRIPTION;
 import static bio.terra.workspace.common.fixtures.PolicyFixtures.IOWA_REGION;
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_NAME;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_NAME;
 import static bio.terra.workspace.common.mocks.MockGcpApi.CREATE_REFERENCED_GCP_GCS_BUCKETS_PATH_FORMAT;
 import static bio.terra.workspace.common.mocks.MockWorkspaceV1Api.WORKSPACES_V1_CLONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -182,7 +182,7 @@ public class ReferencedResourceCloneConnectedTest extends BaseConnectedTest {
     workspaceSetup(ApiCloningInstructionsEnum.REFERENCE);
     ApiCloneWorkspaceRequest request =
         new ApiCloneWorkspaceRequest()
-            .spendProfile(DEFAULT_SPEND_PROFILE_NAME)
+            .spendProfile(DEFAULT_GCP_SPEND_PROFILE_NAME)
             .additionalPolicies(
                 new ApiWsmPolicyInputs().addInputsItem(makeRegionPolicyInput("asiapacific")));
 

--- a/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
+++ b/service/src/test/java/bio/terra/workspace/app/controller/WorkspaceApiControllerTest.java
@@ -1,10 +1,6 @@
 package bio.terra.workspace.app.controller;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_NAME;
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.SHORT_DESCRIPTION_PROPERTY;
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.TYPE_PROPERTY;
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.VERSION_PROPERTY;
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.WORKSPACE_NAME;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.*;
 import static bio.terra.workspace.common.mocks.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.mocks.MockMvcUtils.addAuth;
 import static bio.terra.workspace.common.mocks.MockMvcUtils.addJsonContentType;
@@ -307,7 +303,7 @@ public class WorkspaceApiControllerTest extends BaseSpringBootUnitTestMockDataRe
 
     ApiCloneWorkspaceResult cloneWorkspace =
         mockWorkspaceV1Api.cloneWorkspace(
-            USER_REQUEST, workspaceId, DEFAULT_SPEND_PROFILE_NAME, null, null);
+            USER_REQUEST, workspaceId, DEFAULT_GCP_SPEND_PROFILE_NAME, null, null);
     jobService.waitForJob(cloneWorkspace.getJobReport().getId());
 
     UUID destinationWorkspaceId = cloneWorkspace.getWorkspace().getDestinationWorkspaceId();
@@ -435,6 +431,17 @@ public class WorkspaceApiControllerTest extends BaseSpringBootUnitTestMockDataRe
 
     ApiWorkspaceDescription gotWorkspace =
         mockWorkspaceV1Api.getWorkspace(USER_REQUEST, workspace.getId());
+    assertEquals(0, gotWorkspace.getPolicies().size());
+  }
+
+  @Test
+  public void getWorkspace_includesLimits() throws Exception {
+    when(mockFeatureConfiguration().isTpsEnabled()).thenReturn(false);
+    ApiCreatedWorkspace workspace =
+            mockWorkspaceV1Api.createWorkspaceWithoutCloudContext(USER_REQUEST);
+
+    ApiWorkspaceDescription gotWorkspace =
+            mockWorkspaceV1Api.getWorkspace(USER_REQUEST, workspace.getId());
     assertEquals(0, gotWorkspace.getPolicies().size());
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
@@ -13,7 +13,6 @@ import bio.terra.workspace.service.spendprofile.model.SpendProfileOrganization;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
-
 import java.util.Collections;
 import java.util.UUID;
 import org.mockito.Mockito;

--- a/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/common/BaseAzureConnectedTest.java
@@ -13,6 +13,8 @@ import bio.terra.workspace.service.spendprofile.model.SpendProfileOrganization;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
+
+import java.util.Collections;
 import java.util.UUID;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,7 +80,7 @@ public class BaseAzureConnectedTest extends BaseSpringBootTest {
                 UUID.fromString(azureTestUtils.getAzureCloudContext().getAzureTenantId()),
                 UUID.fromString(azureTestUtils.getAzureCloudContext().getAzureSubscriptionId()),
                 azureTestUtils.getAzureCloudContext().getAzureResourceGroupId(),
-                new SpendProfileOrganization(false)));
+                new SpendProfileOrganization(false, Collections.emptyMap())));
 
     return azureTestUtils.getSpendProfileId();
   }

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -7,6 +7,7 @@ import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
 import bio.terra.stairway.FlightMap;
 import bio.terra.workspace.db.WorkspaceDao;
+import bio.terra.workspace.generated.model.ApiCloudPlatform;
 import bio.terra.workspace.generated.model.ApiCreateWorkspaceRequestBody;
 import bio.terra.workspace.generated.model.ApiProperties;
 import bio.terra.workspace.generated.model.ApiProperty;
@@ -15,7 +16,6 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.spendprofile.model.SpendProfile;
 import bio.terra.workspace.service.spendprofile.model.SpendProfileId;
-import bio.terra.workspace.service.spendprofile.model.SpendProfileOrganization;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
@@ -46,11 +46,8 @@ public class WorkspaceFixtures {
       new SpendProfileId(DEFAULT_GCP_SPEND_PROFILE_NAME);
   public static final SpendProfile DEFAULT_GCP_SPEND_PROFILE =
       SpendProfile.buildGcpSpendProfile(DEFAULT_GCP_SPEND_PROFILE_ID, "billingAccountId");
-  public static final String DEFAULT_AZURE_SPEND_PROFILE_NAME = "facade00-0000-4000-a000-000000000000";
-  public static final SpendProfileId DEFAULT_AZURE_SPEND_PROFILE_ID =
-          new SpendProfileId(DEFAULT_AZURE_SPEND_PROFILE_NAME);
-//  public static final SpendProfile DEFAULT_AZURE_SPEND_PROFILE =
-//          SpendProfile.buildAzureSpendProfile(DEFAULT_AZURE_SPEND_PROFILE_ID, UUID.fromString("decade00-0000-4000-a000-000000000000"), UUID.fromString("5ca1ab1e-0000-4000-a000-000000000000"), "default-MRG", new SpendProfileOrganization(false, ));
+  public static final String DEFAULT_AZURE_SPEND_PROFILE_NAME =
+      "facade00-0000-4000-a000-000000000000";
 
   public static final String DEFAULT_USER_EMAIL = "fake@gmail.com";
   public static final String DEFAULT_USER_SUBJECT_ID = "subjectId123456";
@@ -67,7 +64,12 @@ public class WorkspaceFixtures {
    * <p>All values are mutable, and tests should change any they explicitly need.
    */
   public static ApiCreateWorkspaceRequestBody createWorkspaceRequestBody() {
-    return createWorkspaceRequestBody(ApiWorkspaceStageModel.MC_WORKSPACE);
+    return createWorkspaceRequestBody(ApiWorkspaceStageModel.MC_WORKSPACE, ApiCloudPlatform.GCP);
+  }
+
+  public static ApiCreateWorkspaceRequestBody createWorkspaceRequestBody(
+      ApiCloudPlatform apiCloudPlatform) {
+    return createWorkspaceRequestBody(ApiWorkspaceStageModel.MC_WORKSPACE, apiCloudPlatform);
   }
 
   public static Workspace createDefaultMcWorkspace() {
@@ -134,6 +136,26 @@ public class WorkspaceFixtures {
   }
 
   public static ApiCreateWorkspaceRequestBody createWorkspaceRequestBody(
+      ApiWorkspaceStageModel stageModel, ApiCloudPlatform apiCloudPlatform) {
+    UUID workspaceId = UUID.randomUUID();
+    ApiProperties properties = new ApiProperties();
+    properties.addAll(
+        ImmutableList.of(
+            TYPE_PROPERTY, SHORT_DESCRIPTION_PROPERTY, VERSION_PROPERTY, USER_SET_PROPERTY));
+    return new ApiCreateWorkspaceRequestBody()
+        .id(workspaceId)
+        .displayName(WORKSPACE_NAME)
+        .description("A test workspace created by createWorkspaceRequestBody")
+        .userFacingId(getUserFacingId(workspaceId))
+        .stage(stageModel)
+        .spendProfile(
+            apiCloudPlatform == ApiCloudPlatform.AZURE
+                ? DEFAULT_AZURE_SPEND_PROFILE_NAME
+                : DEFAULT_GCP_SPEND_PROFILE_NAME)
+        .properties(properties);
+  }
+
+  public static ApiCreateWorkspaceRequestBody createAzureWorkspaceRequestBody(
       ApiWorkspaceStageModel stageModel) {
     UUID workspaceId = UUID.randomUUID();
     ApiProperties properties = new ApiProperties();
@@ -146,7 +168,7 @@ public class WorkspaceFixtures {
         .description("A test workspace created by createWorkspaceRequestBody")
         .userFacingId(getUserFacingId(workspaceId))
         .stage(stageModel)
-        .spendProfile(DEFAULT_GCP_SPEND_PROFILE_NAME)
+        .spendProfile(DEFAULT_AZURE_SPEND_PROFILE_NAME)
         .properties(properties);
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
+++ b/service/src/test/java/bio/terra/workspace/common/fixtures/WorkspaceFixtures.java
@@ -15,6 +15,7 @@ import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
 import bio.terra.workspace.service.job.JobMapKeys;
 import bio.terra.workspace.service.spendprofile.model.SpendProfile;
 import bio.terra.workspace.service.spendprofile.model.SpendProfileId;
+import bio.terra.workspace.service.spendprofile.model.SpendProfileOrganization;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import bio.terra.workspace.service.workspace.model.Workspace;
@@ -40,11 +41,17 @@ public class WorkspaceFixtures {
       new ApiProperty().key(Properties.VERSION).value("version 3");
   public static final ApiProperty USER_SET_PROPERTY =
       new ApiProperty().key("userkey").value("uservalue");
-  public static final String DEFAULT_SPEND_PROFILE_NAME = "wm-default-spend-profile";
-  public static final SpendProfileId DEFAULT_SPEND_PROFILE_ID =
-      new SpendProfileId(DEFAULT_SPEND_PROFILE_NAME);
-  public static final SpendProfile DEFAULT_SPEND_PROFILE =
-      SpendProfile.buildGcpSpendProfile(DEFAULT_SPEND_PROFILE_ID, "billingAccountId");
+  public static final String DEFAULT_GCP_SPEND_PROFILE_NAME = "wm-default-spend-profile";
+  public static final SpendProfileId DEFAULT_GCP_SPEND_PROFILE_ID =
+      new SpendProfileId(DEFAULT_GCP_SPEND_PROFILE_NAME);
+  public static final SpendProfile DEFAULT_GCP_SPEND_PROFILE =
+      SpendProfile.buildGcpSpendProfile(DEFAULT_GCP_SPEND_PROFILE_ID, "billingAccountId");
+  public static final String DEFAULT_AZURE_SPEND_PROFILE_NAME = "facade00-0000-4000-a000-000000000000";
+  public static final SpendProfileId DEFAULT_AZURE_SPEND_PROFILE_ID =
+          new SpendProfileId(DEFAULT_AZURE_SPEND_PROFILE_NAME);
+//  public static final SpendProfile DEFAULT_AZURE_SPEND_PROFILE =
+//          SpendProfile.buildAzureSpendProfile(DEFAULT_AZURE_SPEND_PROFILE_ID, UUID.fromString("decade00-0000-4000-a000-000000000000"), UUID.fromString("5ca1ab1e-0000-4000-a000-000000000000"), "default-MRG", new SpendProfileOrganization(false, ));
+
   public static final String DEFAULT_USER_EMAIL = "fake@gmail.com";
   public static final String DEFAULT_USER_SUBJECT_ID = "subjectId123456";
   public static final SamUser SAM_USER =
@@ -64,7 +71,7 @@ public class WorkspaceFixtures {
   }
 
   public static Workspace createDefaultMcWorkspace() {
-    return createDefaultMcWorkspace(DEFAULT_SPEND_PROFILE_ID);
+    return createDefaultMcWorkspace(DEFAULT_GCP_SPEND_PROFILE_ID);
   }
 
   public static Workspace createDefaultMcWorkspace(SpendProfileId spendProfileId) {
@@ -139,7 +146,7 @@ public class WorkspaceFixtures {
         .description("A test workspace created by createWorkspaceRequestBody")
         .userFacingId(getUserFacingId(workspaceId))
         .stage(stageModel)
-        .spendProfile(DEFAULT_SPEND_PROFILE_NAME)
+        .spendProfile(DEFAULT_GCP_SPEND_PROFILE_NAME)
         .properties(properties);
   }
 

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV1Api.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV1Api.java
@@ -82,14 +82,30 @@ public class MockWorkspaceV1Api {
 
   public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
       @Nullable AuthenticatedUserRequest userRequest) throws Exception {
-    return createWorkspaceWithoutCloudContext(userRequest, ApiWorkspaceStageModel.MC_WORKSPACE);
+    return createWorkspaceWithoutCloudContext(
+        userRequest, ApiWorkspaceStageModel.MC_WORKSPACE, ApiCloudPlatform.GCP);
+  }
+
+  public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
+      @Nullable AuthenticatedUserRequest userRequest, ApiCloudPlatform apiCloudPlatform)
+      throws Exception {
+    return createWorkspaceWithoutCloudContext(
+        userRequest, ApiWorkspaceStageModel.MC_WORKSPACE, apiCloudPlatform);
   }
 
   public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
       @Nullable AuthenticatedUserRequest userRequest, ApiWorkspaceStageModel stageModel)
       throws Exception {
+    return createWorkspaceWithoutCloudContext(userRequest, stageModel, ApiCloudPlatform.GCP);
+  }
+
+  public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
+      @Nullable AuthenticatedUserRequest userRequest,
+      ApiWorkspaceStageModel stageModel,
+      ApiCloudPlatform apiCloudPlatform)
+      throws Exception {
     ApiCreateWorkspaceRequestBody request =
-        WorkspaceFixtures.createWorkspaceRequestBody(stageModel);
+        WorkspaceFixtures.createWorkspaceRequestBody(stageModel, apiCloudPlatform);
     String serializedResponse =
         mockMvcUtils.getSerializedResponseForPost(
             userRequest, WORKSPACES_V1_CREATE, objectMapper.writeValueAsString(request));
@@ -99,6 +115,17 @@ public class MockWorkspaceV1Api {
   public ApiCreatedWorkspace createWorkspaceWithoutCloudContext(
       @Nullable AuthenticatedUserRequest userRequest, ApiCreateWorkspaceRequestBody request)
       throws Exception {
+    String serializedResponse =
+        mockMvcUtils.getSerializedResponseForPost(
+            userRequest, WORKSPACES_V1_CREATE, objectMapper.writeValueAsString(request));
+    return objectMapper.readValue(serializedResponse, ApiCreatedWorkspace.class);
+  }
+
+  public ApiCreatedWorkspace createAzureWorkspaceWithoutCloudContext(
+      @Nullable AuthenticatedUserRequest userRequest, ApiWorkspaceStageModel stageModel)
+      throws Exception {
+    ApiCreateWorkspaceRequestBody request =
+        WorkspaceFixtures.createAzureWorkspaceRequestBody(stageModel);
     String serializedResponse =
         mockMvcUtils.getSerializedResponseForPost(
             userRequest, WORKSPACES_V1_CREATE, objectMapper.writeValueAsString(request));
@@ -144,7 +171,8 @@ public class MockWorkspaceV1Api {
 
   public ApiCreatedWorkspace createWorkspaceWithCloudContext(
       AuthenticatedUserRequest userRequest, ApiCloudPlatform apiCloudPlatform) throws Exception {
-    ApiCreatedWorkspace createdWorkspace = createWorkspaceWithoutCloudContext(userRequest);
+    ApiCreatedWorkspace createdWorkspace =
+        createWorkspaceWithoutCloudContext(userRequest, apiCloudPlatform);
     createCloudContextAndWait(userRequest, createdWorkspace.getId(), apiCloudPlatform);
     return createdWorkspace;
   }

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV2Api.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV2Api.java
@@ -55,7 +55,10 @@ public class MockWorkspaceV2Api {
         new ApiCreateWorkspaceV2Request()
             .id(UUID.randomUUID())
             .cloudPlatform(cloudPlatform)
-            .spendProfile(cloudPlatform == ApiCloudPlatform.AZURE ? WorkspaceFixtures.DEFAULT_AZURE_SPEND_PROFILE_NAME : WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_NAME)
+            .spendProfile(
+                cloudPlatform == ApiCloudPlatform.AZURE
+                    ? WorkspaceFixtures.DEFAULT_AZURE_SPEND_PROFILE_NAME
+                    : WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_NAME)
             .stage(ApiWorkspaceStageModel.MC_WORKSPACE)
             .jobControl(new ApiJobControl().id(jobId));
 

--- a/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV2Api.java
+++ b/service/src/test/java/bio/terra/workspace/common/mocks/MockWorkspaceV2Api.java
@@ -55,7 +55,7 @@ public class MockWorkspaceV2Api {
         new ApiCreateWorkspaceV2Request()
             .id(UUID.randomUUID())
             .cloudPlatform(cloudPlatform)
-            .spendProfile(WorkspaceFixtures.DEFAULT_SPEND_PROFILE_NAME)
+            .spendProfile(cloudPlatform == ApiCloudPlatform.AZURE ? WorkspaceFixtures.DEFAULT_AZURE_SPEND_PROFILE_NAME : WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_NAME)
             .stage(ApiWorkspaceStageModel.MC_WORKSPACE)
             .jobControl(new ApiJobControl().id(jobId));
 

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsConnectedTestUtils.java
@@ -46,7 +46,7 @@ public class AwsConnectedTestUtils {
             environment.getMetadata().getEnvironmentAlias(),
             /*workspaceSecurityGroups*/ null),
         new CloudContextCommonFields(
-            WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID,
+            WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID,
             WsmResourceState.READY,
             /* flightId= */ null,
             /* error= */ null));

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsTestUtils.java
@@ -96,7 +96,7 @@ public class AwsTestUtils {
             ENVIRONMENT_ALIAS,
             AWS_WORKSPACE_SECURITY_GROUPS),
         new CloudContextCommonFields(
-                DEFAULT_GCP_SPEND_PROFILE_ID,
+            DEFAULT_GCP_SPEND_PROFILE_ID,
             WsmResourceState.READY,
             /* flightId= */ null,
             /* error= */ null));

--- a/service/src/test/java/bio/terra/workspace/common/utils/AwsTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AwsTestUtils.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.common.utils;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -96,7 +96,7 @@ public class AwsTestUtils {
             ENVIRONMENT_ALIAS,
             AWS_WORKSPACE_SECURITY_GROUPS),
         new CloudContextCommonFields(
-            DEFAULT_SPEND_PROFILE_ID,
+                DEFAULT_GCP_SPEND_PROFILE_ID,
             WsmResourceState.READY,
             /* flightId= */ null,
             /* error= */ null));

--- a/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/AzureTestUtils.java
@@ -35,6 +35,7 @@ import com.azure.resourcemanager.msi.MsiManager;
 import com.azure.resourcemanager.postgresqlflexibleserver.PostgreSqlManager;
 import com.azure.resourcemanager.storage.StorageManager;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -162,6 +163,6 @@ public class AzureTestUtils {
         UUID.fromString(azureTestConfiguration.getTenantId()),
         UUID.fromString(azureTestConfiguration.getSubscriptionId()),
         azureTestConfiguration.getManagedResourceGroupId(),
-        new SpendProfileOrganization(false));
+        new SpendProfileOrganization(false, Collections.emptyMap()));
   }
 }

--- a/service/src/test/java/bio/terra/workspace/common/utils/WorkspaceUnitTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/WorkspaceUnitTestUtils.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.common.utils;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID;
 
 import bio.terra.workspace.common.fixtures.WorkspaceFixtures;
 import bio.terra.workspace.db.WorkspaceDao;
@@ -40,7 +40,7 @@ public class WorkspaceUnitTestUtils {
   public static DbCloudContext makeDbCloudContext(CloudPlatform cloudPlatform, String json) {
     return new DbCloudContext()
         .cloudPlatform(cloudPlatform)
-        .spendProfile(DEFAULT_SPEND_PROFILE_ID)
+        .spendProfile(DEFAULT_GCP_SPEND_PROFILE_ID)
         .contextJson(json)
         .state(WsmResourceState.READY)
         .flightId(null)
@@ -76,7 +76,7 @@ public class WorkspaceUnitTestUtils {
       WorkspaceDao workspaceDao, UUID workspaceUuid, String projectId) {
     String flightId = UUID.randomUUID().toString();
     workspaceDao.createCloudContextStart(
-        workspaceUuid, CloudPlatform.GCP, DEFAULT_SPEND_PROFILE_ID, flightId);
+        workspaceUuid, CloudPlatform.GCP, DEFAULT_GCP_SPEND_PROFILE_ID, flightId);
     workspaceDao.createCloudContextSuccess(
         workspaceUuid,
         CloudPlatform.GCP,
@@ -84,7 +84,7 @@ public class WorkspaceUnitTestUtils {
                 new GcpCloudContextFields(
                     projectId, POLICY_OWNER, POLICY_WRITER, POLICY_READER, POLICY_APPLICATION),
                 new CloudContextCommonFields(
-                    DEFAULT_SPEND_PROFILE_ID,
+                        DEFAULT_GCP_SPEND_PROFILE_ID,
                     WsmResourceState.CREATING,
                     flightId,
                     /* error= */ null))

--- a/service/src/test/java/bio/terra/workspace/common/utils/WorkspaceUnitTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/common/utils/WorkspaceUnitTestUtils.java
@@ -84,7 +84,7 @@ public class WorkspaceUnitTestUtils {
                 new GcpCloudContextFields(
                     projectId, POLICY_OWNER, POLICY_WRITER, POLICY_READER, POLICY_APPLICATION),
                 new CloudContextCommonFields(
-                        DEFAULT_GCP_SPEND_PROFILE_ID,
+                    DEFAULT_GCP_SPEND_PROFILE_ID,
                     WsmResourceState.CREATING,
                     flightId,
                     /* error= */ null))

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.db;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.WorkspaceUnitTestUtils.POLICY_APPLICATION;
 import static bio.terra.workspace.common.utils.WorkspaceUnitTestUtils.POLICY_OWNER;
@@ -338,7 +338,7 @@ class WorkspaceDaoTest extends BaseSpringBootUnitTest {
       // Mismatched flight id
       String flightId = UUID.randomUUID().toString();
       workspaceDao.createCloudContextStart(
-          workspaceUuid, CloudPlatform.GCP, DEFAULT_SPEND_PROFILE_ID, flightId);
+          workspaceUuid, CloudPlatform.GCP, DEFAULT_GCP_SPEND_PROFILE_ID, flightId);
 
       String gcpContextString = makeCloudContext().serialize();
 
@@ -404,7 +404,7 @@ class WorkspaceDaoTest extends BaseSpringBootUnitTest {
     void workspaceCreateErrorDeserializes() {
       var flightId = UUID.randomUUID().toString();
       workspaceDao.createCloudContextStart(
-          workspaceUuid, CloudPlatform.GCP, DEFAULT_SPEND_PROFILE_ID, flightId);
+          workspaceUuid, CloudPlatform.GCP, DEFAULT_GCP_SPEND_PROFILE_ID, flightId);
       var exception = new FieldSizeExceededException("This is a random ErrorReportException");
       workspaceDao.createCloudContextFailure(
           workspaceUuid,
@@ -467,7 +467,7 @@ class WorkspaceDaoTest extends BaseSpringBootUnitTest {
         new GcpCloudContextFields(
             PROJECT_ID, POLICY_OWNER, POLICY_WRITER, POLICY_READER, POLICY_APPLICATION),
         new CloudContextCommonFields(
-            DEFAULT_SPEND_PROFILE_ID,
+                DEFAULT_GCP_SPEND_PROFILE_ID,
             WsmResourceState.READY,
             /* flightId= */ null,
             /* error= */ null));

--- a/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
+++ b/service/src/test/java/bio/terra/workspace/db/WorkspaceDaoTest.java
@@ -467,7 +467,7 @@ class WorkspaceDaoTest extends BaseSpringBootUnitTest {
         new GcpCloudContextFields(
             PROJECT_ID, POLICY_OWNER, POLICY_WRITER, POLICY_READER, POLICY_APPLICATION),
         new CloudContextCommonFields(
-                DEFAULT_GCP_SPEND_PROFILE_ID,
+            DEFAULT_GCP_SPEND_PROFILE_ID,
             WsmResourceState.READY,
             /* flightId= */ null,
             /* error= */ null));

--- a/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/policy/PolicyValidatorTest.java
@@ -308,7 +308,7 @@ public class PolicyValidatorTest {
             new TpsPolicyInput()
                 .namespace(TpsUtilities.TERRA_NAMESPACE)
                 .name(TpsUtilities.DATA_TRACKING_POLICY_NAME));
-    mockSpendProfileResponse(new SpendProfileOrganization(true));
+    mockSpendProfileResponse(new SpendProfileOrganization(true, Collections.emptyMap()));
 
     var errors =
         policyValidator.validateWorkspaceConformsToDataTrackingPolicy(
@@ -328,7 +328,7 @@ public class PolicyValidatorTest {
             new TpsPolicyInput()
                 .namespace(TpsUtilities.TERRA_NAMESPACE)
                 .name(TpsUtilities.DATA_TRACKING_POLICY_NAME));
-    mockSpendProfileResponse(new SpendProfileOrganization(true));
+    mockSpendProfileResponse(new SpendProfileOrganization(true, Collections.emptyMap()));
 
     var errors =
         policyValidator.validateWorkspaceConformsToDataTrackingPolicy(
@@ -390,7 +390,7 @@ public class PolicyValidatorTest {
             new TpsPolicyInput()
                 .namespace(TpsUtilities.TERRA_NAMESPACE)
                 .name(TpsUtilities.DATA_TRACKING_POLICY_NAME));
-    mockSpendProfileResponse(new SpendProfileOrganization(false));
+    mockSpendProfileResponse(new SpendProfileOrganization(false, Collections.emptyMap()));
 
     var errors =
         policyValidator.validateWorkspaceConformsToDataTrackingPolicy(

--- a/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/statetests/GcpResourceStateFailureTest.java
@@ -102,7 +102,7 @@ public class GcpResourceStateFailureTest extends BaseSpringBootUnitTest {
     workspaceDao.createCloudContextStart(
         workspace.getWorkspaceId(),
         CloudPlatform.GCP,
-        WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID,
+        WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID,
         createContextFlightId);
 
     // GCP-Controlled Instance
@@ -332,7 +332,7 @@ public class GcpResourceStateFailureTest extends BaseSpringBootUnitTest {
     workspaceDao.createCloudContextStart(
         targetWorkspace.getWorkspaceId(),
         CloudPlatform.GCP,
-        WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID,
+        WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID,
         createContextFlightId);
 
     mockGcpApi.cloneControlledBqDatasetAsyncAndExpect(

--- a/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendConnectedTestUtils.java
@@ -23,11 +23,11 @@ public class SpendConnectedTestUtils {
    */
   public SpendProfile defaultGcpSpendProfile() {
     if (defaultSpendProfile == null) {
-      SpendProfileConfiguration.SpendProfileModel defaultModel =
-          spendConfig.getSpendProfiles().get(0);
       defaultSpendProfile =
-          SpendProfile.buildGcpSpendProfile(
-              new SpendProfileId(defaultModel.getId()), defaultModel.getBillingAccountId());
+          spendConfig.getSpendProfiles().get(0);
+//      defaultSpendProfile =
+//          SpendProfile.buildGcpSpendProfile(
+//              new SpendProfileId(defaultModel.getId()), defaultModel.getBillingAccountId());
     }
     return defaultSpendProfile;
   }

--- a/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendConnectedTestUtils.java
+++ b/service/src/test/java/bio/terra/workspace/service/spendprofile/SpendConnectedTestUtils.java
@@ -23,11 +23,11 @@ public class SpendConnectedTestUtils {
    */
   public SpendProfile defaultGcpSpendProfile() {
     if (defaultSpendProfile == null) {
-      defaultSpendProfile =
+      SpendProfileConfiguration.SpendProfileModel defaultModel =
           spendConfig.getSpendProfiles().get(0);
-//      defaultSpendProfile =
-//          SpendProfile.buildGcpSpendProfile(
-//              new SpendProfileId(defaultModel.getId()), defaultModel.getBillingAccountId());
+      defaultSpendProfile =
+          SpendProfile.buildGcpSpendProfile(
+              new SpendProfileId(defaultModel.getId()), defaultModel.getBillingAccountId());
     }
     return defaultSpendProfile;
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextConnectedTest.java
@@ -136,7 +136,7 @@ public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
     AwsCloudContext createdCloudContext =
         awsCloudContextService.createCloudContext(
             "flightId",
-            WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID,
+            WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID,
             WorkspaceFixtures.DEFAULT_USER_EMAIL,
             null);
     assertNotNull(createdCloudContext);
@@ -147,7 +147,7 @@ public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
         createdCloudContext.getContextFields());
     AwsTestUtils.assertCloudContextCommonFields(
         createdCloudContext.getCommonFields(),
-        WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID,
+        WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID,
         WsmResourceState.CREATING,
         "flightId");
   }
@@ -171,7 +171,7 @@ public class AwsCloudContextConnectedTest extends BaseAwsConnectedTest {
 
     CloudContextCommonFields commonFields =
         new CloudContextCommonFields(
-            WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID, WsmResourceState.READY, "i", null);
+            WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID, WsmResourceState.READY, "i", null);
 
     // error - bad cloud context
     assertThrows(

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextUnitTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_USER_EMAIL;
 import static bio.terra.workspace.common.utils.AwsTestUtils.ACCOUNT_ID;
 import static bio.terra.workspace.common.utils.AwsTestUtils.AWS_ENVIRONMENT;
@@ -56,7 +56,7 @@ public class AwsCloudContextUnitTest extends BaseAwsSpringBootUnitTest {
 
   private final AwsCloudContext awsCloudContext =
       AwsCloudContextService.createCloudContext(
-          "flightId", DEFAULT_SPEND_PROFILE_ID, AWS_ENVIRONMENT, AWS_WORKSPACE_SECURITY_GROUPS);
+          "flightId", DEFAULT_GCP_SPEND_PROFILE_ID, AWS_ENVIRONMENT, AWS_WORKSPACE_SECURITY_GROUPS);
 
   @Test
   void serdesTest() {
@@ -166,12 +166,12 @@ public class AwsCloudContextUnitTest extends BaseAwsSpringBootUnitTest {
   void createCloudContextTest() {
     AwsCloudContext createdCloudContext =
         AwsCloudContextService.createCloudContext(
-            "flightId", DEFAULT_SPEND_PROFILE_ID, AWS_ENVIRONMENT, AWS_WORKSPACE_SECURITY_GROUPS);
+            "flightId", DEFAULT_GCP_SPEND_PROFILE_ID, AWS_ENVIRONMENT, AWS_WORKSPACE_SECURITY_GROUPS);
     assertNotNull(createdCloudContext);
     AwsTestUtils.assertAwsCloudContextFields(AWS_METADATA, createdCloudContext.getContextFields());
     AwsTestUtils.assertCloudContextCommonFields(
         createdCloudContext.getCommonFields(),
-        DEFAULT_SPEND_PROFILE_ID,
+            DEFAULT_GCP_SPEND_PROFILE_ID,
         WsmResourceState.CREATING,
         "flightId");
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsCloudContextUnitTest.java
@@ -166,12 +166,15 @@ public class AwsCloudContextUnitTest extends BaseAwsSpringBootUnitTest {
   void createCloudContextTest() {
     AwsCloudContext createdCloudContext =
         AwsCloudContextService.createCloudContext(
-            "flightId", DEFAULT_GCP_SPEND_PROFILE_ID, AWS_ENVIRONMENT, AWS_WORKSPACE_SECURITY_GROUPS);
+            "flightId",
+            DEFAULT_GCP_SPEND_PROFILE_ID,
+            AWS_ENVIRONMENT,
+            AWS_WORKSPACE_SECURITY_GROUPS);
     assertNotNull(createdCloudContext);
     AwsTestUtils.assertAwsCloudContextFields(AWS_METADATA, createdCloudContext.getContextFields());
     AwsTestUtils.assertCloudContextCommonFields(
         createdCloudContext.getCommonFields(),
-            DEFAULT_GCP_SPEND_PROFILE_ID,
+        DEFAULT_GCP_SPEND_PROFILE_ID,
         WsmResourceState.CREATING,
         "flightId");
   }

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2ConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2ConnectedTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,7 +53,7 @@ public class AwsWorkspaceV2ConnectedTest extends BaseAwsConnectedTest {
         createdCloudContext.getContextFields());
     AwsTestUtils.assertCloudContextCommonFields(
         createdCloudContext.getCommonFields(),
-        DEFAULT_SPEND_PROFILE_ID,
+            DEFAULT_GCP_SPEND_PROFILE_ID,
         WsmResourceState.READY,
         null);
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2ConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2ConnectedTest.java
@@ -53,7 +53,7 @@ public class AwsWorkspaceV2ConnectedTest extends BaseAwsConnectedTest {
         createdCloudContext.getContextFields());
     AwsTestUtils.assertCloudContextCommonFields(
         createdCloudContext.getCommonFields(),
-            DEFAULT_GCP_SPEND_PROFILE_ID,
+        DEFAULT_GCP_SPEND_PROFILE_ID,
         WsmResourceState.READY,
         null);
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2UnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2UnitTest.java
@@ -65,7 +65,7 @@ public class AwsWorkspaceV2UnitTest extends BaseAwsSpringBootUnitTest {
           null,
           null,
           CloudPlatform.AWS,
-              DEFAULT_GCP_SPEND_PROFILE,
+          DEFAULT_GCP_SPEND_PROFILE,
           null,
           jobId,
           USER_REQUEST);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2UnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/AwsWorkspaceV2UnitTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE;
 import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.SAM_USER;
 import static bio.terra.workspace.common.mocks.MockMvcUtils.USER_REQUEST;
 import static bio.terra.workspace.common.utils.AwsTestUtils.AWS_ENVIRONMENT;
@@ -65,7 +65,7 @@ public class AwsWorkspaceV2UnitTest extends BaseAwsSpringBootUnitTest {
           null,
           null,
           CloudPlatform.AWS,
-          DEFAULT_SPEND_PROFILE,
+              DEFAULT_GCP_SPEND_PROFILE,
           null,
           jobId,
           USER_REQUEST);
@@ -79,7 +79,7 @@ public class AwsWorkspaceV2UnitTest extends BaseAwsSpringBootUnitTest {
           AWS_METADATA, createdCloudContext.getContextFields());
       AwsTestUtils.assertCloudContextCommonFields(
           createdCloudContext.getCommonFields(),
-          WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID,
+          WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID,
           WsmResourceState.READY,
           null);
 

--- a/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/GcpCloudContextConnectedTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.workspace;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID;
 import static bio.terra.workspace.common.mocks.MockGcpApi.CONTROLLED_GCP_GCS_BUCKETS_PATH_FORMAT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -252,7 +252,7 @@ class GcpCloudContextConnectedTest extends BaseConnectedTest {
             .userFacingId("dest-user-facing-id")
             .displayName("Destination Workspace")
             .description("Copied from source")
-            .spendProfileId(DEFAULT_SPEND_PROFILE_ID)
+            .spendProfileId(DEFAULT_GCP_SPEND_PROFILE_ID)
             .build();
 
     String destinationLocation = "us-east1";

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/RemoveUserFromWorkspaceFlightTest.java
@@ -1,6 +1,6 @@
 package bio.terra.workspace.service.workspace.flight.gcp;
 
-import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_SPEND_PROFILE_ID;
+import static bio.terra.workspace.common.fixtures.WorkspaceFixtures.DEFAULT_GCP_SPEND_PROFILE_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -114,7 +114,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
     String makeContextJobId = UUID.randomUUID().toString();
     SpendProfile spendProfile =
         spendProfileService.authorizeLinking(
-            DEFAULT_SPEND_PROFILE_ID, features.isBpmGcpEnabled(), userRequest);
+                DEFAULT_GCP_SPEND_PROFILE_ID, features.isBpmGcpEnabled(), userRequest);
 
     workspaceService.createCloudContext(
         workspace, CloudPlatform.GCP, spendProfile, makeContextJobId, userRequest, null);

--- a/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/RemoveUserFromWorkspaceFlightTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/workspace/flight/gcp/RemoveUserFromWorkspaceFlightTest.java
@@ -114,7 +114,7 @@ public class RemoveUserFromWorkspaceFlightTest extends BaseConnectedTest {
     String makeContextJobId = UUID.randomUUID().toString();
     SpendProfile spendProfile =
         spendProfileService.authorizeLinking(
-                DEFAULT_GCP_SPEND_PROFILE_ID, features.isBpmGcpEnabled(), userRequest);
+            DEFAULT_GCP_SPEND_PROFILE_ID, features.isBpmGcpEnabled(), userRequest);
 
     workspaceService.createCloudContext(
         workspace, CloudPlatform.GCP, spendProfile, makeContextJobId, userRequest, null);

--- a/service/src/test/resources/application-connected-test.yml
+++ b/service/src/test/resources/application-connected-test.yml
@@ -17,6 +17,7 @@ workspace:
     spend-profiles:
       - id: wm-default-spend-profile
         billing-account-id: 01A82E-CA8A14-367457
+        cloud-platform: GCP
       # an empty profile to ensure we are resilient to empty spend profile env var values
       - id:
         billing-account-id:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1869

Adds the `limits` map to the `SpendProfile` and returns it in the `AzureCloudContext` of a `WorkspaceDescription`.  This necessitates adding Azure-specific fields to the `SpendProfileModel` and distinguishing between GCP and Azure spend profiles throughout the texting fixtures.

Tested in a bee using https://github.com/broadinstitute/terra-helmfile/pull/5626 .