### PR TITLE
WOR-1777 Handle more instances of ManagementExceptions when deleting resources

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/DeleteAzureControlledResourceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/DeleteAzureControlledResourceStep.java
@@ -7,6 +7,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneServiceApiException;
 import bio.terra.workspace.common.exception.AzureManagementExceptionUtils;
 import bio.terra.workspace.service.resource.controlled.flight.delete.DeleteControlledResourceStep;
+import bio.terra.workspace.service.resource.controlled.model.ControlledResource;
 import com.azure.core.management.exception.ManagementException;
 import java.util.Arrays;
 import java.util.List;
@@ -16,7 +17,14 @@ import org.springframework.http.HttpStatus;
  * Common base class for deleting Azure resources. Wraps the Azure resource deletion logic with
  * handling for common exceptions.
  */
-public abstract class DeleteAzureControlledResourceStep implements DeleteControlledResourceStep {
+public abstract class DeleteAzureControlledResourceStep<R extends ControlledResource>
+    implements DeleteControlledResourceStep {
+
+  protected final R resource;
+
+  protected DeleteAzureControlledResourceStep(R resource) {
+    this.resource = resource;
+  }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/DeleteAzureControlledResourceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/DeleteAzureControlledResourceStep.java
@@ -89,7 +89,6 @@ public abstract class DeleteAzureControlledResourceStep<R extends ControlledReso
     // LZS can encounter the same management exceptions as above
     // To detect this, we need to examine the message for those error codes
     if (e instanceof LandingZoneServiceApiException && e.getCause() instanceof ApiException apiEx) {
-      // var msg = apiEx.getMessage();
       var code =
           Optional.ofNullable(apiEx.getMessage())
               .flatMap(
@@ -98,7 +97,6 @@ public abstract class DeleteAzureControlledResourceStep<R extends ControlledReso
                           .filter(c -> msg.contains(c))
                           .findFirst());
       if (code.isPresent()) {
-        // && missingResourceManagementCodes.stream().anyMatch(code -> msg.contains(code))) {
         logger.debug(
             "LZS encountered management exception {} when deleting resource {} from workspace {}",
             code.get(),

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/DeleteAzureControlledResourceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/DeleteAzureControlledResourceStep.java
@@ -98,10 +98,10 @@ public abstract class DeleteAzureControlledResourceStep<R extends ControlledReso
                           .findFirst());
       if (code.isPresent()) {
         logger.debug(
-            "LZS encountered management exception {} when deleting resource {} from workspace {}",
-            code.get(),
+            "Unable to delete resource {} from workspace {}, because LZS encountered management exception {}: Returning success for delete step",
             resource.getResourceType().name(),
-            resource.getWorkspaceId());
+            resource.getWorkspaceId(),
+            code.get());
         return StepResult.getStepResultSuccess();
       }
     }
@@ -109,7 +109,7 @@ public abstract class DeleteAzureControlledResourceStep<R extends ControlledReso
     if (e instanceof LandingZoneNotFoundException) {
       // If the landing zone is not present, it's probably because it was removed directly
       logger.debug(
-          "Unable to delete resource {} from workspace {}, because no landing zone was found in LZS",
+          "Unable to delete resource {} from workspace {}, because no landing zone was found in LZS: Returning success for delete step",
           resource.getResourceType().name(),
           resource.getWorkspaceId());
       return StepResult.getStepResultSuccess();

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/DeleteAzureBatchPoolStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/batchpool/DeleteAzureBatchPoolStep.java
@@ -19,23 +19,23 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DeleteAzureBatchPoolStep extends DeleteAzureControlledResourceStep {
+public class DeleteAzureBatchPoolStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureBatchPoolResource> {
   private static final Logger logger = LoggerFactory.getLogger(DeleteAzureBatchPoolStep.class);
 
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final LandingZoneBatchAccountFinder landingZoneBatchAccountFinder;
-  private final ControlledAzureBatchPoolResource resource;
 
   public DeleteAzureBatchPoolStep(
       AzureConfiguration azureConfig,
       CrlService crlService,
       LandingZoneBatchAccountFinder landingZoneBatchAccountFinder,
       ControlledAzureBatchPoolResource resource) {
+    super(resource);
     this.azureConfig = azureConfig;
     this.crlService = crlService;
     this.landingZoneBatchAccountFinder = landingZoneBatchAccountFinder;
-    this.resource = resource;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/DeleteAzureDatabaseStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/DeleteAzureDatabaseStep.java
@@ -21,11 +21,11 @@ import org.slf4j.LoggerFactory;
  * A step for deleting a controlled Azure Database resource. This step uses the following process to
  * actually delete the Azure Database.
  */
-public class DeleteAzureDatabaseStep extends DeleteAzureControlledResourceStep {
+public class DeleteAzureDatabaseStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureDatabaseResource> {
   private static final Logger logger = LoggerFactory.getLogger(DeleteAzureDatabaseStep.class);
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
-  private final ControlledAzureDatabaseResource resource;
   private final LandingZoneApiDispatch landingZoneApiDispatch;
   private final SamService samService;
   private final WorkspaceService workspaceService;
@@ -39,9 +39,9 @@ public class DeleteAzureDatabaseStep extends DeleteAzureControlledResourceStep {
       SamService samService,
       WorkspaceService workspaceService,
       UUID workspaceId) {
+    super(resource);
     this.crlService = crlService;
     this.azureConfig = azureConfig;
-    this.resource = resource;
     this.landingZoneApiDispatch = landingZoneApiDispatch;
     this.samService = samService;
     this.workspaceService = workspaceService;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/DeleteAzureDiskStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/DeleteAzureDiskStep.java
@@ -27,6 +27,7 @@ public class DeleteAzureDiskStep extends DeleteAzureControlledResourceStep {
 
   public DeleteAzureDiskStep(
       AzureConfiguration azureConfig, CrlService crlService, ControlledAzureDiskResource resource) {
+    super(resource);
     this.crlService = crlService;
     this.azureConfig = azureConfig;
     this.resource = resource;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/DetachAzureDiskFromVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/DetachAzureDiskFromVmStep.java
@@ -24,18 +24,18 @@ import org.slf4j.LoggerFactory;
  * functionality of detaching data disk from a virtual machine before disk deletion. It is not
  * possible to delete a disk without detaching it.
  */
-public class DetachAzureDiskFromVmStep extends DeleteAzureControlledResourceStep {
+public class DetachAzureDiskFromVmStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureDiskResource> {
   private static final Logger logger = LoggerFactory.getLogger(DetachAzureDiskFromVmStep.class);
 
   private final CrlService crlService;
   private final AzureConfiguration azureConfig;
-  private final ControlledAzureDiskResource resource;
 
   public DetachAzureDiskFromVmStep(
       AzureConfiguration azureConfig, CrlService crlService, ControlledAzureDiskResource resource) {
+    super(resource);
     this.crlService = crlService;
     this.azureConfig = azureConfig;
-    this.resource = resource;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskAttachedVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskAttachedVmStep.java
@@ -21,19 +21,19 @@ import org.slf4j.LoggerFactory;
  * 'undo' operation at DetachAzureDiskFromVmStep, and we need to guarantee its persistence - which
  * we can't guarantee if it is from the 'do' portion of the same step.
  */
-public class GetAzureDiskAttachedVmStep extends DeleteAzureControlledResourceStep {
+public class GetAzureDiskAttachedVmStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureDiskResource> {
 
   private static final Logger logger = LoggerFactory.getLogger(GetAzureDiskAttachedVmStep.class);
 
   private final CrlService crlService;
   private final AzureConfiguration azureConfig;
-  private final ControlledAzureDiskResource resource;
 
   public GetAzureDiskAttachedVmStep(
       AzureConfiguration azureConfig, CrlService crlService, ControlledAzureDiskResource resource) {
+    super(resource);
     this.crlService = crlService;
     this.azureConfig = azureConfig;
-    this.resource = resource;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/ControlledAzureKubernetesNamespaceResource.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/ControlledAzureKubernetesNamespaceResource.java
@@ -283,10 +283,10 @@ public class ControlledAzureKubernetesNamespaceResource extends ControlledResour
       return List.of(
           getGetManagedIdentityStep(flightBeanBag, MissingIdentityBehavior.ALLOW_MISSING),
           new DeleteFederatedCredentialStep(
-              getKubernetesNamespace(),
               flightBeanBag.getAzureConfig(),
               flightBeanBag.getCrlService(),
-              MissingIdentityBehavior.ALLOW_MISSING));
+              MissingIdentityBehavior.ALLOW_MISSING,
+              this));
     } else {
       return List.of();
     }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteKubernetesNamespaceStep.java
@@ -18,19 +18,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
-public class DeleteKubernetesNamespaceStep extends DeleteAzureControlledResourceStep {
+public class DeleteKubernetesNamespaceStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureKubernetesNamespaceResource> {
   private static final Logger logger = LoggerFactory.getLogger(DeleteKubernetesNamespaceStep.class);
   private final UUID workspaceId;
   private final KubernetesClientProvider kubernetesClientProvider;
-  private final ControlledAzureKubernetesNamespaceResource resource;
 
   public DeleteKubernetesNamespaceStep(
       UUID workspaceId,
       KubernetesClientProvider kubernetesClientProvider,
       ControlledAzureKubernetesNamespaceResource resource) {
+    super(resource);
     this.workspaceId = workspaceId;
     this.kubernetesClientProvider = kubernetesClientProvider;
-    this.resource = resource;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteNamespaceRoleStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/kubernetesNamespace/DeleteNamespaceRoleStep.java
@@ -10,19 +10,19 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DeleteNamespaceRoleStep extends DeleteAzureControlledResourceStep {
+public class DeleteNamespaceRoleStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureKubernetesNamespaceResource> {
   private static final Logger logger = LoggerFactory.getLogger(DeleteNamespaceRoleStep.class);
   private final UUID workspaceId;
   private final AzureDatabaseUtilsRunner azureDatabaseUtilsRunner;
-  private final ControlledAzureKubernetesNamespaceResource resource;
 
   public DeleteNamespaceRoleStep(
       UUID workspaceId,
       AzureDatabaseUtilsRunner azureDatabaseUtilsRunner,
       ControlledAzureKubernetesNamespaceResource resource) {
+    super(resource);
     this.workspaceId = workspaceId;
     this.azureDatabaseUtilsRunner = azureDatabaseUtilsRunner;
-    this.resource = resource;
   }
 
   private String getDeletePodName() {

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/DeleteAzureManagedIdentityStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/DeleteAzureManagedIdentityStep.java
@@ -14,20 +14,20 @@ import org.slf4j.LoggerFactory;
  * A step for deleting a controlled Azure Managed Identity resource. This step uses the following
  * process to actually delete the Azure Managed Identity.
  */
-public class DeleteAzureManagedIdentityStep extends DeleteAzureControlledResourceStep {
+public class DeleteAzureManagedIdentityStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureManagedIdentityResource> {
   private static final Logger logger =
       LoggerFactory.getLogger(DeleteAzureManagedIdentityStep.class);
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
-  private final ControlledAzureManagedIdentityResource resource;
 
   public DeleteAzureManagedIdentityStep(
       AzureConfiguration azureConfig,
       CrlService crlService,
       ControlledAzureManagedIdentityResource resource) {
+    super(resource);
     this.crlService = crlService;
     this.azureConfig = azureConfig;
-    this.resource = resource;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/DeleteFederatedCredentialStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/managedIdentity/DeleteFederatedCredentialStep.java
@@ -5,24 +5,25 @@ import bio.terra.stairway.StepResult;
 import bio.terra.workspace.app.configuration.external.AzureConfiguration;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.resource.controlled.cloud.azure.DeleteAzureControlledResourceStep;
+import bio.terra.workspace.service.resource.controlled.cloud.azure.kubernetesNamespace.ControlledAzureKubernetesNamespaceResource;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys.ControlledResourceKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DeleteFederatedCredentialStep extends DeleteAzureControlledResourceStep {
+public class DeleteFederatedCredentialStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureKubernetesNamespaceResource> {
   private static final Logger logger = LoggerFactory.getLogger(DeleteFederatedCredentialStep.class);
-  public final String k8sNamespace;
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   private final MissingIdentityBehavior missingIdentityBehavior;
 
   public DeleteFederatedCredentialStep(
-      String k8sNamespace,
       AzureConfiguration azureConfig,
       CrlService crlService,
-      MissingIdentityBehavior missingIdentityBehavior) {
-    this.k8sNamespace = k8sNamespace;
+      MissingIdentityBehavior missingIdentityBehavior,
+      ControlledAzureKubernetesNamespaceResource resource) {
+    super(resource);
     this.azureConfig = azureConfig;
     this.crlService = crlService;
     this.missingIdentityBehavior = missingIdentityBehavior;
@@ -49,7 +50,10 @@ public class DeleteFederatedCredentialStep extends DeleteAzureControlledResource
         .manager()
         .serviceClient()
         .getFederatedIdentityCredentials()
-        .delete(azureCloudContext.getAzureResourceGroupId(), uamiName, k8sNamespace);
+        .delete(
+            azureCloudContext.getAzureResourceGroupId(),
+            uamiName,
+            resource.getKubernetesNamespace());
     return StepResult.getStepResultSuccess();
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -1,7 +1,6 @@
 package bio.terra.workspace.service.resource.controlled.cloud.azure.storageContainer;
 
 import bio.terra.common.iam.BearerToken;
-import bio.terra.landingzone.db.exception.LandingZoneNotFoundException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.workspace.amalgam.landingzone.azure.LandingZoneApiDispatch;
@@ -55,38 +54,30 @@ public class DeleteAzureStorageContainerStep
 
     final StorageManager manager = crlService.getStorageManager(azureCloudContext, azureConfig);
 
-    try {
-      // Storage container was created based on landing zone shared storage account
-      var bearerToken = new BearerToken(samService.getWsmServiceAccountToken());
-      UUID landingZoneId =
-          landingZoneApiDispatch.getLandingZoneId(
-              bearerToken, workspaceService.getWorkspace(resource.getWorkspaceId()));
-      Optional<ApiAzureLandingZoneDeployedResource> sharedStorageAccount =
-          landingZoneApiDispatch.getSharedStorageAccount(bearerToken, landingZoneId);
-      if (sharedStorageAccount.isEmpty()) {
-        // storage account is gone, so no container to delete
-        return StepResult.getStepResultSuccess();
-      } else {
-        StorageAccount storageAccount =
-            manager.storageAccounts().getById(sharedStorageAccount.get().getResourceId());
-        var storageAccountName = storageAccount.name();
-        logger.info(
-            "Attempting to delete storage container '{}' in account '{}'",
-            resource.getStorageContainerName(),
-            storageAccountName);
-        manager
-            .blobContainers()
-            .delete(
-                azureCloudContext.getAzureResourceGroupId(),
-                storageAccountName,
-                resource.getStorageContainerName());
-        return StepResult.getStepResultSuccess();
-      }
-    } catch (LandingZoneNotFoundException lzne) { // Thrown by landingZoneApiDispatch
-      // If the landing zone is not present, it's probably because it was removed directly
-      logger.debug(
-          "Unable to delete storage container from workspace {}, because no landing zone was found in LZS",
-          resource.getWorkspaceId());
+    // Storage container was created based on landing zone shared storage account
+    var bearerToken = new BearerToken(samService.getWsmServiceAccountToken());
+    UUID landingZoneId =
+        landingZoneApiDispatch.getLandingZoneId(
+            bearerToken, workspaceService.getWorkspace(resource.getWorkspaceId()));
+    Optional<ApiAzureLandingZoneDeployedResource> sharedStorageAccount =
+        landingZoneApiDispatch.getSharedStorageAccount(bearerToken, landingZoneId);
+    if (sharedStorageAccount.isEmpty()) {
+      // storage account is gone, so no container to delete
+      return StepResult.getStepResultSuccess();
+    } else {
+      StorageAccount storageAccount =
+          manager.storageAccounts().getById(sharedStorageAccount.get().getResourceId());
+      var storageAccountName = storageAccount.name();
+      logger.info(
+          "Attempting to delete storage container '{}' in account '{}'",
+          resource.getStorageContainerName(),
+          storageAccountName);
+      manager
+          .blobContainers()
+          .delete(
+              azureCloudContext.getAzureResourceGroupId(),
+              storageAccountName,
+              resource.getStorageContainerName());
       return StepResult.getStepResultSuccess();
     }
   }

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/storageContainer/DeleteAzureStorageContainerStep.java
@@ -21,12 +21,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A step for deleting a controlled Azure Storage Con resource. */
-public class DeleteAzureStorageContainerStep extends DeleteAzureControlledResourceStep {
+public class DeleteAzureStorageContainerStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureStorageContainerResource> {
   private static final Logger logger =
       LoggerFactory.getLogger(DeleteAzureStorageContainerStep.class);
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
-  private final ControlledAzureStorageContainerResource resource;
   private final LandingZoneApiDispatch landingZoneApiDispatch;
   private final SamService samService;
   private final WorkspaceService workspaceService;
@@ -38,9 +38,9 @@ public class DeleteAzureStorageContainerStep extends DeleteAzureControlledResour
       SamService samService,
       ControlledAzureStorageContainerResource resource,
       WorkspaceService workspaceService) {
+    super(resource);
     this.crlService = crlService;
     this.azureConfig = azureConfig;
-    this.resource = resource;
     this.landingZoneApiDispatch = landingZoneApiDispatch;
     this.samService = samService;
     this.workspaceService = workspaceService;

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/DeleteAzureNetworkInterfaceStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/DeleteAzureNetworkInterfaceStep.java
@@ -11,21 +11,21 @@ import com.azure.resourcemanager.compute.ComputeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DeleteAzureNetworkInterfaceStep extends DeleteAzureControlledResourceStep {
+public class DeleteAzureNetworkInterfaceStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureVmResource> {
   private static final Logger logger =
       LoggerFactory.getLogger(CreateAzureNetworkInterfaceStep.class);
 
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
   // Network interface is not a freestanding WSM resource. It is tightly coupled to the Vm.
-  private final ControlledAzureVmResource resource;
   private final String networkInterfaceName;
 
   public DeleteAzureNetworkInterfaceStep(
       AzureConfiguration azureConfig, CrlService crlService, ControlledAzureVmResource resource) {
+    super(resource);
     this.crlService = crlService;
     this.azureConfig = azureConfig;
-    this.resource = resource;
     this.networkInterfaceName = String.format("nic-%s", resource.getVmName());
   }
 

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/DeleteAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/DeleteAzureVmStep.java
@@ -11,17 +11,17 @@ import com.azure.resourcemanager.compute.ComputeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DeleteAzureVmStep extends DeleteAzureControlledResourceStep {
+public class DeleteAzureVmStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureVmResource> {
   private static final Logger logger = LoggerFactory.getLogger(DeleteAzureVmStep.class);
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
-  private final ControlledAzureVmResource resource;
 
   public DeleteAzureVmStep(
       AzureConfiguration azureConfig, CrlService crlService, ControlledAzureVmResource resource) {
+    super(resource);
     this.crlService = crlService;
     this.azureConfig = azureConfig;
-    this.resource = resource;
   }
 
   @Override

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/RemoveManagedIdentitiesAzureVmStep.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/vm/RemoveManagedIdentitiesAzureVmStep.java
@@ -12,18 +12,18 @@ import com.azure.resourcemanager.compute.ComputeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RemoveManagedIdentitiesAzureVmStep extends DeleteAzureControlledResourceStep {
+public class RemoveManagedIdentitiesAzureVmStep
+    extends DeleteAzureControlledResourceStep<ControlledAzureVmResource> {
   private static final Logger logger =
       LoggerFactory.getLogger(RemoveManagedIdentitiesAzureVmStep.class);
   private final AzureConfiguration azureConfig;
   private final CrlService crlService;
-  private final ControlledAzureVmResource resource;
 
   public RemoveManagedIdentitiesAzureVmStep(
       AzureConfiguration azureConfig, CrlService crlService, ControlledAzureVmResource resource) {
+    super(resource);
     this.azureConfig = azureConfig;
     this.crlService = crlService;
-    this.resource = resource;
   }
 
   @Override

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/DeleteAzureDatabaseStepUnitTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/DeleteAzureDatabaseStepUnitTest.java
@@ -17,6 +17,7 @@ import bio.terra.workspace.common.exception.AzureManagementExceptionUtils;
 import bio.terra.workspace.generated.model.ApiAzureLandingZoneDeployedResource;
 import bio.terra.workspace.service.crl.CrlService;
 import bio.terra.workspace.service.iam.SamService;
+import bio.terra.workspace.service.resource.model.WsmResourceType;
 import bio.terra.workspace.service.workspace.WorkspaceService;
 import bio.terra.workspace.service.workspace.flight.WorkspaceFlightMapKeys;
 import bio.terra.workspace.service.workspace.model.AzureCloudContext;
@@ -162,6 +163,7 @@ public class DeleteAzureDatabaseStepUnitTest {
     doThrow(new LandingZoneServiceApiException(apiException))
         .when(landingZoneApiDispatch)
         .getSharedDatabase(token, landingZoneId);
+    when(resource.getResourceType()).thenReturn(WsmResourceType.CONTROLLED_AZURE_DATABASE);
     var step =
         new DeleteAzureDatabaseStep(
             azureConfig,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskAttachedVmStepTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/disk/GetAzureDiskAttachedVmStepTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -82,6 +84,20 @@ class GetAzureDiskAttachedVmStepTest {
     setupCommonMocks();
     ManagementException resourceNotFoundExceptionMock =
         setupManagementExceptionMock("ResourceNotFound");
+    when(disksMock.getById(anyString())).thenThrow(resourceNotFoundExceptionMock);
+
+    StepResult stepResult = getAzureDiskAttachedVmStep.doStep(flightContextMock);
+    assertThat(stepResult, equalTo(StepResult.getStepResultSuccess()));
+    verify(flightWorkingMapMock, never()).put(any(), any());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"SubscriptionNotFound", "InvalidAuthenticationTokenTenant", "AuthorizationFailed"})
+  void doStep_missingMRGManagementExceptionsReturnsSuccess(String exceptionCode)
+      throws InterruptedException {
+    setupCommonMocks();
+    ManagementException resourceNotFoundExceptionMock = setupManagementExceptionMock(exceptionCode);
     when(disksMock.getById(anyString())).thenThrow(resourceNotFoundExceptionMock);
 
     StepResult stepResult = getAzureDiskAttachedVmStep.doStep(flightContextMock);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1777

* change GetAzureDiskAttachedVmStep to extend DeleteAzureControlledResourceStep for management exception handling
  The output of GetAzureDiskAttachedVmStep is only used by `DetachAzureDiskFromVmStep`, which is already set up to handle a missing value.
* change `DetachAzureDiskFromVmStep` to extend `DeleteAzureControlledResourceStep`
* Parameterize DeleteAzureControlledResourceStep, for better/more central logging options: There was only one step that  didn't already have a parameter named `resource`, of the appropriate type, and that was trivial to add.
* Added `LandingZoneNotFoundException` to common error handling

Because this is changing the parameters of the `FlightMap`, it could cause a running flight to log a `NullPointerException` instead of the appropriate exception, if it failed for one of the covered exceptions when running `DeleteFederatedCredentialStep`. 