### PR TITLE
CORE-486 don't call connected tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradleTask: [unitTest, connectedTest, azureUnitTest, awsUnitTest]
+        gradleTask: [unitTest, azureUnitTest, awsUnitTest]
 
     steps:
     - name: Checkout current code


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-486

Tests where WSM calls any real google things are failing because permissions are messed up. But we don't care enough to fix it so we are disabling tests that do this. This PR stops call connected tests. Integration tests have been disabled in GitHub.