### PR TITLE
[CORE-540] Upgrade commons-beanutils to 1.11.0

### DIFF
--- a/service/dependencies.gradle
+++ b/service/dependencies.gradle
@@ -74,13 +74,17 @@ dependencies {
   implementation group: "org.springframework.security", name: "spring-security-oauth2-jose"
   implementation group: "io.micrometer", name: "micrometer-registry-prometheus"
 
-  implementation group: "commons-validator", name: "commons-validator", version: "1.7"
+  implementation group: "commons-validator", name: "commons-validator", version: "1.9.0"
   // Should match the version used in terra-common-lib
   // Do not use -legacy versions
   implementation group: "io.kubernetes", name: "client-java", version: "23.0.0"
   constraints {
     implementation('org.bouncycastle:bcprov-jdk18on:1.78') {
       because 'https://broadworkbench.atlassian.net/browse/WOR-1652'
+    }
+    // required by commons-validator:commons-validator:1.9.0
+    implementation('commons-beanutils:commons-beanutils:1.11.0') {
+      because("CVE-2025-48734")
     }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-540

---
#### Changes
- [x] Upgraded `commons-validator:commons-validator` from `1.7` to `1.9.0`
- [X] Upgrade `commons-beanutils` to `1.11.0` which a dependency for `commons-validator:commons-validator:1.9.0` because of [CVE-2025-48734](https://nvd.nist.gov/vuln/detail/cve-2025-48734)