### PR TITLE
[WOR-1772] Catch duplicate PAO exception when trying to create a PAO that has been deleted

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
@@ -113,7 +113,16 @@ public class TpsApiDispatch {
       return pao.get();
     }
     // Workspace doesn't have a PAO, so create an empty one for it.
-    createPao(objectId, null, component, objectType);
+    try {
+      createPao(objectId, null, component, objectType);
+    } catch (PolicyServiceDuplicateException e) {
+      // If the PAO wasn't returned above, but creating a new one threw a duplicate exception, the
+      // original PAO has been deleted and we cannot recreate a new one. PAOs are only deleted when
+      // the associated object (workspace, spend-profile) has been deleted. We return null here to
+      // handle the race condition where WSM is returning a workspace that is in the process
+      // of being deleted.
+      return null;
+    }
     return getPao(objectId);
   }
 


### PR DESCRIPTION
[WOR-1772](https://broadworkbench.atlassian.net/browse/WOR-1772)
* If WSM tries to get a PAO and gets a 404, but gets a duplicate exception when it tries to create a new one, then the PAO exists in TPS, but it has been deleted. A workspace's PAO will only be deleted if the workspace itself is in the process of being deleted. To prevent WSM from throwing exceptions if a user tries to get a workspace between when the PAO is deleted and the rest of the workspace is deleted, WSM will catch the duplicate exception thrown when re-creating and return null.

[WOR-1772]: https://broadworkbench.atlassian.net/browse/WOR-1772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ