### PR TITLE
CORE-391: upgrade TCL to 1.1.38

### DIFF
--- a/buildSrc/src/main/groovy/terra-workspace-manager.java-spring-conventions.gradle
+++ b/buildSrc/src/main/groovy/terra-workspace-manager.java-spring-conventions.gradle
@@ -5,7 +5,3 @@ plugins {
     id 'io.spring.dependency-management'
     id 'org.springframework.boot'
 }
-
-// Spring Boot 3.2.3 pulls in opentelemetry-bom 1.31.0.
-// It must have version >= 1.34.1 for compatibility with terra-common-lib 1.0.9:
-ext['opentelemetry.version'] = '1.36.0'

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'bio.terra:terra-test-runner:0.2.1-SNAPSHOT'
 
     // Use Terra Common Library on client side to retry direct Sam calls
-    implementation("bio.terra:terra-common-lib:1.1.38-SNAPSHOT") {
+    implementation("bio.terra:terra-common-lib:1.1.21-SNAPSHOT") {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'bio.terra:terra-test-runner:0.2.1-SNAPSHOT'
 
     // Use Terra Common Library on client side to retry direct Sam calls
-    implementation("bio.terra:terra-common-lib:1.1.11-SNAPSHOT") {
+    implementation("bio.terra:terra-common-lib:1.1.38-SNAPSHOT") {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'bio.terra:terra-test-runner:0.2.1-SNAPSHOT'
 
     // Use Terra Common Library on client side to retry direct Sam calls
-    implementation("bio.terra:terra-common-lib:1.1.21-SNAPSHOT") {
+    implementation("bio.terra:terra-common-lib:1.1.38-SNAPSHOT") {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -44,7 +44,7 @@ dependencies {
   implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.198.42-SNAPSHOT"
 
   // Cloud Resource Library
-  implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: "1.2.31-SNAPSHOT"
+  implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: "1.2.34-SNAPSHOT"
 
   // Terra Landing Zone Service
   implementation ('bio.terra:terra-landing-zone-service:0.0.390-SNAPSHOT')

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -58,6 +58,7 @@ dependencies {
   implementation group: "com.fasterxml.jackson.core", name: "jackson-core"
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava'
   implementation group: "org.webjars", name: "webjars-locator-core", version: "0.46"
+  implementation group: "org.apache.commons", name: "commons-collections4", version: "4.4" // previously pulled in by client-java
 
   // Deps whose versions are controlled by Spring
   implementation group: "jakarta.validation", name: "jakarta.validation-api"
@@ -75,7 +76,9 @@ dependencies {
   implementation group: "io.micrometer", name: "micrometer-registry-prometheus"
 
   implementation group: "commons-validator", name: "commons-validator", version: "1.7"
-  // implementation group: "io.kubernetes", name: "client-java", version: "20.0.1" // Do not use -legacy versions
+  // Should match the version used in terra-common-lib
+  // Do not use -legacy versions
+  implementation group: "io.kubernetes", name: "client-java", version: "23.0.0"
   constraints {
     implementation('org.bouncycastle:bcprov-jdk18on:1.78') {
       because 'https://broadworkbench.atlassian.net/browse/WOR-1652'

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -23,7 +23,7 @@ dependencies {
 
   // Terra deps
   implementation group: "bio.terra", name: "datarepo-client", version: "2.13.0-SNAPSHOT"
-  implementation group: "bio.terra", name:"billing-profile-manager-client", version: "0.1.536-SNAPSHOT"
+  implementation group: "bio.terra", name:"billing-profile-manager-client", version: "0.1.611-SNAPSHOT"
   implementation(group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT") {
     // this conflicts with TCL-provided otel libraries
     exclude group: 'io.opentelemetry.instrumentation', module: 'opentelemetry-spring-boot'

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -31,10 +31,10 @@ dependencies {
   implementation group: "org.glassfish.jersey.inject", name: "jersey-hk2"
 
   // OpenTelemetry @WithSpan annotations:
-  implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0'
+  implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.12.0'
 
   // Get stairway via TCL
-  implementation("bio.terra:terra-common-lib:1.1.21-SNAPSHOT")
+  implementation("bio.terra:terra-common-lib:1.1.38-SNAPSHOT")
 
   // sam
   implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.332"

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -24,7 +24,10 @@ dependencies {
   // Terra deps
   implementation group: "bio.terra", name: "datarepo-client", version: "2.13.0-SNAPSHOT"
   implementation group: "bio.terra", name:"billing-profile-manager-client", version: "0.1.536-SNAPSHOT"
-  implementation group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT"
+  implementation(group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT") {
+    // this conflicts with TCL-provided otel libraries
+    exclude group: 'io.opentelemetry.instrumentation', module: 'opentelemetry-spring-boot'
+  }
   implementation group: "bio.terra", name:"terra-aws-resource-discovery", version:"v0.6.4-SNAPSHOT"
 
   // hk2 is required to use datarepo client, but not correctly exposed by the client

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -34,7 +34,7 @@ dependencies {
   implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0'
 
   // Get stairway via TCL
-  implementation("bio.terra:terra-common-lib:1.1.38-SNAPSHOT")
+  implementation("bio.terra:terra-common-lib:1.1.21-SNAPSHOT")
 
   // sam
   implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.332"

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -34,7 +34,7 @@ dependencies {
   implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0'
 
   // Get stairway via TCL
-  implementation("bio.terra:terra-common-lib:1.1.11-SNAPSHOT")
+  implementation("bio.terra:terra-common-lib:1.1.38-SNAPSHOT")
 
   // sam
   implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.332"

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -47,8 +47,8 @@ dependencies {
   implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: "1.2.31-SNAPSHOT"
 
   // Terra Landing Zone Service
-  implementation ('bio.terra:terra-landing-zone-service:0.0.367-SNAPSHOT')
-  implementation ('bio.terra:landing-zone-service-client:0.0.367-SNAPSHOT')
+  implementation ('bio.terra:terra-landing-zone-service:0.0.390-SNAPSHOT')
+  implementation ('bio.terra:landing-zone-service-client:0.0.390-SNAPSHOT')
 
   // Storage transfer service
   implementation group: 'com.google.apis', name: 'google-api-services-storagetransfer', version: 'v1-rev20230831-2.0.0'
@@ -58,7 +58,6 @@ dependencies {
   implementation group: "com.fasterxml.jackson.core", name: "jackson-core"
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava'
   implementation group: "org.webjars", name: "webjars-locator-core", version: "0.46"
-  implementation group: "org.apache.commons", name: "commons-collections4", version: "4.4" // previously pulled in by client-java
 
   // Deps whose versions are controlled by Spring
   implementation group: "jakarta.validation", name: "jakarta.validation-api"

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -36,7 +36,7 @@ dependencies {
   // OpenTelemetry @WithSpan annotations:
   implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.12.0'
 
-  // Get stairway via TCL
+  // Get stairway and k8s client via TCL
   implementation("bio.terra:terra-common-lib:1.1.38-SNAPSHOT")
 
   // sam
@@ -75,7 +75,7 @@ dependencies {
   implementation group: "io.micrometer", name: "micrometer-registry-prometheus"
 
   implementation group: "commons-validator", name: "commons-validator", version: "1.7"
-  implementation group: "io.kubernetes", name: "client-java", version: "20.0.1" // Do not use -legacy versions
+  // implementation group: "io.kubernetes", name: "client-java", version: "20.0.1" // Do not use -legacy versions
   constraints {
     implementation('org.bouncycastle:bcprov-jdk18on:1.78') {
       because 'https://broadworkbench.atlassian.net/browse/WOR-1652'

--- a/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
+++ b/service/src/main/java/bio/terra/workspace/service/spendprofile/SpendProfileService.java
@@ -224,7 +224,7 @@ public class SpendProfileService {
   @VisibleForTesting
   public void deleteProfile(UUID profileId, AuthenticatedUserRequest userRequest) {
     try {
-      getProfileApi(userRequest).deleteProfile(profileId);
+      getProfileApi(userRequest).deleteProfile(profileId, userRequest.getSubjectId());
     } catch (ApiException e) {
       throw new BillingProfileManagerServiceAPIException(e);
     }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -321,6 +321,10 @@ otel:
   sdk:
     disabled: false # set to true to disable all open telemetry features
 
+  instrumentation:
+    common:
+      default-enabled: false
+
   springboot:
     resource:
       attributes:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -321,10 +321,6 @@ otel:
   sdk:
     disabled: false # set to true to disable all open telemetry features
 
-  instrumentation:
-    common:
-      default-enabled: false
-
   springboot:
     resource:
       attributes:


### PR DESCRIPTION
TCL 1.1.38 has the same version of Spring Boot that WSM uses, so I'm hoping to use that. Many test failures.