### PR TITLE
CORE-69: use latest Sam client

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation project(":client")
 
     // Sam client library
-    implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-73bc2d1"
+    implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.332"
 
     // Terra Test Runner Library
     implementation 'bio.terra:terra-test-runner:0.2.1-SNAPSHOT'

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -37,7 +37,7 @@ dependencies {
   implementation("bio.terra:terra-common-lib:1.1.11-SNAPSHOT")
 
   // sam
-  implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.234"
+  implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.332"
   implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.198.42-SNAPSHOT"
 
   // Cloud Resource Library


### PR DESCRIPTION
Uses a consistent version of the Sam client across integration tests and runtime; updates that version to latest.