### PR TITLE
CORE-376: turn off double-tracing and 'failed to export spans' error

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'bio.terra:terra-test-runner:0.2.1-SNAPSHOT'
 
     // Use Terra Common Library on client side to retry direct Sam calls
-    implementation("bio.terra:terra-common-lib:1.1.38-SNAPSHOT") {
+    implementation("bio.terra:terra-common-lib:1.1.39-SNAPSHOT") {
         exclude group: "org.broadinstitute.dsde.workbench", module: "sam-client_2.13"
     }
 

--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -37,7 +37,7 @@ dependencies {
   implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.12.0'
 
   // Get stairway and k8s client via TCL
-  implementation("bio.terra:terra-common-lib:1.1.38-SNAPSHOT")
+  implementation("bio.terra:terra-common-lib:1.1.39-SNAPSHOT")
 
   // sam
   implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.371"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-376

Update TCL to get its fix for the "failed to export spans" error.

See https://github.com/DataBiosphere/terra-common-lib/pull/229