### PR TITLE
CORE-338: fix Azure unit tests, maybe fix live database utils

### DIFF
--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
@@ -598,11 +598,11 @@ public class AzureDatabaseUtilsRunner {
                     () -> new IllegalStateException("No shared database admin identity found")));
 
     List<V1EnvVar> envVarsWithCommonArgs = new ArrayList<>();
-      logger.warn("~~~~~~~~~~ AZURE_ENVIRONMENT: {}", azureConfig.getAzureEnvironmentConfigString());
-//    envVarsWithCommonArgs.add(
-//        new V1EnvVar()
-//            .name(PARAM_AZURE_ENVIRONMENT)
-//            .value(azureConfig.getAzureEnvironmentConfigString()));
+    logger.warn("~~~~~~~~~~ AZURE_ENVIRONMENT: {}", azureConfig.getAzureEnvironmentConfigString());
+    envVarsWithCommonArgs.add(
+        new V1EnvVar()
+            .name(PARAM_AZURE_ENVIRONMENT)
+            .value(azureConfig.getAzureEnvironmentConfigString()));
     envVarsWithCommonArgs.add(new V1EnvVar().name(PARAM_DB_SERVER_NAME).value(dbServerName));
     envVarsWithCommonArgs.add(new V1EnvVar().name(PARAM_ADMIN_DB_USER_NAME).value(adminDbUserName));
     envVarsWithCommonArgs.addAll(envVars);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
@@ -598,7 +598,6 @@ public class AzureDatabaseUtilsRunner {
                     () -> new IllegalStateException("No shared database admin identity found")));
 
     List<V1EnvVar> envVarsWithCommonArgs = new ArrayList<>();
-    logger.warn("~~~~~~~~~~ AZURE_ENVIRONMENT: {}", azureConfig.getAzureEnvironmentConfigString());
     envVarsWithCommonArgs.add(
         new V1EnvVar()
             .name(PARAM_AZURE_ENVIRONMENT)

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
@@ -598,10 +598,10 @@ public class AzureDatabaseUtilsRunner {
                     () -> new IllegalStateException("No shared database admin identity found")));
 
     List<V1EnvVar> envVarsWithCommonArgs = new ArrayList<>();
-    envVarsWithCommonArgs.add(
-        new V1EnvVar()
-            .name(PARAM_AZURE_ENVIRONMENT)
-            .value(azureConfig.getAzureEnvironmentConfigString()));
+//    envVarsWithCommonArgs.add(
+//        new V1EnvVar()
+//            .name(PARAM_AZURE_ENVIRONMENT)
+//            .value(azureConfig.getAzureEnvironmentConfigString()));
     envVarsWithCommonArgs.add(new V1EnvVar().name(PARAM_DB_SERVER_NAME).value(dbServerName));
     envVarsWithCommonArgs.add(new V1EnvVar().name(PARAM_ADMIN_DB_USER_NAME).value(adminDbUserName));
     envVarsWithCommonArgs.addAll(envVars);

--- a/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
+++ b/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunner.java
@@ -598,6 +598,7 @@ public class AzureDatabaseUtilsRunner {
                     () -> new IllegalStateException("No shared database admin identity found")));
 
     List<V1EnvVar> envVarsWithCommonArgs = new ArrayList<>();
+      logger.warn("~~~~~~~~~~ AZURE_ENVIRONMENT: {}", azureConfig.getAzureEnvironmentConfigString());
 //    envVarsWithCommonArgs.add(
 //        new V1EnvVar()
 //            .name(PARAM_AZURE_ENVIRONMENT)

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -30,7 +30,7 @@ env:
     tps: ${TPS_ADDRESS:https://tps.dsde-dev.broadinstitute.org/}
     lzs: ${LZS_ADDRESS:https://landingzone.dsde-dev.broadinstitute.org/}
   azure:
-    environment: ${AZURE_ENVIRONMENT:AZURE}
+    environment: ${AZURE_ENVIRONMENT:AzureCloud}
     customer:
       usage-attribute: ${AZURE_CUSTOMER_USAGE_ATTRIBUTE:}
 

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
@@ -49,7 +49,7 @@ public class AzureDatabaseUtilsRunnerTest extends BaseMockitoStrictStubbingTest 
   @Mock private ApiAzureLandingZoneDeployedResource mockDatabase;
   @Mock private ApiAzureLandingZoneDeployedResource mockAdminIdentity;
 
-  private final String AZURE_ENV = "AzureCloud";
+  private final String AZURE_ENV = "AZURE";
 
   @BeforeEach
   public void createAzureDatabaseUtilsRunner() {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
@@ -49,7 +49,7 @@ public class AzureDatabaseUtilsRunnerTest extends BaseMockitoStrictStubbingTest 
   @Mock private ApiAzureLandingZoneDeployedResource mockDatabase;
   @Mock private ApiAzureLandingZoneDeployedResource mockAdminIdentity;
 
-  private final String AZURE_ENV = "AZURE";
+  private final String AZURE_ENV = "AzureCloud";
 
   @BeforeEach
   public void createAzureDatabaseUtilsRunner() {

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
@@ -51,6 +51,7 @@ public class AzureDatabaseUtilsRunnerTest extends BaseMockitoStrictStubbingTest 
 
   @BeforeEach
   public void createAzureDatabaseUtilsRunner() {
+    when(mockAzureConfig.getAzureEnvironmentConfigString()).thenReturn("AzureCloud");
     azureDatabaseUtilsRunner =
         new AzureDatabaseUtilsRunner(
             mockAzureConfig,

--- a/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
+++ b/service/src/test/java/bio/terra/workspace/service/resource/controlled/cloud/azure/database/AzureDatabaseUtilsRunnerTest.java
@@ -49,9 +49,11 @@ public class AzureDatabaseUtilsRunnerTest extends BaseMockitoStrictStubbingTest 
   @Mock private ApiAzureLandingZoneDeployedResource mockDatabase;
   @Mock private ApiAzureLandingZoneDeployedResource mockAdminIdentity;
 
+  private final String AZURE_ENV = "AzureCloud";
+
   @BeforeEach
   public void createAzureDatabaseUtilsRunner() {
-    when(mockAzureConfig.getAzureEnvironmentConfigString()).thenReturn("AzureCloud");
+    when(mockAzureConfig.getAzureEnvironmentConfigString()).thenReturn(AZURE_ENV);
     azureDatabaseUtilsRunner =
         new AzureDatabaseUtilsRunner(
             mockAzureConfig,
@@ -172,6 +174,8 @@ public class AzureDatabaseUtilsRunnerTest extends BaseMockitoStrictStubbingTest 
     var expectedEnvWithCommon = new HashMap<>(expectedEnv);
     expectedEnvWithCommon.putAll(
         Map.of(
+            "AZURE_ENVIRONMENT",
+            AZURE_ENV,
             "DB_SERVER_NAME",
             mockDatabase.getResourceId(),
             "ADMIN_DB_USER_NAME",


### PR DESCRIPTION
After looking into it, the azure unit tests were an isolated issue. Any problems we're seeing in production are not directly related to the test failures. However, this PR has an experiment to try to address production, too.

In this PR:
* fix a test assertion in `AzureDatabaseUtilsRunner` that was broken in #1806
* default to the correct value (`AzureCloud`, not `AZURE`) for the azure environment