### PR TITLE
WOR-1777 Handle remaining instances of missing azure resources

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/RemoveManagedIdentitiesAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/RemoveManagedIdentitiesAzureVmStep.java
@@ -7,6 +7,7 @@ import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.DeleteAzureControlledResourceStep;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.ComputeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,8 +34,17 @@ public class RemoveManagedIdentitiesAzureVmStep extends DeleteAzureControlledRes
             .get(ControlledResourceKeys.AZURE_CLOUD_CONTEXT, AzureCloudContext.class);
 
     ComputeManager computeManager = crlService.getComputeManager(azureCloudContext, azureConfig);
-    return AzureVmHelper.removeAllUserAssignedManagedIdentitiesFromVm(
-        azureCloudContext, computeManager, resource.getVmName());
+    var helperResult =
+        AzureVmHelper.removeAllUserAssignedManagedIdentitiesFromVm(
+            azureCloudContext, computeManager, resource.getVmName());
+    if (helperResult.isSuccess()) {
+      return helperResult;
+    } else if (helperResult.getException().isPresent()
+        && helperResult.getException().get() instanceof ManagementException) {
+      throw (ManagementException) helperResult.getException().get();
+    } else {
+      return helperResult;
+    }
   }
 
   @Override

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/RemoveManagedIdentitiesAzureVmStepUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/RemoveManagedIdentitiesAzureVmStepUnitTest.java
@@ -1,0 +1,59 @@
+package bio.terra.workspace.service.resource.controlled.cloud.azure.vm;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.*;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.workspace.service.crl.CrlService;
+import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
+import bio.terra.workspace.service.workspace.model.AzureCloudContext;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.management.exception.ManagementError;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.compute.ComputeManager;
+import com.azure.resourcemanager.compute.models.VirtualMachines;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+public class RemoveManagedIdentitiesAzureVmStepUnitTest {
+
+  @Test
+  public void removeManagedIdentitiesAzureFromVm_returnsSuccessOnMissingMRG()
+      throws InterruptedException {
+    var flightContext = mock(FlightContext.class);
+    var workingMap = mock(FlightMap.class);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    var cloudContext = mock(AzureCloudContext.class);
+    when(cloudContext.getAzureResourceGroupId()).thenReturn("resource-group-id");
+    when(workingMap.get(
+            WorkspaceFlightMapKeys.ControlledResourceKeys.AZURE_CLOUD_CONTEXT,
+            AzureCloudContext.class))
+        .thenReturn(cloudContext);
+
+    var error = new ManagementError("SubscriptionNotFound", "some message about the subscription");
+    var virtualMachines = mock(VirtualMachines.class);
+    doThrow(new ManagementException("some message", mock(HttpResponse.class), error))
+        .when(virtualMachines)
+        .getByResourceGroup(any(), any());
+    var computeManager = mock(ComputeManager.class);
+    when(computeManager.virtualMachines()).thenReturn(virtualMachines);
+
+    var crlService = mock(CrlService.class);
+    when(crlService.getComputeManager(any(), any())).thenReturn(computeManager);
+
+    var resource = mock(ControlledAzureVmResource.class);
+    when(resource.getVmName()).thenReturn("vm-name");
+    var step = new RemoveManagedIdentitiesAzureVmStep(mock(), crlService, resource);
+    step.doStep(flightContext);
+    StepResult stepResult = step.doStep(flightContext);
+
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+  }
+}


### PR DESCRIPTION
Fixes two instances of `ManagementException`s that were not being handled:
* Exceptions encountered by LandingZoneService when retrieving resources
* Exceptions being handled in a shared helper class