### PR TITLE
[CORE-119] Update terra-aws-resource-discovery dependency version

### DIFF
--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -25,7 +25,7 @@ dependencies {
   implementation group: "bio.terra", name: "datarepo-client", version: "2.13.0-SNAPSHOT"
   implementation group: "bio.terra", name:"billing-profile-manager-client", version: "0.1.536-SNAPSHOT"
   implementation group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT"
-  implementation group: "bio.terra", name:"terra-aws-resource-discovery", version:"v0.6.3-SNAPSHOT"
+  implementation group: "bio.terra", name:"terra-aws-resource-discovery", version:"v0.6.4-SNAPSHOT"
 
   // hk2 is required to use datarepo client, but not correctly exposed by the client
   implementation group: "org.glassfish.jersey.inject", name: "jersey-hk2"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-119

#### Description:

Once this [PR is merged and released](https://github.com/DataBiosphere/terra-aws-resource-discovery/pull/51), This PR bumps the `bio.terra terra-aws-resource-discovery` version to `v0.6.4-SNAPSHOT` to include the recent security fix for Apache Avro ([CVE-2024-47561](https://github.com/advisories/GHSA-r7pg-v2c8-mfg3)), ensuring downstream projects use the secure version.

#### Changes:

- Updated to `v0.6.4-SNAPSHOT` to include Apache Avro 1.12.0.