### PR TITLE
[CORE-69]: update LZS libraries

### DIFF
--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -72,7 +72,7 @@ dependencies {
   implementation group: "io.micrometer", name: "micrometer-registry-prometheus"
 
   implementation group: "commons-validator", name: "commons-validator", version: "1.7"
-  implementation group: "io.kubernetes", name: "client-java", version: "20.0.1" // Do not use -legacy versions
+  implementation group: "io.kubernetes", name: "client-java", version: "21.0.2" // Do not use -legacy versions
   constraints {
     implementation('org.bouncycastle:bcprov-jdk18on:1.78') {
       because 'https://broadworkbench.atlassian.net/browse/WOR-1652'

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -72,7 +72,7 @@ dependencies {
   implementation group: "io.micrometer", name: "micrometer-registry-prometheus"
 
   implementation group: "commons-validator", name: "commons-validator", version: "1.7"
-  implementation group: "io.kubernetes", name: "client-java", version: "21.0.2" // Do not use -legacy versions
+  implementation group: "io.kubernetes", name: "client-java", version: "22.0.1" // Do not use -legacy versions
   constraints {
     implementation('org.bouncycastle:bcprov-jdk18on:1.78') {
       because 'https://broadworkbench.atlassian.net/browse/WOR-1652'

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -44,8 +44,8 @@ dependencies {
   implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: "1.2.31-SNAPSHOT"
 
   // Terra Landing Zone Service
-  implementation ('bio.terra:terra-landing-zone-service:0.0.367-SNAPSHOT')
-  implementation ('bio.terra:landing-zone-service-client:0.0.367-SNAPSHOT')
+  implementation ('bio.terra:terra-landing-zone-service:0.0.386-SNAPSHOT')
+  implementation ('bio.terra:landing-zone-service-client:0.0.386-SNAPSHOT')
 
   // Storage transfer service
   implementation group: 'com.google.apis', name: 'google-api-services-storagetransfer', version: 'v1-rev20230831-2.0.0'

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -8,8 +8,8 @@ dependencies {
   implementation 'com.google.auto.value:auto-value-annotations'
 
   // Azure dependencies
-  implementation 'com.azure:azure-storage-blob:12.25.3'
-  implementation 'com.azure.resourcemanager:azure-resourcemanager-monitor:2.37.0'
+  implementation 'com.azure:azure-storage-blob:12.29.0'
+  implementation 'com.azure.resourcemanager:azure-resourcemanager-monitor:2.47.0'
 
   // AWS dependencies
   implementation platform('software.amazon.awssdk:bom:2.25.17')
@@ -34,7 +34,7 @@ dependencies {
   implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0'
 
   // Get stairway via TCL
-  implementation("bio.terra:terra-common-lib:1.1.11-SNAPSHOT")
+  implementation("bio.terra:terra-common-lib:1.1.27-SNAPSHOT")
 
   // sam
   implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.332"
@@ -72,7 +72,7 @@ dependencies {
   implementation group: "io.micrometer", name: "micrometer-registry-prometheus"
 
   implementation group: "commons-validator", name: "commons-validator", version: "1.7"
-  implementation group: "io.kubernetes", name: "client-java", version: "22.0.1" // Do not use -legacy versions
+  implementation group: "io.kubernetes", name: "client-java", version: "21.0.2" // Do not use -legacy versions
   constraints {
     implementation('org.bouncycastle:bcprov-jdk18on:1.78') {
       because 'https://broadworkbench.atlassian.net/browse/WOR-1652'


### PR DESCRIPTION
Updates the Landing Zone Service libraries used by WSM. Most importantly, updates these libraries to a version that includes the fix in https://github.com/DataBiosphere/terra-landing-zone-service/pull/536.