### PR TITLE
[CORE-504] Disable pact verification

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -15,15 +15,15 @@ name: Verify consumer pacts
 # - PACT_BROKER_USERNAME - the Pact Broker username
 # - PACT_BROKER_PASSWORD - the Pact Broker password
 on:
-  pull_request:
-    branches: [ main ]
-    paths-ignore: [ '**.md' ]
-  push:
-    branches: [ main ]
-    paths-ignore: [ '**.md' ]
-  merge_group:
-    branches: [ main ]
-    paths-ignore: [ '**.md' ]
+  # pull_request:
+  #   branches: [ main ]
+  #   paths-ignore: [ '**.md' ]
+  # push:
+  #   branches: [ main ]
+  #   paths-ignore: [ '**.md' ]
+  # merge_group:
+  #   branches: [ main ]
+  #   paths-ignore: [ '**.md' ]
   workflow_dispatch:
     inputs:
       pb-event-type:


### PR DESCRIPTION
Part of https://broadworkbench.atlassian.net/browse/CORE-504 but does not complete that ticket.

WSM's pacts are all with services that are on their way out, and have been failing recently.  It's not worth fixing, so this PR turns off running the verification unless specifically triggered.