### PR TITLE
CORE-69 minor deps no spring boot

### DIFF
--- a/azureDatabaseUtils/build.gradle
+++ b/azureDatabaseUtils/build.gradle
@@ -1,10 +1,10 @@
 // Project Plugins
 plugins {
     id 'terra-workspace-manager.java-spring-conventions'
-    id "com.github.ben-manes.versions" version "0.51.0"
+    id "com.github.ben-manes.versions" version "0.52.0"
     id "com.google.cloud.tools.jib" version "3.4.4"
     id "de.undercouch.download" version "5.6.0"
-    id 'org.gradle.test-retry' version '1.6.0'
+    id 'org.gradle.test-retry' version '1.6.1'
     id "org.sonarqube" version "6.0.1.5171"
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,7 +11,7 @@ repositories {
 dependencies {
     implementation 'org.apache.commons:commons-compress:1.27.1'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.4.2'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.4.1'
     implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '7.0.2'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
     testImplementation group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.12'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,8 +11,8 @@ repositories {
 dependencies {
     implementation 'org.apache.commons:commons-compress:1.27.1'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.4.1'
-    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '7.0.1'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.4.2'
+    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '7.0.2'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
     testImplementation group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.12'
 }

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 dependencies {
     // Google dependencies versioned by bom
-    implementation platform('com.google.cloud:libraries-bom:26.52.0')
+    implementation platform('com.google.cloud:libraries-bom:26.53.0')
     implementation "com.google.api-client:google-api-client"
     implementation "com.google.cloud:google-cloud-bigquery"
     implementation "com.google.cloud:google-cloud-storage"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,11 +1,11 @@
 // Project Plugins
 plugins {
     id 'terra-workspace-manager.java-spring-conventions'
-    id "com.github.ben-manes.versions" version "0.51.0"
+    id "com.github.ben-manes.versions" version "0.52.0"
     id "com.google.cloud.tools.jib" version "3.4.4"
     id "de.undercouch.download" version "5.6.0"
     id "org.hidetake.swagger.generator" version "2.19.2"
-    id 'org.gradle.test-retry' version '1.6.0'
+    id 'org.gradle.test-retry' version '1.6.1'
     id "org.sonarqube" version "6.0.1.5171"
     id "au.com.dius.pact" version "4.6.16"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,5 +30,5 @@ include 'azureDatabaseUtils'
 gradle.ext.wsmVersion = "0.254.1172-SNAPSHOT"
 
 // Single place to define the versions of dependencies shared between components.
-gradle.ext.librarySwaggerAnnotations = "io.swagger.core.v3:swagger-annotations:2.2.27"
+gradle.ext.librarySwaggerAnnotations = "io.swagger.core.v3:swagger-annotations:2.2.28"
 gradle.ext.librarySwaggerCli = "io.swagger.codegen.v3:swagger-codegen-cli:3.0.56"


### PR DESCRIPTION
Copy of #1825, but without the Spring Boot update.

#1825 has test failures; this PR does not. My assumption is that the test failures are caused by one of two things:
1. The Spring Boot update. After this PR merges I will make another one for Spring Boot; we'll see how that one does
2. A difference in secrets used by Dependabot vs. by me (i.e. the "Dependabot" vs. "Actions" distinction in repo secrets). I suspect this is the culprit and will continue to investigate.

---

Bumps the minor-patch-dependencies group with 6 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| io.swagger.core.v3:swagger-annotations | `2.2.27` | `2.2.28` |
| com.github.ben-manes.versions | `0.51.0` | `0.52.0` |
| org.gradle.test-retry | `1.6.0` | `1.6.1` |
| [com.google.cloud:libraries-bom](https://github.com/googleapis/java-cloud-bom) | `26.52.0` | `26.53.0` |
| [com.diffplug.spotless:spotless-plugin-gradle](https://github.com/diffplug/spotless) | `7.0.1` | `7.0.2` |


Updates `io.swagger.core.v3:swagger-annotations` from 2.2.27 to 2.2.28

Updates `com.github.ben-manes.versions` from 0.51.0 to 0.52.0

Updates `org.gradle.test-retry` from 1.6.0 to 1.6.1

Updates `com.google.cloud:libraries-bom` from 26.52.0 to 26.53.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/googleapis/java-cloud-bom/releases">com.google.cloud:libraries-bom's releases</a>.</em></p>
<blockquote>
<h2>v26.53.0</h2>
<p>GCP Libraries BOM 26.53.0</p>
<p>Here are the differences from the previous version (26.52.0)</p>
<p>The group ID of the following artifacts is <code>com.google.cloud</code>.</p>
<h1>Notable Changes</h1>
<h2>google-cloud-bigquery 2.46.0 (prev: 2.45.0)</h2>
<ul>
<li>
<p><strong>bigquery:</strong> Support IAM conditions in datasets in Java client. (<a href="https://redirect.github.com/googleapis/java-bigquery/issues/3602">#3602</a>) (<a href="https://github.com/googleapis/java-bigquery/commit/6696a9c7d42970e3c24bda4da713a855dbe40ce5">6696a9c</a>)</p>
</li>
<li>
<p>NPE when reading BigQueryResultSet from empty tables (<a href="https://redirect.github.com/googleapis/java-bigquery/issues/3627">#3627</a>) (<a href="https://github.com/googleapis/java-bigquery/commit/9a0b05a3b57797b7cdd8ca9739699fc018dbd868">9a0b05a</a>)</p>
</li>
<li>
<p><strong>test:</strong> Force usage of ReadAPI (<a href="https://redirect.github.com/googleapis/java-bigquery/issues/3625">#3625</a>) (<a href="https://github.com/googleapis/java-bigquery/commit/5ca7d4acbbc40d6ef337732464b3bbd130c86430">5ca7d4a</a>)</p>
</li>
</ul>
<h2>google-cloud-pubsub 1.136.0 (prev: 1.135.0)</h2>
<ul>
<li>Add Kafka-based sources to IngestionDataSourceSettings proto and IngestionFailureEvent proto (<a href="https://github.com/googleapis/java-pubsub/commit/2947169c009fa553202bc1e44276cf5a7954cd96">2947169</a>)</li>
</ul>
<h2>google-cloud-spanner 6.85.0 (prev: 6.83.0)</h2>
<ul>
<li>
<p>Add support for ARRAY&lt;STRUCT&gt; to CloudCilentExecutor (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3544">#3544</a>) (<a href="https://github.com/googleapis/java-spanner/commit/6cbaf7ec6502d04fc0a0c09720e2054bd10bead9">6cbaf7e</a>)</p>
</li>
<li>
<p>Add transaction runner for connections (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3559">#3559</a>) (<a href="https://github.com/googleapis/java-spanner/commit/5a1be3dedeafa6858502eadc7918820b9cd90f68">5a1be3d</a>)</p>
</li>
<li>
<p>Exposing InstanceType in Instance configuration (to define PROVISIONED or FREE spanner instance) (<a href="https://github.com/googleapis/java-spanner/commit/8d295c4a4030b4e97b1d653cc3baf412864f3042">8d295c4</a>)</p>
</li>
<li>
<p>Improve tracing by adding attributes (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3576">#3576</a>) (<a href="https://github.com/googleapis/java-spanner/commit/eee333b51fa69123e011dfbd2a0896fd31ac10dc">eee333b</a>)</p>
</li>
<li>
<p><strong>spanner:</strong> Add jdbc support for external hosts (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3536">#3536</a>) (<a href="https://github.com/googleapis/java-spanner/commit/801346a1b2efe7d0144f7442e1568eb5b02ddcbc">801346a</a>)</p>
</li>
<li>
<p>AsyncTransactionManager did not always close the session (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3580">#3580</a>) (<a href="https://github.com/googleapis/java-spanner/commit/d9813a05240b966f444168d3b8c30da9d27a8cc4">d9813a0</a>)</p>
</li>
<li>
<p>Retry specific internal errors (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3565">#3565</a>) (<a href="https://github.com/googleapis/java-spanner/commit/b9ce1a6fcbd11373a5cc82807af15c1cca0dd48e">b9ce1a6</a>)</p>
</li>
<li>
<p>Update max_in_use_session at 10 mins interval (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3570">#3570</a>) (<a href="https://github.com/googleapis/java-spanner/commit/cc1753da72b3e508f8fea8a6d19e1ed3f34e3602">cc1753d</a>)</p>
</li>
<li>
<p>Add gcp client attributes in OpenTelemetry traces (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3595">#3595</a>) (<a href="https://github.com/googleapis/java-spanner/commit/7893f2499f6a43e4e80ec78a9f0da5beedb6967a">7893f24</a>)</p>
</li>
<li>
<p>Add LockHint feature (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3588">#3588</a>) (<a href="https://github.com/googleapis/java-spanner/commit/326442bca41700debcbeb67b6bd11fc36bd4f26d">326442b</a>)</p>
</li>
<li>
<p><strong>spanner:</strong> MTLS setup for spanner external host clients (<a href="https://redirect.github.com/googleapis/java-spanner/issues/3574">#3574</a>) (<a href="https://github.com/googleapis/java-spanner/commit/f8dd15272f2a250c5b57c9f2527d03dbd557d717">f8dd152</a>)</p>
</li>
</ul>
<h2>google-cloud-spanner-jdbc 2.26.0 (prev: 2.25.1)</h2>
<ul>
<li>
<p>Clear interrupted flag after cancel (<a href="https://redirect.github.com/googleapis/java-spanner-jdbc/issues/1880">#1880</a>) (<a href="https://github.com/googleapis/java-spanner-jdbc/commit/e1fd4e131a039b80306991cc93c5c097f2538c90">e1fd4e1</a>), closes <a href="https://redirect.github.com/googleapis/java-spanner-jdbc/issues/1879">#1879</a></p>
</li>
<li>
<p>Support for spanner external host (<a href="https://redirect.github.com/googleapis/java-spanner-jdbc/issues/1884">#1884</a>) (<a href="https://github.com/googleapis/java-spanner-jdbc/commit/123a7bcd9825b20bfbf7e9b057c2bd0f5213cac3">123a7bc</a>)</p>
</li>
</ul>
<h2>google-cloud-storage 2.47.0 (prev: 2.46.0)</h2>
<ul>
<li>
<p>Add MoveObject RPC (<a href="https://github.com/googleapis/java-storage/commit/34b8ac4239bab67b53c73050d2341615254a3ae0">34b8ac4</a>)</p>
</li>
<li>
<p>Introductory beta level support for OpenTelemetry tracing on c.g.c.storage.Storage methods (<a href="https://redirect.github.com/googleapis/java-storage/issues/2837">#2837</a>) (<a href="https://github.com/googleapis/java-storage/commit/dd889ea0d0a57490ef106ab92ba557f26d414406">dd889ea</a>)</p>
</li>
<li>
<p>De-beta storage-v2 artifacts (<a href="https://redirect.github.com/googleapis/java-storage/issues/2852">#2852</a>) (<a href="https://github.com/googleapis/java-storage/commit/77a2e8af341528a4ff3c34a880a7983f828b8cfd">77a2e8a</a>)</p>
</li>
<li>
<p>Fix interrupt spiral in grpc ReadObject drainQueue (<a href="https://redirect.github.com/googleapis/java-storage/issues/2850">#2850</a>) (<a href="https://github.com/googleapis/java-storage/commit/c1dac837387ffc40f00344c8fb0e86e09d009358">c1dac83</a>)</p>
</li>
<li>
<p>Update request handling of gRPC based CopyWriter (<a href="https://redirect.github.com/googleapis/java-storage/issues/2858">#2858</a>) (<a href="https://github.com/googleapis/java-storage/commit/093cb8759d5cfaafa6fd9df43de1bb91c1285f35">093cb87</a>)</p>
</li>
</ul>
<h2>Other libraries</h2>
<ul>
<li>[aiplatform] add a new thought field in content proto (<a href="https://github.com/googleapis/google-cloud-java/commit/b68c98c14e4de0d1f5755bc306278ee16d2c55ce">b68c98c</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/c8074d1c906f5be72d14648d424ca3494d6f6350"><code>c8074d1</code></a> chore: release main (<a href="https://redirect.github.com/googleapis/java-cloud-bom/issues/6904">#6904</a>)</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/a5a6f303272a78c11e465d4f3f54fdfe3eeb0ede"><code>a5a6f30</code></a> deps: update protobuf to 4.29.0 (<a href="https://redirect.github.com/googleapis/java-cloud-bom/issues/6903">#6903</a>)</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/7a0748f0f7cad5071248784a7628e916cee7abfb"><code>7a0748f</code></a> deps: update dependency com.google.cloud:google-cloud-logging-logback to v0.1...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/b617eeef8b6739830fae536f355c1f989c6ea628"><code>b617eee</code></a> deps: update dependency com.google.cloud:google-cloud-logging-bom to v3.21.1 ...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/42aa2428f0027ea96a5b3951ae591e9b5bb70ede"><code>42aa242</code></a> deps: update dependency com.google.cloud:google-cloud-spanner-jdbc to v2.26.0...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/692b250e94d489752aee904ad5e0a075fb133745"><code>692b250</code></a> deps: update dependency com.google.cloud:google-cloud-firestore-bom to v3.30....</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/f37e24d824447fa376aa414578705d4c8bb5136f"><code>f37e24d</code></a> deps: update dependency com.google.cloud:google-cloud-bigquery to v2.46.0 (<a href="https://redirect.github.com/googleapis/java-cloud-bom/issues/6">#6</a>...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/f8b4af6f54d1133a083aa7bc869bbb0a8a55840c"><code>f8b4af6</code></a> deps: update dependency com.google.cloud:google-cloud-spanner-bom to v6.85.0 ...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/1413e7aaa4728d078e7309ba9efb06d80c459010"><code>1413e7a</code></a> deps: update dependency com.google.cloud:google-cloud-datastore-bom to v2.25....</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/68830a5464a90fdc18580baa47bfbe260071201e"><code>68830a5</code></a> deps: update dependency com.google.cloud:google-cloud-pubsublite-bom to v1.15...</li>
<li>Additional commits viewable in <a href="https://github.com/googleapis/java-cloud-bom/compare/v26.52.0...v26.53.0">compare view</a></li>
</ul>
</details>
<br />


Updates `com.diffplug.spotless:spotless-plugin-gradle` from 7.0.1 to 7.0.2
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/diffplug/spotless/releases">com.diffplug.spotless:spotless-plugin-gradle's releases</a>.</em></p>
<blockquote>
<h2>Gradle Plugin v7.0.2</h2>
<h3>Fixed</h3>
<ul>
<li>Node.JS-based tasks now work with the configuration cache (<a href="https://redirect.github.com/diffplug/spotless/issues/2372">#2372</a>)</li>
<li>Eclipse-based tasks can now handle parallel configuration (<a href="https://redirect.github.com/diffplug/spotless/issues/2389">#2389</a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/diffplug/spotless/blob/main/CHANGES.md">com.diffplug.spotless:spotless-plugin-gradle's changelog</a>.</em></p>
<blockquote>
<h1>spotless-lib and spotless-lib-extra releases</h1>
<p>If you are a Spotless user (as opposed to developer), then you are probably looking for:</p>
<ul>
<li><a href="https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md">https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md</a></li>
<li><a href="https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md">https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md</a></li>
</ul>
<p>This document is intended for Spotless developers.</p>
<p>We adhere to the <a href="https://keepachangelog.com/en/1.0.0/">keepachangelog</a> format (starting after version <code>1.27.0</code>).</p>
<h2>[Unreleased]</h2>
<h2>[3.0.2] - 2025-01-14</h2>
<h3>Fixed</h3>
<ul>
<li>Node.JS-based tasks now work with the configuration cache (<a href="https://redirect.github.com/diffplug/spotless/issues/2372">#2372</a>)</li>
<li>Eclipse-based tasks can now handle parallel configuration (<a href="https://redirect.github.com/diffplug/spotless/issues/2389">#2389</a>)</li>
</ul>
<h2>[3.0.1] - 2025-01-07</h2>
<h3>Fixed</h3>
<ul>
<li>Deployment was missing part of the CDT formatter, now fixed. (<a href="https://redirect.github.com/diffplug/spotless/issues/2384">#2384</a>)</li>
</ul>
<h2>[3.0.0] - 2025-01-06</h2>
<h2>Headline changes</h2>
<ul>
<li>All steps now support roundtrip serialization (end of <a href="https://redirect.github.com/diffplug/spotless/issues/987">#987</a>).</li>
<li>Spotless now supports <a href="https://github.com/diffplug/spotless/blob/main/CONTRIBUTING.md#lints">linting</a> in addition to formatting.</li>
</ul>
<h3>Changed</h3>
<ul>
<li>Allow setting Eclipse config from a string, not only from files (<a href="https://redirect.github.com/diffplug/spotless/pull/2337">#2337</a>)</li>
<li>Bump default <code>ktlint</code> version to latest <code>1.3.0</code> -&gt; <code>1.4.0</code>. (<a href="https://redirect.github.com/diffplug/spotless/pull/2314">#2314</a>)</li>
<li>Add <em>Sort Members</em> feature based on <a href="https://github.com/diffplug/spotless/blob/main/plugin-gradle/README.md#eclipse-jdt">Eclipse JDT</a> implementation. (<a href="https://redirect.github.com/diffplug/spotless/pull/2312">#2312</a>)</li>
<li>Bump default <code>jackson</code> version to latest <code>2.18.0</code> -&gt; <code>2.18.1</code>. (<a href="https://redirect.github.com/diffplug/spotless/pull/2319">#2319</a>)</li>
<li>Bump default <code>ktfmt</code> version to latest <code>0.52</code> -&gt; <code>0.53</code>. (<a href="https://redirect.github.com/diffplug/spotless/pull/2320">#2320</a>)</li>
<li>Bump default <code>ktlint</code> version to latest <code>1.4.0</code> -&gt; <code>1.5.0</code>. (<a href="https://redirect.github.com/diffplug/spotless/pull/2354">#2354</a>)</li>
<li>Bump minimum <code>eclipse-cdt</code> version to <code>11.0</code> (removed support for <code>10.7</code>). (<a href="https://redirect.github.com/diffplug/spotless/pull/2373">#2373</a>)</li>
<li>Bump default <code>eclipse</code> version to latest <code>4.32</code> -&gt; <code>4.34</code>. (<a href="https://redirect.github.com/diffplug/spotless/pull/2381">#2381</a>)</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>You can now use <code>removeUnusedImports</code> and <code>googleJavaFormat</code> at the same time again. (fixes <a href="https://redirect.github.com/diffplug/spotless/issues/2159">#2159</a>)</li>
<li>The default list of type annotations used by <code>formatAnnotations</code> now includes Jakarta Validation's <code>Valid</code> and constraints validations (fixes <a href="https://redirect.github.com/diffplug/spotless/issues/2334">#2334</a>)</li>
</ul>
<h2>[3.0.0.BETA4] - 2024-10-24</h2>
<h3>Added</h3>
<ul>
<li>APIs to support linting. (implemented in <a href="https://redirect.github.com/diffplug/spotless/pull/2148">#2148</a>, <a href="https://redirect.github.com/diffplug/spotless/pull/2149">#2149</a>, <a href="https://redirect.github.com/diffplug/spotless/pull/2307">#2307</a>)
<ul>
<li>Spotless is still primarily a formatter, not a linter. But when formatting fails, it's more flexible to model those failures as lints so that the formatting can continue and ideally we can also capture the line numbers causing the failure.</li>
<li><code>Lint</code> models a single change. A <code>FormatterStep</code> can create a lint by:
<ul>
<li>throwing an exception during formatting, ideally <code>throw Lint.atLine(127, &quot;code&quot;, &quot;Well what happened was...&quot;)</code></li>
<li>or by implementing the <code>List&lt;Lint&gt; lint(String content, File file)</code> method to create multiple of them</li>
</ul>
</li>
</ul>
</li>
<li>Support for line ending policy <code>PRESERVE</code> which just takes the first line ending of every given file as setting (no matter if <code>\n</code>, <code>\r\n</code> or <code>\r</code>) (<a href="https://redirect.github.com/diffplug/spotless/pull/2304">#2304</a>)</li>
</ul>
<h3>Changed</h3>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/diffplug/spotless/commit/20e2f5a218a216abe108889fb1a75621b92eecc1"><code>20e2f5a</code></a> Published gradle/7.0.2</li>
<li><a href="https://github.com/diffplug/spotless/commit/37c85b8b76de434625e70b4ac194f9483c35d572"><code>37c85b8</code></a> Published lib/3.0.2</li>
<li><a href="https://github.com/diffplug/spotless/commit/b8b4efcd5f5c80f80d489ed46ab7e05a6839deda"><code>b8b4efc</code></a> Fix eclipse-based parallel downloads (<a href="https://redirect.github.com/diffplug/spotless/issues/2396">#2396</a> fixes <a href="https://redirect.github.com/diffplug/spotless/issues/2389">#2389</a>)</li>
<li><a href="https://github.com/diffplug/spotless/commit/b401228e2bb7286f03eed7509f6ef358982018a8"><code>b401228</code></a> Update changelogs.</li>
<li><a href="https://github.com/diffplug/spotless/commit/3727dfae92d22b806b4525622061b012b34a8151"><code>3727dfa</code></a> Fix deprecations in the Spotless build.</li>
<li><a href="https://github.com/diffplug/spotless/commit/77c480e8844ceb44e8801ffff67553b4adb161f5"><code>77c480e</code></a> Bump equo versions to latest, which fixes parallel downloads.</li>
<li><a href="https://github.com/diffplug/spotless/commit/b50fcaff5367543bbdd96ac6bc8321c077bb9b78"><code>b50fcaf</code></a> fix: workaround for NPM configuration cache (<a href="https://redirect.github.com/diffplug/spotless/issues/2390">#2390</a> fixes <a href="https://redirect.github.com/diffplug/spotless/issues/2372">#2372</a>)</li>
<li><a href="https://github.com/diffplug/spotless/commit/f77aeadc249d0f1b7b87249c169bfb9b2d44bbb1"><code>f77aead</code></a> Update plugin com.github.spotbugs to v6.1.0 (<a href="https://redirect.github.com/diffplug/spotless/issues/2393">#2393</a>)</li>
<li><a href="https://github.com/diffplug/spotless/commit/4c9e39a10b388286684f849db45a455232f74362"><code>4c9e39a</code></a> Update plugin com.github.spotbugs to v6.1.0</li>
<li><a href="https://github.com/diffplug/spotless/commit/feaac904e8e01015c8aa267a9a049e94f9650470"><code>feaac90</code></a> Make sure we use a recent version of <code>gradleRunner</code></li>
<li>Additional commits viewable in <a href="https://github.com/diffplug/spotless/compare/gradle/7.0.1...gradle/7.0.2">compare view</a></li>
</ul>
</details>
<br />
