### PR TITLE
CORE-69: update test runner library

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-73bc2d1"
 
     // Terra Test Runner Library
-    implementation 'bio.terra:terra-test-runner:0.2.0-SNAPSHOT'
+    implementation 'bio.terra:terra-test-runner:0.2.1-SNAPSHOT'
 
     // Use Terra Common Library on client side to retry direct Sam calls
     implementation("bio.terra:terra-common-lib:1.1.11-SNAPSHOT") {


### PR DESCRIPTION
Use matching versions for the `bio.terra:terra-test-runner` library and the `bio.terra.test-runner-plugin` plugin.