### PR TITLE
[WOR-1799] Verify policy service and buffer service credentials and register WSM SA at bootstrap

### DIFF
--- a/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
+++ b/service/src/main/java/bio/terra/workspace/app/StartupInitializer.java
@@ -3,9 +3,14 @@ package bio.terra.workspace.app;
 import bio.terra.common.db.DataSourceManager;
 import bio.terra.common.migrate.LiquibaseMigrator;
 import bio.terra.landingzone.library.LandingZoneMain;
+import bio.terra.workspace.app.configuration.external.BufferServiceConfiguration;
 import bio.terra.workspace.app.configuration.external.FeatureConfiguration;
 import bio.terra.workspace.app.configuration.external.WorkspaceDatabaseConfiguration;
+import bio.terra.workspace.common.utils.Rethrow;
+import bio.terra.workspace.service.buffer.BufferService;
+import bio.terra.workspace.service.iam.SamService;
 import bio.terra.workspace.service.job.StairwayInitializerService;
+import bio.terra.workspace.service.policy.TpsApiDispatch;
 import bio.terra.workspace.service.workspace.WsmApplicationService;
 import javax.sql.DataSource;
 import org.springframework.context.ApplicationContext;
@@ -24,6 +29,7 @@ public final class StartupInitializer {
     WsmApplicationService appService = applicationContext.getBean(WsmApplicationService.class);
     FeatureConfiguration featureConfiguration =
         applicationContext.getBean(FeatureConfiguration.class);
+    SamService samService = applicationContext.getBean(SamService.class);
 
     // Log the state of the feature flags
     featureConfiguration.logFeatures();
@@ -39,6 +45,20 @@ public final class StartupInitializer {
 
     // Initialize Stairway
     stairwayInitializerService.initialize();
+
+    if (featureConfiguration.isTpsEnabled()) {
+      var tpsApiDispatch = applicationContext.getBean(TpsApiDispatch.class);
+      tpsApiDispatch.verifyConfiguration();
+    }
+
+    var bufferConfig = applicationContext.getBean(BufferServiceConfiguration.class);
+    if (bufferConfig.getEnabled()) {
+      var bufferService = applicationContext.getBean(BufferService.class);
+      bufferService.verifyConfiguration();
+    }
+
+    Rethrow.onInterrupted(
+        samService::initializeWsmServiceAccount, "Initialize WSM service account with Sam");
 
     // Process the WSM application configuration
     appService.configure();

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/BufferServiceConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/BufferServiceConfiguration.java
@@ -66,7 +66,7 @@ public class BufferServiceConfiguration {
     return clientCredentialFilePath;
   }
 
-  public String getAccessToken() throws IOException {
+  public String getAccessToken() {
     try {
       if (features.isAzureControlPlaneEnabled()) {
         throw new InternalServerErrorException(

--- a/service/src/main/java/bio/terra/workspace/app/configuration/external/PolicyServiceConfiguration.java
+++ b/service/src/main/java/bio/terra/workspace/app/configuration/external/PolicyServiceConfiguration.java
@@ -44,7 +44,7 @@ public class PolicyServiceConfiguration {
     return clientCredentialFilePath;
   }
 
-  public String getAccessToken() throws IOException {
+  public String getAccessToken() {
     try {
       return AuthUtils.getAccessToken(
           features.isAzureControlPlaneEnabled(),

--- a/service/src/main/java/bio/terra/workspace/service/buffer/BufferService.java
+++ b/service/src/main/java/bio/terra/workspace/service/buffer/BufferService.java
@@ -36,6 +36,10 @@ public class BufferService {
         new ApiClient().getHttpClient().register(new JakartaTracingFilter(openTelemetry));
   }
 
+  public void verifyConfiguration() {
+    this.bufferServiceConfiguration.getAccessToken();
+  }
+
   private ApiClient getApiClient(String accessToken) {
     ApiClient client =
         new ApiClient()

--- a/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/workspace/service/iam/SamService.java
@@ -283,7 +283,7 @@ public class SamService {
    * Register WSM's service account as a user in Sam if it isn't already. This should only need to
    * register with Sam once per environment, so it is implemented lazily.
    */
-  private void initializeWsmServiceAccount() throws InterruptedException {
+  public void initializeWsmServiceAccount() throws InterruptedException {
     if (!wsmServiceAccountInitialized) {
       final String wsmAccessToken;
       try {

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
@@ -2,6 +2,7 @@ package bio.terra.workspace.service.policy;
 
 import bio.terra.common.logging.RequestIdFilter;
 import bio.terra.common.tracing.JakartaTracingFilter;
+import bio.terra.policy.api.PublicApi;
 import bio.terra.policy.api.TpsApi;
 import bio.terra.policy.client.ApiClient;
 import bio.terra.policy.client.ApiException;
@@ -44,9 +45,10 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+/** A service for integrating with the Terra Policy Service (TPS). */
+@Service
 public class TpsApiDispatch {
   private static final Logger logger = LoggerFactory.getLogger(TpsApiDispatch.class);
   private final FeatureConfiguration features;
@@ -92,9 +94,34 @@ public class TpsApiDispatch {
     }
   }
 
-  /** Verify that we can read the needed TPS client credentials and create a TPS API client. */
+  /**
+   * Verify that we can read the needed TPS client credentials and create a TPS API client.
+   *
+   * @throws bio.terra.common.exception.InternalServerErrorException exception if the application is
+   *     misconfigured
+   */
   public void verifyConfiguration() {
     this.policyServiceConfiguration.getAccessToken();
+  }
+
+  /**
+   * Check the status of TPS.
+   *
+   * @return true if the service is up and running
+   */
+  public boolean status() {
+    try {
+      var publicApi =
+          new PublicApi(
+              getApiClient(policyServiceConfiguration.getAccessToken())
+                  .setBasePath(policyServiceConfiguration.getBasePath()));
+
+      publicApi.getStatus();
+      return true;
+    } catch (ApiException e) {
+      logger.error("Error querying TPS API status", e);
+      return false;
+    }
   }
 
   /**

--- a/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
+++ b/service/src/main/java/bio/terra/workspace/service/policy/TpsApiDispatch.java
@@ -32,7 +32,6 @@ import bio.terra.workspace.service.workspace.model.CloudPlatform;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.ws.rs.client.Client;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -91,6 +90,11 @@ public class TpsApiDispatch {
     } catch (ApiException e) {
       throw convertApiException(e);
     }
+  }
+
+  /** Verify that we can read the needed TPS client credentials and create a TPS API client. */
+  public void verifyConfiguration() {
+    this.policyServiceConfiguration.getAccessToken();
   }
 
   /**
@@ -334,17 +338,9 @@ public class TpsApiDispatch {
   }
 
   private TpsApi policyApi() {
-    try {
-      return new TpsApi(
-          getApiClient(policyServiceConfiguration.getAccessToken())
-              .setBasePath(policyServiceConfiguration.getBasePath()));
-    } catch (IOException e) {
-      throw new PolicyServiceAuthorizationException(
-          String.format(
-              "Error reading or parsing credentials file at %s",
-              policyServiceConfiguration.getClientCredentialFilePath()),
-          e.getCause());
-    }
+    return new TpsApi(
+        getApiClient(policyServiceConfiguration.getAccessToken())
+            .setBasePath(policyServiceConfiguration.getBasePath()));
   }
 
   private RuntimeException convertApiException(ApiException ex) {


### PR DESCRIPTION
In testing Helmfile changes to credentials configuration, it was difficult to tell if WSM external service credentials were configured properly without firing live requests at it (i.e,. the service configuration may be valid yaml, but I may have introduced a typo in the credentials path, which did not manifest until actual live workspace traffic was fired at the application resulting in a 500)

### This PR 
* Verifies that credentials are in the right place during application bootstrap. 
* Register the WSM SA with Sam (if needed) during bootstrap, rather than waiting for the creation of a controlled resource. 
* I considered adding TPS + buffer to the WSM status endpoint checks; I've decided not to as I view those as important but non-critical services for a k8s status check. I've left the status hooks in the relevant service classes so those can be easily wired up in the future.