### PR TITLE
DDO-3952 - update test runner and test libraries-bom dependency

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 dependencies {
     // Google dependencies versioned by bom
-    implementation platform('com.google.cloud:libraries-bom:26.49.0')
+    implementation platform('com.google.cloud:libraries-bom:26.51.0')
     implementation "com.google.api-client:google-api-client"
     implementation "com.google.cloud:google-cloud-bigquery"
     implementation "com.google.cloud:google-cloud-storage"
@@ -26,7 +26,7 @@ dependencies {
     implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-73bc2d1"
 
     // Terra Test Runner Library
-    implementation 'bio.terra:terra-test-runner:0.2.0-SNAPSHOT'
+    implementation 'bio.terra:terra-test-runner:0.2.1-SNAPSHOT'
 
     // Use Terra Common Library on client side to retry direct Sam calls
     implementation("bio.terra:terra-common-lib:1.1.11-SNAPSHOT") {


### PR DESCRIPTION
Use an updated test-runner library https://github.com/DataBiosphere/terra-test-runner/pull/51