### PR TITLE
[CORE-97] Route Workspaces team alerts to Core Services slack channel

### DIFF
--- a/.github/workflows/full-integration-tests.yml
+++ b/.github/workflows/full-integration-tests.yml
@@ -90,7 +90,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsp-workspaces-test-alerts"
+        channel: "#dsp-core-services-alerts"
         username: "WSM full integration test"
         author_name: "${{ matrix.gradleTask }}"
         icon_emoji: ":bangbang:"

--- a/.github/workflows/full-service-tests.yml
+++ b/.github/workflows/full-service-tests.yml
@@ -121,7 +121,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsp-workspaces-test-alerts"
+        channel: "#dsp-core-services-alerts"
         username: "WSM full service test branch"
         author_name: "${{ matrix.gradleTask }}"
         icon_emoji: ":bangbang:"

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -94,7 +94,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsp-workspaces-test-alerts"
+        channel: "#dsp-core-services-alerts"
         username: "WSM push to main branch"
         author_name: "integrationTest"
         icon_emoji: ":triangular_ruler:"

--- a/.github/workflows/release-promotion-tests.yml
+++ b/.github/workflows/release-promotion-tests.yml
@@ -144,7 +144,7 @@ jobs:
           author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
           fields: repo,job,workflow,commit,eventName,author,took
 
-      - name: "Notify Workspaces test failure Slack"
+      - name: "Notify WSM test failure Slack"
         if: failure()
         uses: broadinstitute/action-slack@v3.8.0
         # see https://github.com/broadinstitute/action-slack
@@ -152,7 +152,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          channel: "#dsp-workspaces-test-alerts"
+          channel: "#dsp-core-services-alerts"
           username: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} tests"
           author_name: "Workspace Manager ${{ steps.set-env-step.outputs.test-env }} integrationTest"
           fields: repo,job,workflow,commit,eventName,author,took

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       with:
         status: ${{ job.status }}
-        channel: "#dsp-workspaces-test-alerts"
+        channel: "#dsp-core-services-alerts"
         username: "WSM push to main branch"
         author_name: "${{ matrix.gradleTask }}"
         icon_emoji: ":triangular_ruler:"


### PR DESCRIPTION
Ticket: [CORE-97](https://broadworkbench.atlassian.net/browse/CORE-97)

- move #dsp-workspaces-test-alerts to #dsp-core-services-alerts

[CORE-97]: https://broadworkbench.atlassian.net/browse/CORE-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ