### PR TITLE
WOR-1620 WSM 404s during deployment of batch pool

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/ControlledAzureBatchPoolResource.java
@@ -177,7 +177,7 @@ public class ControlledAzureBatchPoolResource extends ControlledResource {
         new VerifyAzureBatchPoolCanBeCreatedStep(
             flightBeanBag.getAzureConfig(),
             flightBeanBag.getCrlService(),
-            userRequest,
+            flightBeanBag.getSamService(),
             flightBeanBag.getLandingZoneBatchAccountFinder(),
             this),
         RetryRules.cloud());

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/VerifyAzureBatchPoolCanBeCreatedStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/VerifyAzureBatchPoolCanBeCreatedStep.java
@@ -8,7 +8,7 @@ import bio.terra.stairway.exception.RetryException;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
 import bio.terra.workspace.service.crl.CrlService;
-import bio.terra.workspace.service.iam.AuthenticatedUserRequest;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.resource.exception.ResourceNotFoundException;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
@@ -24,19 +24,19 @@ public class VerifyAzureBatchPoolCanBeCreatedStep implements Step {
 
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
-  private final AuthenticatedUserRequest userRequest;
+  private final SamService samService;
   private final LandingZoneBatchAccountFinder landingZoneBatchAccountFinder;
   private final ControlledAzureBatchPoolResource resource;
 
   public VerifyAzureBatchPoolCanBeCreatedStep(
       AzureConfiguration azureConfig,
       CrlService crlService,
-      AuthenticatedUserRequest userRequest,
+      SamService samService,
       LandingZoneBatchAccountFinder landingZoneBatchAccountFinder,
       ControlledAzureBatchPoolResource resource) {
     this.azureConfig = azureConfig;
     this.crlService = crlService;
-    this.userRequest = userRequest;
+    this.samService = samService;
     this.landingZoneBatchAccountFinder = landingZoneBatchAccountFinder;
     this.resource = resource;
   }
@@ -62,7 +62,8 @@ public class VerifyAzureBatchPoolCanBeCreatedStep implements Step {
   private StepResult validateBatchAccountExists(
       AzureCloudContext azureCloudContext, FlightContext context, BatchManager batchManager) {
     Optional<ApiAzureLandingZoneDeployedResource> existingSharedBatchAccount =
-        landingZoneBatchAccountFinder.find(userRequest.getRequiredToken(), resource);
+        landingZoneBatchAccountFinder.find(samService.getWsmServiceAccountToken(), resource);
+
     if (existingSharedBatchAccount.isPresent()) {
       BatchAccount batchAccount =
           batchManager.batchAccounts().getById(existingSharedBatchAccount.get().getResourceId());

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/VerifyAzureBatchPoolCanBeCreatedStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/VerifyAzureBatchPoolCanBeCreatedStepTest.java
@@ -9,36 +9,80 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.resourcemanager.batch.BatchManager;
+import com.azure.resourcemanager.batch.models.*;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class VerifyAzureBatchPoolCanBeCreatedStepTest extends BaseBatchPoolTest {
-  VerifyAzureBatchPoolCanBeCreatedStep verifyAzureBatchPoolCanBeCreatedStep;
+@Tag("azure-unit")
+@ExtendWith(MockitoExtension.class)
+public class VerifyAzureBatchPoolCanBeCreatedStepTest {
 
   @Captor ArgumentCaptor<String> keyNameCaptor;
   @Captor ArgumentCaptor<String> keyValueCaptor;
 
-  @Mock LandingZoneBatchAccountFinder mockLandingZoneBatchAccountFinder;
+  public static final String BATCH_ACCOUNT_NAME = "sharedBatchAccount";
+  public static final String AZURE_CLOUD_CONTEXT_RESOURCE_GROUP_ID = "resourceGroup";
+  public static final String TENANT_ID = "tenantId";
+  public static final String SUBSCRIPTION_ID = "subscriptionId";
+
+  @Mock public AzureConfiguration mockAzureConfig;
+  @Mock public CrlService mockCrlService;
+  @Mock public SamService samService;
+  @Mock public LandingZoneBatchAccountFinder mockLandingZoneBatchAccountFinder;
+  @Mock public FlightContext mockFlightContext;
+  @Mock public FlightMap mockWorkingMap;
+  @Mock public BatchManager mockBatchManager;
+  @Mock public BatchAccounts mockBatchAccounts;
+  @Mock public BatchAccount mockBatchAccount;
+  @Mock public AzureCloudContext mockAzureCloudContext;
+
+  @Mock ControlledAzureBatchPoolResource resource;
 
   @BeforeEach
   public void setup() {
-    resource = buildDefaultResourceBuilder().build();
-    initVerifyStep(resource);
-    setupBaseMocks();
+    // setup cloud context
+    when(mockAzureCloudContext.getAzureResourceGroupId())
+        .thenReturn(AZURE_CLOUD_CONTEXT_RESOURCE_GROUP_ID);
+    when(mockAzureCloudContext.getAzureTenantId()).thenReturn(TENANT_ID);
+    when(mockAzureCloudContext.getAzureSubscriptionId()).thenReturn(SUBSCRIPTION_ID);
+    // setup auth request
+    when(samService.getWsmServiceAccountToken()).thenReturn("FAKE_TOKEN");
+    // setup flight context
+    when(mockWorkingMap.get(
+            WorkspaceFlightMapKeys.ControlledResourceKeys.AZURE_CLOUD_CONTEXT,
+            AzureCloudContext.class))
+        .thenReturn(mockAzureCloudContext);
+    when(mockFlightContext.getWorkingMap()).thenReturn(mockWorkingMap);
   }
 
   @Test
   public void sharedLzStorageAccountExistsSuccess() throws InterruptedException {
     setupMocks(true);
-
+    var verifyAzureBatchPoolCanBeCreatedStep =
+        new VerifyAzureBatchPoolCanBeCreatedStep(
+            mockAzureConfig,
+            mockCrlService,
+            samService,
+            mockLandingZoneBatchAccountFinder,
+            resource);
     StepResult stepResult = verifyAzureBatchPoolCanBeCreatedStep.doStep(mockFlightContext);
 
     assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
@@ -52,20 +96,16 @@ public class VerifyAzureBatchPoolCanBeCreatedStepTest extends BaseBatchPoolTest 
   @Test
   public void sharedLzStorageAccountDoesntExistFailure() throws InterruptedException {
     setupMocks(false);
-
-    StepResult stepResult = verifyAzureBatchPoolCanBeCreatedStep.doStep(mockFlightContext);
-
-    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
-  }
-
-  private void initVerifyStep(ControlledAzureBatchPoolResource resource) {
-    verifyAzureBatchPoolCanBeCreatedStep =
+    var verifyAzureBatchPoolCanBeCreatedStep =
         new VerifyAzureBatchPoolCanBeCreatedStep(
             mockAzureConfig,
             mockCrlService,
-            mockAuthenticatedUserRequest,
+            samService,
             mockLandingZoneBatchAccountFinder,
             resource);
+    StepResult stepResult = verifyAzureBatchPoolCanBeCreatedStep.doStep(mockFlightContext);
+
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
   }
 
   private void setupMocks(boolean batchAccountExists) {
@@ -74,9 +114,11 @@ public class VerifyAzureBatchPoolCanBeCreatedStepTest extends BaseBatchPoolTest 
         batchAccountExists ? Optional.of(landingZoneBatchAccountResource) : Optional.empty();
     when(mockLandingZoneBatchAccountFinder.find(any(), eq(resource))).thenReturn(batchAccount);
 
-    when(mockBatchAccount.name()).thenReturn(BATCH_ACCOUNT_NAME);
-    when(mockBatchAccounts.getById(any())).thenReturn(mockBatchAccount);
-    when(mockBatchManager.batchAccounts()).thenReturn(mockBatchAccounts);
     when(mockCrlService.getBatchManager(any(), any())).thenReturn(mockBatchManager);
+    if (batchAccountExists) {
+      when(mockBatchAccount.name()).thenReturn(BATCH_ACCOUNT_NAME);
+      when(mockBatchAccounts.getById(any())).thenReturn(mockBatchAccount);
+      when(mockBatchManager.batchAccounts()).thenReturn(mockBatchAccounts);
+    }
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1620

Switches batch account validation to use the WSM service account token to retrieve the landing zone, similar to other places.